### PR TITLE
Log and globals initialization and finalization/destruction fix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -292,6 +292,8 @@ xbmc/powermanagement/linux/powermanagement_linux.a: force
 	$(MAKE) -C xbmc/powermanagement/linux
 xbmc/powermanagement/osx/powermanagement.a: force
 	$(MAKE) -C xbmc/powermanagement/osx
+xbmc/windowing/X11/windowing_X11.a: force
+	$(MAKE) -C xbmc/windowing/X11
 xbmc/rendering/rendering.a: force
 	$(MAKE) -C xbmc/rendering
 xbmc/rendering/gl/rendering_gl.a: force
@@ -302,8 +304,6 @@ xbmc/windowing/windowing.a: force
 	$(MAKE) -C xbmc/windowing
 xbmc/windowing/egl/windowing_egl.a: force
 	$(MAKE) -C xbmc/windowing/egl
-xbmc/windowing/X11/windowing_X11.a: force
-	$(MAKE) -C xbmc/windowing/X11
 xbmc/windowing/osx/windowing_osx.a: force
 	$(MAKE) -C xbmc/windowing/osx
 xbmc/storage/storage.a: force
@@ -632,7 +632,7 @@ xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC)
 ifeq ($(findstring osx,@ARCH@), osx)
 	$(CXX) $(LDFLAGS) -o xbmc.bin -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(OBJSXBMC) $(LIBS) -rdynamic
 else
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o xbmc.bin -Wl,--whole-archive $(DYNOBJSXBMC) -Wl,--no-whole-archive $(OBJSXBMC) $(LIBS) -rdynamic
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o xbmc.bin -Wl,--whole-archive $(DYNOBJSXBMC) $(OBJSXBMC) -Wl,--no-whole-archive $(LIBS) -rdynamic
 endif
 
 xbmc-xrandr: xbmc-xrandr.c

--- a/configure.in
+++ b/configure.in
@@ -1414,6 +1414,7 @@ OUTPUT_FILES="Makefile \
     xbmc/cores/dvdplayer/Makefile \
     lib/Makefile \
     lib/libdvd/Makefile \
+    xbmc/cores/DllLoader/Makefile \
     xbmc/cores/dvdplayer/DVDCodecs/Makefile \
     xbmc/cores/dvdplayer/DVDCodecs/Audio/Makefile \
     xbmc/cores/dvdplayer/DVDCodecs/Overlay/Makefile \

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -685,6 +685,7 @@
     <ClCompile Include="..\..\xbmc\utils\PCMAmplifier.cpp" />
     <ClCompile Include="..\..\xbmc\utils\PerformanceSample.cpp" />
     <ClCompile Include="..\..\xbmc\utils\PerformanceStats.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\ReferenceCounting.cpp" />
     <ClCompile Include="..\..\xbmc\utils\RegExp.cpp" />
     <ClCompile Include="..\..\xbmc\utils\RingBuffer.cpp" />
     <ClCompile Include="..\..\xbmc\utils\RssReader.cpp" />
@@ -1518,6 +1519,7 @@
     <ClInclude Include="..\..\xbmc\utils\PCMAmplifier.h" />
     <ClInclude Include="..\..\xbmc\utils\PerformanceSample.h" />
     <ClInclude Include="..\..\xbmc\utils\PerformanceStats.h" />
+    <ClInclude Include="..\..\xbmc\utils\ReferenceCounting.h" />
     <ClInclude Include="..\..\xbmc\utils\RegExp.h" />
     <ClInclude Include="..\..\xbmc\utils\RingBuffer.h" />
     <ClInclude Include="..\..\xbmc\utils\RssReader.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2465,6 +2465,9 @@
     <ClCompile Include="..\..\xbmc\win32\stat_utf8.cpp">
       <Filter>win32</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\ReferenceCounting.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -4943,6 +4946,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\win32\stat_utf8.h">
       <Filter>win32</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\ReferenceCounting.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/SectionLoader.cpp
+++ b/xbmc/SectionLoader.cpp
@@ -28,7 +28,10 @@
 
 using namespace std;
 
-class CSectionLoader g_sectionLoader;
+// explicit template instantiation
+template class xbmcutil::Singleton<CSectionLoader>;
+
+#define g_sectionLoader (*(xbmcutil::Singleton<CSectionLoader>::getInstance()))
 
 //  delay for unloading dll's
 #define UNLOAD_DELAY 30*1000 // 30 sec.

--- a/xbmc/SectionLoader.h
+++ b/xbmc/SectionLoader.h
@@ -22,11 +22,12 @@
 
 #include "utils/StdString.h"
 #include "threads/CriticalSection.h"
+#include "utils/ReferenceCounting.h"
 
 //  forward
 class LibraryLoader;
 
