### PR TITLE
added: method of capturing video from the renderer

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -1150,6 +1150,7 @@
 		F551107F0F5C424700955236 /* htsmsg_binary.c in Sources */ = {isa = PBXBuildFile; fileRef = F55110730F5C424700955236 /* htsmsg_binary.c */; };
 		F55110800F5C424700955236 /* htsstr.c in Sources */ = {isa = PBXBuildFile; fileRef = F55110760F5C424700955236 /* htsstr.c */; };
 		F55110820F5C424700955236 /* net_posix.c in Sources */ = {isa = PBXBuildFile; fileRef = F551107B0F5C424700955236 /* net_posix.c */; };
+		F56579AF13060D1E0085ED7F /* RenderCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F56579AD13060D1E0085ED7F /* RenderCapture.cpp */; };
 		F56A084B0F4A18FB003F9F87 /* karaokewindowbackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F56A084A0F4A18FB003F9F87 /* karaokewindowbackground.cpp */; };
 		F57B6F801071B8B500079ACB /* JobManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F57B6F7E1071B8B500079ACB /* JobManager.cpp */; };
 		F57B6F811071B8B500079ACB /* JobManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F57B6F7E1071B8B500079ACB /* JobManager.cpp */; };
@@ -3708,6 +3709,8 @@
 		F55110770F5C424700955236 /* htsstr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = htsstr.h; sourceTree = "<group>"; };
 		F551107A0F5C424700955236 /* net.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net.h; sourceTree = "<group>"; };
 		F551107B0F5C424700955236 /* net_posix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = net_posix.c; sourceTree = "<group>"; };
+		F56579AD13060D1E0085ED7F /* RenderCapture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderCapture.cpp; sourceTree = "<group>"; };
+		F56579AE13060D1E0085ED7F /* RenderCapture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderCapture.h; sourceTree = "<group>"; };
 		F56A08490F4A18FB003F9F87 /* karaokewindowbackground.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = karaokewindowbackground.h; sourceTree = "<group>"; };
 		F56A084A0F4A18FB003F9F87 /* karaokewindowbackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = karaokewindowbackground.cpp; sourceTree = "<group>"; };
 		F57B6F7E1071B8B500079ACB /* JobManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JobManager.cpp; sourceTree = "<group>"; };
@@ -5614,6 +5617,8 @@
 				F5D8D730102BB3B1004A11AB /* OverlayRenderer.h */,
 				431AE5D7109C1A63007428C3 /* OverlayRendererUtil.cpp */,
 				431AE5D8109C1A63007428C3 /* OverlayRendererUtil.h */,
+				F56579AD13060D1E0085ED7F /* RenderCapture.cpp */,
+				F56579AE13060D1E0085ED7F /* RenderCapture.h */,
 				E38E16650D25F9FA00618676 /* RenderManager.cpp */,
 				E38E16660D25F9FA00618676 /* RenderManager.h */,
 				E38E166B0D25F9FA00618676 /* VideoShaders */,
@@ -8184,6 +8189,7 @@
 				433219D912E4C6A500CD7486 /* UDFDirectory.cpp in Sources */,
 				7C4705AE12EF584C00369E51 /* AddonInstaller.cpp in Sources */,
 				18C1D22D13033F6A00CFFE59 /* GLUtils.cpp in Sources */,
