### PR TITLE
TvShows randomizer and predefined channels

### DIFF
--- a/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
+++ b/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
@@ -294,6 +294,11 @@
 		</control>
 	</include>
 	<include name="HomeSubMenuTVShows">
+		<control type="button" id="901001">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>CHANNEL 1</label>
+			<onclick>ActivateWindow(VideoLibrary,Randomizer,1,return)</onclick>
+		</control>
 		<control type="button" id="90171">
 			<include>ButtonHomeSubCommonValues</include>
 			<label>369</label>

--- a/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
+++ b/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
@@ -296,8 +296,28 @@
 	<include name="HomeSubMenuTVShows">
 		<control type="button" id="901001">
 			<include>ButtonHomeSubCommonValues</include>
-			<label>CHANNEL 1</label>
+			<label>PRESET 1</label>
 			<onclick>ActivateWindow(VideoLibrary,Randomizer,1,return)</onclick>
+		</control>
+		<control type="button" id="901002">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>PRESET 2</label>
+			<onclick>ActivateWindow(VideoLibrary,Randomizer,2,return)</onclick>
+		</control>
+		<control type="button" id="901003">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>PRESET 3</label>
+			<onclick>ActivateWindow(VideoLibrary,Randomizer,3,return)</onclick>
+		</control>
+		<control type="button" id="901004">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>PRESET 4</label>
+			<onclick>ActivateWindow(VideoLibrary,Randomizer,4,return)</onclick>
+		</control>
+		<control type="button" id="901005">
+			<include>ButtonHomeSubCommonValues</include>
+			<label>PRESET 5</label>
+			<onclick>ActivateWindow(VideoLibrary,Randomizer,5,return)</onclick>
 		</control>
 		<control type="button" id="90171">
 			<include>ButtonHomeSubCommonValues</include>

--- a/guilib/GUIWindowManager.cpp
+++ b/guilib/GUIWindowManager.cpp
@@ -348,6 +348,14 @@ void CGUIWindowManager::ActivateWindow(int iWindowID, const vector<CStdString>& 
 
 void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<CStdString>& params, bool swappingWindows)
 {
+	if(iWindowID == WINDOW_VIDEO_NAV)
+		if(params.size() ? params[0] == "Randomizer" : false)
+		{
+			int channelID = atoi(params[1].c_str());
+			g_application.PlayChannel(channelID);
+			return;
+		}
+
   // translate virtual windows
   // virtual music window which returns the last open music window (aka the music start window)
   if (iWindowID == WINDOW_MUSIC)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4094,6 +4094,7 @@ void CApplication::StopPlaying()
       m_pKaraokeMgr->Stop();
 #endif
 
+	m_channel =0;
     if (m_pPlayer)
       m_pPlayer->CloseFile();
 
@@ -5357,3 +5358,19 @@ CPerformanceStats &CApplication::GetPerformanceStats()
   return m_perfStats;
 }
 #endif
+
+void CApplication::PlayChannel(int channelID)
+{
+	m_channel = channelID;
+	
+	CFileItemList items;
+	CVideoDatabase videodatabase;
+	videodatabase.Open();
+	bool success = videodatabase.GetNextItemsByChannel(m_channel, false, NULL, items);
+	videodatabase.Close();
+	
+	if(success)
+		getApplicationMessenger().MediaPlay(items);
+	else
+		CGUIDialogOK::ShowAndGetInput("Nothing to play",-1,-1,-1);
+}

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -103,6 +103,8 @@ public:
   virtual bool Create();
   virtual bool Cleanup();
 
+  int m_channel;
+  void PlayChannel(int channelID);
   void StartServices();
   void StopServices();
   void StartWebServer();

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -159,6 +159,25 @@ bool CPlayListPlayer::PlayNext(int offset, bool bAutoPlay)
   // stop playing
   if ((iSong < 0) || (iSong >= playlist.size()) || (playlist.GetPlayable() <= 0))
   {
+	  if(g_application.m_channel > 0)
+	  {
+		  bool isSkipShow = g_application.GetPercentage() > 0;
+		  CFileItemList items;
+		  CVideoDatabase videodatabase;
+		  videodatabase.Open();
+		  CFileItem currentFile = *playlist[iSong-offset];
+		  bool success = videodatabase.GetNextItemsByChannel(g_application.m_channel, isSkipShow, &currentFile, items);
+		  videodatabase.Close();
+		  
+		  if(success)
+		  {
+			Add(m_iCurrentPlayList, items);
+			return Play(iSong, bAutoPlay);
+		  }
+		  else
+			CGUIDialogOK::ShowAndGetInput("Nothing to play",-1,-1,-1);
+	  }
+
     CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_STOPPED, 0, 0, m_iCurrentPlayList, m_iCurrentSong);
     g_windowManager.SendThreadMessage(msg);
     Reset();

