### PR TITLE
MySQL connections should explicitly set UTF-8 charset

### DIFF
--- a/xbmc/MusicDatabase.h
+++ b/xbmc/MusicDatabase.h
@@ -214,7 +214,7 @@ protected:
   std::map<CStdString, CAlbumCache> m_albumCache;
 
   virtual bool CreateTables();
-  virtual int GetMinVersion() const { return 15; };
+  virtual int GetMinVersion() const { return 16; };
   const char *GetDefaultDBName() const { return "MyMusic7"; };
 
   int AddAlbum(const CStdString& strAlbum1, int idArtist, const CStdString &extraArtists, const CStdString &strArtist1, int idThumb, int idGenre, const CStdString &extraGenres, int year);

--- a/xbmc/VideoDatabase.cpp
+++ b/xbmc/VideoDatabase.cpp
@@ -3336,6 +3336,81 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
     {
       m_pDS->exec("ALTER table settings add VerticalShift float");
     }
+    if (iVersion < 44)
+    {
+      // only if MySQL is used and default character set is not utf8
+      // string data needs to be converted to proper utf8
+      CStdString charset = m_pDS->getDatabase()->getDefaultCharset();
+      if (!m_sqlite && !charset.empty() && charset != "utf8")
+      {
+        map<CStdString, CStdStringArray> tables;
+        map<CStdString, CStdStringArray>::iterator itt;
+        CStdStringArray::iterator itc;
+
+        // columns that need to be converted
+        // content columns
+        CStdStringArray c_columns;
+        for (int i = 0; i < 22; i++)
+        {
+          CStdString c;
+          c.Format("c%02d", i);
+          c_columns.push_back(c);
+        }
+
+        tables.insert(pair<CStdString, CStdStringArray> ("episode", c_columns));
+        tables.insert(pair<CStdString, CStdStringArray> ("movie", c_columns));
+        tables.insert(pair<CStdString, CStdStringArray> ("musicvideo", c_columns));
+        tables.insert(pair<CStdString, CStdStringArray> ("tvshow", c_columns));
+
+        //common columns
+        CStdStringArray c1;
+        c1.push_back("strRole");
+        tables.insert(pair<CStdString, CStdStringArray> ("actorlinkepisode", c1));
+        tables.insert(pair<CStdString, CStdStringArray> ("actorlinkmovie", c1));
+        tables.insert(pair<CStdString, CStdStringArray> ("actorlinktvshow", c1));
+
+        //remaining columns
+        CStdStringArray c2;
+        c2.push_back("strActor");
+        tables.insert(pair<CStdString, CStdStringArray> ("actors", c2));
+
+        CStdStringArray c3;
+        c3.push_back("strCountry");
+        tables.insert(pair<CStdString, CStdStringArray> ("country", c3));
+
+        CStdStringArray c4;
+        c4.push_back("strFilename");
+        tables.insert(pair<CStdString, CStdStringArray> ("files", c4));
+
+        CStdStringArray c5;
+        c5.push_back("strGenre");
+        tables.insert(pair<CStdString, CStdStringArray> ("genre", c5));
+
+        CStdStringArray c6;
+        c6.push_back("strSet");
+        tables.insert(pair<CStdString, CStdStringArray> ("sets", c6));
+
+        CStdStringArray c7;
+        c7.push_back("strStudio");
+        tables.insert(pair<CStdString, CStdStringArray> ("studio", c7));
+
+        for (itt = tables.begin(); itt != tables.end(); ++itt)
+        {
+          CStdString q;
+          q = PrepareSQL("UPDATE `%s` SET", itt->first.c_str());
+          for (itc = itt->second.begin(); itc != itt->second.end(); ++itc)
+          {
+            q += PrepareSQL(" `%s` = CONVERT(CAST(CONVERT(`%s` USING %s) AS BINARY) USING utf8)",
+                            itc->c_str(), itc->c_str(), charset.c_str());
+            if (*itc != itt->second.back())
+            {
+              q += ",";
+            }
+          }
+          m_pDS->exec(q);
+        }
+      }
+    }
   }
   catch (...)
   {

--- a/xbmc/VideoDatabase.h
+++ b/xbmc/VideoDatabase.h
@@ -622,7 +622,7 @@ protected:
 private:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 43; };
