### PR TITLE
Exit refactor

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1950,6 +1950,10 @@ void CApplication::NewFrame()
 
 void CApplication::Render()
 {
+  // do not render if we are stopped
+  if (m_bStop)
+    return;
+
   if (!m_AppActive && !m_bStop && (!IsPlayingVideo() || IsPaused()))
   {
     Sleep(1);
@@ -3231,7 +3235,7 @@ bool CApplication::Cleanup()
   }
 }
 
-void CApplication::Stop()
+void CApplication::Stop(int exitCode)
 {
   try
   {
@@ -3268,6 +3272,9 @@ void CApplication::Stop()
       CLog::Log(LOGNOTICE, "Not saving settings (settings.xml is not present)");
 
     m_bStop = true;
+    m_AppActive = false;
+    m_AppFocused = false;
+    m_ExitCode = exitCode;
     CLog::Log(LOGNOTICE, "stop all");
 
     // stop scanning before we kill the network and so on
@@ -3354,6 +3361,7 @@ void CApplication::Stop()
 #endif
 
     g_Windowing.DestroyRenderSystem();
+    g_Windowing.DestroyWindow();
     g_Windowing.DestroyWindowSystem();
 
     CLog::Log(LOGNOTICE, "stopped");
@@ -3366,6 +3374,9 @@ void CApplication::Stop()
   // we may not get to finish the run cycle but exit immediately after a call to g_application.Stop()
   // so we may never get to Destroy() in CXBApplicationEx::Run(), we call it here.
   Destroy();
+
+  // 
+  Sleep(200);
 }
 
 bool CApplication::PlayMedia(const CFileItem& item, int iPlaylist)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -129,7 +129,7 @@ public:
   void StopZeroconf();
   void DimLCDOnPlayback(bool dim);
   bool IsCurrentThread() const;
-  void Stop();
+  void Stop(int exitCode);
   void RestartApp();
   void UnloadSkin(bool forReload = false);
   bool LoadUserWindows();

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -230,23 +230,14 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
 case TMSG_POWERDOWN:
       {
-        g_application.Stop();
-        Sleep(200);
-        g_Windowing.DestroyWindow();
-        #if !(defined(__APPLE__) && defined(__arm__))
+        g_application.Stop(EXITCODE_POWERDOWN);
         g_powerManager.Powerdown();
-        exit(64);
-        #endif
       }
       break;
 
     case TMSG_QUIT:
       {
-        g_application.Stop();
-        Sleep(200);
-        #if !(defined(__APPLE__) && defined(__arm__))
-        exit(0);
-        #endif
+        g_application.Stop(EXITCODE_QUIT);
       }
       break;
 
@@ -265,25 +256,16 @@ case TMSG_POWERDOWN:
     case TMSG_RESTART:
     case TMSG_RESET:
       {
-        g_application.Stop();
-        Sleep(200);
-        g_Windowing.DestroyWindow();
-        #if !(defined(__APPLE__) && defined(__arm__))
+        g_application.Stop(EXITCODE_REBOOT);
         g_powerManager.Reboot();
-        exit(66);
-        #endif
       }
       break;
 
     case TMSG_RESTARTAPP:
       {
 #ifdef _WIN32
-        g_application.Stop();
-        Sleep(200);
+        g_application.Stop(EXITCODE_RESTARTAPP);
 #endif
-        #if !(defined(__APPLE__) && defined(__arm__))
-        exit(65);
-        #endif
         // TODO
       }
       break;

--- a/xbmc/XBApplicationEx.cpp
+++ b/xbmc/XBApplicationEx.cpp
@@ -33,6 +33,7 @@ CXBApplicationEx::CXBApplicationEx()
   m_bStop = false;
   m_AppActive = true;
   m_AppFocused = true;
+  m_ExitCode = EXITCODE_QUIT;
 }
 
 CXBApplicationEx::~CXBApplicationEx()
@@ -46,6 +47,7 @@ bool CXBApplicationEx::Create()
   m_bStop = false;
   m_AppActive = true;
   m_AppFocused = true;
+  m_ExitCode = EXITCODE_QUIT;
 
   // Initialize the app's device-dependent objects
   if (!Initialize())
@@ -163,5 +165,5 @@ INT CXBApplicationEx::Run()
   Destroy();
 
   CLog::Log(LOGNOTICE, "application stopped..." );
-  return 0;
+  return m_ExitCode;
 }

--- a/xbmc/XBApplicationEx.h
+++ b/xbmc/XBApplicationEx.h
@@ -23,6 +23,14 @@
 
 #include "guilib/IWindowManagerCallback.h"
 
