### PR TITLE
Globals fix update

### DIFF
--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -2240,6 +2240,7 @@
 		18C1D22C13033F6A00CFFE59 /* GLUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLUtils.h; sourceTree = "<group>"; };
 		18CCEAEC1112F5B800615FC6 /* PCMRemap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PCMRemap.cpp; sourceTree = "<group>"; };
 		18CCEAED1112F5B800615FC6 /* PCMRemap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCMRemap.h; sourceTree = "<group>"; };
+		38B2BBD013131B4A00F83309 /* GlobalsHandling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GlobalsHandling.h; sourceTree = "<group>"; };
 		430C881312D64A730098821A /* IPowerSyscall.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPowerSyscall.h; sourceTree = "<group>"; };
 		431376FF12D6455C00680C15 /* GUIDialogCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDialogCache.h; sourceTree = "<group>"; };
 		4313777F12D648E900680C15 /* DllLibid3tag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DllLibid3tag.h; sourceTree = "<group>"; };
@@ -6726,6 +6727,7 @@
 		E38E1E220D25F9FD00618676 /* utils */ = {
 			isa = PBXGroup;
 			children = (
+				38B2BBD013131B4A00F83309 /* GlobalsHandling.h */,
 				18C1D22B13033F6A00CFFE59 /* GLUtils.cpp */,
 				18C1D22C13033F6A00CFFE59 /* GLUtils.h */,
 				18B7C9E7129447B9009E7A26 /* MathUtils.h */,

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1499,6 +1499,7 @@
     <ClInclude Include="..\..\xbmc\utils\FileOperationJob.h" />
     <ClInclude Include="..\..\xbmc\utils\FileUtils.h" />
     <ClInclude Include="..\..\xbmc\utils\fstrcmp.h" />
+    <ClInclude Include="..\..\xbmc\utils\GlobalsHandling.h" />
     <ClInclude Include="..\..\xbmc\utils\GLUtils.h" />
     <ClInclude Include="..\..\xbmc\utils\HTMLTable.h" />
     <ClInclude Include="..\..\xbmc\utils\HTMLUtil.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="win32">
@@ -4912,6 +4912,9 @@
       <Filter>cores\VideoRenderers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\ReferenceCounting.h">
+      <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\GlobalsHandling.h">
       <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>

--- a/xbmc/SectionLoader.cpp
+++ b/xbmc/SectionLoader.cpp
@@ -28,10 +28,7 @@
 
 using namespace std;
 
-// explicit template instantiation
-template class xbmcutil::Singleton<CSectionLoader>;
-
-#define g_sectionLoader (*(xbmcutil::Singleton<CSectionLoader>::getInstance()))
+#define g_sectionLoader XBMC_GLOBAL_USE(CSectionLoader)
 
 //  delay for unloading dll's
 #define UNLOAD_DELAY 30*1000 // 30 sec.

--- a/xbmc/SectionLoader.h
+++ b/xbmc/SectionLoader.h
@@ -22,7 +22,7 @@
 
 #include "utils/StdString.h"
 #include "threads/CriticalSection.h"
-#include "utils/ReferenceCounting.h"
+#include "utils/GlobalsHandling.h"
 
 //  forward
 class LibraryLoader;
@@ -63,9 +63,5 @@ protected:
   CCriticalSection m_critSection;
 };
 
-/**
- * This is a hack. There will be an instance of a ref to this "global" statically in each
- *  file that includes this header. This is so that the reference couting will
- *  work correctly from the data segment.
- */
-static xbmcutil::Referenced::ref<CSectionLoader> g_sectionLoaderRef(xbmcutil::Singleton<CSectionLoader>::getInstance);
+XBMC_GLOBAL_REF(CSectionLoader,g_sectionLoader);
+

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -46,7 +46,7 @@
 #include "gui3d.h"
 #include "utils/StdString.h"
 #include "Resolution.h"
-#include "utils/ReferenceCounting.h"
+#include "utils/GlobalsHandling.h"
 
 enum VIEW_TYPE { VIEW_TYPE_NONE = 0,
                  VIEW_TYPE_LIST,
@@ -219,15 +219,7 @@ private:
  \ingroup graphics
  \brief
  */
-/**
- * This is a hack. There will be an instance of a ref to this "global" statically in each
- *  file that includes this header. This is so that the reference couting will
- *  work correctly from the data segment.
- */
-static xbmcutil::Referenced::ref<CGraphicContext> g_graphicsContextRef(xbmcutil::Singleton<CGraphicContext>::getInstance);
-// this works and performs better (than the #define solution) when there are 
-//  no static methods, at the cost of some data segment space per compilation
-//  unit.
-static CGraphicContext& g_graphicsContext = g_graphicsContextRef.getRef();
+
+XBMC_GLOBAL(CGraphicContext,g_graphicsContext);
 
 #endif

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -22,7 +22,7 @@
 
 #include <vector>
 #include "utils/StdString.h"
-#include "utils/ReferenceCounting.h"
+#include "utils/GlobalsHandling.h"
 
 class TiXmlElement;
 
@@ -291,10 +291,4 @@ class CAdvancedSettings : public virtual xbmcutil::Referenced
     bool m_jsonOutputCompact;
 };
 
-/**
- * This is a hack. There will be an instance of a ref to this "global" statically in each
- *  file that includes this header. This is so that the reference couting will
- *  work correctly from the data segment.
- */
-static xbmcutil::Referenced::ref<CAdvancedSettings> g_advancedSettingsRef(xbmcutil::Singleton<CAdvancedSettings>::getInstance);
-#define g_advancedSettings (*(g_advancedSettingsRef.get()))
+XBMC_GLOBAL(CAdvancedSettings,g_advancedSettings);

--- a/xbmc/utils/CharsetConverter.h
+++ b/xbmc/utils/CharsetConverter.h
@@ -24,7 +24,7 @@
 
 #include "threads/CriticalSection.h"
 #include "StdString.h"
-#include "utils/ReferenceCounting.h"
+#include "utils/GlobalsHandling.h"
 
 #include <vector>
 
@@ -80,13 +80,7 @@ public:
   void fromW(const CStdStringW& source, CStdStringA& dest, const CStdStringA& enc);
 };
 