-class CSectionLoader
+class CSectionLoader : public virtual xbmcutil::Referenced
 {
 public:
   class CSection
@@ -61,4 +62,10 @@ protected:
   std::vector<CDll> m_vecLoadedDLLs;
   CCriticalSection m_critSection;
 };
-extern class CSectionLoader g_sectionLoader;
+
+/**
+ * This is a hack. There will be an instance of a ref to this "global" statically in each
+ *  file that includes this header. This is so that the reference couting will
+ *  work correctly from the data segment.
+ */
+static xbmcutil::Referenced::ref<CSectionLoader> g_sectionLoaderRef(xbmcutil::Singleton<CSectionLoader>::getInstance);

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -29,7 +29,6 @@
 #include "guilib/AudioContext.h"
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
-#include "settings/AdvancedSettings.h"
 #include "utils/CharsetConverter.h"
 #include "utils/AlarmClock.h"
 #include "utils/DownloadQueueManager.h"
@@ -48,7 +47,6 @@
 #endif
 
   CGUISettings       g_guiSettings;
-  CAdvancedSettings  g_advancedSettings;
   CSettings          g_settings;
 
 #if defined(_WIN32) && defined(HAS_GL)

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -20,7 +20,6 @@
  */
 #include "system.h"
 #include "cores/VideoRenderers/RenderManager.h"
-#include "guilib/GraphicContext.h"
 #include "input/MouseStat.h"
 #include "Application.h"
 #include "GUILargeTextureManager.h"
@@ -54,7 +53,6 @@
   CLocalizeStrings   g_localizeStrings;
   CLocalizeStrings   g_localizeStringsTemp;
 
-  CGraphicContext    g_graphicsContext;
   CGUIWindowManager  g_windowManager;
   XFILE::CDirectoryCache g_directoryCache;
 

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -19,7 +19,6 @@
  *
  */
 #include "system.h"
-#include "windowing/WindowingFactory.h"
 #include "cores/VideoRenderers/RenderManager.h"
 #include "guilib/GraphicContext.h"
 #include "input/MouseStat.h"
@@ -47,22 +46,6 @@
 
   CGUISettings       g_guiSettings;
   CSettings          g_settings;
-
-#if defined(_WIN32) && defined(HAS_GL)
-  CWinSystemWin32GL  g_Windowing;
-#endif
-
-#if defined(_WIN32) && defined(HAS_DX)
-  CWinSystemWin32DX  g_Windowing;
-#endif
-
-#if defined(__APPLE__)
-  CWinSystemOSXGL    g_Windowing;
-#endif
-
-#if defined(HAS_GLX)
-  CWinSystemX11GL    g_Windowing;
-#endif
 
   CXBMCRenderManager g_renderManager;
   CAudioContext      g_audioContext;

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -29,7 +29,6 @@
 #include "guilib/AudioContext.h"
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
-#include "utils/CharsetConverter.h"
 #include "utils/AlarmClock.h"
 #include "utils/DownloadQueueManager.h"
 #include "GUIInfoManager.h"
@@ -67,7 +66,6 @@
 
   CXBMCRenderManager g_renderManager;
   CAudioContext      g_audioContext;
-  CCharsetConverter  g_charsetConverter;
   CLangInfo          g_langInfo;
   CLangCodeExpander  g_LangCodeExpander;
   CLocalizeStrings   g_localizeStrings;

--- a/xbmc/cores/DllLoader/Makefile.in
+++ b/xbmc/cores/DllLoader/Makefile.in
@@ -9,10 +9,13 @@ SRCS=coff.cpp \
      dll_tracker_file.cpp \
      dll_tracker_library.cpp \
      dll_util.cpp \
-     ldt_keeper.c \
      LibraryLoader.cpp \
      mmap_anon.c \
      SoLoader.cpp \
+
+ifneq ($(findstring freebsd,@ARCH@),freebsd)
+SRCS += ldt_keeper.c
+endif
 
 LIB=dllloader.a
 

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -42,11 +42,24 @@ extern bool g_fullScreen;
 static CSettingInt* g_guiSkinzoom = NULL;
 
 CGraphicContext::CGraphicContext(void) :
