### PR TITLE
make inotify optional

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -475,6 +475,9 @@ AC_CHECK_SIZEOF([size_t])
 # Add top source directory for all builds so we can use config.h
 INCLUDES="$INCLUDES -I\$(abs_top_srcdir)"
 
+# Check inotify availability
+AC_CHECK_HEADER([sys/inotify.h], AC_DEFINE([HAVE_INOTIFY],[1],[Define if we have inotify]),)
+
 # Checks for boost headers using CXX instead of CC
 AC_LANG_PUSH([C++])
 AC_CHECK_HEADER([boost/shared_ptr.hpp],, AC_MSG_ERROR($missing_library))


### PR DESCRIPTION
actually we only uses inotify to find out when
lircd is stopped, which at least on FreeBSD it will also find out
by receiving an eof from the socket fd so we can actually just
disable the inotify code.

lirc device works fine on FreeBSD.
inotify header detection tested on Ubuntu
