### PR TITLE
Add routine for updating the metadata (tags, properties) of an item

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1127,6 +1127,29 @@ bool CFileItem::IsAlbum() const
   return m_bIsAlbum;
 }
 
+void CFileItem::UpdateInfo(const CFileItem &item)
+{
+  if (item.HasVideoInfoTag())
+  { // copy info across (TODO: premiered info is normally stored in m_dateTime by the db)
+    *GetVideoInfoTag() = *item.GetVideoInfoTag();
+    SetOverlayImage(ICON_OVERLAY_UNWATCHED, GetVideoInfoTag()->m_playCount > 0);
+  }
+  if (item.HasMusicInfoTag())
+    *GetMusicInfoTag() = *item.GetMusicInfoTag();
+  if (item.HasPictureInfoTag())
+    *GetPictureInfoTag() = *item.GetPictureInfoTag();
+
+  if (!item.GetLabel().IsEmpty())
+    SetLabel(item.GetLabel());
+  if (!item.GetLabel2().IsEmpty())
+    SetLabel2(item.GetLabel2());
+  if (!item.GetThumbnailImage().IsEmpty())
+    SetThumbnailImage(item.GetThumbnailImage());
+  if (!item.GetIconImage().IsEmpty())
+    SetIconImage(item.GetIconImage());
+  AppendProperties(item);
+}
+
 /////////////////////////////////////////////////////////////////////////////////
 /////
 ///// CFileItemList

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -255,6 +255,15 @@ public:
   void SetExtraInfo(const CStdString& info) { m_extrainfo = info; };
   const CStdString& GetExtraInfo() const { return m_extrainfo; };
 
+  /*! \brief Update an item with information from another item
+   We take metadata information from the given item and supplement the current item
+   with that info.  If tags exist in the new item we use the entire tag information.
+   Properties are appended, and labels, thumbnail and icon are updated if non-empty
+   in the given item.
+   \param item the item used to supplement information
+   */
+  void UpdateInfo(const CFileItem &item);
+
   bool IsSamePath(const CFileItem *item) const;
 
   bool IsAlbum() const;

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -140,11 +140,12 @@ bool CPluginDirectory::GetPluginResult(const CStdString& strPath, CFileItem &res
   bool success = newDir->StartScript(strPath, false);
 
   if (success)
-  { // update the play path, saving the old one as needed
+  { // update the play path and metadata, saving the old one as needed
     if (!resultItem.HasProperty("original_listitem_url"))
       resultItem.SetProperty("original_listitem_url", resultItem.m_strPath);
     resultItem.m_strPath = newDir->m_fileResult->m_strPath;
     resultItem.SetMimeType(newDir->m_fileResult->GetMimeType(false));
+    resultItem.UpdateInfo(*newDir->m_fileResult);
   }
   delete newDir;
 

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -410,5 +410,6 @@ double CGUIListItem::GetPropertyDouble(const CStdString &strKey) const
 
 void CGUIListItem::AppendProperties(const CGUIListItem &item)
 {
-  m_mapProperties.insert(item.m_mapProperties.begin(), item.m_mapProperties.end());
+  for (PropertyMap::const_iterator i = m_mapProperties.begin(); i != m_mapProperties.end(); ++i)
+    SetProperty(i->first, i->second);
 }

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -408,4 +408,7 @@ double CGUIListItem::GetPropertyDouble(const CStdString &strKey) const
   return atof(GetProperty(strKey).c_str()) ;
 }
 
-
+void CGUIListItem::AppendProperties(const CGUIListItem &item)
+{
+  m_mapProperties.insert(item.m_mapProperties.begin(), item.m_mapProperties.end());
+}

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -113,6 +113,13 @@ public:
 
   void ClearProperties();
 
+  /*! \brief Append the properties of one CGUIListItem to another.
+   Any existing properties in the current item will be overridden if they
+   are set in the passed in item.
+   \param item the item containing the properties to append.
+   */
+  void AppendProperties(const CGUIListItem &item);
+
   void Archive(CArchive& ar);
   void Serialize(CVariant& value);
 


### PR DESCRIPTION
This is used primarily to take care of http://trac.xbmc.org/ticket/10958

It is also used in the new files_in_lib branch to set metadata from the library into file listings.

I'll pull sometime tomorrow if noone has any suggestions.