--- a/xbmc/VideoDatabase.cpp
+++ b/xbmc/VideoDatabase.cpp
@@ -4977,6 +4977,16 @@ bool CVideoDatabase::GetNextItemsByChannel(int channelID, bool isSkipShow, CFile
 
 	if(byOrder)
 	{
+		/* 
+		order by
+					case when c12>0 then			cast(c12 as integer) * 100 + cast(c13 as integer) 
+					else case when c16<>4096 then	cast(c15 as integer) * 100 + cast(c16 as integer)
+						 else					    (cast(c15 as integer) + 1) * 100 - 1 + (cast (c13 as real) / 1000)
+						 end
+					end
+		limit 1
+		*/
+
 		if(previousEpisodeID > 0)
 		{
 			CFileItemList previousItems;
@@ -4986,26 +4996,26 @@ bool CVideoDatabase::GetNextItemsByChannel(int channelID, bool isSkipShow, CFile
 
 			// try next episode for current season 
 			strFirstTry = strSQL + PrepareSQL(" and episodeview.c12=%i and episodeview.c13>%i ", numSeason, numEpisode)
-				        + " order by cast(episodeview.c13 as integer) + (cast(episodeview.c12 as integer) * 100) limit 1";
+				        + " order by case when c12>0 then cast(c12 as integer) * 100 + cast(c13 as integer) else case when c16<>4096 then  cast(c15 as integer) * 100 + cast(c16 as integer) else (cast(c15 as integer) + 1) * 100 - 1 + (cast (c13 as real) / 1000) end end limit 1 ";
 
 			m_pDS->query(strFirstTry);
 			if (m_pDS->num_rows() == 0)
 			{
 				// try next season or later
 				strSecondTry = strSQL + PrepareSQL(" and episodeview.c12>%i ", numSeason)
-							 + " order by cast(episodeview.c13 as integer) + (cast(episodeview.c12 as integer) * 100) limit 1";
+							 + " order by case when c12>0 then cast(c12 as integer) * 100 + cast(c13 as integer) else case when c16<>4096 then  cast(c15 as integer) * 100 + cast(c16 as integer) else (cast(c15 as integer) + 1) * 100 - 1 + (cast (c13 as real) / 1000) end end limit 1 ";
 
 				m_pDS->query(strSecondTry);
 				if (m_pDS->num_rows() == 0)
 				{
-					strSQL += " order by cast(episodeview.c13 as integer) + (cast(episodeview.c12 as integer) * 100) limit 1";
+					strSQL += " order by case when c12>0 then cast(c12 as integer) * 100 + cast(c13 as integer) else case when c16<>4096 then  cast(c15 as integer) * 100 + cast(c16 as integer) else (cast(c15 as integer) + 1) * 100 - 1 + (cast (c13 as real) / 1000) end end limit 1 ";
 					m_pDS->query(strSQL);
 				}
 			}
 		}
 		else
 		{
-			strSQL += " order by cast(episodeview.c13 as integer) + (cast(episodeview.c12 as integer) * 100) limit 1";
+			strSQL += " order by case when c12>0 then cast(c12 as integer) * 100 + cast(c13 as integer) else case when c16<>4096 then  cast(c15 as integer) * 100 + cast(c16 as integer) else (cast(c15 as integer) + 1) * 100 - 1 + (cast (c13 as real) / 1000) end end limit 1 ";
 			m_pDS->query(strSQL);
 		}
 	}

--- a/xbmc/VideoDatabase.cpp
+++ b/xbmc/VideoDatabase.cpp
@@ -4884,7 +4884,7 @@ bool CVideoDatabase::GetNextItemsByChannel(int channelID, bool isSkipShow, CFile
 	if(!isSkipShow)
 		strSQL = PrepareSQL("SELECT (SELECT idEpisode FROM episodeview where tvshow.c00 = episodeview.strTitle AND playCount IS NULL AND idEpisode<>%i ORDER BY cast(episodeview.c13 as integer) + (cast(episodeview.c12 as integer) * 100) LIMIT 1) AS idEpisode FROM tvshow WHERE idEpisode IS NOT NULL ORDER BY RANDOM() LIMIT 1", currentEpisodeID);
 	else
-		strSQL = PrepareSQL("SELECT (SELECT idEpisode FROM episodeview where tvshow.c00 = episodeview.strTitle AND playCount IS NULL ORDER BY cast(episodeview.c13 as integer) + (cast(episodeview.c12 as integer) * 100) LIMIT 1) AS idEpisode FROM tvshow WHERE c00<>%s AND idEpisode IS NOT NULL ORDER BY RANDOM() LIMIT 1", item->GetVideoInfoTag()->m_strTitle);
+		strSQL = PrepareSQL("SELECT (SELECT idEpisode FROM episodeview where tvshow.c00 = episodeview.strTitle AND playCount IS NULL ORDER BY cast(episodeview.c13 as integer) + (cast(episodeview.c12 as integer) * 100) LIMIT 1) AS idEpisode FROM tvshow WHERE c00<>'%s' AND idEpisode IS NOT NULL ORDER BY RANDOM() LIMIT 1", item->GetVideoInfoTag()->m_strTitle);
 
     if (!m_pDS->query(strSQL.c_str())) return false;
     if (m_pDS->num_rows() == 0)

--- a/xbmc/VideoDatabase.h
+++ b/xbmc/VideoDatabase.h
@@ -522,6 +522,8 @@ public:
   bool GetEpisodesByWhere(const CStdString& strBaseDir, const CStdString &where, CFileItemList& items, bool appendFullShowPath = true);
   bool GetMusicVideosByWhere(const CStdString &baseDir, const CStdString &whereClause, CFileItemList& items, bool checkLocks = true);
 
+  bool GetNextItemsByChannel(int channelID, bool isSkipShow, CFileItem* item, CFileItemList& items);
+
   // partymode
   int GetMusicVideoCount(const CStdString& strWhere);
   unsigned int GetMusicVideoIDs(const CStdString& strWhere, std::vector<std::pair<int,int> > &songIDs);

--- a/xbmc/VideoDatabase.h
+++ b/xbmc/VideoDatabase.h
@@ -523,6 +523,7 @@ public:
   bool GetMusicVideosByWhere(const CStdString &baseDir, const CStdString &whereClause, CFileItemList& items, bool checkLocks = true);
 
   bool GetNextItemsByChannel(int channelID, bool isSkipShow, CFileItem* item, CFileItemList& items);
+  void GetEpisodeItem(int idEpisode, CFileItemList& items);
 
   // partymode
   int GetMusicVideoCount(const CStdString& strWhere);
@@ -624,7 +625,7 @@ protected:
 private:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 43; };
+  virtual int GetMinVersion() const { return 44; };
   const char *GetDefaultDBName() const { return "MyVideos34.db"; };
 
   void ConstructPath(CStdString& strDest, const CStdString& strPath, const CStdString& strFileName);


### PR DESCRIPTION
this is not a complete work, but a feature suggestion.
the following changes adds the functionality to set up channels (or presets) for TV shows.
I started this project for the main purpose of watching episodes <b>continuously</b> while randomizing between shows only; jumping to the next unwatched episode of the random picked show.

a channel may be set by the following (combined) options:
- play all/by selected shows.
- play episodes by order / randomly.
- play episodes that are: watched / unwatched / any.
- play by selected genres (optional).

Here is an external (windows .net 3.5) channel editor: https://github.com/downloads/ohara/xbmc/channelEditor.zip .
It only work after making the changes in the database (<b>backup</b> first).
I also uploaded a compiled version to my fork page at https://github.com/downloads/ohara/xbmc/XBMC_TvRandom_Test.exe (windows).

I added to confluence home-tvshows menu five presets. they will start the randomizer by the preset options set by the external editor. playback will start with one episode. after playback ends (or skipped), the randomizer will add to "Now Playing" a new episode and will start its playback, and so on...
