### PR TITLE
Addon dependency checking

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2162,6 +2162,8 @@
   <string id="24041">Install from zip file</string>
   <string id="24042">Downloading %i%%</string>
   <string id="24043">Available Updates</string>
+  <string id="24044">Dependencies not met</string>
+  <string id="24045">Add-on does not have the correct structure</string>
 
   <string id="24050">Available Add-ons</string>
   <string id="24051">Version:</string>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -219,6 +219,7 @@
 #include "dialogs/GUIDialogSlider.h"
 #include "guilib/GUIControlFactory.h"
 #include "dialogs/GUIDialogCache.h"
+#include "addons/AddonInstaller.h"
 
 #ifdef HAS_PERFORMANCE_SAMPLE
 #include "utils/PerformanceSample.h"
@@ -4787,7 +4788,7 @@ void CApplication::ProcessSlow()
 #endif
   
   if (!IsPlayingVideo())
-    ADDON::CAddonMgr::Get().UpdateRepos();
+    CAddonInstaller::Get().UpdateRepos();
 }
 
 // Global Idle Time in Seconds

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -288,11 +288,9 @@ void AddonProps::BuildDependencies(const cp_plugin_info_t *plugin)
 {
   if (!plugin)
     return;
-  // TODO: no need for a pair of versions here here - could use the optional flag instead?
   for (unsigned int i = 0; i < plugin->num_imports; ++i)
     dependencies.insert(make_pair(CStdString(plugin->imports[i].plugin_id),
-                        make_pair(AddonVersion(plugin->imports[i].version),
-                                  AddonVersion(plugin->imports[i].version))));
+                        make_pair(AddonVersion(plugin->imports[i].version), plugin->imports[i].optional != 0)));
 }
 
 /**

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -273,6 +273,17 @@ AddonProps::AddonProps(const cp_extension_t *ext)
   BuildDependencies(ext->plugin);
 }
 
+AddonProps::AddonProps(const cp_plugin_info_t *plugin)
+  : id(plugin->identifier)
+  , version(plugin->version)
+  , name(plugin->name)
+  , path(plugin->plugin_path)
+  , author(plugin->provider_name)
+  , stars(0)
+{
+  BuildDependencies(plugin);
+}
+
 void AddonProps::BuildDependencies(const cp_plugin_info_t *plugin)
 {
   if (!plugin)
@@ -300,6 +311,18 @@ CAddon::CAddon(const cp_extension_t *ext)
   m_hasSettings = true;
   m_hasStrings = false;
   m_checkedStrings = false;
+  m_settingsLoaded = false;
+  m_userSettingsLoaded = false;
+}
+
+CAddon::CAddon(const cp_plugin_info_t *plugin)
+  : m_props(plugin)
+  , m_parent(AddonPtr())
+{
+  m_enabled = true;
+  m_hasSettings = false;
+  m_hasStrings = false;
+  m_checkedStrings = true;
   m_settingsLoaded = false;
   m_userSettingsLoaded = false;
 }

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -270,6 +270,18 @@ AddonProps::AddonProps(const cp_extension_t *ext)
     EMPTY_IF("noicon",icon)
     EMPTY_IF("nochangelog",changelog)
   }
+  BuildDependencies(ext->plugin);
+}
+
+void AddonProps::BuildDependencies(const cp_plugin_info_t *plugin)
+{
+  if (!plugin)
+    return;
+  // TODO: no need for a pair of versions here here - could use the optional flag instead?
+  for (unsigned int i = 0; i < plugin->num_imports; ++i)
+    dependencies.insert(make_pair(CStdString(plugin->imports[i].plugin_id),
+                        make_pair(AddonVersion(plugin->imports[i].version),
+                                  AddonVersion(plugin->imports[i].version))));
 }
 
 /**
@@ -603,11 +615,6 @@ const CStdString CAddon::Icon() const
 const CStdString CAddon::LibPath() const
 {
   return URIUtils::AddFileToFolder(m_props.path, m_strLibName);
-}
-
-ADDONDEPS CAddon::GetDeps()
-{
-  return CAddonMgr::Get().GetDeps(ID());
 }
 
 /**

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -246,6 +246,7 @@ CStdString AddonVersion::Print() const
 AddonProps::AddonProps(const cp_extension_t *ext)
   : id(ext->plugin->identifier)
   , version(ext->plugin->version)
+  , minversion(ext->plugin->abi_bw_compatibility)
   , name(ext->plugin->name)
   , path(ext->plugin->plugin_path)
   , author(ext->plugin->provider_name)
@@ -276,6 +277,7 @@ AddonProps::AddonProps(const cp_extension_t *ext)
 AddonProps::AddonProps(const cp_plugin_info_t *plugin)
   : id(plugin->identifier)
   , version(plugin->version)
+  , minversion(plugin->abi_bw_compatibility)
   , name(plugin->name)
   , path(plugin->plugin_path)
   , author(plugin->provider_name)
@@ -363,9 +365,9 @@ AddonPtr CAddon::Clone(const AddonPtr &self) const
   return AddonPtr(new CAddon(*this, self));
 }
 
-const AddonVersion CAddon::Version()
+bool CAddon::MeetsVersion(const AddonVersion &version) const
 {
-  return m_props.version;
+  return m_props.minversion <= version && version <= m_props.version;
 }
 
 //TODO platform/path crap should be negotiated between the addon and

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -62,10 +62,11 @@ public:
 class AddonProps
 {
 public:
-  AddonProps(const CStdString &id, TYPE type, const CStdString &versionstr)
+  AddonProps(const CStdString &id, TYPE type, const CStdString &versionstr, const CStdString &minversionstr)
     : id(id)
     , type(type)
     , version(versionstr)
+    , minversion(minversionstr)
     , stars(0)
   {
   }
@@ -83,6 +84,7 @@ public:
   CStdString id;
   TYPE type;
   AddonVersion version;
+  AddonVersion minversion;
   CStdString name;
   CStdString parent;
   CStdString license;
@@ -159,7 +161,8 @@ public:
   const CStdString Name() const { return m_props.name; }
   bool Enabled() const { return m_enabled; }
   virtual bool IsInUse() const { return false; };
-  const AddonVersion Version();
+  const AddonVersion Version() const { return m_props.version; }
+  const AddonVersion MinVersion() const { return m_props.minversion; }
   const CStdString Summary() const { return m_props.summary; }
   const CStdString Description() const { return m_props.description; }
   const CStdString Path() const { return m_props.path; }
@@ -173,6 +176,12 @@ public:
   const CStdString Disclaimer() const { return m_props.disclaimer; }
   const InfoMap &ExtraInfo() const { return m_props.extrainfo; }
   const ADDONDEPS &GetDeps() const { return m_props.dependencies; }
+
+  /*! \brief return whether or not this addon satisfies the given version requirements
+   \param version the version to meet.
+   \return true if  min_version <= version <= current_version, false otherwise.
+   */
+  bool MeetsVersion(const AddonVersion &version) const;
 
 protected:
   CAddon(const CAddon&); // protected as all copying is handled by Clone()

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -71,6 +71,7 @@ public:
   }
 
   AddonProps(const cp_extension_t *ext);
