### PR TITLE
Remove redundant calls to sws_rgb2rgb_init

### DIFF
--- a/lib/DllSwScale.h
+++ b/lib/DllSwScale.h
@@ -50,14 +50,8 @@ extern "C" {
   #elif (defined HAVE_FFMPEG_SWSCALE_H)
     #include <ffmpeg/swscale.h>
   #endif
-  #if (defined HAVE_LIBSWSCALE_RGB2RGB_H)
-    #include <libswscale/rgb2rgb.h>
-  #elif (defined HAVE_FFMPEG_RGB2RGB_H)
-    #include <ffmpeg/rgb2rgb.h>
-  #endif
 #else
   #include "libswscale/swscale.h"
-  #include "libswscale/rgb2rgb.h"
 #endif
 }
 
@@ -94,11 +88,6 @@ public:
 
    virtual int sws_scale(struct SwsContext *context, uint8_t* src[], int srcStride[], int srcSliceY,
                          int srcSliceH, uint8_t* dst[], int dstStride[])=0;
-    #if (! defined USE_EXTERNAL_FFMPEG)
-      virtual void sws_rgb2rgb_init(int flags)=0;
-    #elif (defined HAVE_LIBSWSCALE_RGB2RGB_H) || (defined HAVE_FFMPEG_RGB2RGB_H)
-      virtual void sws_rgb2rgb_init(int flags)=0;
-    #endif
 
    virtual void sws_freeContext(struct SwsContext *context)=0;
 };
@@ -122,11 +111,6 @@ public:
   virtual int sws_scale(struct SwsContext *context, uint8_t* src[], int srcStride[], int srcSliceY,
                 int srcSliceH, uint8_t* dst[], int dstStride[])  
     { return ::sws_scale(context, src, srcStride, srcSliceY, srcSliceH, dst, dstStride); }
-  #if (! defined USE_EXTERNAL_FFMPEG)
-    virtual void sws_rgb2rgb_init(int flags) { ::sws_rgb2rgb_init(flags); }
-  #elif (defined HAVE_LIBSWSCALE_RGB2RGB_H) || (defined HAVE_FFMPEG_RGB2RGB_H)
-    virtual void sws_rgb2rgb_init(int flags) { ::sws_rgb2rgb_init(flags); }
-  #endif
   virtual void sws_freeContext(struct SwsContext *context) { ::sws_freeContext(context); }
   
   // DLL faking.
@@ -148,14 +132,12 @@ class DllSwScale : public DllDynamic, public DllSwScaleInterface
   DEFINE_METHOD10(struct SwsContext *, sws_getContext, ( int p1, int p2, int p3, int p4, int p5, int p6, int p7, 
 							 SwsFilter * p8, SwsFilter * p9, double * p10))
   DEFINE_METHOD7(int, sws_scale, (struct SwsContext *p1, uint8_t** p2, int *p3, int p4, int p5, uint8_t **p6, int *p7))
-  DEFINE_METHOD1(void, sws_rgb2rgb_init, (int p1))
   DEFINE_METHOD1(void, sws_freeContext, (struct SwsContext *p1))
 
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(sws_getCachedContext)
     RESOLVE_METHOD(sws_getContext)
     RESOLVE_METHOD(sws_scale)
-    RESOLVE_METHOD(sws_rgb2rgb_init)
     RESOLVE_METHOD(sws_freeContext)
   END_METHOD_RESOLVE()
 

--- a/xbmc/cores/VideoRenderers/LinuxRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRenderer.cpp
@@ -586,12 +586,6 @@ unsigned int CLinuxRenderer::PreInit()
   if (!m_dllSwScale->Load())
         CLog::Log(LOGERROR,"CLinuxRendererGL::PreInit - failed to load rescale libraries!");
 
-  #if (! defined USE_EXTERNAL_FFMPEG)
-    m_dllSwScale->sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-  #elif (defined HAVE_LIBSWSCALE_RGB2RGB_H) || (defined HAVE_FFMPEG_RGB2RGB_H)
-    m_dllSwScale->sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-  #endif
-
   return 0;
 }
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererATI.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererATI.cpp
@@ -257,11 +257,6 @@ unsigned int CLinuxRendererATI::PreInit()
     CLog::Log(LOGERROR,"CLinuxRendererATI::PreInit - failed to load rescale libraries!");
 #endif
 
