### PR TITLE
Backup .db file on update of database version

### DIFF
--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -61,5 +61,5 @@ protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
   virtual int GetMinVersion() const { return 6; };
-  const char *GetDefaultDBName() const { return "Textures"; };
+  const char *GetBaseDBName() const { return "Textures"; };
 };

--- a/xbmc/ViewDatabase.h
+++ b/xbmc/ViewDatabase.h
@@ -38,5 +38,5 @@ protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
   virtual int GetMinVersion() const { return 3; };
-  const char *GetDefaultDBName() const { return "ViewModes"; };
+  const char *GetBaseDBName() const { return "ViewModes"; };
 };

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -99,6 +99,6 @@ protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
   virtual int GetMinVersion() const { return 12; }
-  const char *GetDefaultDBName() const { return "Addons"; }
+  const char *GetBaseDBName() const { return "Addons"; }
 };
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -262,21 +262,19 @@ bool CDatabase::Open(DatabaseSettings &dbSettings)
   if ( dbSettings.type.Equals("mysql") )
   {
     // check we have all information before we cancel the fallback
-    if ( ! (dbSettings.host.IsEmpty() || dbSettings.user.IsEmpty() || dbSettings.pass.IsEmpty()) )
+    if ( ! (dbSettings.host.IsEmpty() || dbSettings.name.IsEmpty() ||
+            dbSettings.user.IsEmpty() || dbSettings.pass.IsEmpty()) )
       m_sqlite = false;
     else
-      CLog::Log(LOGINFO, "essential mysql database information is missing (eg. host, user, pass)");
+      CLog::Log(LOGINFO, "essential mysql database information is missing (eg. host, name, user, pass)");
   }
-
-  // set default database name if appropriate
-  if ( dbSettings.name.IsEmpty() )
-    dbSettings.name = GetDefaultDBName();
 
   // always safely fallback to sqlite3
   if (m_sqlite)
   {
     dbSettings.type = "sqlite3";
     dbSettings.host = _P(g_settings.GetDatabaseFolder());
+    dbSettings.name = GetDefaultDBName();
   }
 
   if (Connect(dbSettings, true) && UpdateVersion(dbSettings.name))

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -313,7 +313,7 @@ bool CDatabase::Open(DatabaseSettings &dbSettings)
   m_pDS.reset(m_pDB->CreateDataset());
   m_pDS2.reset(m_pDB->CreateDataset());
 
-  if (m_pDB->connect() != DB_CONNECTION_OK)
+  if (m_pDB->connect(true) != DB_CONNECTION_OK)
   {
     CLog::Log(LOGERROR, "Unable to open database at host: %s db: %s (old version?)", dbSettings.host.c_str(), dbSettings.name.c_str());
     return false;

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -393,7 +393,7 @@ void CDatabase::Close()
     return ;
   }
 
-  m_iRefCount--;
+  m_iRefCount = 0;
   m_bOpen = false;
 
   if (NULL == m_pDB.get() ) return ;

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -116,7 +116,6 @@ protected:
 
   bool UpdateVersion(const CStdString &dbName);
 
-  bool m_bOpen;
   bool m_sqlite; ///< \brief whether we use sqlite (defaults to true)
 
   std::auto_ptr<dbiplus::Database> m_pDB;
@@ -128,5 +127,5 @@ private:
   bool UpdateVersionNumber();
 
   bool m_bMultiWrite; /*!< True if there are any queries in the queue, false otherwise */
-  int m_iRefCount;
+  unsigned int m_openCount;
 };

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -114,6 +114,8 @@ protected:
   virtual int GetMinVersion() const=0;
   virtual const char *GetDefaultDBName() const=0;
 
+  bool UpdateVersion(const CStdString &dbName);
+
   bool m_bOpen;
   bool m_sqlite; ///< \brief whether we use sqlite (defaults to true)
 

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -112,7 +112,7 @@ protected:
   virtual bool UpdateOldVersion(int version) { return true; };
 
   virtual int GetMinVersion() const=0;
-  virtual const char *GetDefaultDBName() const=0;
+  virtual const char *GetBaseDBName() const=0;
 
   bool UpdateVersion(const CStdString &dbName);
 

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -124,6 +124,7 @@ protected:
   std::auto_ptr<dbiplus::Dataset> m_pDS2;
 
 private:
+  bool Connect(DatabaseSettings &db, bool create);
   bool UpdateVersionNumber();
 
   bool m_bMultiWrite; /*!< True if there are any queries in the queue, false otherwise */

--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -60,7 +60,7 @@ int Database::connectFull(const char *newHost, const char *newPort, const char *
   db = newDb;
   login = newLogin;
   passwd = newPasswd;
-  return connect();
+  return connect(true);
 }
 
 

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -115,7 +115,7 @@ public:
   virtual int setErr(int err_code, const char *qry)=0;
   virtual const char *getErrorMsg(void) { return error.c_str(); }
 	
-  virtual int connect(void) { return DB_COMMAND_OK; }
+  virtual int connect(bool create) { return DB_COMMAND_OK; }
   virtual int connectFull( const char *newDb, const char *newHost=NULL,
                       const char *newLogin=NULL, const char *newPasswd=NULL,const char *newPort=NULL);
   virtual void disconnect(void) { active = false; }

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -104,7 +104,7 @@ const char *MysqlDatabase::getErrorMsg() {
    return error.c_str();
 }
 