-/**
- * This is a hack. There will be an instance of a ref to this "global" statically in each
- *  file that includes this header. This is so that the reference couting will
- *  work correctly from the data segment.
- */
-static xbmcutil::Referenced::ref<CCharsetConverter> g_charsetConverterRef(xbmcutil::Singleton<CCharsetConverter>::getInstance);
-#define g_charsetConverter (*(g_charsetConverterRef.get()))
+XBMC_GLOBAL(CCharsetConverter,g_charsetConverter);
 
 size_t iconv_const (void* cd, const char** inbuf, size_t *inbytesleft, char* * outbuf, size_t *outbytesleft);
 

--- a/xbmc/utils/GlobalsHandling.h
+++ b/xbmc/utils/GlobalsHandling.h
@@ -1,0 +1,164 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#pragma once
+
+#include "utils/ReferenceCounting.h"
+
+/**
+ * This file contains the pattern for moving "globals" from the BSS Segment to the heap.
+ * A note on usage of this pattern for globals replacement:
+ *
+ * This pattern uses a singleton pattern and some compiler/cpreprocessor sugar to allow 
+ * "global" variables to be lazy instantiated and initialized and moved from the BSS segment 
+ * to the heap (that is, they are instantiated on the heap when they are first used rather 
+ * than relying on the startup code to initialize the BSS segment). This eliminates the 
+ * problem associated with global variable dependencies across compilation units.
+ *
+ * Reference counting from the BSS segment is used to destruct these globals at the time the 
+ * last compilation unit that knows about it is finalized by the post-main shutdown. The book 
+ * keeping is done by smuggling a smart pointer into every file that references a particular 
+ * "global class" through the use of a 'static' declaration of an instance of that smart 
+ * pointer in the header file of the global class (did you ever think you'd see a file scope 
+ * 'static' variable in a header file - on purpose?)
+ *
+ * For more details see xbmc/utils/ReferenceCounting.h/cpp.
+ *
+ * There are two different ways to use this pattern when replacing global variables.
+ * The selection of which one to use depends on whether or not there is a possiblity
+ * that the code in the .cpp file for the global can be executed from a static method
+ * somewhere. This may take some explanation.
+ *
+ * The (at least) two ways to do this:
+ *
+ * 1) You can use the reference object Referenced::ref to access the global variable.
+ *
+ * This would be the preferred means since it is (very slightly) more efficent than
+ * the alternative. To use this pattern you replace standard static references to
+ * the global with access through the reference. If you use the c-preprocessor to
+ * do this for you can put the following code in the header file where the global's
+ * class is declared:
+ *
+ * static xbmcutil::Referenced::ref<GlobalVariableClass> g_globalVariableRef(xbmcutil::GlobalsSingleton<GlobalVariableClass>::getInstance);
+ * #define g_globalVariable (g_globalVariableRef.getRef())
+ *
+ * Note what this does. In every file that includes this header there will be a *static*
+ * instance of the Referenced::ref<GlobalVariableClass> smart pointer. This effectively
+ * reference counts the singleton from every compilation unit (ie, object code file that
+ * results from a compilation of a .c/.cpp file) that references this global directly.
+ *
+ * There is a problem with this, however. Keep in mind that the instance of the smart pointer
+ * (being in the BSS segment of the compilation unit) is ITSELF an object that depends on
+ * the BSS segment initialization in order to be initialized with an instance from the
+ * Singleton. That means, depending on the code structure, it is possible to get into a
+ * circumstance where the above #define could be exercised PRIOR TO the setting of the
+ * value of the smart pointer.
+ *
+ * Some reflection on this should lead you to the conclusion that the only way for this to
+ * happen is if access to this global can take place through a static/global method, directly
+ * or indirectly (ie, the static/global method can call another method that uses the
+ * reference), where that static is called from initialization code exercised prior to
+ * the start of 'main.'
+ *
+ * Because of the "indirectly" in the above statement, this situation can be difficult to
+ * determine beforehand.
+ *
+ * 2) Alternately, when you KNOW that the global variable can suffer from the above described
+ * problem, you can restrict all access to the varaible to the singleton by changing
+ * the #define to:
+ *
+ * #define g_globalVariable (*(xbmcutil::Singleton<GlobalVariableClass>::getInstance()))
+ *
+ * A few things to note about this. First, this separates the reference counting aspect
+ * from the access aspect of this solution. The smart pointers are no longer used for
+ * reference, only for access. Secondly, all access is through the Singleton directly
+ * so there is no reliance on the state of the BSS segment for the code to operate
+ * correctly.
+ *
+ * This solution is required for g_Windowing because it's accessed (both directly and
+ * indirectly) from the static methods of CLog which are called repeatedly from
+ * code exercised during the initialization of the BSS segment.
+ */
+
+namespace xbmcutil
+{
+
+  /**
+   * Currently THIS IS NOT THREAD SAFE! Why not just add a lock you ask?
+   *  Because this singleton is used to initialize global variables and
+   *  there is an issue with having the lock used prior to its 
+   *  initialization. No matter what, if this class is used as a replacement
+   *  for global variables there's going to be a race condition if it's used
+   *  anywhere else. So currently this is the only prescribed use.
+   *
+   * Therefore this hack depends on the fact that compilation unit global/static 
+   *  initialization is done in a single thread.
+   *
+   * In the spirit of making changes incrementally I've opted to not add Atomic*
+   *  locking to this class yet. It doesn't need it (yet) as it's only called
+   *  from the static initialization thread prior to main.
+   */
+  template <class T> class GlobalsSingleton
+  {
+    static T* instance;
+  public:
+    static T* getInstance()
+    {
+      if (instance == NULL)
+        instance = new T;
+      return instance;
+    }
+  };
+
+  template <class T> T* GlobalsSingleton<T>::instance;
+}
+
+/**
+ * For pattern (2) above, you can use the following macro. This pattern is safe to
+ * use in all cases but may be very slightly less efficent. 
+ *
+ * Also, you must also use a #define to replace the actual global variable since 
+ * there's no way to use a macro to add a #define. An example would be:
+ *
+ * XBMC_GLOBAL_REF(CWinSystemWin32DX, g_Windowing);
+ * #define g_Windowing XBMC_GLOBAL_USE(CWinSystemWin32DX)
+ *
+ */
+#define XBMC_GLOBAL_REF(classname,g_variable) \
+  static xbmcutil::Referenced::ref<classname> g_variable##Ref(xbmcutil::GlobalsSingleton<classname>::getInstance)
+
+/**
+ * This declares the actual use of the variable. It needs to be used in another #define
+ * of the form:
+ *
+ * #define g_variable XBMC_GLOBAL_USE(classname)
+ */
+#define XBMC_GLOBAL_USE(classname) (*(xbmcutil::GlobalsSingleton<classname>::getInstance()))
+
+/**
+ * For pattern (1) above, you can use the following macro. WARNING: this should only 
+ * be used when the global in question is never accessed, directly or indirectly, from
+ * a static method called (again, directly or indirectly) durring startup or shutdown.
+ */
+#define XBMC_GLOBAL(classname,g_variable) \
+  XBMC_GLOBAL_REF(classname,g_variable); \
+  static classname & g_variable = g_variable##Ref.getRef()
+

