### PR TITLE
JSON RPC PlayMedia

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3301,6 +3301,14 @@ void CApplication::Stop(int exitCode)
 
 bool CApplication::PlayMedia(const CFileItem& item, int iPlaylist)
 {
+	//If item is a plugin, expand out now and run ourselves again
+	if (item.IsPlugin())
+	{
+		CFileItem item_new(item);
+		if (XFILE::CPluginDirectory::GetPluginResult(item.GetPath(), item_new))
+			return PlayMedia(item_new, iPlaylist);
+		return false;
+	}
   if (item.IsLastFM())
   {
     g_partyModeManager.Disable();

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -314,10 +314,17 @@ case TMSG_POWERDOWN:
               }
             }
 
-            g_playlistPlayer.ClearPlaylist(playlist);
-            g_playlistPlayer.Add(playlist, (*list));
-            g_playlistPlayer.SetCurrentPlaylist(playlist);
-            g_playlistPlayer.Play(pMsg->dwParam1);
+            //For single item lists try PlayMedia. This covers some more cases where a playlist is not appropriate
+            //It will fall through to PlayFile
+            if (list->Size() == 1 && !(*list)[0]->IsPlayList())
+            	g_application.PlayMedia(*((*list)[0]), playlist);
+            else
+            {
+							g_playlistPlayer.ClearPlaylist(playlist);
+							g_playlistPlayer.Add(playlist, (*list));
+							g_playlistPlayer.SetCurrentPlaylist(playlist);
+							g_playlistPlayer.Play(pMsg->dwParam1);
+            }
           }
 
           delete list;


### PR DESCRIPTION
Allows calls to g_ApplicationMessenger.MediaPlay (from JSON RPC for example) to feed through to g_Application.PlayMedia in appropriate circumstances (single file, not a playlist). This Allows Smart Playlists/Last.FM streams to be played using the JSON RPC.

Also adds plugin resolver code to PlayMedia so that plugins can resolve to internet playlists etc.
See this thread: http://forum.xbmc.org/showthread.php?p=749348#post749348