-int MysqlDatabase::connect() {
+int MysqlDatabase::connect(bool create_new) {
   try
   {
     // don't reconnect if ping is ok
@@ -221,7 +221,7 @@ int MysqlDatabase::query_with_reconnect(const char* query) {
   {
     CLog::Log(LOGINFO,"MYSQL server has gone. Will try %d more attempt(s) to reconnect.", attempts);
     active = false;
-    connect();
+    connect(true);
   }
 
   // grab the latest error if not ok
@@ -299,7 +299,7 @@ void MysqlDatabase::rollback_transaction() {
 
 bool MysqlDatabase::exists() {
   // Uncorrect name, check if tables are present inside the db
-  connect();
+  connect(true);
   if (active && conn != NULL)
   {
     MYSQL_RES* res = mysql_list_dbs(conn, db.c_str());

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -57,7 +57,7 @@ public:
   virtual const char *getErrorMsg();
 
 /* func. connects to database-server */
-  virtual int connect();
+  virtual int connect(bool create);
 /* func. disconnects from database-server */
   virtual void disconnect();
 /* func. creates new database */

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -30,7 +30,6 @@
 #include <string>
 
 #include "sqlitedataset.h"
-#include "utils/log.h"
 #include "system.h" // for Sleep(), OutputDebugString() and GetLastError()
 
 using namespace std;
@@ -220,13 +219,10 @@ int SqliteDatabase::connect(bool create) {
       return DB_CONNECTION_OK;
     }
 
-    CLog::Log(LOGERROR, "Unable to open database: %s (%u)", db_fullpath.c_str(), GetLastError());
     return DB_CONNECTION_NONE;
   }
   catch(...)
   {
-    CLog::Log(LOGERROR, "Unable to open database: %s (%u)",
-              db_fullpath.c_str(), GetLastError());
   }
   return DB_CONNECTION_NONE;
 }

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -166,7 +166,7 @@ const char *SqliteDatabase::getErrorMsg() {
    return error.c_str();
 }
 
-int SqliteDatabase::connect() {
+int SqliteDatabase::connect(bool create) {
   if (host.empty() || db.empty())
     return DB_CONNECTION_NONE;
   
@@ -205,7 +205,10 @@ int SqliteDatabase::connect() {
   {
 
     disconnect();
-    if (sqlite3_open(db_fullpath.c_str(), &conn)==SQLITE_OK)
+    int flags = SQLITE_OPEN_READWRITE;
+    if (create)
+      flags |= SQLITE_OPEN_CREATE;
+    if (sqlite3_open_v2(db_fullpath.c_str(), &conn, flags, NULL)==SQLITE_OK)
     {
       sqlite3_busy_handler(conn, busy_callback, NULL);
       char* err=NULL;
@@ -253,7 +256,7 @@ void SqliteDatabase::disconnect(void) {
 }
 
 int SqliteDatabase::create() {
-  return connect();
+  return connect(true);
 }
 
 int SqliteDatabase::drop() {

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -67,7 +67,7 @@ public:
   virtual const char *getErrorMsg();
   
 /* func. connects to database-server */
-  virtual int connect();
+  virtual int connect(bool create);
 /* func. disconnects from database-server */
   virtual void disconnect();
 /* func. creates new database */

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -215,7 +215,7 @@ protected:
 
   virtual bool CreateTables();
   virtual int GetMinVersion() const { return 16; };
-  const char *GetDefaultDBName() const { return "MyMusic7"; };
+  const char *GetBaseDBName() const { return "MyMusic"; };
 
   int AddAlbum(const CStdString& strAlbum1, int idArtist, const CStdString &extraArtists, const CStdString &strArtist1, int idThumb, int idGenre, const CStdString &extraGenres, int year);
   int AddGenre(const CStdString& strGenre);

--- a/xbmc/programs/ProgramDatabase.h
+++ b/xbmc/programs/ProgramDatabase.h
@@ -66,7 +66,7 @@ protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
   virtual int GetMinVersion() const { return 3; };
-  const char *GetDefaultDBName() const { return "MyPrograms6"; };
+  const char *GetBaseDBName() const { return "MyPrograms"; };
 
   FILETIME TimeStampToLocalTime( uint64_t timeStamp );
 };

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -639,7 +639,7 @@ private:
   int RunQuery(const CStdString &sql);
 
   virtual int GetMinVersion() const { return 44; };
-  const char *GetDefaultDBName() const { return "MyVideos34.db"; };
+  const char *GetBaseDBName() const { return "MyVideos"; };
 
   void ConstructPath(CStdString& strDest, const CStdString& strPath, const CStdString& strFileName);
   void SplitPath(const CStdString& strFileNameAndPath, CStdString& strPath, CStdString& strFileName);


### PR DESCRIPTION
Attached patch supports loading <basename><version>.db, falling back to old versions etc.

It's currently only implemented for sqlite - I need someone (firnsy?) to review what needs to be done for mysql.

Comments/criticisms welcome
