### PR TITLE
Runtime detection of cpu features (MMX, SSE, etc) for swscale

### DIFF
--- a/lib/DllSwScale.h
+++ b/lib/DllSwScale.h
@@ -66,15 +66,23 @@ extern "C" {
 #endif
 }
 
+#include "../xbmc/utils/CPUInfo.h"
+
 inline int SwScaleCPUFlags()
 {
-#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__)
-  return SWS_CPU_CAPS_MMX;
-#elif defined(__powerpc__) || defined(__ppc__)
-  return SWS_CPU_CAPS_ALTIVEC;
-#else
-  return 0;
-#endif
+  unsigned int cpuFeatures = g_cpuInfo.GetCPUFeatures();
+  int flags = 0;
+
+  if (cpuFeatures & CPU_FEATURE_MMX)
+    flags |= SWS_CPU_CAPS_MMX;
+  if (cpuFeatures & CPU_FEATURE_MMX2)
+    flags |= SWS_CPU_CAPS_MMX2;
+  if (cpuFeatures & CPU_FEATURE_3DNOW)
+    flags |= SWS_CPU_CAPS_3DNOW;
+  if (cpuFeatures & CPU_FEATURE_ALTIVEC)
+    flags |= SWS_CPU_CAPS_ALTIVEC;
+
+  return flags;
 }
 
 class DllSwScaleInterface

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -241,6 +241,11 @@ CCPUInfo::CCPUInfo(void)
 
   readProcStat(m_userTicks, m_niceTicks, m_systemTicks, m_idleTicks, m_ioTicks);
 #endif
+
+  // Set MMX2 when SSE is present as SSE is a superset of MMX2 and Intel doesn't set the MMX2 cap
+  if (m_cpuFeatures & CPU_FEATURE_SSE)
+    m_cpuFeatures |= CPU_FEATURE_MMX2;
+
 }
 
 CCPUInfo::~CCPUInfo()
@@ -545,10 +550,6 @@ void CCPUInfo::ReadCPUFeatures()
     if (CPUInfo[CPUINFO_EDX] & CPUID_80000001_EDX_3DNOWEXT)
       m_cpuFeatures |= CPU_FEATURE_3DNOWEXT;
   }
-
-  // Set MMX2 when SSE is present as SSE is a superset of MMX2 and Intel doesn't set the MMX2 cap
-  if (m_cpuFeatures & CPU_FEATURE_SSE)
-    m_cpuFeatures |= CPU_FEATURE_MMX2;
 
 #elif !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__)
   m_cpuFeatures |= CPU_FEATURE_MMX;

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -121,8 +121,6 @@ CCPUInfo::CCPUInfo(void)
     m_cores[core.m_id] = core;
   }
 
-  ReadCPUFeatures();
-
 #elif defined(_WIN32)
   char rgValue [128];
   HKEY hKey;
@@ -143,8 +141,6 @@ CCPUInfo::CCPUInfo(void)
 
   CoreInfo core;
   m_cores[0] = core;
-
-  ReadCPUFeatures();
 
 #else
   m_fProcStat = fopen("/proc/stat", "r");
@@ -241,6 +237,8 @@ CCPUInfo::CCPUInfo(void)
 
   readProcStat(m_userTicks, m_niceTicks, m_systemTicks, m_idleTicks, m_ioTicks);
 #endif
+
+  ReadCPUFeatures();
 
   // Set MMX2 when SSE is present as SSE is a superset of MMX2 and Intel doesn't set the MMX2 cap
   if (m_cpuFeatures & CPU_FEATURE_SSE)
@@ -583,6 +581,8 @@ void CCPUInfo::ReadCPUFeatures()
     else
       m_cpuFeatures |= CPU_FEATURE_MMX;
   #endif
+#elif defined(LINUX)
+// empty on purpose, the implementation is in the constructor
 #elif !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__)
   m_cpuFeatures |= CPU_FEATURE_MMX;
 #elif defined(__powerpc__) || defined(__ppc__)

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -551,6 +551,38 @@ void CCPUInfo::ReadCPUFeatures()
       m_cpuFeatures |= CPU_FEATURE_3DNOWEXT;
   }
 