--- a/xbmc/utils/ReferenceCounting.h
+++ b/xbmc/utils/ReferenceCounting.h
@@ -21,8 +21,17 @@
 
 #pragma once
 
-#include "threads/CriticalSection.h"
-#include "threads/SingleLock.h"
+#include <stddef.h>
+
+// Comment in this #define in order to log REFCNT errors.
+// WARNING! defining DEBUG_REFS prevents the Referenced objects from EVER
+// being deleted. They will ALL LEAK! This is just for debugging.
+//#define DEBUG_REFS
+#ifdef DEBUG_REFS
+#define refcheck if (ac != NULL) ac->Referenced::check()
+#else
+#define refcheck
+#endif
 
 namespace xbmcutil
 {
@@ -41,6 +50,10 @@ namespace xbmcutil
     void Release() const;
     void Acquire() const;
 
+#ifdef DEBUG_REFS
+    void check() const;
+#endif
+
     /**
      * This class is a smart pointer for a Referenced class.
      */
@@ -50,34 +63,55 @@ namespace xbmcutil
     public:
       typedef T*(*factory)();
 
-      inline ref(factory factoryMethod) : ac( (*factoryMethod)() ) { if (ac) ac->Acquire(); }
+      inline ref(factory factoryMethod) : ac( (*factoryMethod)() ) { if (ac) ac->Acquire(); refcheck; }
       inline ref() : ac(NULL) {}
-      inline ref(const T* addonClass) : ac((T*)addonClass) { if (ac) ac->Acquire(); }
+      inline ref(const T* _ac) : ac((T*)_ac) { if (ac) ac->Acquire(); refcheck; }
 
       // copy semantics
-      inline ref(const ref<T>& oref) : ac((T*)(oref.get())) { if (ac) ac->Acquire(); }
-      inline ref<T>& operator=(const ref<T>& oref)  
-      { if (ac) ac->Release(); ac=((T*)oref.get()); if (ac) ac->Acquire(); return *this; }
+      inline ref(ref<T> const & oref) : ac((T*)(oref.get())) { if (ac) ac->Acquire(); refcheck; }
+      template<class O> inline ref(ref<O> const & oref) : ac(static_cast<T*>(oref.get())) { if (ac) ac->Acquire(); refcheck; }
 
-      inline ref<T>& operator=(T* addonClass) { if (ac) ac->Release(); ac = addonClass; if (ac) ac->Acquire(); return *this; }
-      inline ref<T>& operator=(const T* addonClass) const 
-      { if (ac) ac->Release(); ac = addonClass; if (ac) ac->Acquire(); return *this; }
+      /**
+       * operator= should work with either another smart pointer or a pointer since it will 
+       *  be able to convert a pointer to a smart pointer using one of the above constuctors.
+       *
+       * Note: There is a trick here. The temporary varialbe is necessary because otherwise the 
+       *  following code will fail:
+       *
+       *  ref<T> ptr = new T;
+       *  ptr = ptr;
+       *
+       * What happens without the tmp is the derefernce is called first so the object ends up
+       *  deleted and then the reference happens on a deleted object. The order is reversed
+       *  in the following.
+       *
+       * Note: Operator= is ambiguous if you define both an operator=(ref<T>&) and an operator=(T*). I'm
+       *  opting for the route the boost took here figuring it has more history behind it.
+       */
+      inline ref<T>& operator=(ref<T> const & oref)  
+      { T* tmp = ac; ac=((T*)oref.get()); if (ac) ac->Acquire(); if (tmp) tmp->Release(); refcheck; return *this; }
 
-      inline T* operator->() { return ac; }
-      inline const T* operator->() const { return ac; }
-      inline operator T*() { return ac; }
-      inline operator const T*() const { return ac; }
-      inline const T* get() const { return ac; }
-      inline T* get() { return ac; }
-      inline T& getRef() { return *ac; }
-      inline const T& getRef() const { return *ac; }
+      inline T* operator->() const { refcheck; return ac; }
 
-      inline ~ref() { if (ac) ac->Release(); }
-      inline bool isNull() const { return ac == NULL; }
-      inline bool isNotNull() const { return ac; }
-      inline bool isSet() const { return ac; }
-      inline bool operator!() const { return ac != NULL; }
+      /**
+       * This operator doubles as the value in a boolean expression.
+       */
+      inline operator T*() const { refcheck; return ac; }
+      inline T* get() const { refcheck; return ac; }
+      inline T& getRef() const { refcheck; return *ac; }
+
+      inline ~ref() { refcheck; if (ac) ac->Release(); }
+      inline bool isNull() const { refcheck; return ac == NULL; }
+      inline bool isNotNull() const { refcheck; return ac; }
+      inline bool isSet() const { refcheck; return ac; }
+      inline bool operator!() const { refcheck; return ac == NULL; }
+
+      // This is there only for boost compatibility
+      template<class O> inline void reset(ref<O> const & oref) { refcheck; (*this) = static_cast<T*>(oref.get()); refcheck; }
+      template<class O> inline void reset(O * oref) { refcheck; (*this) = static_cast<T*>(oref); refcheck; }
+      inline void reset() { refcheck; if (ac) ac->Release(); ac = NULL; }
     };