+  AddonProps(const cp_plugin_info_t *plugin);
 
   bool operator==(const AddonProps &rhs)
   { 
@@ -110,6 +111,7 @@ class CAddon : public IAddon
 public:
   CAddon(const AddonProps &addonprops);
   CAddon(const cp_extension_t *ext);
+  CAddon(const cp_plugin_info_t *plugin);
   virtual ~CAddon() {}
   virtual AddonPtr Clone(const AddonPtr& parent) const;
 

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -99,6 +99,8 @@ public:
   CStdString broken;
   InfoMap    extrainfo;
   int        stars;
+private:
+  void BuildDependencies(const cp_plugin_info_t *plugin);
 };
 
 typedef std::vector<class AddonProps> VECADDONPROPS;
@@ -168,7 +170,7 @@ public:
   int Stars() const { return m_props.stars; }
   const CStdString Disclaimer() const { return m_props.disclaimer; }
   const InfoMap &ExtraInfo() const { return m_props.extrainfo; }
-  ADDONDEPS GetDeps();
+  const ADDONDEPS &GetDeps() const { return m_props.dependencies; }
 
 protected:
   CAddon(const CAddon&); // protected as all copying is handled by Clone()

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -56,7 +56,9 @@ public:
   bool operator<(const AddonVersion &rhs) const;
   bool operator<=(const AddonVersion &rhs) const;
   CStdString Print() const;
-  const CStdString str;
+  const char *c_str() const { return str.c_str(); };
+private:
+  CStdString str;
 };
 
 class AddonProps

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -193,9 +193,9 @@ int CAddonDatabase::AddAddon(const AddonPtr& addon,
                                addon->Description().c_str(),addon->Stars(),
                                addon->Path().c_str(), addon->Props().icon.c_str(),
                                addon->ChangeLog().c_str(),addon->FanArt().c_str(),
-                               addon->ID().c_str(), addon->Version().str.c_str(),
+                               addon->ID().c_str(), addon->Version().c_str(),
                                addon->Author().c_str(),addon->Disclaimer().c_str(),
-                               addon->MinVersion().str.c_str());
+                               addon->MinVersion().c_str());
     m_pDS->exec(sql.c_str());
     int idAddon = (int)m_pDS->lastinsertid();
 