+				F56579AF13060D1E0085ED7F /* RenderCapture.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -301,6 +301,7 @@
     <ClCompile Include="..\..\xbmc\BackgroundInfoLoader.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDCodecs\Video\CrystalHD.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamBluray.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\VideoRenderers\RenderCapture.cpp" />
     <ClCompile Include="..\..\xbmc\cores\VideoRenderers\VideoShaders\WinVideoFilter.cpp" />
     <ClCompile Include="..\..\xbmc\CueDocument.cpp" />
     <ClCompile Include="..\..\xbmc\DateTime.cpp" />
@@ -1107,6 +1108,7 @@
     <ClInclude Include="..\..\xbmc\BackgroundInfoLoader.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDCodecs\Video\CrystalHD.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamBluray.h" />
+    <ClInclude Include="..\..\xbmc\cores\VideoRenderers\RenderCapture.h" />
     <ClInclude Include="..\..\xbmc\cores\VideoRenderers\VideoShaders\WinVideoFilter.h" />
     <ClInclude Include="..\..\xbmc\CueDocument.h" />
     <ClInclude Include="..\..\xbmc\DateTime.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2465,6 +2465,9 @@
     <ClCompile Include="..\..\xbmc\win32\stat_utf8.cpp">
       <Filter>win32</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\VideoRenderers\RenderCapture.cpp">
+      <Filter>cores\VideoRenderers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -4943,6 +4946,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\win32\stat_utf8.h">
       <Filter>win32</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\cores\VideoRenderers\RenderCapture.h">
+      <Filter>cores\VideoRenderers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2048,6 +2048,7 @@ void CApplication::Render()
   g_graphicsContext.Flip();
 
   g_renderManager.UpdateResolution();
+  g_renderManager.ManageCaptures();
 
 #ifdef HAS_SDL
   SDL_mutexP(m_frameMutex);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -40,6 +40,7 @@
 #include "DllSwScale.h"
 #include "utils/log.h"
 #include "utils/GLUtils.h"
+#include "RenderCapture.h"
 
 #ifdef HAVE_LIBVDPAU
 #include "cores/dvdplayer/DVDCodecs/Video/VDPAU.h"

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -30,7 +30,8 @@
 #include "RenderFlags.h"
 #include "guilib/GraphicContext.h"
 #include "BaseRenderer.h"
-#include "RenderCapture.h"
+
+class CRenderCapture;
 
 class CVDPAU;
 class CBaseTexture;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -30,6 +30,7 @@
 #include "RenderFlags.h"
 #include "guilib/GraphicContext.h"
 #include "BaseRenderer.h"
+#include "RenderCapture.h"
 
 class CVDPAU;
 class CBaseTexture;
@@ -126,6 +127,8 @@ public:
   virtual void SetupScreenshot() {};
 
   void CreateThumbnail(CBaseTexture *texture, unsigned int width, unsigned int height);
+
+  bool RenderCapture(CRenderCapture* capture);
 
   // Player functions
   virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -1333,6 +1333,46 @@ void CLinuxRendererGLES::CreateThumbnail(CBaseTexture* texture, unsigned int wid
   m_destRect = saveSize;
 }
 
+bool CLinuxRendererGLES::RenderCapture(CRenderCapture* capture)
+{
+  if (!m_bValidated)
+    return false;
+
+  // get our screen rect
+  const CRect rv = g_graphicsContext.GetViewWindow();
+
+  // save current video rect
+  CRect saveSize = m_destRect;
+
+  // new video rect is thumbnail size
+  m_destRect.SetRect(0, 0, (float)width, (float)height);
+
+  // clear framebuffer and invert Y axis to get non-inverted image
+  glDisable(GL_BLEND);
+  g_matrices.MatrixMode(MM_MODELVIEW);
+  g_matrices.PushMatrix();
+  g_matrices.Translatef(0, height, 0);
+  g_matrices.Scalef(1.0, -1.0f, 1.0f);
+
+  capture->BeginRender();
+
+  Render(RENDER_FLAG_NOOSD, m_iYV12RenderBuffer);
+  // read pixels
+  glReadPixels(0, rv.y2 - capture->GetHeight(), capture->GetWidth(), capture->GetHeight(),
+               GL_RGBA, GL_UNSIGNED_BYTE, capture->GetRenderBuffer());
+
+  capture->EndRender();
+
+  // revert model view matrix
+  g_matrices.MatrixMode(MM_MODELVIEW);
+  g_matrices.PopMatrix();
+
+  // restore original video rect
+  m_destRect = saveSize;
+
+  return true;
+}
+
 //********************************************************************************************************
 // YV12 Texture creation, deletion, copying + clearing
 //********************************************************************************************************

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -42,6 +42,7 @@
 #include "lib/DllSwScale.h"
 #include "../dvdplayer/DVDCodecs/Video/OpenMaxVideo.h"
 #include "threads/SingleLock.h"
+#include "RenderCapture.h"
 
 using namespace Shaders;
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -31,7 +31,8 @@
 #include "guilib/GraphicContext.h"
 #include "BaseRenderer.h"
 #include "../dvdplayer/DVDCodecs/Video/DVDVideoCodec.h"
-#include "RenderCapture.h"
+
+class CRenderCapture;
 
 class CBaseTexture;
 namespace Shaders { class BaseYUV2RGBShader; }

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -31,6 +31,7 @@
 #include "guilib/GraphicContext.h"
 #include "BaseRenderer.h"
 #include "../dvdplayer/DVDCodecs/Video/DVDVideoCodec.h"
+#include "RenderCapture.h"
 
 class CBaseTexture;
 namespace Shaders { class BaseYUV2RGBShader; }
@@ -125,6 +126,8 @@ public:
   virtual void SetupScreenshot() {};
 
   void CreateThumbnail(CBaseTexture *texture, unsigned int width, unsigned int height);
+
+  bool RenderCapture(CRenderCapture* capture);
 
   // Player functions
   virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags);

--- a/xbmc/cores/VideoRenderers/Makefile.in
+++ b/xbmc/cores/VideoRenderers/Makefile.in
@@ -2,6 +2,7 @@ SRCS=BaseRenderer.cpp \
      LinuxRenderer.cpp \
      OverlayRenderer.cpp \
      OverlayRendererUtil.cpp \
+     RenderCapture.cpp \
      RenderManager.cpp \
 
 ifeq (@USE_OPENGL@,1)

--- a/xbmc/cores/VideoRenderers/RenderCapture.cpp
+++ b/xbmc/cores/VideoRenderers/RenderCapture.cpp
@@ -1,0 +1,454 @@
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+/*
+usage:
+
+//capture from the renderer from CApplication thread:
+CRenderCapture* capture = g_renderManager.AllocRenderCapture();
+//don't forget the CAPTUREFLAG_IMMEDIATELY flag
+g_renderManager.Capture(capture, width, height, CAPTUREFLAG_IMMEDIATELY);
+if (capture->GetUserState() == CAPTURESTATE_DONE)
+  //do something with capture->GetPixels();
+g_renderManager.ReleaseRenderCapture(capture);
+
+//schedule a capture from CApplication thread:
+m_capture = g_renderManager.AllocRenderCapture();
+g_renderManager.Capture(m_capture, width, height, 0);
+//capture will be done after a couple calls to CApplication::Render()
+if (m_capture->GetUserState() != CAPTURESTATE_WORKING)
+{
+  if (m_capture->GetUserState() == CAPTURESTATE_DONE)
+    //do something with m_capture->GetPixels();
+  g_renderManager.ReleaseRenderCapture(m_capture);
+}
+
+//capture from another thread:
+CRenderCapture* capture = g_renderManager.AllocRenderCapture();
+//you can set the CAPTUREFLAG_IMMEDIATELY flag to get the capture a little faster, at the cost of a busy wait
+g_renderManager.Capture(capture, width, height, 0);
+capture->GetEvent().Wait();
+if (capture->GetUserState() == CAPTURESTATE_DONE)
+  //do something with capture->GetPixels();
+g_renderManager.ReleaseRenderCapture(capture);
+
+//continuous capture from another thread:
+CRenderCapture* capture = g_renderManager.AllocRenderCapture();
+//if you set CAPTUREFLAG_IMMEDIATELY here, you'll get the captures faster,
+//but CApplication thread will do a lot of busy waiting
+g_renderManager.Capture(capture, width, height, CAPTUREFLAG_CONTINUOUS);
+while (!m_bStop)
+{
+  capture->GetEvent().Wait();
+  if (capture->GetUserState() == CAPTURESTATE_DONE)
+    //do something with capture->GetPixels();
+}
+g_renderManager.ReleaseRenderCapture(capture);
+
+if you want to make several captures in a row, you can reuse the same CRenderCapture
+even if they're a different size
+
+*/
+
+#include "system.h"
+#include "utils/log.h"
+#include "RenderCapture.h"
+#include "windowing/WindowingFactory.h"
+#include "utils/fastmemcpy.h"
+
+CRenderCaptureBase::CRenderCaptureBase()
+{
+  m_state          = CAPTURESTATE_FAILED;
+  m_userState      = CAPTURESTATE_FAILED;
+  m_pixels         = NULL;
+  m_width          = 0;
+  m_height         = 0;
+  m_bufferSize     = 0;
+  m_flags          = 0;
+  m_asyncSupported = false;
+  m_asyncChecked   = false;
+}
+
+CRenderCaptureBase::~CRenderCaptureBase()
+{
+}
+
+#if defined(HAS_GL) || defined(HAS_GLES)
+
+CRenderCaptureGL::CRenderCaptureGL()
+{
+  m_pbo   = 0;
+  m_query = 0;
+}
+
+CRenderCaptureGL::~CRenderCaptureGL()
+{
+#ifndef HAS_GLES
+  if (m_asyncSupported)
+  {
+    if (m_pbo)
+    {
+      glBindBufferARB(GL_PIXEL_PACK_BUFFER_ARB, m_pbo);
+      glUnmapBufferARB(GL_PIXEL_PACK_BUFFER_ARB);
+      glBindBufferARB(GL_PIXEL_PACK_BUFFER_ARB, 0);
+      glDeleteBuffersARB(1, &m_pbo);
+    }
+
+    if (m_query)
+      glDeleteQueriesARB(1, &m_query);
+  }
+#endif
+
+  delete[] m_pixels;
+}
+
+void CRenderCaptureGL::BeginRender()
+{
+  if (!m_asyncChecked)
+  {
+#ifndef HAS_GLES
+    m_asyncSupported = g_Windowing.IsExtSupported("GL_ARB_occlusion_query") && g_Windowing.IsExtSupported("GL_ARB_pixel_buffer_object");
+
+    if (m_flags & CAPTUREFLAG_CONTINUOUS)
+    {
+      if (!g_Windowing.IsExtSupported("GL_ARB_occlusion_query"))
+        CLog::Log(LOGWARNING, "CRenderCaptureGL: GL_ARB_occlusion_query not supported, performance might suffer");
+      if (!g_Windowing.IsExtSupported("GL_ARB_occlusion_query"))
+        CLog::Log(LOGWARNING, "CRenderCaptureGL: GL_ARB_pixel_buffer_object not supported, performance might suffer");
+    }
+#endif
+    m_asyncChecked = true;
+  }
+
+#ifndef HAS_GLES
+  if (m_asyncSupported)
+  {
+    if (!m_pbo)
+      glGenBuffersARB(1, &m_pbo);
+
+    if (!m_query)
+      glGenQueriesARB(1, &m_query);
+
+    //start the occlusion query
+    glBeginQueryARB(GL_SAMPLES_PASSED_ARB, m_query);
+
+    //allocate data on the pbo and pixel buffer
+    glBindBufferARB(GL_PIXEL_PACK_BUFFER_ARB, m_pbo);
+    if (m_bufferSize != m_width * m_height * 4)
+    {
+      m_bufferSize = m_width * m_height * 4;
+      glBufferDataARB(GL_PIXEL_PACK_BUFFER_ARB, m_bufferSize, 0, GL_STREAM_READ_ARB);
+      delete[] m_pixels;
+      m_pixels = new uint8_t[m_bufferSize];
+    }
+  }
+  else
+#endif
+  {
+    if (m_bufferSize != m_width * m_height * 4)
+    {
+      delete[] m_pixels;
+      m_bufferSize = m_width * m_height * 4;
+      m_pixels = new uint8_t[m_bufferSize];
+    }
+  }
+}
+
+void CRenderCaptureGL::EndRender()
+{
+#ifndef HAS_GLES
+  if (m_asyncSupported)
+  {
+    glBindBufferARB(GL_PIXEL_PACK_BUFFER_ARB, 0);
+    glEndQueryARB(GL_SAMPLES_PASSED_ARB);
+
+    if (m_flags & CAPTUREFLAG_IMMEDIATELY)
+      PboToBuffer();
+    else
+      SetState(CAPTURESTATE_NEEDSREADOUT);
+  }
+  else
+#endif
+  {
+    SetState(CAPTURESTATE_DONE);
+  }
+}
+
+void* CRenderCaptureGL::GetRenderBuffer()
+{
+#ifndef HAS_GLES
+  if (m_asyncSupported)
+  {
+    return NULL; //offset into the pbo
+  }
+  else
+#endif
+  {
+    return m_pixels;
+  }
+}
+
+void CRenderCaptureGL::ReadOut()
+{
+#ifndef HAS_GLES
+  if (m_asyncSupported)
+  {
+    //we don't care about the occlusion query, we just want to know if the result is available
+    //when it is, the write into the pbo is probably done as well,
+    //so it can be mapped and read without a busy wait
+
+    GLuint readout;
+    glGetQueryObjectuivARB(m_query, GL_QUERY_RESULT_AVAILABLE_ARB, &readout);
+    if (readout)
+      PboToBuffer();
+  }
+#endif
+}
+
+void CRenderCaptureGL::PboToBuffer()
+{
+#ifndef HAS_GLES
+  glBindBufferARB(GL_PIXEL_PACK_BUFFER_ARB, m_pbo);
+  GLvoid* pboPtr = glMapBufferARB(GL_PIXEL_PACK_BUFFER_ARB, GL_READ_ONLY_ARB);
+
+  if (pboPtr)
+  {
+    fast_memcpy(m_pixels, pboPtr, m_bufferSize);
+    SetState(CAPTURESTATE_DONE);
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "CRenderCaptureGL::PboToBuffer: glMapBufferARB failed");
+    SetState(CAPTURESTATE_FAILED);
+  }
+
+  glUnmapBufferARB(GL_PIXEL_PACK_BUFFER_ARB);
+  glBindBufferARB(GL_PIXEL_PACK_BUFFER_ARB, 0);
+#endif
+}
+
+#elif HAS_DX /*HAS_GL*/
+
+CRenderCaptureDX::CRenderCaptureDX()
+{
+  m_renderSurface = NULL;
+  m_copySurface   = NULL;
+  m_query         = NULL;
+  m_surfaceWidth  = 0;
+  m_surfaceHeight = 0;
+
+  g_Windowing.Register(this);
+}
+
+CRenderCaptureDX::~CRenderCaptureDX()
+{
+  CleanupDX();
+  delete[] m_pixels;
+
+  g_Windowing.Unregister(this);
+}
+
+void CRenderCaptureDX::BeginRender()
+{
+  LPDIRECT3DDEVICE9 pD3DDevice = g_Windowing.Get3DDevice();
+
+  if (!m_asyncChecked)
+  {
+    //check if occlusion query is supported
+    m_asyncSupported = pD3DDevice->CreateQuery(D3DQUERYTYPE_OCCLUSION, NULL) == D3D_OK;
+    if (!m_asyncSupported && (m_flags & CAPTUREFLAG_CONTINUOUS))
+      CLog::Log(LOGWARNING, "CRenderCaptureDX: D3DQUERYTYPE_OCCLUSION not supported, performance might suffer");
+
+    m_asyncChecked = true;
+  }
+
+  HRESULT result;
+
+  if (m_surfaceWidth != m_width || m_surfaceHeight != m_height)
+  {
+    if (m_renderSurface)
+    {
+      while(m_renderSurface->Release() > 0);
+      m_renderSurface = NULL;
+    }
+
+    if (m_copySurface)
+    {
+      while (m_copySurface->Release() > 0);
+      m_copySurface = NULL;
+    }
+
+    result = pD3DDevice->CreateRenderTarget(m_width, m_height, D3DFMT_A8R8G8B8, D3DMULTISAMPLE_NONE, 0, TRUE, &m_renderSurface, NULL);
+    if (result != D3D_OK)
+    {
+      CLog::Log(LOGERROR, "CRenderCaptureDX::BeginRender: CreateRenderTarget failed %s",
+                g_Windowing.GetErrorDescription(result).c_str());
+      SetState(CAPTURESTATE_FAILED);
+      return;
+    }
+
+    result = pD3DDevice->CreateOffscreenPlainSurface(m_width, m_height, D3DFMT_A8R8G8B8, D3DPOOL_SYSTEMMEM, &m_copySurface, NULL);
+    if (result != D3D_OK)
+    {
+      CLog::Log(LOGERROR, "CRenderCaptureDX::BeginRender: CreateOffscreenPlainSurface failed %s",
+                g_Windowing.GetErrorDescription(result).c_str());
+      SetState(CAPTURESTATE_FAILED);
+      return;
+    }
+
+    m_surfaceWidth = m_width;
+    m_surfaceHeight = m_height;
+  }
+
+  if (m_bufferSize != m_width * m_height * 4)
+  {
+    m_bufferSize = m_width * m_height * 4;
+    delete[] m_pixels;
+    m_pixels = new uint8_t[m_bufferSize];
+  }
+
+  result = pD3DDevice->SetRenderTarget(0, m_renderSurface);
+  if (result != D3D_OK)
+  {
+    CLog::Log(LOGERROR, "CRenderCaptureDX::BeginRender: SetRenderTarget failed %s",
+              g_Windowing.GetErrorDescription(result).c_str());
+    SetState(CAPTURESTATE_FAILED);
+    return;
+  }
+
+  if (m_asyncSupported && !m_query)
+  {
+    result = pD3DDevice->CreateQuery(D3DQUERYTYPE_OCCLUSION, &m_query);
+    if (result != D3D_OK)
+    {
+      CLog::Log(LOGERROR, "CRenderCaptureDX::BeginRender: CreateQuery failed %s",
+                g_Windowing.GetErrorDescription(result).c_str());
+      m_asyncSupported = false;
+    }
+  }
+
+  if (m_asyncSupported)
+    m_query->Issue(D3DISSUE_BEGIN);
+}
+
+void CRenderCaptureDX::EndRender()
+{
+  LPDIRECT3DDEVICE9 pD3DDevice = g_Windowing.Get3DDevice();
+  //GetRenderTargetData should be async on most drivers,
+  //so the render thread doesn't have to wait for the gpu to copy the data to m_copySurface
+  pD3DDevice->GetRenderTargetData(m_renderSurface, m_copySurface);
+
+  if (m_asyncSupported)
+  {
+    m_query->Issue(D3DISSUE_END);
+    m_query->GetData(NULL, 0, D3DGETDATA_FLUSH); //flush the query request
+  }
+
+  if (m_flags & CAPTUREFLAG_IMMEDIATELY)
+    SurfaceToBuffer();
+  else
+    SetState(CAPTURESTATE_NEEDSREADOUT);
+}
+
+void CRenderCaptureDX::ReadOut()
+{
+  if (m_asyncSupported)
+  {
+    //if the result of the occlusion query is available, the data is probably also written into m_copySurface
+    HRESULT result = m_query->GetData(NULL, 0, D3DGETDATA_FLUSH);
+    if (result == S_OK)
+    {
+      SurfaceToBuffer();
+    }
+    else if (result != S_FALSE)
+    {
+      CLog::Log(LOGERROR, "CRenderCaptureDX::ReadOut: GetData failed");
+      SurfaceToBuffer();
+    }
+  }
+  else
+  {
+    SurfaceToBuffer();
+  }
+}
+
+void CRenderCaptureDX::SurfaceToBuffer()
+{
+  D3DLOCKED_RECT lockedRect;
+  if (m_copySurface->LockRect(&lockedRect, NULL, D3DLOCK_READONLY) == D3D_OK)
+  {
+    //if pitch is same, do a direct copy, otherwise copy one line at a time
+    if (lockedRect.Pitch == m_width * 4)
+    {
+      fast_memcpy(m_pixels, lockedRect.pBits, m_width * m_height * 4);
+    }
+    else
+    {
+      for (unsigned int y = 0; y < m_height; y++)
+        fast_memcpy(m_pixels + y * m_width * 4, (uint8_t*)lockedRect.pBits + y * lockedRect.Pitch, m_width * 4);
+    }
+    m_copySurface->UnlockRect();
+    SetState(CAPTURESTATE_DONE);
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "CRenderCaptureDX::SurfaceToBuffer: locking m_copySurface failed");
+    SetState(CAPTURESTATE_FAILED);
+  }
+}
+
+void CRenderCaptureDX::OnLostDevice()
+{
+  CleanupDX();
+  SetState(CAPTURESTATE_FAILED);
+}
+
+void CRenderCaptureDX::OnDestroyDevice()
+{
+  CleanupDX();
+  SetState(CAPTURESTATE_FAILED);
+}
+
+void CRenderCaptureDX::CleanupDX()
+{
+  if (m_renderSurface)
+  {
+    while (m_renderSurface->Release() > 0);
+    m_renderSurface = NULL;
+  }
+
+  if (m_copySurface)
+  {
+    while (m_copySurface->Release() > 0);
+    m_copySurface = NULL;
+  }
+
+  if (m_asyncSupported && m_query)
+  {
+    while (m_query->Release() > 0);
+    m_query = NULL;
+  }
+
+  m_surfaceWidth = 0;
+  m_surfaceHeight = 0;
+}
+
+#endif /*HAS_DX*/