+
   };
 
   /**

--- a/xbmc/utils/ReferenceCounting.h
+++ b/xbmc/utils/ReferenceCounting.h
@@ -75,21 +75,11 @@ namespace xbmcutil
        * operator= should work with either another smart pointer or a pointer since it will 
        *  be able to convert a pointer to a smart pointer using one of the above constuctors.
        *
-       * Note: There is a trick here. The temporary varialbe is necessary because otherwise the 
-       *  following code will fail:
-       *
-       *  ref<T> ptr = new T;
-       *  ptr = ptr;
-       *
-       * What happens without the tmp is the derefernce is called first so the object ends up
-       *  deleted and then the reference happens on a deleted object. The order is reversed
-       *  in the following.
-       *
        * Note: Operator= is ambiguous if you define both an operator=(ref<T>&) and an operator=(T*). I'm
-       *  opting for the route the boost took here figuring it has more history behind it.
+       *  opting for the route that boost took here figuring it has more history behind it.
        */
       inline ref<T>& operator=(ref<T> const & oref)  
-      { T* tmp = ac; ac=((T*)oref.get()); if (ac) ac->Acquire(); if (tmp) tmp->Release(); refcheck; return *this; }
+      { if (this != &oref) { if (ac) ac->Release(); ac=((T*)oref.get()); if (ac) ac->Acquire(); } refcheck; return *this; }
 
       inline T* operator->() const { refcheck; return ac; }
 

