### PR TITLE
DVD navigation improvement (use of Prev / Next in menu structures when appropriate)

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1194,9 +1194,6 @@ void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName)
 
 bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
 {
-  if(chapter < 1)
-    chapter = 1;
-
   CDVDInputStream::IChapter* ich = dynamic_cast<CDVDInputStream::IChapter*>(m_pInput);
   if(ich)
   {
@@ -1210,6 +1207,9 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
     Flush();
     return true;
   }
+
+  if(chapter < 1)
+    chapter = 1;
 
   if(m_pFormatContext == NULL)
     return false;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -474,6 +474,8 @@ int CDVDInputStreamBluray::GetChapter()
 
 bool CDVDInputStreamBluray::SeekChapter(int ch)
 {
+  if(ch < 1)
+    ch = 1;
   if(m_title && m_dll->bd_seek_chapter(m_bd, ch-1) < 0)
     return false;
   else

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -764,7 +764,7 @@ void CDVDInputStreamNavigator::OnBack()
 // we don't allow skipping in menu's cause it will remove menu overlays
 void CDVDInputStreamNavigator::OnNext()
 {
-  if (m_dvdnav && !IsInMenu())
+  if (m_dvdnav && !(IsInMenu() && GetTotalButtons() > 0))
   {
     m_dll.dvdnav_next_pg_search(m_dvdnav);
   }
@@ -773,7 +773,7 @@ void CDVDInputStreamNavigator::OnNext()
 // we don't allow skipping in menu's cause it will remove menu overlays
 void CDVDInputStreamNavigator::OnPrevious()
 {
-  if (m_dvdnav && !IsInMenu())
+  if (m_dvdnav && !(IsInMenu() && GetTotalButtons() > 0))
   {
     m_dll.dvdnav_prev_pg_search(m_dvdnav);
   }
@@ -1054,11 +1054,22 @@ bool CDVDInputStreamNavigator::SeekTime(int iTimeInMsec)
 
 bool CDVDInputStreamNavigator::SeekChapter(int iChapter)
 {
+  if (!m_dvdnav)
+    return false;
+
+  // cannot allow to return true in case of buttons (overlays) because otherwise back in DVDPlayer FlushBuffers will remove menu overlays
+  // therefore we just skip the request in case there are buttons and return false
+  if (IsInMenu() && GetTotalButtons() > 0)
+  {
+    CLog::Log(LOGDEBUG, "%s - Seeking chapter is not allowed in menu set with buttons");
+    return false;
+  }
+
   bool enabled = IsSubtitleStreamEnabled();
   int audio    = GetActiveAudioStream();
   int subtitle = GetActiveSubtitleStream();
 
-  if (iChapter == (m_iPart + 1))
+  if (iChapter > 0 && iChapter == (m_iPart + 1))
   {
     if (m_dll.dvdnav_next_pg_search(m_dvdnav) == DVDNAV_STATUS_ERR)
     {
@@ -1067,7 +1078,7 @@ bool CDVDInputStreamNavigator::SeekChapter(int iChapter)
     }
   }
   else
-  if (iChapter == (m_iPart - 1))
+  if (iChapter < 0 || iChapter == (m_iPart - 1))
   {
     if (m_dll.dvdnav_prev_pg_search(m_dvdnav) == DVDNAV_STATUS_ERR)
     {

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3115,6 +3115,16 @@ bool CDVDPlayer::OnAction(const CAction &action)
     {
       switch (action.GetID())
       {
+      case ACTION_NEXT_ITEM:
+      case ACTION_PAGE_UP:
+        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()+1)); // needs the modified CDVDInputStreamNavigator::SeekChapter(int iChapter) method, assuming dvdnav_next_pg_search
+        g_infoManager.SetDisplayAfterSeek();
+        return true;
+      case ACTION_PREV_ITEM:
+      case ACTION_PAGE_DOWN:
+        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()-1)); // needs the modified CDVDInputStreamNavigator::SeekChapter(int iChapter) method, assuming dvdnav_prev_pg_search
+        g_infoManager.SetDisplayAfterSeek();
+        return true;
       case ACTION_PREVIOUS_MENU:
         {
           THREAD_ACTION(action);


### PR DESCRIPTION
@elupus - please review

This is a patch for the use of Prev/Next in DVD menu structures especially in DVDs where the "trailers" are part of the menu structure. Currently the Prev/Next function does not work, and brings you straight back to the xbmc menu. The reason is that the action doesn't get handled so it's delegated to the GUI. 

There are DVD's where it can be quite annoying that you have to wait several minutes (sometimes 10 mins or so), before you can get to the DVD root menu. It does not happen that frequently, but I have two cases of DVDs where trailers are part of the menu. 

See reopened Trac ticket 9674.

Note: the code _comments_ in DVDPlayer.cpp stating "// needs the modified CDVDInputStreamNavigator::SeekChapter(int iChapter) method, assuming dvdnav_..." are only relevant when this DVD playback, but the code itself is -of course- generally applicable.
