### PR TITLE
UPnP Server enhancements/fixes

### DIFF
--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -534,7 +534,7 @@ CUPnPServer::PopulateObjectFromTag(CVideoInfoTag&         tag,
 
     object.m_Description.description = tag.m_strTagLine;
     object.m_Description.long_description = tag.m_strPlot;
-    if (resource) resource->m_Duration = StringUtils::TimeStringToSeconds(tag.m_strRuntime.c_str());
+    if (resource) resource->m_Duration = tag.m_streamDetails.GetVideoDuration();
     if (resource) resource->m_Resolution = NPT_String::FromInteger(tag.m_streamDetails.GetVideoWidth()) + "x" + NPT_String::FromInteger(tag.m_streamDetails.GetVideoHeight());
 
     return NPT_SUCCESS;

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -503,11 +503,13 @@ CUPnPServer::PopulateObjectFromTag(CVideoInfoTag&         tag,
           object.m_Recorded.series_title = tag.m_strShowTitle;
           object.m_Recorded.episode_number = tag.m_iSeason * 100 + tag.m_iEpisode;
           object.m_Title = object.m_Recorded.series_title + " - " + object.m_Recorded.program_title;
+          object.m_Date = tag.m_strFirstAired;
           if(tag.m_iSeason != -1)
               object.m_ReferenceID = NPT_String::Format("videodb://2/0/%i", tag.m_iDbId);
         } else {
           object.m_ObjectClass.type = "object.item.videoItem.movie";
           object.m_Title = tag.m_strTitle;
+          object.m_Date = NPT_String::FromInteger(tag.m_iYear) + "-01-01";
           object.m_ReferenceID = NPT_String::Format("videodb://1/2/%i", tag.m_iDbId);
         }
     }
@@ -621,11 +623,6 @@ CUPnPServer::BuildObject(const CFileItem&              item,
         }
         if(resource.m_Size == 0)
           resource.m_Size = (NPT_LargeSize)-1;
-
-        // set date
-        if (item.m_dateTime.IsValid()) {
-            object->m_Date = item.m_dateTime.GetAsLocalizedDate();
-        }
 
         if (upnp_server) {
             // iterate through ip addresses and build list of resources

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -769,11 +769,10 @@ CUPnPServer::BuildObject(const CFileItem&              item,
             item.GetThumbnailImage());
         // Set DLNA profileID by extension, defaulting to JPEG.
         NPT_String ext = URIUtils::GetExtension(item.GetThumbnailImage()).c_str();
-        if (strcmp(ext, ".png") == 0) {
+        if (strcmp(ext, ".png") == 0)
             object->m_ExtraInfo.album_art_uri_dlna_profile = "PNG_TN";
-        } else {
+        else
             object->m_ExtraInfo.album_art_uri_dlna_profile = "JPEG_TN";
-        }
     }
 
     return object;

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -535,6 +535,7 @@ CUPnPServer::PopulateObjectFromTag(CVideoInfoTag&         tag,
     object.m_Description.description = tag.m_strTagLine;
     object.m_Description.long_description = tag.m_strPlot;
     if (resource) resource->m_Duration = StringUtils::TimeStringToSeconds(tag.m_strRuntime.c_str());
+    if (resource) resource->m_Resolution = NPT_String::FromInteger(tag.m_streamDetails.GetVideoWidth()) + "x" + NPT_String::FromInteger(tag.m_streamDetails.GetVideoHeight());
 
     return NPT_SUCCESS;
 }

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -762,6 +762,7 @@ CUPnPServer::BuildObject(const CFileItem&              item,
         object->m_ExtraInfo.album_art_uri = upnp_server->BuildSafeResourceUri(
             (*ips.GetFirstItem()).ToString(),
             item.GetThumbnailImage());
+        object->m_ExtraInfo.album_art_uri_dlna_profile = "JPEG_TN";
     }
 
     return object;

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -762,6 +762,12 @@ CUPnPServer::BuildObject(const CFileItem&              item,
         object->m_ExtraInfo.album_art_uri = upnp_server->BuildSafeResourceUri(
             (*ips.GetFirstItem()).ToString(),
             item.GetThumbnailImage());
+        // Set DLNA profileID by extension, defaulting to JPEG.
+        NPT_String ext = URIUtils::GetExtension(item.GetThumbnailImage()).c_str();
+        if (strcmp(ext, ".png") == 0)
+            object->m_ExtraInfo.album_art_uri_dlna_profile = "PNG_TN";
+        else
+            object->m_ExtraInfo.album_art_uri_dlna_profile = "JPEG_TN";
     }
 
     return object;

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -767,7 +767,13 @@ CUPnPServer::BuildObject(const CFileItem&              item,
         object->m_ExtraInfo.album_art_uri = upnp_server->BuildSafeResourceUri(
             (*ips.GetFirstItem()).ToString(),
             item.GetThumbnailImage());
-        object->m_ExtraInfo.album_art_uri_dlna_profile = "JPEG_TN";
+        // Set DLNA profileID by extension, defaulting to JPEG.
+        NPT_String ext = URIUtils::GetExtension(item.GetThumbnailImage()).c_str();
+        if (strcmp(ext, ".png") == 0) {
+            object->m_ExtraInfo.album_art_uri_dlna_profile = "PNG_TN";
+        } else {
+            object->m_ExtraInfo.album_art_uri_dlna_profile = "JPEG_TN";
+        }
     }
 
     return object;

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -625,6 +625,11 @@ CUPnPServer::BuildObject(const CFileItem&              item,
         if(resource.m_Size == 0)
           resource.m_Size = (NPT_LargeSize)-1;
 
+        // set date
+        if (object->m_Date.IsEmpty() && item.m_dateTime.IsValid()) {
+            object->m_Date = item.m_dateTime.GetAsLocalizedDate();
+        }
+
         if (upnp_server) {
             // iterate through ip addresses and build list of resources
             // through http file server


### PR DESCRIPTION
This adds/fixes 4 issues:
- PS3 properly displays thumbnails (Ticket #7708 - http://trac.xbmc.org/ticket/7708)
- Properly sets the duration
- Properly sets the date
- Adds resolution info.

This is my first use of github and first work on XBMC, so please be gentle... :) I'm a big fan o' XBMC and use it extensively with a PS3 as my UPnP client, and I decided to try and improve the out of the box experience. There's still quite a bit more that can be done around UPnP support, but these changes are all pretty minor, so I figured I'd start by pushing them upstream to see if what I'm doing is useful, or if there's changes I need to make. For the last 3 items I didn't see any trac tickets, but if you'd prefer me to open them, let me know, I'm happy to do whatever - or if I need to submit via a different format, or whatever. Thanks!