--- a/xbmc/utils/ReferenceCounting.h
+++ b/xbmc/utils/ReferenceCounting.h
@@ -114,33 +114,4 @@ namespace xbmcutil
 
   };
 
-  /**
-   * Currently THIS IS NOT THREAD SAFE! Why not just add a lock you ask?
-   *  Because this singleton is used to initialize global variables and
-   *  there is an issue with having the lock used prior to its 
-   *  initialization. No matter what, if this class is used as a replacement
-   *  for global variables there's going to be a race condition if it's used
-   *  anywhere else. So currently this is the only prescribed use.
-   *
-   * Therefore this hack depends on the fact that compilation unit global/static 
-   *  initialization is done in a single thread.
-   *
-   * In the spirit of making changes incrementally I've opted to not add Atomic*
-   *  locking to this class yet. It doesn't need it (yet) as it's only called
-   *  from the static initialization thread prior to main.
-   */
-  template <class T> class Singleton
-  {
-    static T* instance;
-  public:
-    static T* getInstance()
-    {
-      if (instance == NULL)
-        instance = new T;
-      return instance;
-    }
-  };
-
-  template <class T> T* Singleton<T>::instance;
-
 }

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -27,17 +27,13 @@
 #include "threads/SingleLock.h"
 #include "threads/Thread.h"
 #include "utils/StdString.h"