@@ -211,7 +211,7 @@ int CAddonDatabase::AddAddon(const AddonPtr& addon,
     const ADDONDEPS &deps = addon->GetDeps();
     for (ADDONDEPS::const_iterator i = deps.begin(); i != deps.end(); ++i)
     {
-      sql = PrepareSQL("insert into dependencies(id, addon, version, optional) values (%i, '%s', '%s', %i)", idAddon, i->first.c_str(), i->second.first.str.c_str(), i->second.second ? 1 : 0);
+      sql = PrepareSQL("insert into dependencies(id, addon, version, optional) values (%i, '%s', '%s', %i)", idAddon, i->first.c_str(), i->second.first.c_str(), i->second.second ? 1 : 0);
       m_pDS->exec(sql.c_str());
     }
     return idAddon;
@@ -581,7 +581,7 @@ void CAddonDatabase::SetPropertiesFromAddon(const AddonPtr& addon,
   pItem->SetProperty("Addon.Type", TranslateType(addon->Type(),true));
   pItem->SetProperty("Addon.intType", TranslateType(addon->Type()));
   pItem->SetProperty("Addon.Name", addon->Name());
-  pItem->SetProperty("Addon.Version", addon->Version().str);
+  pItem->SetProperty("Addon.Version", addon->Version().c_str());
   pItem->SetProperty("Addon.Summary", addon->Summary());
   pItem->SetProperty("Addon.Description", addon->Description());
   pItem->SetProperty("Addon.Creator", addon->Author());

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -641,29 +641,19 @@ bool CAddonDatabase::DisableAddon(const CStdString &addonID, bool disable /* = t
   return false;
 }
 
-bool CAddonDatabase::BreakAddon(const CStdString &addonID, bool broken /* = true */, const CStdString& reason)
+bool CAddonDatabase::BreakAddon(const CStdString &addonID, const CStdString& reason)
 {
   try
   {
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
-    if (broken)
-    {
-      CStdString sql = PrepareSQL("select id from broken where addonID='%s'", addonID.c_str());
-      m_pDS->query(sql.c_str());
-      if (m_pDS->eof()) // not found
-      {
-        m_pDS->close();
-        sql = PrepareSQL("insert into broken(id, addonID, reason) values(NULL, '%s', '%s')", addonID.c_str(),reason.c_str());
-        m_pDS->exec(sql);
-        return true;
-      }
-      return false; // already disabled or failed query
-    }
-    else
-    {
-      CStdString sql = PrepareSQL("delete from broken where addonID='%s'", addonID.c_str());
+    CStdString sql = PrepareSQL("delete from broken where addonID='%s'", addonID.c_str());
+    m_pDS->exec(sql);
+
+    if (!reason.IsEmpty())
+    { // broken
+      sql = PrepareSQL("insert into broken(id, addonID, reason) values(NULL, '%s', '%s')", addonID.c_str(),reason.c_str());
       m_pDS->exec(sql);
     }
     return true;

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -98,7 +98,7 @@ public:
 protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 12; }
+  virtual int GetMinVersion() const { return 13; }
   const char *GetBaseDBName() const { return "Addons"; }
 };
 

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -81,13 +81,12 @@ public:
   bool HasDisabledAddons();
 
   /*! \brief Mark an addon as broken
-   Sets a flag that this addon has been marked as broken in the repository. 
+   Sets a flag that this addon has been marked as broken in the repository.
    \param addonID id of the addon to mark as broken
-   \param broken whether to mark or not.  Defaults to true
-   \param reason why it is broken.  Defaults to blank 
+   \param reason why it is broken - if non empty we take it as broken.  Defaults to empty
    \return true on success, false on failure
    \sa IsAddonBroken */
-  bool BreakAddon(const CStdString &addonID, bool broken = true, const CStdString& reason="");
+  bool BreakAddon(const CStdString &addonID, const CStdString& reason="");
 
   /*! \brief Check whether an addon has been marked as broken via BreakAddon.
    \param addonID id of the addon to check

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -97,7 +97,7 @@ public:
 protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 13; }
+  virtual int GetMinVersion() const { return 14; }
   const char *GetBaseDBName() const { return "Addons"; }
 };
 

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -254,7 +254,7 @@ void CAddonInstaller::InstallFromXBMCRepo(const set<CStdString> &addonIDs)
   }
   // now install the addons
   for (set<CStdString>::const_iterator i = addonIDs.begin(); i != addonIDs.end(); ++i)
-    CAddonInstaller::Get().Install(*i);
+    Install(*i);
 }
 
 bool CAddonInstaller::CheckDependencies(const AddonPtr &addon)

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -181,7 +181,10 @@ bool CAddonInstaller::DoInstall(const AddonPtr &addon, const CStdString &hash, b
   //       it may be better to install the dependencies first to minimise the chance of an addon becoming orphaned due to
   //       missing deps.
   if (!CheckDependencies(addon))
+  {
+    g_application.m_guiDialogKaiToast.QueueNotification(addon->Icon(), addon->Name(), g_localizeStrings.Get(24044), TOAST_DISPLAY_TIME, false);
     return false;
+  }
 
   if (background)
   {
@@ -212,7 +215,10 @@ bool CAddonInstaller::InstallFromZip(const CStdString &path)
   CStdString zipDir;
   URIUtils::CreateArchivePath(zipDir, "zip", path, "");
   if (!CDirectory::GetDirectory(zipDir, items) || items.Size() != 1 || !items[0]->m_bIsFolder)
+  {
+    g_application.m_guiDialogKaiToast.QueueNotification("", path, g_localizeStrings.Get(24045), TOAST_DISPLAY_TIME, false);
     return false;
+  }
 
   // TODO: possibly add support for github generated zips here?
   CStdString archive = URIUtils::AddFileToFolder(items[0]->m_strPath, "addon.xml");
@@ -227,6 +233,7 @@ bool CAddonInstaller::InstallFromZip(const CStdString &path)
     // install the addon
     return DoInstall(addon);
   }
+  g_application.m_guiDialogKaiToast.QueueNotification("", path, g_localizeStrings.Get(24045), TOAST_DISPLAY_TIME, false);
   return false;
 }
 

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -273,7 +273,7 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon)
     { // we have it but our version isn't good enough, or we don't have it and we need it
       if (!database.GetAddon(addonID, dep) || !dep->MeetsVersion(version))
       { // we don't have it in a repo, or we have it but the version isn't good enough, so dep isn't satisfied.
-        CLog::Log(LOGDEBUG, "Addon %s requires %s version %s which is not available", addon->ID().c_str(), addonID.c_str(), version.str.c_str());
+        CLog::Log(LOGDEBUG, "Addon %s requires %s version %s which is not available", addon->ID().c_str(), addonID.c_str(), version.c_str());
         return false;
       }
     }
@@ -449,7 +449,7 @@ bool CAddonInstallJob::Install(const CStdString &installFrom)
   CAddonMgr::Get().FindAddons(); // needed as GetDeps() grabs directly from c-pluff via the addon manager
   ADDONDEPS deps = addon->GetDeps();
   CStdString referer;
-  referer.Format("Referer=%s-%s.zip",addon->ID().c_str(),addon->Version().str.c_str());
+  referer.Format("Referer=%s-%s.zip",addon->ID().c_str(),addon->Version().c_str());
   for (ADDONDEPS::iterator it  = deps.begin(); it != deps.end(); ++it)
   {
     if (it->first.Equals("xbmc.metadata"))

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -334,6 +334,14 @@ bool CAddonInstallJob::OnPreInstall()
   return false;
 }
 
+void CAddonInstallJob::DeleteAddon(const CStdString &addonFolder)
+{
+  CFileItemList list;
+  list.Add(CFileItemPtr(new CFileItem(addonFolder, true)));
+  list[0]->Select(true);
+  CJobManager::GetInstance().AddJob(new CFileOperationJob(CFileOperationJob::ActionDelete, list, ""), NULL);
+}
+
 bool CAddonInstallJob::Install(const CStdString &installFrom)
 {
   CStdString addonFolder(installFrom);
@@ -352,10 +360,7 @@ bool CAddonInstallJob::Install(const CStdString &installFrom)
     CStdString addonID = URIUtils::GetFileName(addonFolder);
     ReportInstallError(addonID, addonID);
     CLog::Log(LOGERROR,"Could not read addon description of %s", addonID.c_str());
-    CFileItemList list;
-    list.Add(CFileItemPtr(new CFileItem(addonFolder, true)));
-    list[0]->Select(true);
-    CJobManager::GetInstance().AddJob(new CFileOperationJob(CFileOperationJob::ActionDelete, list, ""), NULL);
+    DeleteAddon(addonFolder);
     return false;
   }
 

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -296,14 +296,14 @@ void CAddonInstaller::UpdateRepos(bool force)
   CAddonMgr::Get().GetAddons(ADDON_REPOSITORY,addons);
   for (unsigned int i=0;i<addons.size();++i)
   {
-    RepositoryPtr repo = boost::dynamic_pointer_cast<CRepository>(addons[i]);
     CAddonDatabase database;
     database.Open();
-    CDateTime lastUpdate = database.GetRepoTimestamp(repo->ID());
+    CDateTime lastUpdate = database.GetRepoTimestamp(addons[i]->ID());
     if (force || !lastUpdate.IsValid() || lastUpdate + CDateTimeSpan(0,6,0,0) < CDateTime::GetCurrentDateTime())
     {
-      CLog::Log(LOGDEBUG,"Checking repository %s for updates",repo->Name().c_str());
-      CJobManager::GetInstance().AddJob(new CRepositoryUpdateJob(repo), NULL);
+      CLog::Log(LOGDEBUG,"Checking repositories for updates (triggered by %s)",addons[i]->Name().c_str());
+      CJobManager::GetInstance().AddJob(new CRepositoryUpdateJob(addons), this);
+      return;
     }
   }
 }

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -270,9 +270,9 @@ bool CAddonInstaller::CheckDependencies(const AddonPtr &addon)
     bool optional = i->second.second;
     AddonPtr dep;
     bool haveAddon = CAddonMgr::Get().GetAddon(addonID, dep);
-    if ((haveAddon && dep->Version() < version) || (!haveAddon && !optional))
+    if ((haveAddon && !dep->MeetsVersion(version)) || (!haveAddon && !optional))
     { // we have it but our version isn't good enough, or we don't have it and we need it
-      if (!database.GetAddon(addonID, dep) || dep->Version() < version)
+      if (!database.GetAddon(addonID, dep) || !dep->MeetsVersion(version))
       { // we don't have it in a repo, or we have it but the version isn't good enough, so dep isn't satisfied.
         CLog::Log(LOGDEBUG, "Addon %s requires %s version %s which is not available", addon->ID().c_str(), addonID.c_str(), version.str.c_str());
         return false;

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -22,6 +22,7 @@
 
 #include "utils/FileOperationJob.h"
 #include "addons/IAddon.h"
+#include "utils/Stopwatch.h"
 
 class CAddonInstaller : public IJobCallback
 {
@@ -63,6 +64,13 @@ public:
    */
   bool CheckDependencies(const ADDON::AddonPtr &addon);
 
+  /*! \brief Update all repositories (if needed)
+   Runs through all available repositories and queues an update of them if they
+   need it (according to the set timeouts) or if forced.
+   \param force whether we should run an update regardless of the normal update cycle. Defaults to false.
+   */
+  void UpdateRepos(bool force = false);
+
   void OnJobComplete(unsigned int jobID, bool success, CJob* job);
   void OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job);
 
@@ -99,6 +107,7 @@ private:
 
   CCriticalSection m_critSection;
   JobMap m_downloadJobs;
+  CStopWatch m_repoUpdateWatch;   ///< repository updates are done based on this counter
 };
 
 class CAddonInstallJob : public CFileOperationJob

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -108,6 +108,7 @@ private:
   CCriticalSection m_critSection;
   JobMap m_downloadJobs;
   CStopWatch m_repoUpdateWatch;   ///< repository updates are done based on this counter
+  unsigned int m_repoUpdateJob;   ///< the job ID of the repository updates
 };
 
 class CAddonInstallJob : public CFileOperationJob

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -53,7 +53,7 @@ public:
   /*! \brief Install a set of addons from the official repository (if needed)
    \param addonIDs a set of addon IDs to install
    */