--- a/xbmc/cores/VideoRenderers/RenderCapture.cpp
+++ b/xbmc/cores/VideoRenderers/RenderCapture.cpp
@@ -19,57 +19,8 @@
  *
  */
 
-/*
-usage:
-
-//capture from the renderer from CApplication thread:
-CRenderCapture* capture = g_renderManager.AllocRenderCapture();
-//don't forget the CAPTUREFLAG_IMMEDIATELY flag
-g_renderManager.Capture(capture, width, height, CAPTUREFLAG_IMMEDIATELY);
-if (capture->GetUserState() == CAPTURESTATE_DONE)
-  //do something with capture->GetPixels();
-g_renderManager.ReleaseRenderCapture(capture);
-
-//schedule a capture from CApplication thread:
-m_capture = g_renderManager.AllocRenderCapture();
-g_renderManager.Capture(m_capture, width, height, 0);
-//capture will be done after a couple calls to CApplication::Render()
-if (m_capture->GetUserState() != CAPTURESTATE_WORKING)
-{
-  if (m_capture->GetUserState() == CAPTURESTATE_DONE)
-    //do something with m_capture->GetPixels();
-  g_renderManager.ReleaseRenderCapture(m_capture);
-}
-
-//capture from another thread:
-CRenderCapture* capture = g_renderManager.AllocRenderCapture();
-//you can set the CAPTUREFLAG_IMMEDIATELY flag to get the capture a little faster, at the cost of a busy wait
-g_renderManager.Capture(capture, width, height, 0);
-capture->GetEvent().Wait();
-if (capture->GetUserState() == CAPTURESTATE_DONE)
-  //do something with capture->GetPixels();
-g_renderManager.ReleaseRenderCapture(capture);
-
-//continuous capture from another thread:
-CRenderCapture* capture = g_renderManager.AllocRenderCapture();
-//if you set CAPTUREFLAG_IMMEDIATELY here, you'll get the captures faster,
-//but CApplication thread will do a lot of busy waiting
-g_renderManager.Capture(capture, width, height, CAPTUREFLAG_CONTINUOUS);
-while (!m_bStop)
-{
-  capture->GetEvent().Wait();
-  if (capture->GetUserState() == CAPTURESTATE_DONE)
-    //do something with capture->GetPixels();
-}
-g_renderManager.ReleaseRenderCapture(capture);
-
-if you want to make several captures in a row, you can reuse the same CRenderCapture
-even if they're a different size
-
-*/
-
-#include "utils/log.h"
 #include "RenderCapture.h"