-#include "utils/ReferenceCounting.h"
 
-// explicit template instantiation
-template class xbmcutil::Singleton<CLog::CLogGlobals>;
-
-#define critSec (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->critSec)
-#define m_file (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->m_file)
-#define m_repeatCount (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->m_repeatCount)
-#define m_repeatLogLevel (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->m_repeatLogLevel)
-#define m_repeatLine (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->m_repeatLine)
-#define m_logLevel (xbmcutil::Singleton<CLog::CLogGlobals>::getInstance()->m_logLevel)
+#define critSec XBMC_GLOBAL_USE(CLog::CLogGlobals).critSec
+#define m_file XBMC_GLOBAL_USE(CLog::CLogGlobals).m_file
+#define m_repeatCount XBMC_GLOBAL_USE(CLog::CLogGlobals).m_repeatCount
+#define m_repeatLogLevel XBMC_GLOBAL_USE(CLog::CLogGlobals).m_repeatLogLevel
+#define m_repeatLine XBMC_GLOBAL_USE(CLog::CLogGlobals).m_repeatLine
+#define m_logLevel XBMC_GLOBAL_USE(CLog::CLogGlobals).m_logLevel
 
 static char levelNames[][8] =
 {"DEBUG", "INFO", "NOTICE", "WARNING", "ERROR", "SEVERE", "FATAL", "NONE"};

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <string>
 
+#include "threads/CriticalSection.h"
 #include "utils/ReferenceCounting.h"
 
 #define LOG_LEVEL_NONE         -1 // nothing at all is logged

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -25,7 +25,7 @@
 #include <string>
 
 #include "threads/CriticalSection.h"
-#include "utils/ReferenceCounting.h"
+#include "utils/GlobalsHandling.h"
 
 #define LOG_LEVEL_NONE         -1 // nothing at all is logged
 #define LOG_LEVEL_NORMAL        0 // shows notice, error, severe and fatal
@@ -78,9 +78,4 @@ private:
   static void OutputDebugString(const std::string& line);
 };
 
-/**
- * This is a hack. There will be an instance of a ref to this "global" statically in each
- *  file that includes this header. This is so that the reference couting will
- *  work correctly from the data segment.
- */
-static xbmcutil::Referenced::ref<CLog::CLogGlobals> g_log_globals(xbmcutil::Singleton<CLog::CLogGlobals>::getInstance);
+XBMC_GLOBAL_REF(CLog::CLogGlobals,g_log_globals);

--- a/xbmc/windowing/X11/WinSystemX11GL.h
+++ b/xbmc/windowing/X11/WinSystemX11GL.h
@@ -25,7 +25,7 @@
  */
 #include "WinSystemX11.h"
 #include "rendering/gl/RenderSystemGL.h"