-  m_iScreenHeight(576), m_iScreenWidth(720), m_iScreenId(0), m_strMediaDir(""), 
-  /*m_videoRect,*/ m_bFullScreenRoot(false), m_bFullScreenVideo(false),
-  m_bCalibrating(false), m_Resolution(RES_INVALID), m_windowResolution(RES_INVALID),
-  m_guiScaleX(1.0f), m_guiScaleY(1.0f) /*,m_cameras, m_origins, m_clipRegions,*/
-  /*m_guiTransform, m_finalTransform, m_groupTransform*/
+  m_iScreenHeight(576), 
+  m_iScreenWidth(720), 
+  m_iScreenId(0), 
+  m_strMediaDir(""), 
+  /*m_videoRect,*/ 
+  m_bFullScreenRoot(false), 
+  m_bFullScreenVideo(false),
+  m_bCalibrating(false), 
+  m_Resolution(RES_INVALID), 
+  m_windowResolution(RES_INVALID),
+  m_guiScaleX(1.0f), 
+  m_guiScaleY(1.0f) 
+  /*,m_cameras, */ 
+  /*m_origins, */
+  /*m_clipRegions,*/
+  /*m_guiTransform,*/
+  /*m_finalTransform, */
+  /*m_groupTransform*/
 {
 }
 

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -41,17 +41,13 @@ extern bool g_fullScreen;
 /* quick access to a skin setting, fine unless we starts clearing video settings */
 static CSettingInt* g_guiSkinzoom = NULL;
 
-CGraphicContext::CGraphicContext(void)
+CGraphicContext::CGraphicContext(void) :
+  m_iScreenHeight(576), m_iScreenWidth(720), m_iScreenId(0), m_strMediaDir(""), 
+  /*m_videoRect,*/ m_bFullScreenRoot(false), m_bFullScreenVideo(false),
+  m_bCalibrating(false), m_Resolution(RES_INVALID), m_windowResolution(RES_INVALID),
+  m_guiScaleX(1.0f), m_guiScaleY(1.0f) /*,m_cameras, m_origins, m_clipRegions,*/
+  /*m_guiTransform, m_finalTransform, m_groupTransform*/
 {
-  m_iScreenWidth = 720;
-  m_iScreenHeight = 576;
-  m_iScreenId = 0;
-  m_strMediaDir = "";
-  m_bCalibrating = false;
-  m_Resolution = RES_INVALID;
-  m_guiScaleX = m_guiScaleY = 1.0f;
-  m_windowResolution = RES_INVALID;
-  m_bFullScreenRoot = false;
 }
 
 CGraphicContext::~CGraphicContext(void)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -22,6 +22,7 @@
 
 #include <vector>
 #include "utils/StdString.h"
+#include "utils/ReferenceCounting.h"
 
 class TiXmlElement;
 
@@ -59,10 +60,12 @@ struct RefreshOverride
 
 typedef std::vector<TVShowRegexp> SETTINGS_TVSHOWLIST;
 
-class CAdvancedSettings
+class CAdvancedSettings : public virtual xbmcutil::Referenced
 {
   public:
     CAdvancedSettings();
+
+    static CAdvancedSettings* getInstance();
 
     void Initialize();
 
@@ -288,5 +291,10 @@ class CAdvancedSettings
     bool m_jsonOutputCompact;
 };
 
-extern CAdvancedSettings g_advancedSettings;
-
+/**
+ * This is a hack. There will be an instance of a ref to this "global" statically in each
+ *  file that includes this header. This is so that the reference couting will
+ *  work correctly from the data segment.
+ */
+static xbmcutil::Referenced::ref<CAdvancedSettings> g_advancedSettingsRef(xbmcutil::Singleton<CAdvancedSettings>::getInstance);
+#define g_advancedSettings (*(g_advancedSettingsRef.get()))