-  static void InstallFromXBMCRepo(const std::set<CStdString> &addonIDs);
+  void InstallFromXBMCRepo(const std::set<CStdString> &addonIDs);
 
   /*! \brief Check whether dependencies of an addon exist or are installable.
    Iterates through the addon's dependencies, checking they're installed or installable.

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -38,12 +38,14 @@ public:
    \param force whether to force the install even if the addon is already installed (eg for updating). Defaults to false.
    \param referer string to use for referer for http fetch. Set to previous version when updating, parent when fetching a dependency
    \param background whether to install in the background or not. Defaults to true.
+   \sa DoInstall
    */
   void Install(const CStdString &addonID, bool force = false, const CStdString &referer="", bool background = true);
 
   /*! \brief Install an addon from the given zip path
    \param path the zip file to install from
    \return true if successful, false otherwise
+   \sa DoInstall
    */
   bool InstallFromZip(const CStdString &path);
 
@@ -75,6 +77,16 @@ private:
   CAddonInstaller(const CAddonInstaller&);
   CAddonInstaller const& operator=(CAddonInstaller const&);
   virtual ~CAddonInstaller();
+
+  /*! \brief Install an addon from a repository or zip
+   \param addon the AddonPtr describing the addon
+   \param hash the hash to verify the install. Defaults to "".
+   \param update whether this is an update of an existing addon, or a new install. Defaults to false.
+   \param referer string to use for referer for http fetch. Defaults to "".
+   \param background whether to install in the background or not. Defaults to true.
+   \return true on successful install, false on failure.
+   */
+  bool DoInstall(const ADDON::AddonPtr &addon, const CStdString &hash = "", bool update = false, const CStdString &referer = "", bool background = true);
 
   CCriticalSection m_critSection;
   JobMap m_downloadJobs;

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -55,6 +55,14 @@ public:
    */
   static void InstallFromXBMCRepo(const std::set<CStdString> &addonIDs);
 
+  /*! \brief Check whether dependencies of an addon exist or are installable.
+   Iterates through the addon's dependencies, checking they're installed or installable.
+   Each dependency must also satisfies CheckDependencies in turn.
+   \param addon the addon to check
+   \return true if dependencies are available, false otherwise.
+   */
+  bool CheckDependencies(const ADDON::AddonPtr &addon);
+
   void OnJobComplete(unsigned int jobID, bool success, CJob* job);
   void OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job);
 

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -38,9 +38,10 @@ public:
    \param force whether to force the install even if the addon is already installed (eg for updating). Defaults to false.
    \param referer string to use for referer for http fetch. Set to previous version when updating, parent when fetching a dependency
    \param background whether to install in the background or not. Defaults to true.
+   \return true on successful install, false on failure.
    \sa DoInstall
    */