-#include "utils/ReferenceCounting.h"
+#include "utils/GlobalsHandling.h"
 
 class CWinSystemX11GL : public CWinSystemX11, public CRenderSystemGL, public virtual xbmcutil::Referenced
 {
@@ -55,13 +55,8 @@ protected:
   int m_iVSyncErrors;
 };
 
-/**
- * This is a hack. There will be an instance of a ref to this "global" statically in each
- *  file that includes this header. This is so that the reference couting will
- *  work correctly from the data segment.
- */
-static xbmcutil::Referenced::ref<CWinSystemX11GL> g_WindowingRef(xbmcutil::Singleton<CWinSystemX11GL>::getInstance);
-#define g_Windowing (*(g_WindowingRef))
+XBMC_GLOBAL_REF(CWinSystemX11GL,g_Windowing);
+#define g_Windowing XBMC_GLOBAL_USE(CWinSystemX11GL)
 
 
 #endif // WINDOW_SYSTEM_H

--- a/xbmc/windowing/egl/WinSystemEGL.cpp
+++ b/xbmc/windowing/egl/WinSystemEGL.cpp
@@ -73,8 +73,6 @@ static int contextAttributes[] =
   EGL_NONE
 };
 
-CWinSystemEGL g_Windowing;
-
 CWinSystemEGL::CWinSystemEGL() : CWinSystemBase()
 , m_eglOMXContext(0)
 {

--- a/xbmc/windowing/egl/WinSystemEGL.h
+++ b/xbmc/windowing/egl/WinSystemEGL.h
@@ -27,7 +27,7 @@
 #include <EGL/egl.h>
 #include <X11/Xlib.h>
 #include "rendering/gles/RenderSystemGLES.h"
-#include "utils/ReferenceCounting.h"
+#include "utils/GlobalsHandling.h"
 
 class CWinSystemEGL : public CWinSystemBase, public CRenderSystemGLES, public virtual xbmcutil::Referenced
 {
@@ -80,12 +80,7 @@ protected:
   int m_iVSyncErrors;
 };
 
-/**
- * This is a hack. There will be an instance of a ref to this "global" statically in each
- *  file that includes this header. This is so that the reference couting will
- *  work correctly from the data segment.
- */
-static xbmcutil::Referenced::ref<CWinSystemEGL> g_WindowingRef(xbmcutil::Singleton<CWinSystemEGL>::getInstance);
-#define g_Windowing (*(g_WindowingRef))
+XBMC_GLOBAL_REF(CWinSystemEGL,g_Windowing);
+#define g_Windowing XBMC_GLOBAL_USE(CWinSystemEGL)
 
 #endif // WINDOW_SYSTEM_H

--- a/xbmc/windowing/osx/WinSystemOSXGL.h
+++ b/xbmc/windowing/osx/WinSystemOSXGL.h
@@ -25,7 +25,7 @@
  */
 #include "WinSystemOSX.h"
 #include "rendering/gl/RenderSystemGL.h"
-#include "utils/ReferenceCounting.h"
+#include "utils/GlobalsHandling.h"
 
 class CWinSystemOSXGL : public CWinSystemOSX, public CRenderSystemGL, public virtual xbmcutil::Referenced
 {
@@ -40,12 +40,7 @@ protected:
   virtual void SetVSyncImpl(bool enable);  
 };
 
-/**
- * This is a hack. There will be an instance of a ref to this "global" statically in each
- *  file that includes this header. This is so that the reference couting will
- *  work correctly from the data segment.
- */
-static xbmcutil::Referenced::ref<CWinSystemOSXGL> g_WindowingRef(xbmcutil::Singleton<CWinSystemOSXGL>::getInstance);
-#define g_Windowing (*(xbmcutil::Singleton<CWinSystemOSXGL>::getInstance()))
+XBMC_GLOBAL_REF(CWinSystemOSXGL,g_Windowing);
+#define g_Windowing XBMC_GLOBAL_USE(CWinSystemOSXGL)
 
 #endif // WINDOW_SYSTEM_H

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -29,7 +29,7 @@
 #include <dxdiag.h>
 #include "windowing/windows/WinSystemWin32.h"
 #include "rendering/dx/RenderSystemDX.h"
-#include "utils/ReferenceCounting.h"
+#include "utils/GlobalsHandling.h"
 
 #ifdef HAS_DX
 
@@ -48,13 +48,8 @@ protected:
   bool UseWindowedDX(bool fullScreen);
 };
 
