### PR TITLE
Windows renderer support for CrystalHD formats (NV12, UVYV)

### DIFF
--- a/system/shaders/yuv2rgb_d3d.fx
+++ b/system/shaders/yuv2rgb_d3d.fx
@@ -24,10 +24,6 @@ texture g_UTexture;
 texture g_VTexture;
 float4x4 g_ColorMatrix;
 
-#ifdef SINGLEPASS
-
-// Color conversion + bilinear resize in one pass
-
 sampler YSampler =
   sampler_state {
     Texture = <g_YTexture>;
@@ -36,21 +32,6 @@ sampler YSampler =
     MinFilter = LINEAR;
     MagFilter = LINEAR;
   };
-
-#else
-
-// Color conversion only
-
-sampler YSampler =
-  sampler_state {
-    Texture = <g_YTexture>;
-    AddressU = CLAMP;
-    AddressV = CLAMP;
-    MinFilter = POINT;
-    MagFilter = POINT;
-  };
-
-#endif
 
 sampler USampler =
   sampler_state {

--- a/system/shaders/yuv2rgb_d3d.fx
+++ b/system/shaders/yuv2rgb_d3d.fx
@@ -87,10 +87,16 @@ struct PS_OUTPUT
 PS_OUTPUT YUV2RGB( VS_OUTPUT In)
 {
   PS_OUTPUT OUT;
+#if defined(XBMC_YV12)
   float4 YUV = float4(tex2D (YSampler, In.TextureY).x
                     , tex2D (USampler, In.TextureU).x
                     , tex2D (VSampler, In.TextureV).x
                     , 1.0);
+#elif defined(XBMC_NV12)
+  float4 YUV = float4(tex2D (YSampler, In.TextureY).x
+                    , tex2D (USampler, In.TextureU).ra
+                    , 1.0);
+#endif
   OUT.RGBColor = mul(YUV, g_ColorMatrix);
   OUT.RGBColor.a = 1.0;
   return OUT;

--- a/system/shaders/yuv2rgb_d3d.fx
+++ b/system/shaders/yuv2rgb_d3d.fx
@@ -23,6 +23,7 @@ texture g_YTexture;
 texture g_UTexture;
 texture g_VTexture;
 float4x4 g_ColorMatrix;
+float2  g_StepXY;
 
 sampler YSampler =
   sampler_state {
@@ -77,7 +78,35 @@ PS_OUTPUT YUV2RGB( VS_OUTPUT In)
   float4 YUV = float4(tex2D (YSampler, In.TextureY).x
                     , tex2D (USampler, In.TextureU).ra
                     , 1.0);
+#elif defined(XBMC_YUY2) || defined(XBMC_UYVY)
+  // The HLSL compiler is smart enough to optimize away these redundant assignments.
+  // That way the code is almost identical to the OGL shader.
+  float2 stepxy = g_StepXY;
+  float2 pos    = In.TextureY;
+  pos           = float2(pos.x - (stepxy.x * 0.25), pos.y);
+  float2 f      = frac(pos / stepxy);
+
+  //y axis will be correctly interpolated by opengl
+  //x axis will not, so we grab two pixels at the center of two columns and interpolate ourselves
+  float4 c1 = tex2D(YSampler, float2(pos.x + ((0.5 - f.x) * stepxy.x), pos.y));
+  float4 c2 = tex2D(YSampler, float2(pos.x + ((1.5 - f.x) * stepxy.x), pos.y));
+
+  /* each pixel has two Y subpixels and one UV subpixel
+      YUV  Y  YUV
+      check if we're left or right of the middle Y subpixel and interpolate accordingly*/
+  #if defined(XBMC_YUY2) // BGRA = YUYV
+    float  leftY  = lerp(c1.b, c1.r, f.x * 2.0);
+    float  rightY = lerp(c1.r, c2.b, f.x * 2.0 - 1.0);
+    float2 outUV  = lerp(c1.ga, c2.ga, f.x);
+  #elif defined(XBMC_UYVY) // BGRA = UYVY
+    float  leftY  = lerp(c1.g, c1.a, f.x * 2.0);
+    float  rightY = lerp(c1.a, c2.g, f.x * 2.0 - 1.0);
+    float2 outUV  = lerp(c1.br, c2.br, f.x);
+  #endif
+    float  outY   = lerp(leftY, rightY, step(0.5, f.x));
+    float4 YUV    = float4(outY, outUV, 1.0);
 #endif
+
   OUT.RGBColor = mul(YUV, g_ColorMatrix);
   OUT.RGBColor.a = 1.0;
   return OUT;

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -192,15 +192,13 @@ bool CWinShader::Execute()
 
 //==================================================================================
 
-bool CYUV2RGBShader::Create(bool singlepass, unsigned int sourceWidth, unsigned int sourceHeight, BufferFormat fmt)
+bool CYUV2RGBShader::Create(unsigned int sourceWidth, unsigned int sourceHeight, BufferFormat fmt)
 {
   ReleaseInternal();
 
   CWinShader::CreateVertexBuffer(D3DFVF_XYZRHW | D3DFVF_TEX3, 4, sizeof(CUSTOMVERTEX), 2);
 
   DefinesMap defines;
-  if (singlepass)
-    defines["SINGLEPASS"] = "";
 
   if (fmt == YV12)
     defines["XBMC_YV12"] = "";

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -99,6 +99,7 @@ private:
   unsigned int   m_sourceWidth, m_sourceHeight;
   CRect          m_sourceRect, m_destRect;
   CD3DTexture    m_YUVPlanes[3];
+  float          m_texSteps[2];
 
   struct CUSTOMVERTEX {
       FLOAT x, y, z;

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -76,7 +76,7 @@ private:
 class CYUV2RGBShader : public CWinShader
 {
 public:
-  virtual bool Create(bool singlepass, unsigned int sourceWidth, unsigned int sourceHeight);
+  virtual bool Create(bool singlepass, unsigned int sourceWidth, unsigned int sourceHeight, BufferFormat fmt);
   virtual void Render(CRect sourceRect,
                       CRect destRect,
                       float contrast,
@@ -90,7 +90,7 @@ protected:
                                  float contrast,
                                  float brightness,
                                  unsigned int flags);
-  virtual void SetShaderParameters();
+  virtual void SetShaderParameters(YUVBuffer* YUVbuf);
   virtual void ReleaseInternal();
   virtual bool UploadToGPU(YUVBuffer* YUVbuf);
 

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -76,7 +76,7 @@ private:
 class CYUV2RGBShader : public CWinShader
 {
 public:
-  virtual bool Create(bool singlepass, unsigned int sourceWidth, unsigned int sourceHeight, BufferFormat fmt);
+  virtual bool Create(unsigned int sourceWidth, unsigned int sourceHeight, BufferFormat fmt);
   virtual void Render(CRect sourceRect,
                       CRect destRect,
                       float contrast,

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -91,6 +91,24 @@ CWinRenderer::~CWinRenderer()
   UnInit();
 }
 
+static BufferFormat BufferFormatFromFlags(unsigned int flags)
+{
+  if      (CONF_FLAGS_FORMAT_MASK(flags) == CONF_FLAGS_FORMAT_YV12) return YV12;
+  else if (CONF_FLAGS_FORMAT_MASK(flags) == CONF_FLAGS_FORMAT_NV12) return NV12;
+  else if (CONF_FLAGS_FORMAT_MASK(flags) == CONF_FLAGS_FORMAT_YUY2) return YUY2;
+  else if (CONF_FLAGS_FORMAT_MASK(flags) == CONF_FLAGS_FORMAT_UYVY) return UYVY;
+  else return Invalid;
+}
+
+static enum PixelFormat PixelFormatFromFlags(unsigned int flags)
+{
+  if      (CONF_FLAGS_FORMAT_MASK(flags) == CONF_FLAGS_FORMAT_YV12) return PIX_FMT_YUV420P;
+  else if (CONF_FLAGS_FORMAT_MASK(flags) == CONF_FLAGS_FORMAT_NV12) return PIX_FMT_NV12;
+  else if (CONF_FLAGS_FORMAT_MASK(flags) == CONF_FLAGS_FORMAT_UYVY) return PIX_FMT_UYVY422;
+  else if (CONF_FLAGS_FORMAT_MASK(flags) == CONF_FLAGS_FORMAT_YUY2) return PIX_FMT_YUYV422;
+  else return PIX_FMT_NONE;
+}
+
 void CWinRenderer::ManageTextures()
 {
   int neededbuffers = 2;
@@ -535,9 +553,7 @@ void CWinRenderer::UpdatePSVideoFilter()
 {
   SAFE_RELEASE(m_scalerShader)
 
-  BufferFormat format;
-  if (CONF_FLAGS_FORMAT_MASK(m_flags) == CONF_FLAGS_FORMAT_YV12)      format = YV12;
-  else if (CONF_FLAGS_FORMAT_MASK(m_flags) == CONF_FLAGS_FORMAT_NV12) format = NV12;
+  BufferFormat format = BufferFormatFromFlags(m_flags);
 
   if (m_bUseHQScaler)
   {
@@ -686,10 +702,7 @@ void CWinRenderer::Render(DWORD flags)
 
 void CWinRenderer::RenderSW()
 {
-  enum PixelFormat format;
-
-  if (CONF_FLAGS_FORMAT_MASK(m_flags) == CONF_FLAGS_FORMAT_YV12)      format = PIX_FMT_YUV420P;
-  else if (CONF_FLAGS_FORMAT_MASK(m_flags) == CONF_FLAGS_FORMAT_NV12) format = PIX_FMT_NV12;
+  enum PixelFormat format = PixelFormatFromFlags(m_flags);
 
   // 1. convert yuv to rgb
   m_sw_scale_ctx = m_dllSwScale->sws_getCachedContext(m_sw_scale_ctx,
@@ -1013,9 +1026,7 @@ bool CWinRenderer::CreateYV12Texture(int index)
   {
     YUVBuffer *buf = new YUVBuffer();
 
-    BufferFormat format;
-    if (CONF_FLAGS_FORMAT_MASK(m_flags) == CONF_FLAGS_FORMAT_YV12)      format = YV12;
-    else if (CONF_FLAGS_FORMAT_MASK(m_flags) == CONF_FLAGS_FORMAT_NV12) format = NV12;
+    BufferFormat format = BufferFormatFromFlags(m_flags);
 
     if (!buf->Create(format, m_sourceWidth, m_sourceHeight))
     {

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -580,8 +580,9 @@ void CWinRenderer::UpdatePSVideoFilter()
   if (m_bUseHQScaler)
   {
     m_colorShader = new CYUV2RGBShader();
-    if (!m_colorShader->Create(false, m_sourceWidth, m_sourceHeight, format))
+    if (!m_colorShader->Create(m_sourceWidth, m_sourceHeight, format))
     {
+      // Try again after disabling the HQ scaler and freeing its resources
       m_IntermediateTarget.Release();
       SAFE_RELEASE(m_scalerShader)
       SAFE_RELEASE(m_colorShader);
@@ -592,7 +593,7 @@ void CWinRenderer::UpdatePSVideoFilter()
   if (!m_bUseHQScaler) //fallback from HQ scalers and multipass creation above
   {
     m_colorShader = new CYUV2RGBShader();
-    if (!m_colorShader->Create(true, m_sourceWidth, m_sourceHeight, format))
+    if (!m_colorShader->Create(m_sourceWidth, m_sourceHeight, format))
       SAFE_RELEASE(m_colorShader);
     // we're in big trouble - should fallback on D3D accelerated or sw method
   }

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -115,10 +115,19 @@ enum RenderMethod
 #define PLANE_Y 0
 #define PLANE_U 1
 #define PLANE_V 2
+#define PLANE_UV 1
 
 #define FIELD_FULL 0
 #define FIELD_TOP 1
 #define FIELD_BOT 2
+
+enum BufferFormat
+{
+  YV12,
+  NV12,
+  YUY2,
+  UYVY
+};
 
 struct SVideoBuffer
 {
@@ -139,17 +148,20 @@ struct SVideoPlane
 struct YUVBuffer : SVideoBuffer
 {
   ~YUVBuffer();
-  bool Create(unsigned int width, unsigned int height);
+  bool Create(BufferFormat format, unsigned int width, unsigned int height);
   virtual void Release();
   virtual void StartDecode();
   virtual void StartRender();
   virtual void Clear();
+  unsigned int GetActivePlanes() { return m_activeplanes; }
 
   SVideoPlane planes[MAX_PLANES];
 
 private:
   unsigned int     m_width;
   unsigned int     m_height;
+  BufferFormat     m_format;
+  unsigned int     m_activeplanes;
 };
 
 struct DXVABuffer : SVideoBuffer

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -123,6 +123,7 @@ enum RenderMethod
 
 enum BufferFormat
 {
+  Invalid,
   YV12,
   NV12,
   YUY2,

--- a/xbmc/guilib/D3DResource.h
+++ b/xbmc/guilib/D3DResource.h
@@ -49,12 +49,16 @@ public:
   bool GetLevelDesc(UINT level, D3DSURFACE_DESC *desc);
   bool GetSurfaceLevel(UINT level, LPDIRECT3DSURFACE9 *surface);
 
+  // Accessors
   LPDIRECT3DTEXTURE9 Get() const { return m_texture; };
+  UINT GetWidth()  { return m_width; }
+  UINT GetHeight() { return m_height; }
 
   virtual void OnDestroyDevice();
   virtual void OnCreateDevice();
   virtual void OnLostDevice();
   virtual void OnResetDevice();
+
 
 private:
   unsigned int GetMemoryUsage(unsigned int pitch) const;


### PR DESCRIPTION
This branch allows the Windows renderer to understand the formats output natively by the CrystalHD cards, and removes the need for the expensive CPU conversion to YV12 before render.
Tested with the #ifdefs in DVDPlayerVideo to force format conversion, I don't have a CHD card.

The shader is mostly a GLSL to HLSL translation, except for NV12, where a texture fetch is avoided with a swizzle.

Comment away, I'll push in a few days otherwise.