--- a/xbmc/threads/SingleLock.h
+++ b/xbmc/threads/SingleLock.h
@@ -33,9 +33,6 @@
 class CSingleLock
 {
 public:
-  void Unlock();
-  void Lock();
-
   CSingleLock(CCriticalSection& cs);
   CSingleLock(const CCriticalSection& cs);
   virtual ~CSingleLock();

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -24,10 +24,11 @@
 
 #include "threads/CriticalSection.h"
 #include "StdString.h"
+#include "utils/ReferenceCounting.h"
 
 #include <vector>
 
-class CCharsetConverter
+class CCharsetConverter : public virtual xbmcutil::Referenced
 {
 public:
   CCharsetConverter();
@@ -79,7 +80,13 @@ public:
   void fromW(const CStdStringW& source, CStdStringA& dest, const CStdStringA& enc);
 };
 
-extern CCharsetConverter g_charsetConverter;
+/**
+ * This is a hack. There will be an instance of a ref to this "global" statically in each
+ *  file that includes this header. This is so that the reference couting will
+ *  work correctly from the data segment.
+ */
+static xbmcutil::Referenced::ref<CCharsetConverter> g_charsetConverterRef(xbmcutil::Singleton<CCharsetConverter>::getInstance);
+#define g_charsetConverter (*(g_charsetConverterRef.get()))
 
 size_t iconv_const (void* cd, const char** inbuf, size_t *inbytesleft, char* * outbuf, size_t *outbytesleft);
 

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -31,6 +31,7 @@ SRCS=AlarmClock.cpp \
      PCMRemap.cpp \
      PerformanceSample.cpp \
      PerformanceStats.cpp \
+     ReferenceCounting.cpp \
      RegExp.cpp \
      RingBuffer.cpp \
      RssReader.cpp \

--- a/xbmc/utils/ReferenceCounting.cpp
+++ b/xbmc/utils/ReferenceCounting.cpp
@@ -31,9 +31,11 @@ namespace xbmcutil
 {
   Referenced::~Referenced() 
   {
-#ifdef LOG_LIFECYCLE_EVENTS
-    CLog::Log(LOGDEBUG,"REFCNT deleting 0x%lx", (long)(((void*)this)));
-#endif
+// Cannot use the log from the destructor of Referenced because the
+//  log uses Referenced and in the destructor it's uninitialized.
+//#ifdef LOG_LIFECYCLE_EVENTS
+//    CLog::Log(LOGDEBUG,"REFCNT deleting 0x%lx", (long)(((void*)this)));
+//#endif
   }
 
   void Referenced::Release() const

--- a/xbmc/utils/ReferenceCounting.cpp
+++ b/xbmc/utils/ReferenceCounting.cpp
@@ -21,7 +21,7 @@
 
 #include "ReferenceCounting.h"
 
-#define LOG_LIFECYCLE_EVENTS
+//#define LOG_LIFECYCLE_EVENTS
 
 #ifdef LOG_LIFECYCLE_EVENTS
 #include "utils/log.h"

--- a/xbmc/utils/ReferenceCounting.cpp
+++ b/xbmc/utils/ReferenceCounting.cpp
@@ -21,6 +21,7 @@
 
 #include "ReferenceCounting.h"
 
+// Comment in this #define in order to see REFCNT events in the log.
 //#define LOG_LIFECYCLE_EVENTS
 
 #ifdef LOG_LIFECYCLE_EVENTS
@@ -29,20 +30,12 @@
 
 namespace xbmcutil
 {
-  Referenced::~Referenced() 
-  {
-// Cannot use the log from the destructor of Referenced because the
-//  log uses Referenced and in the destructor it's uninitialized.
-//#ifdef LOG_LIFECYCLE_EVENTS
-//    CLog::Log(LOGDEBUG,"REFCNT deleting 0x%lx", (long)(((void*)this)));
-//#endif
-  }
+  Referenced::~Referenced() { /* place for the vtab */  }
 
   void Referenced::Release() const
   {
     long ct = InterlockedDecrement((long*)&refs);
 #ifdef LOG_LIFECYCLE_EVENTS
-//    CLog::Log(LOGDEBUG,"REFCNT decrementing to %ld on %s 0x%lx", ct,classname.c_str(), (long)(((void*)this)));
     CLog::Log(LOGDEBUG,"REFCNT decrementing to %ld on 0x%lx", ct, (long)(((void*)this)));
 #endif
     if(ct == 0)
@@ -52,8 +45,6 @@ namespace xbmcutil
   void Referenced::Acquire() const
   {
 #ifdef LOG_LIFECYCLE_EVENTS
-//    CLog::Log(LOGDEBUG,"REFCNT incrementing to %ld on %s 0x%lx",
-//              InterlockedIncrement((long*)&refs),classname.c_str(), (long)(((void*)this)));
     CLog::Log(LOGDEBUG,"REFCNT incrementing to %ld on 0x%lx",
               InterlockedIncrement((long*)&refs), (long)(((void*)this)));
 #else

--- a/xbmc/utils/ReferenceCounting.cpp
+++ b/xbmc/utils/ReferenceCounting.cpp
@@ -1,0 +1,61 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "ReferenceCounting.h"
+
+#define LOG_LIFECYCLE_EVENTS
+
+#ifdef LOG_LIFECYCLE_EVENTS
+#include "utils/log.h"
+#endif
+
+namespace xbmcutil
+{
+  Referenced::~Referenced() 
+  {
+#ifdef LOG_LIFECYCLE_EVENTS
+    CLog::Log(LOGDEBUG,"REFCNT deleting 0x%lx", (long)(((void*)this)));
+#endif
+  }
+
+  void Referenced::Release() const
+  {
+    long ct = InterlockedDecrement((long*)&refs);
+#ifdef LOG_LIFECYCLE_EVENTS
+//    CLog::Log(LOGDEBUG,"REFCNT decrementing to %ld on %s 0x%lx", ct,classname.c_str(), (long)(((void*)this)));
+    CLog::Log(LOGDEBUG,"REFCNT decrementing to %ld on 0x%lx", ct, (long)(((void*)this)));
+#endif
+    if(ct == 0)
+      delete this;
+  }
+
+  void Referenced::Acquire() const
+  {
+#ifdef LOG_LIFECYCLE_EVENTS
+//    CLog::Log(LOGDEBUG,"REFCNT incrementing to %ld on %s 0x%lx",
+//              InterlockedIncrement((long*)&refs),classname.c_str(), (long)(((void*)this)));
+    CLog::Log(LOGDEBUG,"REFCNT incrementing to %ld on 0x%lx",
+              InterlockedIncrement((long*)&refs), (long)(((void*)this)));
+#else
+    InterlockedIncrement((long*)&refs);
+#endif
+  }
+}

--- a/xbmc/utils/ReferenceCounting.h
+++ b/xbmc/utils/ReferenceCounting.h
@@ -33,10 +33,8 @@ namespace xbmcutil
   {
   private:
     long   refs;
-//    std::string classname;
 
   public:
-//    Referenced(const char* _classname) : refs(0), classname(_classname) {}
     Referenced() : refs(0) {}
     virtual ~Referenced();
 
@@ -92,6 +90,10 @@ namespace xbmcutil
    *
    * Therefore this hack depends on the fact that compilation unit global/static 
    *  initialization is done in a single thread.
+   *
+   * In the spirit of making changes incrementally I've opted to not add Atomic*
+   *  locking to this class yet. It doesn't need it (yet) as it's only called
+   *  from the static initialization thread prior to main.
    */
   template <class T> class Singleton
   {

--- a/xbmc/utils/ReferenceCounting.h
+++ b/xbmc/utils/ReferenceCounting.h
@@ -71,6 +71,8 @@ namespace xbmcutil
       inline operator const T*() const { return ac; }
       inline const T* get() const { return ac; }
       inline T* get() { return ac; }
+      inline T& getRef() { return *ac; }
+      inline const T& getRef() const { return *ac; }
 
       inline ~ref() { if (ac) ac->Release(); }
       inline bool isNull() const { return ac == NULL; }

--- a/xbmc/utils/ReferenceCounting.h
+++ b/xbmc/utils/ReferenceCounting.h
@@ -1,0 +1,108 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#pragma once
+
+#include "threads/CriticalSection.h"
+#include "threads/SingleLock.h"
+
+namespace xbmcutil
+{
+  /**
+   * This class is the superclass for all reference counted classes.
+   */
+  class Referenced
+  {
+  private:
+    long   refs;
+//    std::string classname;
+
+  public:
+//    Referenced(const char* _classname) : refs(0), classname(_classname) {}
+    Referenced() : refs(0) {}
+    virtual ~Referenced();
+
+    void Release() const;
+    void Acquire() const;
+
+    /**
+     * This class is a smart pointer for a Referenced class.
+     */
+    template <class T> class ref
+    {
+      T * ac;
+    public:
+      typedef T*(*factory)();
+
+      inline ref(factory factoryMethod) : ac( (*factoryMethod)() ) { if (ac) ac->Acquire(); }
+      inline ref() : ac(NULL) {}
+      inline ref(const T* addonClass) : ac((T*)addonClass) { if (ac) ac->Acquire(); }
+
+      // copy semantics
+      inline ref(const ref<T>& oref) : ac((T*)(oref.get())) { if (ac) ac->Acquire(); }
+      inline ref<T>& operator=(const ref<T>& oref)  
+      { if (ac) ac->Release(); ac=((T*)oref.get()); if (ac) ac->Acquire(); return *this; }
+
+      inline ref<T>& operator=(T* addonClass) { if (ac) ac->Release(); ac = addonClass; if (ac) ac->Acquire(); return *this; }
+      inline ref<T>& operator=(const T* addonClass) const 
+      { if (ac) ac->Release(); ac = addonClass; if (ac) ac->Acquire(); return *this; }
+
+      inline T* operator->() { return ac; }
+      inline const T* operator->() const { return ac; }
+      inline operator T*() { return ac; }
+      inline operator const T*() const { return ac; }
+      inline const T* get() const { return ac; }
+      inline T* get() { return ac; }
+
+      inline ~ref() { if (ac) ac->Release(); }
+      inline bool isNull() const { return ac == NULL; }
+      inline bool isNotNull() const { return ac; }
+      inline bool isSet() const { return ac; }
+      inline bool operator!() const { return ac != NULL; }
+    };
+  };
+
+  /**
+   * Currently THIS IS NOT THREAD SAFE! Why not just add a lock you ask?
+   *  Because this singleton is used to initialize global variables and
+   *  there is an issue with having the lock used prior to its 
+   *  initialization. No matter what, if this class is used as a replacement
+   *  for global variables there's going to be a race condition if it's used
+   *  anywhere else. So currently this is the only prescribed use.
+   *
+   * Therefore this hack depends on the fact that compilation unit global/static 
+   *  initialization is done in a single thread.
+   */
+  template <class T> class Singleton
+  {
+    static T* instance;
+  public:
+    static T* getInstance()
+    {
+      if (instance == NULL)
+        instance = new T;
+      return instance;
+    }
+  };
+
+  template <class T> T* Singleton<T>::instance;
+
+}

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -27,14 +27,17 @@
 #include "threads/SingleLock.h"
 #include "threads/Thread.h"
 #include "utils/StdString.h"
+#include "utils/ReferenceCounting.h"
 
-FILE*       CLog::m_file            = NULL;
-int         CLog::m_repeatCount     = 0;
-int         CLog::m_repeatLogLevel  = -1;
-std::string CLog::m_repeatLine;
-int         CLog::m_logLevel        = LOG_LEVEL_DEBUG;
+// explicit template instantiation
+template class xbmcutil::Singleton<CLog::CLogGlobals>;
 
-static CCriticalSection critSec;
+#define critSec (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->critSec)
+#define m_file (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->m_file)
+#define m_repeatCount (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->m_repeatCount)
+#define m_repeatLogLevel (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->m_repeatLogLevel)
+#define m_repeatLine (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->m_repeatLine)
+#define m_logLevel (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->m_logLevel)
 
 static char levelNames[][8] =
 {"DEBUG", "INFO", "NOTICE", "WARNING", "ERROR", "SEVERE", "FATAL", "NONE"};
@@ -47,6 +50,7 @@ CLog::~CLog()
 
 void CLog::Close()
 {
+  
   CSingleLock waitLock(critSec);
   if (m_file)
   {

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -24,6 +24,8 @@
 #include <stdio.h>
 #include <string>
 
+#include "utils/ReferenceCounting.h"
+
 #define LOG_LEVEL_NONE         -1 // nothing at all is logged
 #define LOG_LEVEL_NORMAL        0 // shows notice, error, severe and fatal
 #define LOG_LEVEL_DEBUG         1 // shows all
@@ -49,12 +51,20 @@
 
 class CLog
 {
-  static FILE*       m_file;
-  static int         m_logLevel;
-  static int         m_repeatCount;
-  static int         m_repeatLogLevel;
-  static std::string m_repeatLine;
 public:
+
+  class CLogGlobals : public xbmcutil::Referenced
+  {
+  public:
+    CLogGlobals() : m_file(NULL), m_repeatCount(0), m_repeatLogLevel(-1), m_logLevel(LOG_LEVEL_DEBUG) {}
+    FILE*       m_file;
+    int         m_repeatCount;
+    int         m_repeatLogLevel;
+    std::string m_repeatLine;
+    int         m_logLevel;
+    CCriticalSection critSec;
+  };
+
   CLog();
   virtual ~CLog(void);
   static void Close();
@@ -67,3 +77,9 @@ private:
   static void OutputDebugString(const std::string& line);
 };
 
+/**
+ * This is a hack. There will be an instance of a ref to this "global" statically in each
+ *  file that includes this header. This is so that the reference couting will
+ *  work correctly from the data segment.
+ */
+static xbmcutil::Referenced::ref<CLog::CLogGlobals> g_log_globals(xbmcutil::Singleton<CLog::CLogGlobals>::getInstance);

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -26,6 +26,7 @@ using namespace std;
 
 CWinSystemBase::CWinSystemBase()
 {
+  m_eWindowSystem = WINDOW_SYSTEM_WIN32; // this is the 0 value enum
   m_nWidth = 0;
   m_nHeight = 0;
   m_nTop = 0;

--- a/xbmc/windowing/WindowingFactory.h
+++ b/xbmc/windowing/WindowingFactory.h
@@ -24,27 +24,22 @@
 
 #if defined(_WIN32) && defined(HAS_GL)
 #include "windows/WinSystemWin32GL.h"
-extern CWinSystemWin32GL g_Windowing;
 #endif
 
 #if defined(_WIN32) && defined(HAS_DX)
 #include "windows/WinSystemWin32DX.h"
-extern CWinSystemWin32DX g_Windowing;
 #endif
 
 #if defined(__APPLE__)
 #include "osx/WinSystemOSXGL.h"
-extern CWinSystemOSXGL g_Windowing;
 #endif
 
 #if defined(HAS_GLX)
 #include "X11/WinSystemX11GL.h"
-extern CWinSystemX11GL g_Windowing;
 #endif
 
 #if defined(HAS_EGL)
 #include "egl/WinSystemEGL.h"
-extern CWinSystemEGL g_Windowing;
 #endif
 
 #endif // WINDOWING_FACTORY_H

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -39,6 +39,9 @@ CWinSystemX11::CWinSystemX11() : CWinSystemBase(), m_screensaverReset(true)
   m_glContext = NULL;
   m_SDLSurface = NULL;
   m_dpy = NULL;
+  m_glWindow = NULL;
+  m_wmWindow = NULL;
+  m_bWasFullScreenBeforeMinimize = false;
 }
 
 CWinSystemX11::~CWinSystemX11()

--- a/xbmc/windowing/X11/WinSystemX11GL.h
+++ b/xbmc/windowing/X11/WinSystemX11GL.h
@@ -25,8 +25,9 @@
  */
 #include "WinSystemX11.h"
 #include "rendering/gl/RenderSystemGL.h"
+#include "utils/ReferenceCounting.h"
 
-class CWinSystemX11GL : public CWinSystemX11, public CRenderSystemGL
+class CWinSystemX11GL : public CWinSystemX11, public CRenderSystemGL, public virtual xbmcutil::Referenced
 {
 public:
   CWinSystemX11GL();
@@ -53,5 +54,14 @@ protected:
 
   int m_iVSyncErrors;
 };
+
+/**
+ * This is a hack. There will be an instance of a ref to this "global" statically in each
+ *  file that includes this header. This is so that the reference couting will
+ *  work correctly from the data segment.
+ */
+static xbmcutil::Referenced::ref<CWinSystemX11GL> g_WindowingRef(xbmcutil::Singleton<CWinSystemX11GL>::getInstance);
+#define g_Windowing (*(g_WindowingRef))
+
 
 #endif // WINDOW_SYSTEM_H

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -79,12 +79,14 @@ CWinSystemEGL::CWinSystemEGL() : CWinSystemBase()
 , m_eglOMXContext(0)
 {
   m_eWindowSystem = WINDOW_SYSTEM_EGL;
+  m_bWasFullScreenBeforeMinimize = false;
 
   m_SDLSurface = NULL;
   m_eglDisplay = NULL;
   m_eglContext = NULL;
   m_eglSurface = NULL;
   m_eglWindow  = NULL;
+  m_wmWindow   = NULL;
   m_dpy        = NULL;
   
   m_iVSyncErrors = 0;

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -27,8 +27,9 @@
 #include <EGL/egl.h>
 #include <X11/Xlib.h>
 #include "rendering/gles/RenderSystemGLES.h"
+#include "utils/ReferenceCounting.h"
 
-class CWinSystemEGL : public CWinSystemBase, public CRenderSystemGLES
+class CWinSystemEGL : public CWinSystemBase, public CRenderSystemGLES, public virtual xbmcutil::Referenced
 {
 public:
   CWinSystemEGL();
@@ -78,5 +79,13 @@ protected:
 
   int m_iVSyncErrors;
 };
+
+/**
+ * This is a hack. There will be an instance of a ref to this "global" statically in each
+ *  file that includes this header. This is so that the reference couting will
+ *  work correctly from the data segment.
+ */
+static xbmcutil::Referenced::ref<CWinSystemEGL> g_WindowingRef(xbmcutil::Singleton<CWinSystemEGL>::getInstance);
+#define g_Windowing (*(g_WindowingRef))
 
 #endif // WINDOW_SYSTEM_H

--- a/xbmc/windowing/osx/WinSystemOSXGL.h
+++ b/xbmc/windowing/osx/WinSystemOSXGL.h
@@ -25,8 +25,9 @@
  */
 #include "WinSystemOSX.h"
 #include "rendering/gl/RenderSystemGL.h"
+#include "utils/ReferenceCounting.h"
 
-class CWinSystemOSXGL : public CWinSystemOSX, public CRenderSystemGL
+class CWinSystemOSXGL : public CWinSystemOSX, public CRenderSystemGL, public virtual xbmcutil::Referenced
 {
 public:
   CWinSystemOSXGL();
@@ -39,4 +40,12 @@ protected:
   virtual void SetVSyncImpl(bool enable);  
 };
 
-#endif // WINDOW_SYSTEM_H
+/**
+ * This is a hack. There will be an instance of a ref to this "global" statically in each
+ *  file that includes this header. This is so that the reference couting will
+ *  work correctly from the data segment.
+ */
+static xbmcutil::Referenced::ref<CWinSystemOSXGL> g_WindowingRef(xbmcutil::Singleton<CWinSystemOSXGL>::getInstance);
+#define g_Windowing (*(g_WindowingRef))
+
+endif // WINDOW_SYSTEM_H

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -29,10 +29,11 @@
 #include <dxdiag.h>
 #include "windowing/windows/WinSystemWin32.h"
 #include "rendering/dx/RenderSystemDX.h"
+#include "utils/ReferenceCounting.h"
 
 #ifdef HAS_DX
 
-class CWinSystemWin32DX : public CWinSystemWin32, public CRenderSystemDX
+class CWinSystemWin32DX : public CWinSystemWin32, public CRenderSystemDX, public virtual xbmcutil::Referenced
 {
 public:
   CWinSystemWin32DX();
@@ -46,6 +47,14 @@ protected:
   virtual void UpdateMonitor();
   bool UseWindowedDX(bool fullScreen);
 };
+
+/**
+ * This is a hack. There will be an instance of a ref to this "global" statically in each
+ *  file that includes this header. This is so that the reference couting will
+ *  work correctly from the data segment.
+ */
+static xbmcutil::Referenced::ref<CWinSystemWin32DX> g_WindowingRef(xbmcutil::Singleton<CWinSystemWin32DX>::getInstance);
+#define g_Windowing (*(g_WindowingRef))
 
 #endif
 

--- a/xbmc/windowing/windows/WinSystemWin32GL.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32GL.cpp
@@ -40,6 +40,7 @@
 
 CWinSystemWin32GL::CWinSystemWin32GL()
 {
+  m_hglrc = NULL;
   m_wglSwapIntervalEXT = NULL;
 }
 

--- a/xbmc/windowing/windows/WinSystemWin32GL.h
+++ b/xbmc/windowing/windows/WinSystemWin32GL.h
@@ -30,7 +30,7 @@
  */
 #include "WinSystemWin32.h"
 #include "rendering/gl/RenderSystemGL.h"
-#include "utils/Referenced.h"
+#include "utils/ReferenceCounting.h"
 
 class CWinSystemWin32GL : public CWinSystemWin32, public CRenderSystemGL, public virtual xbmcutil::Referenced
 {
@@ -49,6 +49,8 @@ protected:
   BOOL (APIENTRY *m_wglSwapIntervalEXT)( int );
 };
 
+#ifdef HAS_GL
+
 /**
  * This is a hack. There will be an instance of a ref to this "global" statically in each
  *  file that includes this header. This is so that the reference couting will
@@ -56,6 +58,7 @@ protected:
  */
 static xbmcutil::Referenced::ref<CWinSystemWin32GL> g_WindowingRef(xbmcutil::Singleton<CWinSystemWin32GL>::getInstance);
 #define g_Windowing (*(g_WindowingRef))
+#endif
 
 #endif // WINDOW_SYSTEM_H
 

--- a/xbmc/windowing/windows/WinSystemWin32GL.h
+++ b/xbmc/windowing/windows/WinSystemWin32GL.h
@@ -30,8 +30,9 @@
  */
 #include "WinSystemWin32.h"
 #include "rendering/gl/RenderSystemGL.h"
+#include "utils/Referenced.h"
 
-class CWinSystemWin32GL : public CWinSystemWin32, public CRenderSystemGL
+class CWinSystemWin32GL : public CWinSystemWin32, public CRenderSystemGL, public virtual xbmcutil::Referenced
 {
 public:
   CWinSystemWin32GL();
@@ -47,6 +48,14 @@ protected:
   HGLRC m_hglrc;
   BOOL (APIENTRY *m_wglSwapIntervalEXT)( int );
 };
+
+/**
+ * This is a hack. There will be an instance of a ref to this "global" statically in each
+ *  file that includes this header. This is so that the reference couting will
+ *  work correctly from the data segment.
+ */
+static xbmcutil::Referenced::ref<CWinSystemWin32GL> g_WindowingRef(xbmcutil::Singleton<CWinSystemWin32GL>::getInstance);
+#define g_Windowing (*(g_WindowingRef))
 
 #endif // WINDOW_SYSTEM_H
 


### PR DESCRIPTION
This fix uses a singleton pattern and some compiler/cpreprocessor sugar to allow  "global" variables to be lazy instantiated and initialized and moved from the BSS segment to the heap (that is, they are instantiated on the heap when they are first used rather than relying on the startup code to initialize the BSS segment). This eliminates the problem associated with global variable dependencies across compilation units.

Reference counting from the BSS segment is used to destruct these globals at the time the last compilation unit that knows about it is finalized by the post-main shutdown. The book keeping is done by smuggling a smart pointer into every file that references a particular "global class" through the use of a 'static' declaration of an instance of that smart pointer in the header file of the global class (did you ever think you'd see a file scope 'static' variable in a header file - on purpose?)

See xbmc/utils/ReferenceCounting.h/cpp.

I built and ran this under Ubuntu, Windows OpenGL, and Mac OS X. I could only build (but not run) the Windows DX configuration.

Currently I know, on Mac OS X, there is at least one more global in the LinuxVideoRenderer\* that causes a CRITSEC error. I'll fix that on a subsequent update along with everything else in SystemGlobals.cpp.