+#elif defined(__APPLE__)
+  #if defined(__ppc__)
+    m_cpuFeatures |= CPU_FEATURE_ALTIVEC;
+  #elif defined(__arm__)
+  #else
+    len = 512;
+    char buffer[512];
+
+    if (sysctlbyname("machdep.cpu.features", &buffer, &len, NULL, 0) == 0)
+    {
+      if (strstr(buffer,"MMX"))
+        m_cpuFeatures |= CPU_FEATURE_MMX;
+      if (strstr(buffer,"SSE "))
+        m_cpuFeatures |= CPU_FEATURE_SSE;
+      if (strstr(buffer,"SSE2"))
+        m_cpuFeatures |= CPU_FEATURE_SSE2;
+      if (strstr(buffer,"SSE3"))
+        m_cpuFeatures |= CPU_FEATURE_SSE3;
+      if (strstr(buffer,"SSSE3"))
+        m_cpuFeatures |= CPU_FEATURE_SSSE3;
+      if (strstr(buffer,"SSE4.1"))
+        m_cpuFeatures |= CPU_FEATURE_SSE4;
+      if (strstr(buffer,"SSE4.2"))
+        m_cpuFeatures |= CPU_FEATURE_SSE42;
+      if (strstr(buffer,"3DNOW"))
+        m_cpuFeatures |= CPU_FEATURE_3DNOW;
+      if (strstr(buffer,"3DNOWEXT"))
+       m_cpuFeatures |= CPU_FEATURE_3DNOWEXT;
+    }
+    else
+      m_cpuFeatures |= CPU_FEATURE_MMX;
+  #endif
 #elif !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__)
   m_cpuFeatures |= CPU_FEATURE_MMX;
 #elif defined(__powerpc__) || defined(__ppc__)

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -90,10 +90,10 @@ private:
   unsigned long long m_idleTicks;
   unsigned long long m_ioTicks;
 
-  int m_lastUsedPercentage;
-  time_t m_lastReadTime;
-  std::string m_cpuModel;
-  int m_cpuCount;
+  int          m_lastUsedPercentage;
+  time_t       m_lastReadTime;
+  std::string  m_cpuModel;
+  int          m_cpuCount;
   unsigned int m_cpuFeatures;
 
   std::map<int, CoreInfo> m_cores;

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -29,6 +29,18 @@
 #include <string>
 #include <map>
 
+#define CPU_FEATURE_MMX      1 << 0
+#define CPU_FEATURE_MMX2     1 << 1
+#define CPU_FEATURE_SSE      1 << 2
+#define CPU_FEATURE_SSE2     1 << 3
+#define CPU_FEATURE_SSE3     1 << 4
+#define CPU_FEATURE_SSSE3    1 << 5
+#define CPU_FEATURE_SSE4     1 << 6
+#define CPU_FEATURE_SSE42    1 << 7
+#define CPU_FEATURE_3DNOW    1 << 8
+#define CPU_FEATURE_3DNOWEXT 1 << 9
+#define CPU_FEATURE_ALTIVEC  1 << 10
+
 struct CoreInfo
 {
   int    m_id;
@@ -61,9 +73,12 @@ public:
 
   CStdString GetCoresUsageString() const;
 
+  unsigned int GetCPUFeatures() { return m_cpuFeatures; }
+
 private:
   bool readProcStat(unsigned long long& user, unsigned long long& nice, unsigned long long& system,
     unsigned long long& idle, unsigned long long& io);
+  void ReadCPUFeatures();
 
   FILE* m_fProcStat;
   FILE* m_fProcTemperature;
@@ -79,8 +94,10 @@ private:
   time_t m_lastReadTime;
   std::string m_cpuModel;
   int m_cpuCount;
+  unsigned int m_cpuFeatures;
 
   std::map<int, CoreInfo> m_cores;
+
 };
 
 extern CCPUInfo g_cpuInfo;


### PR DESCRIPTION
This commit series reads the cpu capabilities at runtime and passes them to swscale instead of using hardcoded values per platform.

This will later be useful for the AE branch, with its different assembly code paths for mmx, sse and without any extensions.

Linux and OSX have to provide an implementation, until then they use the current hardcoded values.