-/**
- * This is a hack. There will be an instance of a ref to this "global" statically in each
- *  file that includes this header. This is so that the reference couting will
- *  work correctly from the data segment.
- */
-static xbmcutil::Referenced::ref<CWinSystemWin32DX> g_WindowingRef(xbmcutil::Singleton<CWinSystemWin32DX>::getInstance);
-#define g_Windowing (*(g_WindowingRef))
+XBMC_GLOBAL_REF(CWinSystemWin32DX,g_Windowing);
+#define g_Windowing XBMC_GLOBAL_USE(CWinSystemWin32DX)
 
 #endif
 

--- a/xbmc/windowing/windows/WinSystemWin32GL.h
+++ b/xbmc/windowing/windows/WinSystemWin32GL.h
@@ -30,7 +30,7 @@
  */
 #include "WinSystemWin32.h"
 #include "rendering/gl/RenderSystemGL.h"
-#include "utils/ReferenceCounting.h"
+#include "utils/GlobalsHandling.h"
 
 class CWinSystemWin32GL : public CWinSystemWin32, public CRenderSystemGL, public virtual xbmcutil::Referenced
 {
@@ -51,13 +51,9 @@ protected:
 
 #ifdef HAS_GL
 
-/**
- * This is a hack. There will be an instance of a ref to this "global" statically in each
- *  file that includes this header. This is so that the reference couting will
- *  work correctly from the data segment.
- */
-static xbmcutil::Referenced::ref<CWinSystemWin32GL> g_WindowingRef(xbmcutil::Singleton<CWinSystemWin32GL>::getInstance);
-#define g_Windowing (*(g_WindowingRef))
+XBMC_GLOBAL_REF(CWinSystemWin32GL,g_Windowing)
+#define g_Windowing XBMC_GLOBAL_USE(CWinSystemWin32GL)
+
 #endif
 
 #endif // WINDOW_SYSTEM_H

--- a/xbmc/windowing/windows/WinSystemWin32GL.h
+++ b/xbmc/windowing/windows/WinSystemWin32GL.h
@@ -51,7 +51,7 @@ protected:
 
 #ifdef HAS_GL
 
-XBMC_GLOBAL_REF(CWinSystemWin32GL,g_Windowing)
+XBMC_GLOBAL_REF(CWinSystemWin32GL,g_Windowing);
 #define g_Windowing XBMC_GLOBAL_USE(CWinSystemWin32GL)
 
 #endif


### PR DESCRIPTION
This pull requests contains several fixes for the previous globals change. 

1) ReferenceCounting.h/cpp have been completely rewritten after significant unit testing and extensive use in the boost-nuke fork. They are now much more robust than they were previously.
2) A separate header file has been added to define several macros requested by elupus. Also, the Singleton template was renamed (since it's really specific for this globals functionality) and moved into this new file. This file has a long and detailed documentation on what's intended by this fix.
3) The macros were employed for most of the previous globals that were moved to this pattern
4) The macros were employed to handle all of the g_Windowing values which had previously created instability on several builds I couldn't test here. These include EGL (trac 11231) and Phaeodaria's case. It would be great if Pharodaria could test this new configuration.
5) Removed the former Singleton definition from ReferenceCounting.h since the new one is now in the new file GlobalsHandling.h along with the macros (See (2) above).
6) An additional fix for EGL - trac 11231
7) Added new file to xcode
8) Added new file to Win32 build.

This fixes existing problems. Please take a look and acknowledge that they're ok.
