### PR TITLE
Make the Windows build download the prebuilt deps from the XBMC mirror system

### DIFF
--- a/project/BuildDependencies/scripts/PIL_d.txt
+++ b/project/BuildDependencies/scripts/PIL_d.txt
@@ -1,2 +1,2 @@
-; filename                        source of the file
-PIL-1.1.7.win32-py2.4.exe         http://effbot.org/media/downloads/
+; filename                        mirror                                     source of the file
+PIL-1.1.7.win32-py2.4.exe         http://mirrors.xbmc.org/build-deps/win32/  http://effbot.org/media/downloads/

--- a/project/BuildDependencies/scripts/fontconfig_d.txt
+++ b/project/BuildDependencies/scripts/fontconfig_d.txt
@@ -1,4 +1,4 @@
-; filename                        source of the file
-fontconfig-dev_2.8.0-2_win32.zip  http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies
-fontconfig_2.8.0-2_win32.zip      http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies
-freetype_2.3.12-1_win32.zip       http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies
+; filename                        mirror                                           source of the file
+fontconfig-dev_2.8.0-2_win32.zip  http://mirrors.xbmc.org/build-deps/win32/        http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies
+fontconfig_2.8.0-2_win32.zip      http://mirrors.xbmc.org/build-deps/win32/        http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies
+freetype_2.3.12-1_win32.zip       http://mirrors.xbmc.org/build-deps/win32/        http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies

--- a/project/BuildDependencies/scripts/get_mingw_env.txt
+++ b/project/BuildDependencies/scripts/get_mingw_env.txt
@@ -1,17 +1,17 @@
-; filename                        source of the file
-mingwrt-3.18-mingw32-dev.tar.gz			  		http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/RuntimeLibrary/MinGW-RT/mingwrt-3.18/
-mingwrt-3.18-mingw32-dll.tar.gz           		http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/RuntimeLibrary/MinGW-RT/mingwrt-3.18/
-w32api-3.15-1-mingw32-dev.tar.lzma				http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/RuntimeLibrary/Win32-API/w32api-3.15/
-gcc-core-4.5.0-1-mingw32-bin.tar.lzma			http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GCC/Version4/gcc-4.5.0-1/
-gcc-c++-4.5.0-1-mingw32-bin.tar.lzma			http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GCC/Version4/gcc-4.5.0-1/
-libstdc++-4.5.0-1-mingw32-dll-6.tar.lzma		http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GCC/Version4/gcc-4.5.0-1/
-binutils-2.21-2-mingw32-bin.tar.lzma			http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GNU-Binutils/binutils-2.21/
-yasm-1.1.0-win32.exe							http://www.tortall.net/projects/yasm/releases/
-dlfcn-win32-static-r19.tar.bz2					http://dlfcn-win32.googlecode.com/files/
-libexpat-2.0.1-1-mingw32-dev.tar.gz				http://downloads.sourceforge.net/project/mingw/MinGW/expat/expat-2.0.1-1/
-libz-1.2.3-1-mingw32-dev.tar.gz					http://downloads.sourceforge.net/project/mingw/MinGW/zlib/zlib-1.2.3-1-mingw32/
-libgmp-5.0.1-1-mingw32-dll-10.tar.lzma			http://downloads.sourceforge.net/project/mingw/MinGW/gmp/gmp-5.0.1-1/
-libmpc-0.8.1-1-mingw32-dll-2.tar.lzma			http://downloads.sourceforge.net/project/mingw/MinGW/mpc/mpc-0.8.1-1/
-libmpfr-2.4.1-1-mingw32-dll-1.tar.lzma			http://downloads.sourceforge.net/project/mingw/MinGW/mpfr/mpfr-2.4.1-1/
-automake1.11-1.11.1-1-mingw32-bin.tar.lzma		http://downloads.sourceforge.net/project/mingw/MinGW/automake/automake1.11/automake1.11-1.11.1-1/
-libtool-2.4-1-mingw32-bin.tar.lzma				http://downloads.sourceforge.net/project/mingw/MinGW/libtool/libtool-2.4-1/
+; filename                                  mirror                                                     source of the file
+mingwrt-3.18-mingw32-dev.tar.gz             http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/RuntimeLibrary/MinGW-RT/mingwrt-3.18/
+mingwrt-3.18-mingw32-dll.tar.gz             http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/RuntimeLibrary/MinGW-RT/mingwrt-3.18/
+w32api-3.15-1-mingw32-dev.tar.lzma          http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/RuntimeLibrary/Win32-API/w32api-3.15/
+gcc-core-4.5.0-1-mingw32-bin.tar.lzma       http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GCC/Version4/gcc-4.5.0-1/
+gcc-c++-4.5.0-1-mingw32-bin.tar.lzma        http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GCC/Version4/gcc-4.5.0-1/
+libstdc++-4.5.0-1-mingw32-dll-6.tar.lzma    http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GCC/Version4/gcc-4.5.0-1/
+binutils-2.21-2-mingw32-bin.tar.lzma        http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/BaseSystem/GNU-Binutils/binutils-2.21/
+yasm-1.1.0-win32.exe                        http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://www.tortall.net/projects/yasm/releases/
+dlfcn-win32-static-r19.tar.bz2              http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://dlfcn-win32.googlecode.com/files/
+libexpat-2.0.1-1-mingw32-dev.tar.gz         http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/expat/expat-2.0.1-1/
+libz-1.2.3-1-mingw32-dev.tar.gz             http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/zlib/zlib-1.2.3-1-mingw32/
+libgmp-5.0.1-1-mingw32-dll-10.tar.lzma      http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/gmp/gmp-5.0.1-1/
+libmpc-0.8.1-1-mingw32-dll-2.tar.lzma       http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/mpc/mpc-0.8.1-1/
+libmpfr-2.4.1-1-mingw32-dll-1.tar.lzma      http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/mpfr/mpfr-2.4.1-1/
+automake1.11-1.11.1-1-mingw32-bin.tar.lzma  http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/automake/automake1.11/automake1.11-1.11.1-1/
+libtool-2.4-1-mingw32-bin.tar.lzma          http://mirrors.xbmc.org/build-deps/win32/mingw-msys/       http://downloads.sourceforge.net/project/mingw/MinGW/libtool/libtool-2.4-1/

