### PR TITLE
replace /bin/bash by @SHELL@

### DIFF
--- a/Makefile.include.in
+++ b/Makefile.include.in
@@ -1,7 +1,7 @@
 AR=ar
 ARFLAGS=crus
 RM=rm -rf
-SHELL=/bin/bash
+SHELL=@SHELL@
 ARCH=@ARCH@
 abs_top_srcdir=@abs_top_srcdir@
 prefix=@prefix@

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -1,6 +1,6 @@
 CC=@CC@
 CXX=@CXX@
-SHELL=/bin/bash
+SHELL=@SHELL@
 LDFLAGS=-shared -fPIC -rdynamic
 ARCH=@ARCH@
 SYSDIR=@abs_top_srcdir@/system/players/dvdplayer

--- a/xbmc/interfaces/python/linux/Makefile.in
+++ b/xbmc/interfaces/python/linux/Makefile.in
@@ -3,7 +3,7 @@ ARCH=@ARCH@
 CC=@CC@
 CFLAGS=@CFLAGS@
 LDFLAGS=@LDFLAGS@
-SHELL=/bin/bash
+SHELL=@SHELL@
 SYSDIR=$(abs_top_srcdir)/system/python
 
 ifeq (@USE_PYTHON2_6@,1)


### PR DESCRIPTION
there is no /bin/bash on FreeBSD, so let's autotools find the good shell
i successfully build xbmc with /bin/sh shell, but i think it's more clean to use @SHELL@ macro.

can i have confirmation that does not break build for other arch like: ppc, arm, apple, linux.

thanks
