### PR TITLE
Prepend date to git version string

### DIFF
--- a/addons/skin.confluence/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence/720p/SettingsSystemInfo.xml
@@ -266,7 +266,7 @@
 					<description>XBMC XBE BUILD Version</description>
 					<posx>750</posx>
 					<posy>400</posy>
-					<width>700</width>
+					<width>730</width>
 					<label>144</label>
 					<align>right</align>
 					<textcolor>blue</textcolor>

--- a/configure.in
+++ b/configure.in
@@ -1237,7 +1237,7 @@ else
 fi
 
 if test "$HAVE_GIT" = "yes"; then
-  GIT_REV=$(git rev-parse --short HEAD)
+  GIT_REV=$(git log -1 --pretty=format:"%h %ci" HEAD | awk '{gsub("-", "");print $2"-"$1}')
 fi
 if test "$GIT_REV" = ""; then
   GIT_REV="Unknown"

--- a/project/Win32BuildSetup/BuildSetup.bat
+++ b/project/Win32BuildSetup/BuildSetup.bat
@@ -207,8 +207,7 @@ IF %comp%==vs2010 (
   call genNsisIncludes.bat
   ECHO ------------------------------------------------------------
   CALL extract_git_rev.bat
-  SET GIT_REV=_%GIT_REV%
-  SET XBMC_SETUPFILE=XBMCSetup-Rev%GIT_REV%-%target%.exe
+  SET XBMC_SETUPFILE=XBMCSetup-%GIT_REV%-%target%.exe
   ECHO Creating installer %XBMC_SETUPFILE%...
   IF EXIST %XBMC_SETUPFILE% del %XBMC_SETUPFILE% > NUL
   rem get path to makensis.exe from registry, first try tab delim

--- a/project/Win32BuildSetup/XBMC for Windows.nsi
+++ b/project/Win32BuildSetup/XBMC for Windows.nsi
@@ -15,7 +15,7 @@
 
   ;Name and file
   Name "XBMC"
-  OutFile "XBMCSetup-Rev${xbmc_revision}-${xbmc_target}.exe"
+  OutFile "XBMCSetup-${xbmc_revision}-${xbmc_target}.exe"
 
   XPStyle on
   

--- a/project/Win32BuildSetup/extract_git_rev.bat
+++ b/project/Win32BuildSetup/extract_git_rev.bat
@@ -26,7 +26,7 @@ GOTO :done
 
 SET oldCurrentDir=%CD%
 CD ..\..
-FOR /F "tokens=1 delims= " %%A IN ('%GITEXE% rev-parse --short HEAD') DO SET GIT_REV=%%A
+FOR /F "tokens=1-4 delims=-" %%A IN ('"%GITEXE% --no-pager log -1 --date=short --pretty=format:"%%cd-%%h""') DO SET GIT_REV=%%A%%B%%C-%%D
 CD %oldCurrentDir%
 
 :done

--- a/project/Win32BuildSetup/readme.txt
+++ b/project/Win32BuildSetup/readme.txt
@@ -8,4 +8,4 @@ Usage:
 1) Run BuildSetup.bat in project\Win32BuildSetup
 2) Watch the screen, maybe you're asked for input
 3) Wait... Wait... Wait...
-You should now have XBMCSetup-Rev<svnrevisionnr>.exe file.
+You should now have XBMCSetup-<lastcommitdate-gitrev>.exe file.


### PR DESCRIPTION
I've mentioned this a few times on IRC. Should be working on linux/osx/win32. Would an ack from BSD that there aren't any silly issues with the awk.

This is mainly to address sorting on the mirrors, but also lets us see easily where a git revision lines up chronologically, regardless of the build date.