+#include "utils/log.h"
 #include "windowing/WindowingFactory.h"
 #include "utils/fastmemcpy.h"
 

--- a/xbmc/cores/VideoRenderers/RenderCapture.cpp
+++ b/xbmc/cores/VideoRenderers/RenderCapture.cpp
@@ -68,7 +68,6 @@ even if they're a different size
 
 */
 
-#include "system.h"
 #include "utils/log.h"
 #include "RenderCapture.h"
 #include "windowing/WindowingFactory.h"

--- a/xbmc/cores/VideoRenderers/RenderCapture.h
+++ b/xbmc/cores/VideoRenderers/RenderCapture.h
@@ -102,7 +102,13 @@ class CRenderCaptureGL : public CRenderCaptureBase
     GLuint m_query;
 };
 
-typedef CRenderCaptureGL CRenderCapture;
+//used instead of typedef CRenderCaptureGL CRenderCapture
+//since C++ doesn't allow you to forward declare a typedef
+class CRenderCapture : public CRenderCaptureGL
+{
+  public:
+    CRenderCapture() {};
+};
 
 #elif HAS_DX /*HAS_GL*/
 
@@ -132,6 +138,10 @@ class CRenderCaptureDX : public CRenderCaptureBase, public ID3DResource
     unsigned int       m_surfaceHeight;
 };
 