--- a/project/BuildDependencies/scripts/get_msys_env.txt
+++ b/project/BuildDependencies/scripts/get_msys_env.txt
@@ -1,30 +1,30 @@
-; filename                        source of the file
-msysCORE-1.0.16-1-msys-1.0.16-bin.tar.lzma				http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/msys-core/msys-1.0.16-1/
-msysCORE-1.0.16-1-msys-1.0.16-ext.tar.lzma				http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/msys-core/msys-1.0.16-1/
-libregex-1.20090805-2-msys-1.0.13-dll-1.tar.lzma		http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/regex/regex-1.20090805-2/
-libtermcap-0.20050421_1-2-msys-1.0.13-dll-0.tar.lzma	http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/termcap/termcap-0.20050421_1-2/
-gettext-0.17-2-msys-1.0.13-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/gettext/gettext-0.17-2/
-libintl-0.17-2-msys-dll-8.tar.lzma						http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/gettext/gettext-0.17-2/
-libiconv-1.13.1-2-msys-1.0.13-dll-2.tar.lzma			http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/libiconv/libiconv-1.13.1-2/
-coreutils-5.97-3-msys-1.0.13-bin.tar.lzma				http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/coreutils/coreutils-5.97-3/
-bash-3.1.17-4-msys-1.0.16-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/bash/bash-3.1.17-4/
-rxvt-2.7.2-3-msys-1.0.14-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/rxvt/rxvt-2.7.2-3/
-make-3.81-3-msys-1.0.13-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/make/make-3.81-3/
-sed-4.2.1-2-msys-1.0.13-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/sed/sed-4.2.1-2/
-grep-2.5.4-2-msys-1.0.13-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/grep/grep-2.5.4-2/
-diffutils-2.8.7.20071206cvs-3-msys-1.0.13-bin.tar.lzma	http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/diffutils/diffutils-2.8.7.20071206cvs-3/
-tar-1.23-1-msys-1.0.13-bin.tar.lzma						http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/tar/tar-1.23-1/
-gzip-1.3.12-2-msys-1.0.13-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/gzip/gzip-1.3.12-2/
-gawk-3.1.7-2-msys-1.0.13-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/gawk/gawk-3.1.7-2/
-xz-4.999.9beta_20100401-1-msys-1.0.13-bin.tar.gz		http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/xz/xz-4.999.9beta_20100401-1/
-patch-2.6.1-1-msys-1.0.13-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/patch/patch-2.6.1-1/
-perl-5.6.1_2-2-msys-1.0.13-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/perl/perl-5.6.1_2-2/
-libcrypt-1.1_1-3-msys-1.0.13-dll-0.tar.lzma				http://downloads.sourceforge.net/project/mingw/MSYS/crypt/crypt-1.1_1-3/
-autoconf-2.67-1-msys-1.0.15-bin.tar.lzma				http://downloads.sourceforge.net/project/mingw/MSYS/autoconf/autoconf-2.67-1/
-m4-1.4.14-1-msys-1.0.13-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/m4/m4-1.4.14-1/
+; filename                                              mirror                                                   source of the file
+msysCORE-1.0.16-1-msys-1.0.16-bin.tar.lzma              http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/msys-core/msys-1.0.16-1/
+msysCORE-1.0.16-1-msys-1.0.16-ext.tar.lzma              http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/msys-core/msys-1.0.16-1/
+libregex-1.20090805-2-msys-1.0.13-dll-1.tar.lzma        http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/regex/regex-1.20090805-2/
+libtermcap-0.20050421_1-2-msys-1.0.13-dll-0.tar.lzma    http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/termcap/termcap-0.20050421_1-2/
+gettext-0.17-2-msys-1.0.13-bin.tar.lzma                 http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/gettext/gettext-0.17-2/
+libintl-0.17-2-msys-dll-8.tar.lzma                      http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/gettext/gettext-0.17-2/
+libiconv-1.13.1-2-msys-1.0.13-dll-2.tar.lzma            http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/libiconv/libiconv-1.13.1-2/
+coreutils-5.97-3-msys-1.0.13-bin.tar.lzma               http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/coreutils/coreutils-5.97-3/
+bash-3.1.17-4-msys-1.0.16-bin.tar.lzma                  http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/bash/bash-3.1.17-4/
+rxvt-2.7.2-3-msys-1.0.14-bin.tar.lzma                   http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/rxvt/rxvt-2.7.2-3/
+make-3.81-3-msys-1.0.13-bin.tar.lzma                    http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/make/make-3.81-3/
+sed-4.2.1-2-msys-1.0.13-bin.tar.lzma                    http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/sed/sed-4.2.1-2/
+grep-2.5.4-2-msys-1.0.13-bin.tar.lzma                   http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/grep/grep-2.5.4-2/
+diffutils-2.8.7.20071206cvs-3-msys-1.0.13-bin.tar.lzma  http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/diffutils/diffutils-2.8.7.20071206cvs-3/
+tar-1.23-1-msys-1.0.13-bin.tar.lzma                     http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/tar/tar-1.23-1/
+gzip-1.3.12-2-msys-1.0.13-bin.tar.lzma                  http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/gzip/gzip-1.3.12-2/
+gawk-3.1.7-2-msys-1.0.13-bin.tar.lzma                   http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/gawk/gawk-3.1.7-2/
+xz-4.999.9beta_20100401-1-msys-1.0.13-bin.tar.gz        http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/BaseSystem/xz/xz-4.999.9beta_20100401-1/
+patch-2.6.1-1-msys-1.0.13-bin.tar.lzma                  http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/patch/patch-2.6.1-1/
+perl-5.6.1_2-2-msys-1.0.13-bin.tar.lzma                 http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/perl/perl-5.6.1_2-2/
+libcrypt-1.1_1-3-msys-1.0.13-dll-0.tar.lzma             http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/crypt/crypt-1.1_1-3/
+autoconf-2.67-1-msys-1.0.15-bin.tar.lzma                http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/autoconf/autoconf-2.67-1/
+m4-1.4.14-1-msys-1.0.13-bin.tar.lzma                    http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/m4/m4-1.4.14-1/
 ; to get pr.exe