-  void Install(const CStdString &addonID, bool force = false, const CStdString &referer="", bool background = true);
+  bool Install(const CStdString &addonID, bool force = false, const CStdString &referer="", bool background = true);
 
   /*! \brief Install an addon from the given zip path
    \param path the zip file to install from

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -110,6 +110,11 @@ private:
    */
   bool CheckHash(const CStdString& addonZip);
 
+  /*! \brief Delete an addon following install failure
+   \param addonFolder - the folder to delete
+   */
+  void DeleteAddon(const CStdString &addonFolder);
+
   ADDON::AddonPtr m_addon;
   CStdString m_hash;
   bool m_update;

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -23,6 +23,7 @@
 #include "utils/FileOperationJob.h"
 #include "addons/IAddon.h"
 #include "utils/Stopwatch.h"
+#include "threads/Event.h"
 
 class CAddonInstaller : public IJobCallback
 {
@@ -66,10 +67,12 @@ public:
 
   /*! \brief Update all repositories (if needed)
    Runs through all available repositories and queues an update of them if they
-   need it (according to the set timeouts) or if forced.
+   need it (according to the set timeouts) or if forced.  Optionally busy wait
+   until the repository updates are complete.
    \param force whether we should run an update regardless of the normal update cycle. Defaults to false.
+   \param wait whether we should busy wait for the updates to be performed. Defaults to false.
    */
-  void UpdateRepos(bool force = false);
+  void UpdateRepos(bool force = false, bool wait = false);
 
   void OnJobComplete(unsigned int jobID, bool success, CJob* job);
   void OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job);
@@ -109,6 +112,7 @@ private:
   JobMap m_downloadJobs;
   CStopWatch m_repoUpdateWatch;   ///< repository updates are done based on this counter
   unsigned int m_repoUpdateJob;   ///< the job ID of the repository updates
