### PR TITLE
Add thread name to CThread

### DIFF
--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -350,7 +350,7 @@ void CThread::SetPrioritySched_RR(void)
 
   // make thread fixed, set to 'true' for a non-fixed thread
   theFixedPolicy.timeshare = false;
-  result = thread_policy_set(pthread_mach_thread_np(ThreadId()), THREAD_EXTENDED_POLICY, 
+  result = thread_policy_set(pthread_mach_thread_np(ThreadId()), THREAD_EXTENDED_POLICY,
     (thread_policy_t)&theFixedPolicy, THREAD_EXTENDED_POLICY_COUNT);
 
   int policy;
@@ -454,7 +454,7 @@ CStdString CThread::GetTypeName(void)
     name = name.Right(name.length() - 6);
 
   // gcc provides __cxa_demangle to demangle the name
-#ifdef USING_GCC
+#if defined(__GNUC__)
   char* demangled;
   int   status
 

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -33,7 +33,7 @@ typedef unsigned (WINAPI *PBEGINTHREADEX_THREADFUNC)(LPVOID lpThreadParameter);
 typedef int (*PBEGINTHREADEX_THREADFUNC)(LPVOID lpThreadParameter);
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 #include <cxxabi.h>
 using namespace __cxxabiv1;
 #endif
@@ -456,7 +456,7 @@ CStdString CThread::GetTypeName(void)
   // Visual Studio 2010 returns the name as "class CThread" etc
   if (name.substr(0, 6) == "class ")
     name = name.Right(name.length() - 6);
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && !defined(__clang__)
   // gcc provides __cxa_demangle to demangle the name
   char* demangled = NULL;
   int   status;

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -33,6 +33,11 @@ typedef unsigned (WINAPI *PBEGINTHREADEX_THREADFUNC)(LPVOID lpThreadParameter);
 typedef int (*PBEGINTHREADEX_THREADFUNC)(LPVOID lpThreadParameter);
 #endif
 
+#if defined(__GNUC__)
+#include <cxxabi.h>
+using namespace __cxxabiv1;
+#endif
+
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
 
@@ -445,18 +450,16 @@ void CThread::SetName( LPCTSTR szThreadName )
 // and attempt to clean it.
 CStdString CThread::GetTypeName(void)
 {
-  CStdString name;
-
-  name = typeid(*this).name();
-
+  CStdString name = typeid(*this).name();
+ 
+#if defined(_MSC_VER)
   // Visual Studio 2010 returns the name as "class CThread" etc
   if (name.substr(0, 6) == "class ")
     name = name.Right(name.length() - 6);
-
+#elif defined(__GNUC__)
   // gcc provides __cxa_demangle to demangle the name
-#if defined(__GNUC__)
-  char* demangled;
-  int   status
+  char* demangled = NULL;
+  int   status;
 
   demangled = __cxa_demangle(name.c_str(), NULL, 0, &status);
   if (status == 0)

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -54,8 +54,8 @@ public:
 class CThread
 {
 public:
-  CThread(const char* ThreadName = "");
-  CThread(IRunnable* pRunnable, const char* ThreadName = "");
+  CThread(const char* ThreadName = NULL);
+  CThread(IRunnable* pRunnable, const char* ThreadName = NULL);
   virtual ~CThread();
   void Create(bool bAutoDelete = false, unsigned stacksize = 0);
   bool WaitForThreadExit(unsigned int milliseconds);
@@ -92,6 +92,9 @@ protected:
   HANDLE m_ThreadHandle;
 
 private:
+  CStdString GetTypeName(void);
+
+private:
   ThreadIdentifier ThreadId() const;
   bool m_bAutoDelete;
   HANDLE m_StopEvent;
@@ -103,7 +106,6 @@ private:
   unsigned __int64 m_iLastTime;
   float m_fLastUsage;
 
-protected:
   CStdString m_ThreadName;
 
 private:

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -49,7 +49,6 @@ CRssReader::CRssReader() : CThread()
   m_spacesBetweenFeeds = 0;
   m_bIsRunning = false;
   m_SavedScrollPos = 0;
-  m_ThreadName = "CRssReader";
 }
 
 CRssReader::~CRssReader()


### PR DESCRIPTION
See http://trac.xbmc.org/ticket/11311.
This is quite a simple change to CThread that adds a name to the thread and includes the name in xbmc.log.

However I need help from the unix/OSX chaps. I use typeid(*this).name() to get the object name, but gcc returns it in decorated form and you need **cxa_demangle to clean up the name, and a #ifdef to make sure the code is only called when compiling with gcc. Presumably this applies to MingW as well, so #ifdef _LINUX and #ifdef __APPLE** aren't enough. If anyone using Linux/OSX can get the code starting at line 457 in Thread.cpp that would be great.