-coreutils-5.97-MSYS-1.0.11-snapshot.tar.bz2				http://www.finalmediaplayer.com/downloads/3rdparty/
+coreutils-5.97-MSYS-1.0.11-snapshot.tar.bz2             http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://www.finalmediaplayer.com/downloads/3rdparty/
 ; for xargs.exe
-findutils-4.4.2-2-msys-1.0.13-bin.tar.lzma				http://downloads.sourceforge.net/project/mingw/MSYS/findutils/findutils-4.4.2-2/
-automake-1.11.1-1-msys-1.0.13-bin.tar.lzma				http://downloads.sourceforge.net/project/mingw/MSYS/automake/automake-1.11.1-1/
-mktemp-1.6-2-msys-1.0.13-bin.tar.lzma					http://downloads.sourceforge.net/project/mingw/MSYS/mktemp/mktemp-1.6-2/
+findutils-4.4.2-2-msys-1.0.13-bin.tar.lzma              http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/findutils/findutils-4.4.2-2/
+automake-1.11.1-1-msys-1.0.13-bin.tar.lzma              http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/automake/automake-1.11.1-1/
+mktemp-1.6-2-msys-1.0.13-bin.tar.lzma                   http://mirrors.xbmc.org/build-deps/win32/mingw-msys/     http://downloads.sourceforge.net/project/mingw/MSYS/mktemp/mktemp-1.6-2/