-typedef CRenderCaptureDX CRenderCapture;
+class CRenderCapture : public CRenderCaptureDX
+{
+  public:
+    CRenderCapture() {};
+};
 
 #endif

--- a/xbmc/cores/VideoRenderers/RenderCapture.h
+++ b/xbmc/cores/VideoRenderers/RenderCapture.h
@@ -21,9 +21,9 @@
  *
  */
 
-#ifdef HAS_GL
-  #include <GL/gl.h>
-#elif HAS_DX
+#include "system.h"
+
+#ifdef HAS_DX
   #include "guilib/D3DResource.h"
 #endif
 

--- a/xbmc/cores/VideoRenderers/RenderCapture.h
+++ b/xbmc/cores/VideoRenderers/RenderCapture.h
@@ -1,3 +1,8 @@
+/*!
+\file RenderCapture.h
+\brief
+*/
+
 #pragma once
 
 /*
@@ -21,7 +26,56 @@
  *
  */
 
-#include "system.h"
+/*
+\brief usage:
+
+//capture from the renderer from CApplication thread:
+CRenderCapture* capture = g_renderManager.AllocRenderCapture();
+//don't forget the CAPTUREFLAG_IMMEDIATELY flag
+g_renderManager.Capture(capture, width, height, CAPTUREFLAG_IMMEDIATELY);
+if (capture->GetUserState() == CAPTURESTATE_DONE)
+  //do something with capture->GetPixels();
+g_renderManager.ReleaseRenderCapture(capture);
+
+//schedule a capture from CApplication thread:
+m_capture = g_renderManager.AllocRenderCapture();
+g_renderManager.Capture(m_capture, width, height, 0);
+//capture will be done after a couple calls to CApplication::Render()
+if (m_capture->GetUserState() != CAPTURESTATE_WORKING)
+{
+  if (m_capture->GetUserState() == CAPTURESTATE_DONE)
+    //do something with m_capture->GetPixels();
+  g_renderManager.ReleaseRenderCapture(m_capture);
+}
+
+//capture from another thread:
+CRenderCapture* capture = g_renderManager.AllocRenderCapture();
+//you can set the CAPTUREFLAG_IMMEDIATELY flag to get the capture a little faster, at the cost of a busy wait
+g_renderManager.Capture(capture, width, height, 0);
+capture->GetEvent().Wait();
+if (capture->GetUserState() == CAPTURESTATE_DONE)
+  //do something with capture->GetPixels();
+g_renderManager.ReleaseRenderCapture(capture);
+
+//continuous capture from another thread:
+CRenderCapture* capture = g_renderManager.AllocRenderCapture();
+//if you set CAPTUREFLAG_IMMEDIATELY here, you'll get the captures faster,
+//but CApplication thread will do a lot of busy waiting
+g_renderManager.Capture(capture, width, height, CAPTUREFLAG_CONTINUOUS);
+while (!m_bStop)
+{
+  capture->GetEvent().Wait();
+  if (capture->GetUserState() == CAPTURESTATE_DONE)
+    //do something with capture->GetPixels();
+}
+g_renderManager.ReleaseRenderCapture(capture);
+
+if you want to make several captures in a row, you can reuse the same CRenderCapture
+even if they're a different size
+
+*/
+
+#include "system.h" //HAS_DX, HAS_GL, HAS_GLES, opengl headers, direct3d headers
 
 #ifdef HAS_DX
   #include "guilib/D3DResource.h"