-  #if (! defined USE_EXTERNAL_FFMPEG) && (defined HAS_DVD_SWSCALE)
-    m_dllSwScale.sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-  #elif ((defined HAVE_LIBSWSCALE_RGB2RGB_H) || (defined HAVE_FFMPEG_RGB2RGB_H)) && (defined HAS_DVD_SWSCALE)
-    m_dllSwScale.sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-  #endif
   return true;
 }
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -751,12 +751,6 @@ unsigned int CLinuxRendererGL::PreInit()
   if (!m_dllSwScale->Load())
     CLog::Log(LOGERROR,"CLinuxRendererGL::PreInit - failed to load rescale libraries!");
 
-  #if (! defined USE_EXTERNAL_FFMPEG)
-    m_dllSwScale->sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-  #elif (defined HAVE_LIBSWSCALE_RGB2RGB_H) || (defined HAVE_FFMPEG_RGB2RGB_H)
-    m_dllSwScale->sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-  #endif
-
   return true;
 }
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -650,12 +650,6 @@ unsigned int CLinuxRendererGLES::PreInit()
   if (!m_dllSwScale->Load())
     CLog::Log(LOGERROR,"CLinuxRendererGL::PreInit - failed to load rescale libraries!");
 
-  #if (! defined USE_EXTERNAL_FFMPEG)
-    m_dllSwScale->sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-  #elif (defined HAVE_LIBSWSCALE_RGB2RGB_H) || (defined HAVE_FFMPEG_RGB2RGB_H)
-    m_dllSwScale->sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-  #endif
-
   return true;
 }
 

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -187,8 +187,6 @@ bool CWinRenderer::UpdateRenderMethod()
     if (!m_dllSwScale->Load())
       CLog::Log(LOGERROR,"CDVDDemuxFFmpeg::Open - failed to load ffmpeg libraries");
 
-    m_dllSwScale->sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-
     if(!m_SWTarget.Create(m_sourceWidth, m_sourceHeight, 1, D3DUSAGE_DYNAMIC, D3DFMT_X8R8G8B8, D3DPOOL_DEFAULT))
     {
       CLog::Log(LOGNOTICE, __FUNCTION__": Failed to create sw render target.");

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -163,12 +163,6 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
 
   m_dllAvCodec.avcodec_register_all();
 
-  #if (! defined USE_EXTERNAL_FFMPEG)
-    m_dllSwScale.sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-  #elif (defined HAVE_LIBSWSCALE_RGB2RGB_H) || (defined HAVE_FFMPEG_RGB2RGB_H)
-    m_dllSwScale.sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-  #endif
-
   m_bSoftware     = hints.software;
   m_pCodecContext = m_dllAvCodec.avcodec_alloc_context();
 
@@ -427,17 +421,8 @@ int CDVDVideoCodecFFmpeg::Decode(BYTE* pData, int iSize, double dts, double pts)
   && m_pCodecContext->pix_fmt != PIX_FMT_YUVJ420P
   && m_pHardware == NULL)
   {
-    if (!m_dllSwScale.IsLoaded())
-    {
-      if(!m_dllSwScale.Load())
+    if (!m_dllSwScale.IsLoaded() && !m_dllSwScale.Load())
         return VC_ERROR;
-
-        #if (! defined USE_EXTERNAL_FFMPEG)
-          m_dllSwScale.sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-        #elif (defined HAVE_LIBSWSCALE_RGB2RGB_H) || (defined HAVE_FFMPEG_RGB2RGB_H)
-          m_dllSwScale.sws_rgb2rgb_init(SWS_CPU_CAPS_MMX2);
-        #endif
-    }
 
     if (!m_pConvertFrame)
     {


### PR DESCRIPTION
The function is already called internally by swscale when creating a swscale context.
The calls would be necessary only if xbmc called the rgb conversion functions directly, which is not the case.