--- a/project/BuildDependencies/scripts/libbluray_d.txt
+++ b/project/BuildDependencies/scripts/libbluray_d.txt
@@ -1,2 +1,2 @@
-; filename                        source of the file
-libbluray-20110222-dll.zip         http://mirrors.xbmc.org/build-deps/win32/eden/
+; filename                         source of the file
+libbluray-20110222-dll.zip         http://mirrors.xbmc.org/build-deps/win32/

--- a/project/BuildDependencies/scripts/libbzip2_d.txt
+++ b/project/BuildDependencies/scripts/libbzip2_d.txt
@@ -1,2 +1,2 @@
-; filename                        source of the file
-bzip2-1.0.5-lib.zip         http://downloads.sourceforge.net/project/gnuwin32/bzip2/1.0.5/
+; filename                  mirror                                     source of the file
+bzip2-1.0.5-lib.zip         http://mirrors.xbmc.org/build-deps/win32/  http://downloads.sourceforge.net/project/gnuwin32/bzip2/1.0.5/

--- a/project/BuildDependencies/scripts/libcurl_d.txt
+++ b/project/BuildDependencies/scripts/libcurl_d.txt
@@ -1,2 +1,2 @@
-; filename                        source of the file
-curl-7.21.1-devel-mingw32.zip           http://www.gknw.de/mirror/curl/win32/old_releases/
+; filename                        mirror                                     source of the file
+curl-7.21.1-devel-mingw32.zip     http://mirrors.xbmc.org/build-deps/win32/  http://www.gknw.de/mirror/curl/win32/old_releases/

--- a/project/BuildDependencies/scripts/libexpat_d.txt
+++ b/project/BuildDependencies/scripts/libexpat_d.txt
@@ -1,3 +1,3 @@
-; filename                        source of the file
-expat_2.0.1-1_win32.zip           http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies
-expat-dev_2.0.1-1_win32.zip       http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies
+; filename                        mirror                                           source of the file
+expat_2.0.1-1_win32.zip           http://mirrors.xbmc.org/build-deps/win32/        http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies
+expat-dev_2.0.1-1_win32.zip       http://mirrors.xbmc.org/build-deps/win32/        http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies

--- a/project/BuildDependencies/scripts/libfribidi_d.txt
+++ b/project/BuildDependencies/scripts/libfribidi_d.txt
@@ -1,2 +1,2 @@
-; filename                        source of the file
-fribidi-0.19.2-lib.zip         http://xbmcwindeps.googlecode.com/files/
+; filename                     mirror                                     source of the file
+fribidi-0.19.2-lib.zip         http://mirrors.xbmc.org/build-deps/win32/  http://xbmcwindeps.googlecode.com/files/

--- a/project/BuildDependencies/scripts/libglew_d.txt
+++ b/project/BuildDependencies/scripts/libglew_d.txt
@@ -1,2 +1,2 @@
-; filename                        source of the file
-glew-1.5.0-win32.zip          http://downloads.sourceforge.net/glew/
+; filename                    mirror                                     source of the file
+glew-1.5.0-win32.zip          http://mirrors.xbmc.org/build-deps/win32/  http://downloads.sourceforge.net/glew/

--- a/project/BuildDependencies/scripts/librtmp_d.txt
+++ b/project/BuildDependencies/scripts/librtmp_d.txt
@@ -1,3 +1,3 @@
-; filename                        source of the file
-rtmpdump-2.3-windows.zip          http://rtmpdump.mplayerhq.hu/download/
-rtmpdump-2.3.tgz                  http://rtmpdump.mplayerhq.hu/download/
+; filename                        mirror                                     source of the file
+rtmpdump-2.3-windows.zip          http://mirrors.xbmc.org/build-deps/win32/  http://rtmpdump.mplayerhq.hu/download/
+rtmpdump-2.3.tgz                  http://mirrors.xbmc.org/build-deps/win32/  http://rtmpdump.mplayerhq.hu/download/

--- a/project/BuildDependencies/scripts/libsdl_d.txt
+++ b/project/BuildDependencies/scripts/libsdl_d.txt
@@ -1,3 +1,3 @@
-; filename                        source of the file
-SDL-devel-1.2.14-VC8.zip          http://www.libsdl.org/release/
-SDL_image-devel-1.2.10-VC.zip     http://www.libsdl.org/projects/SDL_image/release/
+; filename                        mirror                                     source of the file
+SDL-devel-1.2.14-VC8.zip          http://mirrors.xbmc.org/build-deps/win32/  http://www.libsdl.org/release/
+SDL_image-devel-1.2.10-VC.zip     http://mirrors.xbmc.org/build-deps/win32/  http://www.libsdl.org/projects/SDL_image/release/

--- a/project/BuildDependencies/scripts/mysqlclient_d.txt
+++ b/project/BuildDependencies/scripts/mysqlclient_d.txt
@@ -1,2 +1,2 @@
-; filename                        source of the file
-mysql-connector-c-noinstall-6.0.2-win32.zip         http://ftp.gwdg.de/pub/misc/mysql/Downloads/Connector-C/
+; filename                                      mirror                                     source of the file
+mysql-connector-c-noinstall-6.0.2-win32.zip     http://mirrors.xbmc.org/build-deps/win32/  http://ftp.gwdg.de/pub/misc/mysql/Downloads/Connector-C/

--- a/project/BuildDependencies/scripts/pysqlite_d.txt
+++ b/project/BuildDependencies/scripts/pysqlite_d.txt
@@ -1,2 +1,2 @@
-; filename                        source of the file
-pysqlite-2.5.6.win32-py2.4.exe    http://pysqlite.googlecode.com/files/
+; filename                        mirror                                     source of the file
+pysqlite-2.5.6.win32-py2.4.exe    http://mirrors.xbmc.org/build-deps/win32/  http://pysqlite.googlecode.com/files/


### PR DESCRIPTION
The original source for a prebuilt package is not always stable, especially for older revisions. With this change, the packages are stored in the XBMC mirror system and the Windows build will download from there.
The original URL is still there just in case.

@WiSo, I didn't do the MingW/Msys environment but I think it would be a bit better to store those in a sub directory. It doesn't make much of a difference anyway. What do you think?
