### PR TITLE
Gles x86

### DIFF
--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -41,6 +41,7 @@
 #include "guilib/Texture.h"
 #include "lib/DllSwScale.h"
 #include "../dvdplayer/DVDCodecs/Video/OpenMaxVideo.h"
+#include "threads/SingleLock.h"
 
 using namespace Shaders;
 


### PR DESCRIPTION
Just a simple header missing from xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp

Fix as described in http://trac.xbmc.org/ticket/11173, for GLES compilation.
