### PR TITLE
Remove treatstackasfile

### DIFF
--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -612,7 +612,6 @@ void CGUISettings::Initialize()
 
   CSettingsCategory* vid = AddCategory(5, "myvideos", 14081);
   AddInt(vid, "myvideos.selectaction", 22079, SELECT_ACTION_PLAY_OR_RESUME, SELECT_ACTION_CHOOSE, 1, SELECT_ACTION_INFO, SPIN_CONTROL_TEXT);
-  AddBool(NULL, "myvideos.treatstackasfile", 20051, true);
   AddBool(vid, "myvideos.extractflags",20433, true);
   AddBool(vid, "myvideos.cleanstrings", 20418, false);
   AddBool(NULL, "myvideos.extractthumb",20433, true);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -807,10 +807,8 @@ int  CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item)
   m_database.Open();
   long startoffset = 0;
 
-  if (item->IsStack() && (!g_guiSettings.GetBool("myvideos.treatstackasfile") ||
-                          CFileItem(CStackDirectory::GetFirstStackedFile(item->m_strPath),false).IsDVDImage()) )
-  {
-
+  if (item->IsStack() && CFileItem(CStackDirectory::GetFirstStackedFile(item->m_strPath),false).IsDVDImage()) )
+  { // TODO: why don't we support stacked dvd images??
     CStdStringArray movies;
     GetStackedFiles(item->m_strPath, movies);
 
@@ -1352,9 +1350,8 @@ void CGUIWindowVideoBase::PlayMovie(const CFileItem *item)
   int selectedFile = 1;
   long startoffset = item->m_lStartOffset;
 
-  if (item->IsStack() && (!g_guiSettings.GetBool("myvideos.treatstackasfile") ||
-                          CFileItem(CStackDirectory::GetFirstStackedFile(item->m_strPath),false).IsDVDImage()) )
-  {
+  if (item->IsStack() && CFileItem(CStackDirectory::GetFirstStackedFile(item->m_strPath),false).IsDVDImage() )
+  { // TODO: why don't we allow stacked dvd images?
     CStdStringArray movies;
     GetStackedFiles(item->m_strPath, movies);
 


### PR DESCRIPTION
This (advanced) setting is IMO useless.  Removing it, and removing the hackery that is avoiding ISOs from stacking will allow a fair amount of cleanup, which should help other things (eg autoplaynextitem is more trivial to implement generally).

@elupus - in particular I'm after your comments on the ISO stacking stuff.  I can't see any reason (other than seek not working across file boundaries perhaps?) why these would be particularly bad.