+// Do not change the numbering, external scripts depend on them
+enum {
+  EXITCODE_QUIT      = 0,
+  EXITCODE_POWERDOWN = 64,
+  EXITCODE_RESTARTAPP= 65,
+  EXITCODE_REBOOT    = 66,
+};
+
 class CXBApplicationEx : public IWindowManagerCallback
 {
 public:
@@ -31,6 +39,7 @@ public:
 
   // Variables for timing
   bool m_bStop;
+  int  m_ExitCode;
   bool m_AppActive;
   bool m_AppFocused;
 

--- a/xbmc/osx/SDLMain.mm
+++ b/xbmc/osx/SDLMain.mm
@@ -458,11 +458,12 @@ int main(int argc, char *argv[])
   // call SDL_main which calls our real main in xbmc.cpp
   // we never return from here as quiting xbmc will call exit() directly.
   // see http://lists.libsdl.org/pipermail/sdl-libsdl.org/2008-September/066542.html
-  SDL_main(gArgc, gArgv);
+  int status;
+  status = SDL_main(gArgc, gArgv);
 
   [xbmc_delegate release];
   [pool release];
 
-  return 0;
+  return status;
 }
 #endif

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -64,7 +64,7 @@ CPowerManager::~CPowerManager()
 
 void CPowerManager::Initialize()
 {
-#if defined(__APPLE__) && !defined(__arm__)
+#if defined(__APPLE__)
   m_instance = new CCocoaPowerSyscall();
 #elif defined(_LINUX) && defined(HAS_DBUS)
   if (CConsoleUPowerSyscall::HasDeviceConsoleKit())

--- a/xbmc/powermanagement/osx/CocoaPowerSyscall.h
+++ b/xbmc/powermanagement/osx/CocoaPowerSyscall.h
@@ -21,10 +21,16 @@
 #ifndef _COCOA_POWER_SYSCALL_H_
 #define _COCOA_POWER_SYSCALL_H_
 
-#if defined (__APPLE__) && !defined(__arm__)
+#if defined (__APPLE__)
 #include "powermanagement/IPowerSyscall.h"
+#if defined(__arm__)
+#include <pthread.h>
+typedef mach_port_t io_object_t;
+typedef io_object_t io_service_t;
+#else
 #include <IOKit/pwr_mgt/IOPMLib.h>
 #include <IOKit/IOMessage.h>
+#endif
 
 class CCocoaPowerSyscall : public CPowerSyscallWithoutEvents
 {
@@ -59,10 +65,12 @@ private:
   int  m_BatteryPercent;
   bool m_SentBatteryMessage;
 
+#if !defined(__arm__)
   io_connect_t m_root_port;             // a reference to the Root Power Domain IOService
   io_object_t  m_notifier_object;       // notifier object, used to deregister later
   IONotificationPortRef m_notify_port;  // notification port allocated by IORegisterForSystemPower
   CFRunLoopSourceRef m_power_source;
+#endif
 };
 #endif
 #endif

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -966,9 +966,8 @@ void CGUISettings::AddHex(CSettingsCategory* cat, const char *strSetting, int iL
 
 int CGUISettings::GetInt(const char *strSetting) const
 {
-#if !(defined(__APPLE__) && defined(__arm__))
   ASSERT(settingsMap.size());
-#endif
+
   constMapIter it = settingsMap.find(CStdString(strSetting).ToLower());
   if (it != settingsMap.end())
   {

--- a/xbmc/xbmc.cpp
+++ b/xbmc/xbmc.cpp
@@ -46,6 +46,7 @@
 
 int main(int argc, char* argv[])
 {
+  int status = -1;
   //this can't be set from CAdvancedSettings::Initialize() because it will overwrite
   //the loglevel set with the --debug flag
 #ifdef _DEBUG
@@ -155,7 +156,7 @@ int main(int argc, char* argv[])
   if (!g_application.Create())
   {
     fprintf(stderr, "ERROR: Unable to create application. Exiting\n");
-    return -1;
+    return status;
   }
 
   if (playlist.Size() > 0)
@@ -169,18 +170,15 @@ int main(int argc, char* argv[])
 
   try
   {
-    while (1)
-    {
-      g_application.Run();
-    }
+    status = g_application.Run();
   }
   catch(...)
   {
     fprintf(stderr, "ERROR: Exception caught on main loop. Exiting\n");
-    return -1;
+    status = -1;
   }
 
-  return 0;
+  return status;
 }
 
 extern "C"


### PR DESCRIPTION
Refactor XBMC's exit(xx) handling into power manager. Cleans up ifdef spew in ApplicationMessenger.cpp.

Since this touches all platforms, need signoffs from windows and linux devs.