@@ -48,22 +102,54 @@ class CRenderCaptureBase
     CRenderCaptureBase();
     ~CRenderCaptureBase();
 
+    /* \brief Called by the rendermanager to set the state, should not be called by anything else */
     void SetState(ECAPTURESTATE state)          { m_state = state;     }
+
+    /* \brief Called by the rendermanager to get the state, should not be called by anything else */
     ECAPTURESTATE GetState()                    { return m_state;      }
+
+    /* \brief Called by the rendermanager to set the userstate, should not be called by anything else */
     void SetUserState(ECAPTURESTATE state)      { m_userState = state; }
+
+    /* \brief Called by the code requesting the capture
+       \return CAPTURESTATE_WORKING when the capture is in progress,
+       CAPTURESTATE_DONE when the capture has succeeded,
+       CAPTURESTATE_FAILED when the capture has failed
+    */
     ECAPTURESTATE GetUserState()                { return m_userState;  }
 
+    /* \brief The internal event will be set when the rendermanager has captured and read a videoframe, or when it has failed
+       \return A reference to m_event
+    */
     CEvent& GetEvent()                          { return m_event; }
 
+    /* \brief Called by the rendermanager to set the flags, should not be called by anything else */
     void         SetFlags(int flags)            { m_flags = flags; }
+
+    /* \brief Called by the rendermanager to get the flags, should not be called by anything else */
     int          GetFlags()                     { return m_flags;  }
 
+    /* \brief Called by the rendermanager to set the width, should not be called by anything else */
     void         SetWidth(unsigned int width)   { m_width = width;   }
+
+    /* \brief Called by the rendermanager to set the height, should not be called by anything else */
     void         SetHeight(unsigned int height) { m_height = height; }
+
+    /* \brief Called by the code requesting the capture to get the width */
     unsigned int GetWidth()                     { return m_width;    }
+
+    /* \brief Called by the code requesting the capture to get the height */
     unsigned int GetHeight()                    { return m_height;   }
+
+    /* \brief Called by the code requesting the capture to get the buffer where the videoframe is stored,
+       the format is BGRA for GL and DX, and RGBA for GLES, this buffer is only valid when GetUserState returns CAPTURESTATE_DONE.
+       The size of the buffer is GetWidth() * GetHeight() * 4.
+    */
     uint8_t*     GetPixels()                    { return m_pixels;   }
 
+    /* \brief Called by the rendermanager to know if the capture is readout async (using dma for example),
+       should not be called by anything else.
+    */
     bool         IsAsync()                      { return m_asyncSupported; }
 
   protected:

--- a/xbmc/cores/VideoRenderers/RenderCapture.h
+++ b/xbmc/cores/VideoRenderers/RenderCapture.h
@@ -1,0 +1,142 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#ifdef HAS_GL
+  #include <GL/gl.h>
+#elif HAS_DX
+  #include "guilib/D3DResource.h"
+#endif
+
+#include "threads/Event.h"
+
+enum ECAPTURESTATE
+{
+  CAPTURESTATE_WORKING,
+  CAPTURESTATE_NEEDSRENDER,
+  CAPTURESTATE_NEEDSREADOUT,
+  CAPTURESTATE_DONE,
+  CAPTURESTATE_FAILED,
+  CAPTURESTATE_NEEDSDELETE
+};
+
+#define CAPTUREFLAG_CONTINUOUS  0x01 //after a render is done, render a new one immediately
+#define CAPTUREFLAG_IMMEDIATELY 0x02 //read out immediately after render, this can cause a busy wait
+
+class CRenderCaptureBase
+{
+  public:
+    CRenderCaptureBase();
+    ~CRenderCaptureBase();
+
+    void SetState(ECAPTURESTATE state)          { m_state = state;     }
+    ECAPTURESTATE GetState()                    { return m_state;      }
+    void SetUserState(ECAPTURESTATE state)      { m_userState = state; }
+    ECAPTURESTATE GetUserState()                { return m_userState;  }
+
+    CEvent& GetEvent()                          { return m_event;    }
+
+    void         SetFlags(int flags)            { m_flags = flags; }
+    int          GetFlags()                     { return m_flags;  }
+
+    void         SetWidth(unsigned int width)   { m_width = width;   }
+    void         SetHeight(unsigned int height) { m_height = height; }
+    unsigned int GetWidth()                     { return m_width;    }
+    unsigned int GetHeight()                    { return m_height;   }
+    uint8_t*     GetPixels()                    { return m_pixels;   }
+
+    virtual void BeginRender() {}
+    virtual void EndRender()   {}
+
+    virtual void ReadOut() {}
+    virtual bool IsAsync() { return m_asyncSupported; }
+
+  protected:
+    ECAPTURESTATE    m_state;     //state for the rendermanager
+    ECAPTURESTATE    m_userState; //state for the thread that wants the capture
+    int              m_flags;
+    CEvent           m_event;
+
+    uint8_t*         m_pixels;
+    unsigned int     m_width;
+    unsigned int     m_height;
+    unsigned int     m_bufferSize;
+
+    //this is set after the first render
+    bool             m_asyncSupported;
+    bool             m_asyncChecked;
+};
+
+#if defined(HAS_GL) || defined(HAS_GLES)
+
+class CRenderCaptureGL : public CRenderCaptureBase
+{
+  public:
+    CRenderCaptureGL();
+    ~CRenderCaptureGL();
+
+    virtual void BeginRender();
+    virtual void EndRender();
+    void*        GetRenderBuffer();
+
+    virtual void ReadOut();
+
+  private:
+    void   PboToBuffer();
+    GLuint m_pbo;
+    GLuint m_query;
+};
+
+typedef CRenderCaptureGL CRenderCapture;
+
+#elif HAS_DX /*HAS_GL*/
+
+class CRenderCaptureDX : public CRenderCaptureBase, public ID3DResource
+{
+  public:
+    CRenderCaptureDX();
+    ~CRenderCaptureDX();
+
+    virtual void BeginRender();
+    virtual void EndRender();
+
+    virtual void ReadOut();
+    
+    virtual void OnDestroyDevice();
+    virtual void OnLostDevice();
+    virtual void OnCreateDevice() {};
+
+  private:
+    void SurfaceToBuffer();
+    void CleanupDX();
+
+    LPDIRECT3DSURFACE9 m_renderSurface;
+    LPDIRECT3DSURFACE9 m_copySurface;
+    LPDIRECT3DQUERY9   m_query;
+
+    unsigned int       m_surfaceWidth;
+    unsigned int       m_surfaceHeight;
+};
+
+typedef CRenderCaptureDX CRenderCapture;
+
+#endif

--- a/xbmc/cores/VideoRenderers/RenderCapture.h
+++ b/xbmc/cores/VideoRenderers/RenderCapture.h
@@ -53,7 +53,7 @@ class CRenderCaptureBase
     void SetUserState(ECAPTURESTATE state)      { m_userState = state; }
     ECAPTURESTATE GetUserState()                { return m_userState;  }
 
-    CEvent& GetEvent()                          { return m_event;    }
+    CEvent& GetEvent()                          { return m_event; }
 
     void         SetFlags(int flags)            { m_flags = flags; }
     int          GetFlags()                     { return m_flags;  }
@@ -64,11 +64,7 @@ class CRenderCaptureBase
     unsigned int GetHeight()                    { return m_height;   }
     uint8_t*     GetPixels()                    { return m_pixels;   }
 
-    virtual void BeginRender() {}
-    virtual void EndRender()   {}
-
-    virtual void ReadOut() {}
-    virtual bool IsAsync() { return m_asyncSupported; }
+    bool         IsAsync()                      { return m_asyncSupported; }
 
   protected:
     ECAPTURESTATE    m_state;     //state for the rendermanager
@@ -94,11 +90,11 @@ class CRenderCaptureGL : public CRenderCaptureBase
     CRenderCaptureGL();
     ~CRenderCaptureGL();
 
-    virtual void BeginRender();
-    virtual void EndRender();
-    void*        GetRenderBuffer();
+    void  BeginRender();
+    void  EndRender();
+    void  ReadOut();
 
-    virtual void ReadOut();
+    void* GetRenderBuffer();
 
   private:
     void   PboToBuffer();
@@ -116,10 +112,9 @@ class CRenderCaptureDX : public CRenderCaptureBase, public ID3DResource
     CRenderCaptureDX();
     ~CRenderCaptureDX();
 
-    virtual void BeginRender();
-    virtual void EndRender();
-
-    virtual void ReadOut();
+    void BeginRender();
+    void EndRender();
+    void ReadOut();
     
     virtual void OnDestroyDevice();
     virtual void OnLostDevice();

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -45,6 +45,8 @@
   #include "LinuxRenderer.h"
 #endif
 
+#include "RenderCapture.h"
+
 /* to use the same as player */
 #include "../dvdplayer/DVDClock.h"
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -460,8 +460,7 @@ void CXBMCRenderManager::ManageCaptures()
 
 void CXBMCRenderManager::RenderCapture(CRenderCapture* capture)
 {
-  CSingleLock gfxLock(g_graphicsContext);
-  CSharedLock sharedLock(m_sharedSection);
+  CSharedLock lock(m_sharedSection);
   if (!m_pRenderer || !m_pRenderer->RenderCapture(capture))
     capture->SetState(CAPTURESTATE_FAILED);
 }

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -99,6 +99,7 @@ CXBMCRenderManager::CXBMCRenderManager()
   m_presentsource = 0;
   m_presentmethod = VS_INTERLACEMETHOD_NONE;
   m_bReconfigured = false;
+  m_hasCaptures = false;
 }
 
 CXBMCRenderManager::~CXBMCRenderManager()
@@ -371,6 +372,9 @@ void CXBMCRenderManager::ReleaseRenderCapture(CRenderCapture* capture)
     capture->SetState(CAPTURESTATE_NEEDSDELETE);
     m_captures.push_back(capture);
   }