+  virtual int GetMinVersion() const { return 44; };
   const char *GetDefaultDBName() const { return "MyVideos34.db"; };
 
   void ConstructPath(CStdString& strDest, const CStdString& strPath, const CStdString& strFileName);

--- a/xbmc/lib/sqLite/dataset.h
+++ b/xbmc/lib/sqLite/dataset.h
@@ -70,7 +70,8 @@ protected:
   bool active;
   std::string error, // Error description
     host, port, db, login, passwd, //Login info
-    sequence_table; //Sequence table for nextid
+    sequence_table, //Sequence table for nextid
+    default_charset; //Default character set
 
 public:
 /* constructor */
@@ -104,7 +105,8 @@ public:
   void setSequenceTable(const char *new_seq_table) { sequence_table = new_seq_table; };
 /* Get name of sequence table */
   const char *getSequenceTable(void) { return sequence_table.c_str(); }
-
+/* Get the default character set */
+  const char *getDefaultCharset(void) { return default_charset.c_str(); }
 
 /* virtual methods that must be overloaded in derived classes */
 

--- a/xbmc/lib/sqLite/mysqldataset.cpp
+++ b/xbmc/lib/sqLite/mysqldataset.cpp
@@ -121,12 +121,24 @@ int MysqlDatabase::connect() {
     // TODO block to avoid multiple connect on db
     if (mysql_real_connect(conn,host.c_str(),login.c_str(),passwd.c_str(),db.c_str(),atoi(port.c_str()),NULL,0) != NULL)
     {
+      if(mysql_set_character_set(conn, "utf8")) // returns 0 on success
+      {
+        CLog::Log(LOGERROR, "Unable to set utf8 charset: %s [%d](%s)",
+                  db.c_str(), mysql_errno(conn), mysql_error(conn));
+      }
+
       active = true;
       return DB_CONNECTION_OK;
     }
     // Database doesn't exists
     if (mysql_errno(conn) == 1049)
     {
+      if (mysql_set_character_set(conn, "utf8")) // returns 0 on success
+      {
+        CLog::Log(LOGERROR, "Unable to set utf8 charset: %s [%d](%s)",
+                  db.c_str(), mysql_errno(conn), mysql_error(conn));
+      }
+
       if (create() == MYSQL_OK)
       {
         active = true;

--- a/xbmc/lib/sqLite/mysqldataset.cpp
+++ b/xbmc/lib/sqLite/mysqldataset.cpp
@@ -52,6 +52,7 @@ MysqlDatabase::MysqlDatabase() {
   login = "root";
   passwd = "null";
   conn = NULL;
+  default_charset = "";
 }
 
 MysqlDatabase::~MysqlDatabase() {
@@ -121,6 +122,7 @@ int MysqlDatabase::connect() {
     // TODO block to avoid multiple connect on db
     if (mysql_real_connect(conn,host.c_str(),login.c_str(),passwd.c_str(),db.c_str(),atoi(port.c_str()),NULL,0) != NULL)
     {
+      default_charset = mysql_character_set_name(conn);
       if(mysql_set_character_set(conn, "utf8")) // returns 0 on success
       {
         CLog::Log(LOGERROR, "Unable to set utf8 charset: %s [%d](%s)",
@@ -133,6 +135,7 @@ int MysqlDatabase::connect() {
     // Database doesn't exists
     if (mysql_errno(conn) == 1049)
     {
+      default_charset = mysql_character_set_name(conn);
       if (mysql_set_character_set(conn, "utf8")) // returns 0 on success
       {
         CLog::Log(LOGERROR, "Unable to set utf8 charset: %s [%d](%s)",


### PR DESCRIPTION
The MySQL connection does not have an explicit charset defined, which results in broken strings being stored in the database and lack of compatibility between systems with different defaults.

First commit simply sets the charset to UTF8, the second one adds a database update procedure that fixes strings already stored.