+  CEvent m_repoUpdateDone;        ///< event set when the repository updates are complete
 };
 
 class CAddonInstallJob : public CFileOperationJob

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -174,6 +174,7 @@ bool CAddonMgr::CheckUserDirs(const cp_cfg_element_t *settings)
 
 CAddonMgr::CAddonMgr()
 {
+  m_cpluff = NULL;
 }
 
 CAddonMgr::~CAddonMgr()

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -624,8 +624,13 @@ bool CAddonMgr::GetExtList(cp_cfg_element_t *base, const char *path, vector<CStd
 
 AddonPtr CAddonMgr::GetAddonFromDescriptor(const cp_plugin_info_t *info)
 {
-  if (!info || !info->extensions)
+  if (!info)
     return AddonPtr();
+
+  if (!info->extensions)
+  { // no extensions, so we need only the dep information
+    return AddonPtr(new CAddon(info));
+  }
 
   // FIXME: If we want to support multiple extension points per addon, we'll need to extend this to not just take
   //        the first extension point (eg use the TYPE information we pass in)

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -603,24 +603,6 @@ const cp_extension_t *CAddonMgr::GetExtension(const cp_plugin_info_t *props, con
   return NULL;
 }
 
-ADDONDEPS CAddonMgr::GetDeps(const CStdString &id)
-{
-  ADDONDEPS result;
-  cp_status_t status;
-
-  cp_plugin_info_t *info = m_cpluff->get_plugin_info(m_cp_context,id.c_str(),&status);
-  if (info)
-  {
-    for (unsigned int i=0;i<info->num_imports;++i)
-      result.insert(make_pair(CStdString(info->imports[i].plugin_id),
-                              make_pair(AddonVersion(info->version),
-                                        AddonVersion(info->version))));
-    m_cpluff->release_info(m_cp_context, info);
-  }
-
-  return result;
-}
-
 CStdString CAddonMgr::GetExtValue(cp_cfg_element_t *base, const char *path)
 {
   const char *value = NULL;

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -508,26 +508,6 @@ AddonPtr CAddonMgr::AddonFromProps(AddonProps& addonProps)
   return AddonPtr();
 }
 
-void CAddonMgr::UpdateRepos(bool force)
-{
-  CSingleLock lock(m_critSection);
-  if (!force && m_watch.IsRunning() && m_watch.GetElapsedSeconds() < 600)
-    return;
-  m_watch.StartZero();
-  VECADDONS addons;
-  GetAddons(ADDON_REPOSITORY,addons);
-  for (unsigned int i=0;i<addons.size();++i)
-  {
-    RepositoryPtr repo = boost::dynamic_pointer_cast<CRepository>(addons[i]);
-    CDateTime lastUpdate = m_database.GetRepoTimestamp(repo->ID());
-    if (force || !lastUpdate.IsValid() || lastUpdate + CDateTimeSpan(0,6,0,0) < CDateTime::GetCurrentDateTime())
-    {
-      CLog::Log(LOGDEBUG,"Checking repository %s for updates",repo->Name().c_str());
-      CJobManager::GetInstance().AddJob(new CRepositoryUpdateJob(repo), NULL);
-    }
-  }
-}
-
 /*
  * libcpluff interaction
  */

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -24,8 +24,6 @@
 #include "tinyXML/tinyxml.h"
 #include "threads/CriticalSection.h"
 #include "utils/StdString.h"
-#include "utils/Job.h"
-#include "utils/Stopwatch.h"
 #include <vector>
 #include <map>
 #include <deque>
@@ -112,7 +110,6 @@ namespace ADDON
 
     const char *GetTranslatedString(const cp_cfg_element_t *root, const char *tag);
     static AddonPtr AddonFromProps(AddonProps& props);
-    void UpdateRepos(bool force=false);
     void FindAddons();
     void RemoveAddon(const CStdString& ID);
 
@@ -194,7 +191,6 @@ namespace ADDON
     virtual ~CAddonMgr();
 
     static std::map<TYPE, IAddonMgrCallback*> m_managers;
-    CStopWatch m_watch;
     CCriticalSection m_critSection;
     CAddonDatabase m_database;
   };

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -153,7 +153,6 @@ namespace ADDON
      \return true if the repository XML file is parsed, false otherwise.
      */
     bool AddonsFromRepoXML(const TiXmlElement *root, VECADDONS &addons);
-    ADDONDEPS GetDeps(const CStdString& id);
 
     /*! \brief Start all services addons.
         \return True is all addons are started, false otherwise

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -142,7 +142,7 @@ void CGUIDialogAddonInfo::UpdateControls()
 void CGUIDialogAddonInfo::OnUpdate()
 {
   CStdString referer;
-  referer.Format("Referer=%s-%s.zip",m_localAddon->ID().c_str(),m_localAddon->Version().str.c_str());
+  referer.Format("Referer=%s-%s.zip",m_localAddon->ID().c_str(),m_localAddon->Version().c_str());
   CAddonInstaller::Get().Install(m_addon->ID(), true, referer); // force install
   Close();
 }

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -191,7 +191,7 @@ bool CGUIWindowAddonBrowser::OnContextButton(int itemNumber,
   if (button == CONTEXT_BUTTON_SCAN)
   {
     RepositoryPtr repo = boost::dynamic_pointer_cast<CRepository>(addon);
-    CJobManager::GetInstance().AddJob(new CRepositoryUpdateJob(repo,false),&CAddonInstaller::Get());
+    CAddonInstaller::Get().UpdateRepos(true);
     return true;
   }
 

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -69,7 +69,7 @@ namespace ADDON
 
   class CAddonMgr;
   class AddonVersion;
-  typedef std::map<CStdString, std::pair<const AddonVersion, const AddonVersion> > ADDONDEPS;
+  typedef std::map<CStdString, std::pair<const AddonVersion, bool> > ADDONDEPS;
   typedef std::map<CStdString, CStdString> InfoMap;
   class AddonProps;
 

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -105,7 +105,7 @@ namespace ADDON
     virtual CStdString GetSetting(const CStdString& key) =0;
     virtual TiXmlElement* GetSettingsXML() =0;
     virtual CStdString GetString(uint32_t id) =0;
-    virtual ADDONDEPS GetDeps() =0;
+    virtual const ADDONDEPS &GetDeps() const =0;
 
   protected:
     virtual const AddonPtr Parent() const =0;

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -86,7 +86,8 @@ namespace ADDON
     virtual const CStdString Name() const =0;
     virtual bool Enabled() const =0;
     virtual bool IsInUse() const =0;
-    virtual const AddonVersion Version() =0;
+    virtual const AddonVersion Version() const =0;
+    virtual const AddonVersion MinVersion() const =0;
     virtual const CStdString Summary() const =0;
     virtual const CStdString Description() const =0;
     virtual const CStdString Path() const =0;
@@ -106,6 +107,7 @@ namespace ADDON
     virtual TiXmlElement* GetSettingsXML() =0;
     virtual CStdString GetString(uint32_t id) =0;
     virtual const ADDONDEPS &GetDeps() const =0;
+    virtual bool MeetsVersion(const AddonVersion &version) const =0;
 
   protected:
     virtual const AddonPtr Parent() const =0;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -214,12 +214,9 @@ bool CRepositoryUpdateJob::DoWork()
                                              g_localizeStrings.Get(24097),
                                              ""))
           database.DisableAddon(addons[i]->ID());
-
-        database.BreakAddon(addons[i]->ID(),true,addons[i]->Props().broken);
       }
     }
-    if (addons[i]->Props().broken.IsEmpty())
-      database.BreakAddon(addons[i]->ID(),false);
+    database.BreakAddon(addons[i]->ID(), addons[i]->Props().broken);
   }
 
   return true;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -186,6 +186,9 @@ bool CRepositoryUpdateJob::DoWork()
   database.Open();
   for (unsigned int i=0;i<addons.size();++i)
   {
+    if (!CAddonInstaller::Get().CheckDependencies(addons[i]))
+      addons[i]->Props().broken = g_localizeStrings.Get(24044);
+
     AddonPtr addon;
     CAddonMgr::Get().GetAddon(addons[i]->ID(),addon);
     if (addon && addons[i]->Version() > addon->Version())

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -181,7 +181,7 @@ bool CRepositoryUpdateJob::DoWork()
   for (VECADDONS::const_iterator i = m_repos.begin(); i != m_repos.end(); ++i)
   {
     RepositoryPtr repo = boost::dynamic_pointer_cast<CRepository>(*i);
-    VECADDONS newAddons = GrabAddons(repo, true);
+    VECADDONS newAddons = GrabAddons(repo);
     addons.insert(addons.end(), newAddons.begin(), newAddons.end());
   }
   if (addons.empty())
@@ -231,16 +231,13 @@ bool CRepositoryUpdateJob::DoWork()
   return true;
 }
 
-VECADDONS CRepositoryUpdateJob::GrabAddons(RepositoryPtr& repo,
-                                           bool check)
+VECADDONS CRepositoryUpdateJob::GrabAddons(RepositoryPtr& repo)
 {
   CAddonDatabase database;
   database.Open();
   CStdString checksum;
   int idRepo = database.GetRepoChecksum(repo->ID(),checksum);
-  CStdString reposum=checksum;
-  if (check)
-    reposum = repo->Checksum();
+  CStdString reposum = repo->Checksum();
   VECADDONS addons;
   if (idRepo == -1 || !checksum.Equals(reposum))
   {

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -152,9 +152,12 @@ VECADDONS CRepository::Parse()
       AddonPtr addon = *i;
       if (m_zipped)
       {
-        addon->Props().path = URIUtils::AddFileToFolder(m_datadir,addon->ID()+"/"+addon->ID()+"-"+addon->Version().str+".zip");
+        CStdString file;
+        file.Format("%s/%s-%s.zip", addon->ID().c_str(), addon->ID().c_str(), addon->Version().c_str());
+        addon->Props().path = URIUtils::AddFileToFolder(m_datadir,file);
         SET_IF_NOT_EMPTY(addon->Props().icon,URIUtils::AddFileToFolder(m_datadir,addon->ID()+"/icon.png"))
-        SET_IF_NOT_EMPTY(addon->Props().changelog,URIUtils::AddFileToFolder(m_datadir,addon->ID()+"/changelog-"+addon->Version().str+".txt"))
+        file.Format("%s/changelog-%s.txt", addon->ID().c_str(), addon->Version().c_str());
+        SET_IF_NOT_EMPTY(addon->Props().changelog,URIUtils::AddFileToFolder(m_datadir,file))
         SET_IF_NOT_EMPTY(addon->Props().fanart,URIUtils::AddFileToFolder(m_datadir,addon->ID()+"/fanart.jpg"))
       }
       else
@@ -203,7 +206,7 @@ bool CRepositoryUpdateJob::DoWork()
       {
         CStdString referer;
         if (URIUtils::IsInternetStream(addons[i]->Path()))
-          referer.Format("Referer=%s-%s.zip",addon->ID().c_str(),addon->Version().str.c_str());
+          referer.Format("Referer=%s-%s.zip",addon->ID().c_str(),addon->Version().c_str());
 
         CAddonInstaller::Get().Install(addon->ID(), true, referer);
       }

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -170,14 +170,20 @@ VECADDONS CRepository::Parse()
   return result;
 }
 
-CRepositoryUpdateJob::CRepositoryUpdateJob(RepositoryPtr& repo, bool check)
+CRepositoryUpdateJob::CRepositoryUpdateJob(const VECADDONS &repos)
+  : m_repos(repos)
 {
-  m_repo = boost::dynamic_pointer_cast<CRepository>(repo->Clone(repo));
 }
 
 bool CRepositoryUpdateJob::DoWork()
 {
-  VECADDONS addons = GrabAddons(m_repo,true);
+  VECADDONS addons;
+  for (VECADDONS::const_iterator i = m_repos.begin(); i != m_repos.end(); ++i)
+  {
+    RepositoryPtr repo = boost::dynamic_pointer_cast<CRepository>(*i);
+    VECADDONS newAddons = GrabAddons(repo, true);
+    addons.insert(addons.end(), newAddons.begin(), newAddons.end());
+  }
   if (addons.empty())
     return false;
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -66,6 +66,7 @@ namespace ADDON
     CRepositoryUpdateJob(const VECADDONS& repos);
     virtual ~CRepositoryUpdateJob() {}
 
+    virtual const char *GetType() const { return "repoupdate"; };
     virtual bool DoWork();
     static VECADDONS GrabAddons(RepositoryPtr& repo, bool check);
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -68,7 +68,8 @@ namespace ADDON
 
     virtual const char *GetType() const { return "repoupdate"; };
     virtual bool DoWork();
-    static VECADDONS GrabAddons(RepositoryPtr& repo, bool check);
+  private:
+    VECADDONS GrabAddons(RepositoryPtr& repo);
 
     VECADDONS m_repos;
   };

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -63,13 +63,13 @@ namespace ADDON
   class CRepositoryUpdateJob : public CJob
   {
   public:
-    CRepositoryUpdateJob(RepositoryPtr& repo, bool param = true);
+    CRepositoryUpdateJob(const VECADDONS& repos);
     virtual ~CRepositoryUpdateJob() {}
 
     virtual bool DoWork();
     static VECADDONS GrabAddons(RepositoryPtr& repo, bool check);
 
-    RepositoryPtr m_repo;
+    VECADDONS m_repos;
   };
 }
 

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -302,6 +302,9 @@ bool CScraper::Load()
   bool result=m_parser.Load(LibPath());
   if (result)
   {
+    // TODO: this routine assumes that deps are a single level, and assumes the dep is installed.
+    //       1. Does it make sense to have recursive dependencies?
+    //       2. Should we be checking the dep versions or do we assume it is ok?
     ADDONDEPS deps = GetDeps();
     ADDONDEPS::iterator itr = deps.begin();
     while (itr != deps.end())
@@ -315,7 +318,7 @@ bool CScraper::Load()
       if (!CAddonMgr::Get().GetAddon((*itr).first, dep))
         return false;
       TiXmlDocument doc;
-      if (doc.LoadFile(dep->LibPath()))
+      if (dep->Type() == ADDON_SCRAPER_LIBRARY && doc.LoadFile(dep->LibPath()))
         m_parser.AddDocument(&doc);
       itr++;
     }

--- a/xbmc/addons/ScreenSaver.cpp
+++ b/xbmc/addons/ScreenSaver.cpp
@@ -26,7 +26,7 @@ namespace ADDON
 {
 
   CScreenSaver::CScreenSaver(const char *addonID)
-   : ADDON::CAddonDll<DllScreenSaver, ScreenSaver, SCR_PROPS>(AddonProps(addonID, ADDON_UNKNOWN, ""))
+   : ADDON::CAddonDll<DllScreenSaver, ScreenSaver, SCR_PROPS>(AddonProps(addonID, ADDON_UNKNOWN, "", ""))
   {
   }
 

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -214,7 +214,7 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(AddonPtr &addon, const CStdStri
   CFileItemPtr item(new CFileItem(path, folder));
   item->SetLabel(addon->Name());
   if (!(basePath.Equals("addons://") && addon->Type() == ADDON_REPOSITORY))
-    item->SetLabel2(addon->Version().str);
+    item->SetLabel2(addon->Version().c_str());
   item->SetThumbnailImage(addon->Icon());
   item->SetLabelPreformated(true);
   item->SetIconImage("DefaultAddon.png");

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -27,6 +27,7 @@
 #include "DirectoryCache.h"
 #include "FileItem.h"
 #include "addons/Repository.h"
+#include "addons/AddonInstaller.h"
 #include "addons/PluginSource.h"
 #include "guilib/TextureManager.h"
 #include "File.h"
@@ -96,13 +97,12 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
     CAddonMgr::Get().GetAddon(path.GetHostName(),addon);
     if (!addon)
       return false;
+
+    // ensure our repos are up to date
+    CAddonInstaller::Get().UpdateRepos(false, true);
     CAddonDatabase database;
     database.Open();
-    if (!database.GetRepository(addon->ID(),addons))
-    {
-      RepositoryPtr repo = boost::dynamic_pointer_cast<CRepository>(addon);
-      addons = CRepositoryUpdateJob::GrabAddons(repo,false);
-    }
+    database.GetRepository(addon->ID(),addons);
     items.SetProperty("reponame",addon->Name());
   }
 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -39,6 +39,7 @@
 #include "video/windows/GUIWindowVideoBase.h"
 #include "addons/GUIWindowAddonBrowser.h"
 #include "addons/Addon.h" // for TranslateType, TranslateContent
+#include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
 #include "addons/PluginSource.h"
 #include "music/LastFmManager.h"
@@ -1437,7 +1438,7 @@ int CBuiltins::Execute(const CStdString& execString)
   }
   else if (execute.Equals("updateaddonrepos"))
   {
-    CAddonMgr::Get().UpdateRepos(true);
+    CAddonInstaller::Get().UpdateRepos(true);
   }
   else if (execute.Equals("toggledpms"))
   {

--- a/xbmc/interfaces/python/xbmcmodule/PythonAddon.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/PythonAddon.cpp
@@ -255,7 +255,7 @@ namespace PYXBMC
     else if (strcmpi(id, "type") == 0)
       return Py_BuildValue((char*)"s", ADDON::TranslateType(self->pAddon->Type()).c_str());
     else if (strcmpi(id, "version") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->Version().str.c_str());
+      return Py_BuildValue((char*)"s", self->pAddon->Version().c_str());
     else
     {
       CStdString error;

--- a/xbmc/interfaces/python/xbmcmodule/winxml.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/winxml.cpp
@@ -102,7 +102,7 @@ namespace PYXBMC
       {
         // Finally fallback to the DefaultSkin as it didn't exist in either the XBMC Skin folder or the fallback skin folder
         CStdString str("none");
-        AddonProps props(str, ADDON_SKIN, str);
+        AddonProps props(str, ADDON_SKIN, "", "");
         CSkinInfo skinInfo(props, CSkinInfo::TranslateResolution(resolution, RES_HDTV_720p));
         basePath = URIUtils::AddFileToFolder(fallbackPath, strDefault);
         

--- a/xbmc/interfaces/python/xbmcmodule/winxmldialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/winxmldialog.cpp
@@ -102,7 +102,7 @@ namespace PYXBMC
       {
         // Finally fallback to the DefaultSkin as it didn't exist in either the XBMC Skin folder or the fallback skin folder
         CStdString str("none");
-        AddonProps props(str, ADDON_SKIN, str);
+        AddonProps props(str, ADDON_SKIN, "", "");
         CSkinInfo skinInfo(props, CSkinInfo::TranslateResolution(resolution, RES_HDTV_720p));
         
         CStdString basePath = URIUtils::AddFileToFolder(fallbackPath, strDefault);

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3122,7 +3122,7 @@ bool CMusicDatabase::UpdateOldVersion(int version)
       }
       m_pDS->close();
       // ensure these scrapers are installed
-      CAddonInstaller::InstallFromXBMCRepo(scrapers);
+      CAddonInstaller::Get().InstallFromXBMCRepo(scrapers);
     }
     if (version < 16)
     {

--- a/xbmc/music/infoscanner/MusicInfoScraper.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScraper.cpp
@@ -91,7 +91,7 @@ void CMusicInfoScraper::FindAlbumInfo()
 
   CLog::Log(LOGDEBUG, "%s: Searching for '%s - %s' using %s scraper (path: '%s', content: '%s', version: '%s')",
     __FUNCTION__, m_strArtist.c_str(), strAlbum.c_str(), m_scraper->Name().c_str(), m_scraper->Path().c_str(),
-    ADDON::TranslateContent(m_scraper->Content()).c_str(), m_scraper->Version().str.c_str());
+    ADDON::TranslateContent(m_scraper->Content()).c_str(), m_scraper->Version().c_str());
   
   vector<CStdString> extras;
   extras.push_back(strAlbum);
@@ -187,7 +187,7 @@ void CMusicInfoScraper::FindArtistInfo()
   
   CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper (file: '%s', content: '%s', version: '%s')",
     __FUNCTION__, m_strArtist.c_str(), m_scraper->Name().c_str(), m_scraper->Path().c_str(),
-    ADDON::TranslateContent(m_scraper->Content()).c_str(), m_scraper->Version().str.c_str());
+    ADDON::TranslateContent(m_scraper->Content()).c_str(), m_scraper->Version().c_str());
 
   CScraperUrl scrURL;
   vector<CStdString> url = m_scraper->Run("CreateArtistSearchUrl",scrURL,m_http,&extras);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3359,7 +3359,7 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
       }
       m_pDS->close();
       // ensure these scrapers are installed
-      CAddonInstaller::InstallFromXBMCRepo(scrapers);
+      CAddonInstaller::Get().InstallFromXBMCRepo(scrapers);
     }
     if (iVersion < 40)
     {

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -74,7 +74,7 @@ int CVideoInfoDownloader::InternalFindMovie(const CStdString &strMovie,
 
   CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper (path: '%s', content: '%s', version: '%s')",
     __FUNCTION__, movieTitle.c_str(), m_info->Name().c_str(), m_info->Path().c_str(),
-    ADDON::TranslateContent(m_info->Content()).c_str(), m_info->Version().str.c_str());
+    ADDON::TranslateContent(m_info->Content()).c_str(), m_info->Version().c_str());
 
   if (m_info->GetParser().HasFunction("CreateSearchUrl"))
   {


### PR DESCRIPTION
Currently we don't check whether dependencies are met when installing addons.

The commits here add support for this as follows:
1. We change repository updates to occur all at once, prior to addons being installed.  This ensures that the repositories are always up to date so we don't have issues with repoA being up to date, while addons in repoA depend on repoB which is not up to date.
2. On repo update, we check dependencies and if not found (or not installable) we mark the addon as broken, rendering it uninstallable.
3. In addition, we check dependencies on install (which handles install from zip for instance) and fail the install for an addon if a dependency can't be installed.

Cases that aren't handled:

a. It is feasible that at some point a dependency may be removed which would leave an addon installed for which the dependencies aren't met.  Currently this isn't much of an issue, as most dependencies are libraries that can't be easily uninstalled.  We may need to think about dependency resolution at runtime or some such.

b. The retrieval of addons by id + version from the database needs a little bit of smartening up to ensure it handles 1.2.10 vs 1.10.2 versioning order.

c. If an addon fails to install due to a dep, any other deps installed in the process won't be removed (we can't easily tell whether the dep was previously installed).