+
+  if (!m_captures.empty())
+    m_hasCaptures = true;
 }
 
 void CXBMCRenderManager::Capture(CRenderCapture* capture, unsigned int width, unsigned int height, int flags)
@@ -407,10 +411,17 @@ void CXBMCRenderManager::Capture(CRenderCapture* capture, unsigned int width, un
     //schedule this capture for a render and readout
     m_captures.push_back(capture);
   }
+
+  if (!m_captures.empty())
+    m_hasCaptures = true;
 }
 
 void CXBMCRenderManager::ManageCaptures()
 {
+  //no captures, return here so we don't do an unnecessary lock
+  if (!m_hasCaptures)
+    return;
+
   CSingleLock lock(m_captCritSect);
 
   std::list<CRenderCapture*>::iterator it = m_captures.begin();
@@ -456,6 +467,9 @@ void CXBMCRenderManager::ManageCaptures()
       it++;
     }
   }
+
+  if (m_captures.empty())
+    m_hasCaptures = false;
 }
 
 void CXBMCRenderManager::RenderCapture(CRenderCapture* capture)

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -37,7 +37,8 @@
 #include "threads/Thread.h"
 #include "settings/VideoSettings.h"
 #include "OverlayRenderer.h"
-#include "RenderCapture.h"
+
+class CRenderCapture;
 
 namespace DXVA { class CProcessor; }
 namespace VAAPI { class CSurfaceHolder; }

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -21,6 +21,8 @@
  *
  */
 
+#include <list>
+
 #if defined (HAS_GL)
   #include "LinuxRendererGL.h"
 #elif HAS_GLES == 2
@@ -35,6 +37,7 @@
 #include "threads/Thread.h"
 #include "settings/VideoSettings.h"
 #include "OverlayRenderer.h"
+#include "RenderCapture.h"
 
 namespace DXVA { class CProcessor; }
 namespace VAAPI { class CSurfaceHolder; }
@@ -56,6 +59,11 @@ public:
   void SetupScreenshot();
 
   void CreateThumbnail(CBaseTexture *texture, unsigned int width, unsigned int height);
+
+  CRenderCapture* AllocRenderCapture();
+  void ReleaseRenderCapture(CRenderCapture* capture);
+  void Capture(CRenderCapture *capture, unsigned int width, unsigned int height, int flags);
+  void ManageCaptures();
 
   void SetViewMode(int iViewMode) { CSharedLock lock(m_sharedSection); if (m_pRenderer) m_pRenderer->SetViewMode(iViewMode); };
 
@@ -243,6 +251,11 @@ protected:
 
 
   OVERLAY::CRenderer m_overlays;
+
+  void RenderCapture(CRenderCapture* capture);
+  void RemoveCapture(CRenderCapture* capture);
+  CCriticalSection           m_captCritSect;
+  std::list<CRenderCapture*> m_captures;
 };
 
 extern CXBMCRenderManager g_renderManager;

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -257,6 +257,9 @@ protected:
   void RemoveCapture(CRenderCapture* capture);
   CCriticalSection           m_captCritSect;
   std::list<CRenderCapture*> m_captures;
+  //set to true when adding something to m_captures, set to false when m_captures is made empty
+  //std::list::empty() isn't thread safe, using an extra bool will save a lock per render when no captures are requested
+  bool                       m_hasCaptures; 
 };
 
 extern CXBMCRenderManager g_renderManager;

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -995,6 +995,39 @@ void CWinRenderer::CreateThumbnail(CBaseTexture *texture, unsigned int width, un
 }
 
 
+bool CWinRenderer::RenderCapture(CRenderCapture* capture)
+{
+  if (!m_bConfigured || m_NumYV12Buffers == 0)
+    return false;
+
+  bool succeeded = false;
+
+  LPDIRECT3DDEVICE9 pD3DDevice = g_Windowing.Get3DDevice();
+
+  CRect saveSize = m_destRect;
+  m_destRect.SetRect(0, 0, (float)capture->GetWidth(), (float)capture->GetHeight());
+
+  LPDIRECT3DSURFACE9 oldSurface;
+  pD3DDevice->GetRenderTarget(0, &oldSurface);
+
+  capture->BeginRender();
+  if (capture->GetState() != CAPTURESTATE_FAILED)
+  {
+    pD3DDevice->BeginScene();
+    Render(0);
+    pD3DDevice->EndScene();
+    capture->EndRender();
+    succeeded = true;
+  }
+
+  pD3DDevice->SetRenderTarget(0, oldSurface);
+  oldSurface->Release();
+
+  m_destRect = saveSize;
+
+  return succeeded;
+}
+
 //********************************************************************************************************
 // YV12 Texture creation, deletion, copying + clearing
 //********************************************************************************************************

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -27,6 +27,7 @@
 #include "RenderFlags.h"
 #include "BaseRenderer.h"
 #include "guilib/D3DResource.h"
+#include "RenderCapture.h"
 #include "settings/VideoSettings.h"
 //#define MP_DIRECTRENDERING
 
@@ -188,7 +189,10 @@ public:
 
   virtual void Update(bool bPauseDrawing);
   virtual void SetupScreenshot() {};
+
   void CreateThumbnail(CBaseTexture *texture, unsigned int width, unsigned int height);
+
+  bool RenderCapture(CRenderCapture* capture);
 
   // Player functions
   virtual bool         Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags);

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -25,6 +25,7 @@
 #include "Application.h"
 #ifdef HAS_VIDEO_PLAYBACK
 #include "cores/VideoRenderers/RenderManager.h"
+#include "cores/VideoRenderers/RenderCapture.h"
 #endif
 #include "pictures/Picture.h"
 #include "dialogs/GUIDialogContextMenu.h"


### PR DESCRIPTION
This adds a method of capturing video frames from the renderer, from any thread.
It's like g_renderManager.CreateThumbnail(), but by using GL_ARB_pixel_buffer_object on GL and GetRenderTargetData on dx, and by using an occlusion query to poll when the render is done, performance is increased and there should be no cpu waits on the gpu.

The things I'm not sure about is the graphicscontext locking, and if I should move CRenderCaptureGL and CRenderCaptureDX to different files.
