### PR TITLE
solution for ticket #11006: Problem with display of .idx/.sub (Vobsub) subtitles

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -56,6 +56,8 @@ bool CDVDOverlayCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &optio
   m_pCodecContext->dsp_mask = FF_MM_FORCE | FF_MM_MMX | FF_MM_MMXEXT | FF_MM_SSE;
   m_pCodecContext->sub_id = hints.identifier;
   m_pCodecContext->codec_tag = hints.codec_tag;
+  m_pCodecContext->width = hints.width;
+  m_pCodecContext->height = hints.height;
 
   if( hints.extradata && hints.extrasize > 0 )
   {

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1194,9 +1194,6 @@ void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName)
 
 bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
 {
-  if(chapter < 1)
-    chapter = 1;
-
   CDVDInputStream::IChapter* ich = dynamic_cast<CDVDInputStream::IChapter*>(m_pInput);
   if(ich)
   {
@@ -1210,6 +1207,9 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
     Flush();
     return true;
   }
+
+  if(chapter < 1)
+    chapter = 1;
 
   if(m_pFormatContext == NULL)
     return false;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -474,6 +474,8 @@ int CDVDInputStreamBluray::GetChapter()
 
 bool CDVDInputStreamBluray::SeekChapter(int ch)
 {
+  if(ch < 1)
+    ch = 1;
   if(m_title && m_dll->bd_seek_chapter(m_bd, ch-1) < 0)
     return false;
   else

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -764,7 +764,7 @@ void CDVDInputStreamNavigator::OnBack()
 // we don't allow skipping in menu's cause it will remove menu overlays
 void CDVDInputStreamNavigator::OnNext()
 {
-  if (m_dvdnav && !IsInMenu())
+  if (m_dvdnav && !(IsInMenu() && GetTotalButtons() > 0))
   {
     m_dll.dvdnav_next_pg_search(m_dvdnav);
   }
@@ -773,7 +773,7 @@ void CDVDInputStreamNavigator::OnNext()
 // we don't allow skipping in menu's cause it will remove menu overlays
 void CDVDInputStreamNavigator::OnPrevious()
 {
-  if (m_dvdnav && !IsInMenu())
+  if (m_dvdnav && !(IsInMenu() && GetTotalButtons() > 0))
   {
     m_dll.dvdnav_prev_pg_search(m_dvdnav);
   }
@@ -1054,11 +1054,22 @@ bool CDVDInputStreamNavigator::SeekTime(int iTimeInMsec)
 
 bool CDVDInputStreamNavigator::SeekChapter(int iChapter)
 {
+  if (!m_dvdnav)
+    return false;
+
+  // cannot allow to return true in case of buttons (overlays) because otherwise back in DVDPlayer FlushBuffers will remove menu overlays
+  // therefore we just skip the request in case there are buttons and return false
+  if (IsInMenu() && GetTotalButtons() > 0)
+  {
+    CLog::Log(LOGDEBUG, "%s - Seeking chapter is not allowed in menu set with buttons");
+    return false;
+  }
+
   bool enabled = IsSubtitleStreamEnabled();
   int audio    = GetActiveAudioStream();
   int subtitle = GetActiveSubtitleStream();
 
-  if (iChapter == (m_iPart + 1))
+  if (iChapter > 0 && iChapter == (m_iPart + 1))
   {
     if (m_dll.dvdnav_next_pg_search(m_dvdnav) == DVDNAV_STATUS_ERR)
     {
@@ -1067,7 +1078,7 @@ bool CDVDInputStreamNavigator::SeekChapter(int iChapter)
     }
   }
   else
-  if (iChapter == (m_iPart - 1))
+  if (iChapter < 0 || iChapter == (m_iPart - 1))
   {
     if (m_dll.dvdnav_prev_pg_search(m_dvdnav) == DVDNAV_STATUS_ERR)
     {

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3115,6 +3115,16 @@ bool CDVDPlayer::OnAction(const CAction &action)
     {
       switch (action.GetID())
       {
+      case ACTION_NEXT_ITEM:
+      case ACTION_PAGE_UP:
+        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()+1)); // needs the modified CDVDInputStreamNavigator::SeekChapter(int iChapter) method, assuming dvdnav_next_pg_search
+        g_infoManager.SetDisplayAfterSeek();
+        return true;
+      case ACTION_PREV_ITEM:
+      case ACTION_PAGE_DOWN:
+        m_messenger.Put(new CDVDMsgPlayerSeekChapter(GetChapter()-1)); // needs the modified CDVDInputStreamNavigator::SeekChapter(int iChapter) method, assuming dvdnav_prev_pg_search
+        g_infoManager.SetDisplayAfterSeek();
+        return true;
       case ACTION_PREVIOUS_MENU:
         {
           THREAD_ACTION(action);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2672,6 +2672,12 @@ bool CDVDPlayer::OpenSubtitleStream(int iStream, int source)
       CloseSubtitleStream(false);
     }
 
+    if (hint.height == 0 && hint.width == 0) 
+    {
+       hint.height = m_CurrentVideo.hint.height;
+       hint.width = m_CurrentVideo.hint.width;
+    }
+
     if(!m_dvdPlayerSubtitle.OpenStream(hint, filename))
     {
       CLog::Log(LOGWARNING, "%s - Unsupported stream %d. Stream disabled.", __FUNCTION__, iStream);


### PR DESCRIPTION
It seems that it takes awhile before the subtitles renderer figures out how big the screen is and where to position the pictures (how big and what position)... What I mean by that is that if in the beginning there are top-centered subs apparently the sub picture is stretched too much vertically, and if the subs are "short" then in the beginning they are not centered and appear to the right, again too much stretched horizontally.

The problem is in CDVDOverlayCodecFFmpeg::GetOverlay() where the OverlayCodec tries to determine the m_width and m_height based on the size of the overlays! So what I see happening is that the first few subs are "determined" at 1280x480 (while the actual resolution should be 1920x1080). It takes a few larger subs before the correct resolution is determined. 

This can be avoided if CDVDOverlayCodecFFmpeg::Open(..) receives the proper dimensions from the CodecContext in m_pCodecContext = m_dllAvCodec.avcodec_alloc_context();

Fixed by this commit.
