### PR TITLE
Container.Foldername support throughout the UI

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1290,12 +1290,10 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
       CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
       if (window)
       {
-        strLabel = CURL(((CGUIMediaWindow*)window)->CurrentDirectory().m_strPath).GetWithoutUserDetails();
         if (info==CONTAINER_FOLDERNAME)
-        {
-          URIUtils::RemoveSlashAtEnd(strLabel);
-          strLabel=URIUtils::GetFileName(strLabel);
-        }
+          strLabel = ((CGUIMediaWindow*)window)->CurrentDirectory().GetLabel();
+        else
+          strLabel = CURL(((CGUIMediaWindow*)window)->CurrentDirectory().m_strPath).GetWithoutUserDetails();
       }
       break;
     }

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -214,11 +214,11 @@ CStdString CUtil::GetTitleFromPath(const CStdString& strFileNameAndPath, bool bI
 
   // Music Playlists
   else if (path.Left(24).Equals("special://musicplaylists"))
-    strFilename = g_localizeStrings.Get(20011);
+    strFilename = g_localizeStrings.Get(136);
 
   // Video Playlists
   else if (path.Left(24).Equals("special://videoplaylists"))
-    strFilename = g_localizeStrings.Get(20012);
+    strFilename = g_localizeStrings.Get(136);
 
   // now remove the extension if needed
   if (!g_guiSettings.GetBool("filelists.showextensions") && !bIsFolder)

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -212,6 +212,10 @@ CStdString CUtil::GetTitleFromPath(const CStdString& strFileNameAndPath, bool bI
   else if (url.GetProtocol() == "sap" && strFilename.IsEmpty())
     strFilename = "SAP Streams";
 
+  // Root file views
+  else if (url.GetProtocol() == "sources")
+    strFilename = g_localizeStrings.Get(744);
+
   // Music Playlists
   else if (path.Left(24).Equals("special://musicplaylists"))
     strFilename = g_localizeStrings.Get(136);
@@ -219,6 +223,9 @@ CStdString CUtil::GetTitleFromPath(const CStdString& strFileNameAndPath, bool bI
   // Video Playlists
   else if (path.Left(24).Equals("special://videoplaylists"))
     strFilename = g_localizeStrings.Get(136);
+
+  else if ((url.GetProtocol() == "rar" || url.GetProtocol() == "zip") && strFilename.IsEmpty())
+    strFilename = URIUtils::GetFileName(url.GetHostName());
 
   // now remove the extension if needed
   if (!g_guiSettings.GetBool("filelists.showextensions") && !bIsFolder)

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -63,22 +63,26 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
   {
     CAddonMgr::Get().GetAllAddons(addons, true);
     items.SetProperty("reponame",g_localizeStrings.Get(24062));
+    items.SetLabel(g_localizeStrings.Get(24062));
   }
   else if (path.GetHostName().Equals("disabled"))
   { // grab all disabled addons, including disabled repositories
     reposAsFolders = false;
     CAddonMgr::Get().GetAllAddons(addons, false, true);
     items.SetProperty("reponame",g_localizeStrings.Get(24039));
+    items.SetLabel(g_localizeStrings.Get(24039));
   }
   else if (path.GetHostName().Equals("outdated"))
   {
     reposAsFolders = false;
     CAddonMgr::Get().GetAllOutdatedAddons(addons);
     items.SetProperty("reponame",g_localizeStrings.Get(24043));
+    items.SetLabel(g_localizeStrings.Get(24043));
   }
   else if (path.GetHostName().Equals("repos"))
   {
     CAddonMgr::Get().GetAddons(ADDON_REPOSITORY,addons,true);
+    items.SetLabel(g_localizeStrings.Get(24033)); // Get Add-ons
   }
   else if (path.GetHostName().Equals("sources"))
   {
@@ -90,6 +94,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
     database.Open();
     database.GetAddons(addons);
     items.SetProperty("reponame",g_localizeStrings.Get(24032));
+    items.SetLabel(g_localizeStrings.Get(24032));
   }
   else
   {
@@ -105,6 +110,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
     database.Open();
     database.GetRepository(addon->ID(),addons);
     items.SetProperty("reponame",addon->Name());
+    items.SetLabel(addon->Name());
   }
 
   if (path.GetFileName().IsEmpty())
@@ -136,6 +142,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
   {
     TYPE type = TranslateType(path.GetFileName());
     items.SetProperty("addoncategory",TranslateType(type, true));
+    items.SetLabel(TranslateType(type, true));
     items.m_strPath = strPath;
 
     // FIXME: Categorisation of addons needs adding here

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -273,6 +273,7 @@ bool CAddonsDirectory::GetScriptsAndPlugins(const CStdString &content, CFileItem
   items.Add(GetMoreItem(content));
 
   items.SetContent("addons");
+  items.SetLabel(g_localizeStrings.Get(24001)); // Add-ons
 
   return items.Size() > 0;
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -60,6 +60,7 @@ bool CMusicDatabaseDirectory::GetDirectory(const CStdString& strPath, CFileItemL
         item->SetIconImage(strImage);
     }
   }
+  items.SetLabel(pNode->GetLocalizedName());
 
   return bResult;
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -150,32 +150,23 @@ bool CMusicDatabaseDirectory::GetLabel(const CStdString& strDirectory, CStdStrin
     return false;
 
   // get genre
-  CStdString strTemp;
   if (params.GetGenreId() >= 0)
-  {
-    strTemp = "";
-    musicdatabase.GetGenreById(params.GetGenreId(), strTemp);
-    strLabel += strTemp;
-  }
+    strLabel += musicdatabase.GetGenreById(params.GetGenreId());
 
   // get artist
   if (params.GetArtistId() >= 0)
   {
-    strTemp = "";
-    musicdatabase.GetArtistById(params.GetArtistId(), strTemp);
     if (!strLabel.IsEmpty())
       strLabel += " / ";
-    strLabel += strTemp;
+    strLabel += musicdatabase.GetArtistById(params.GetArtistId());
   }
 
   // get album
   if (params.GetAlbumId() >= 0)
   {
-    strTemp = "";
-    musicdatabase.GetAlbumById(params.GetAlbumId(), strTemp);
     if (!strLabel.IsEmpty())
       strLabel += " / ";
-    strLabel += strTemp;
+    strLabel += musicdatabase.GetAlbumById(params.GetAlbumId());
   }
 
   if (strLabel.IsEmpty())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -155,7 +155,7 @@ CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const CStdString& str
 }
 
 //  Current node name
-const CStdString& CDirectoryNode::GetName()
+const CStdString& CDirectoryNode::GetName() const
 {
   return m_strName;
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -160,6 +160,11 @@ const CStdString& CDirectoryNode::GetName() const
   return m_strName;
 }
 
+int CDirectoryNode::GetID() const
+{
+  return atoi(m_strName.c_str());
+}
+
 //  Current node type
 NODE_TYPE CDirectoryNode::GetType()
 {

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -165,6 +165,11 @@ int CDirectoryNode::GetID() const
   return atoi(m_strName.c_str());
 }
 
+CStdString CDirectoryNode::GetLocalizedName() const
+{
+  return "";
+}
+
 //  Current node type
 NODE_TYPE CDirectoryNode::GetType()
 {

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -171,13 +171,13 @@ CStdString CDirectoryNode::GetLocalizedName() const
 }
 
 //  Current node type
-NODE_TYPE CDirectoryNode::GetType()
+NODE_TYPE CDirectoryNode::GetType() const
 {
   return m_Type;
 }
 
 //  Return the parent directory node or NULL, if there is no
-CDirectoryNode* CDirectoryNode::GetParent()
+CDirectoryNode* CDirectoryNode::GetParent() const
 {
   return m_pParent;
 }
@@ -190,13 +190,13 @@ void CDirectoryNode::RemoveParent()
 //  should be overloaded by a derived class
 //  to get the content of a node. Will be called
 //  by GetChilds() of a parent node
-bool CDirectoryNode::GetContent(CFileItemList& items)
+bool CDirectoryNode::GetContent(CFileItemList& items) const
 {
   return false;
 }
 
 //  Creates a musicdb url
-CStdString CDirectoryNode::BuildPath()
+CStdString CDirectoryNode::BuildPath() const
 {
   CStdStringArray array;
 
@@ -223,7 +223,7 @@ CStdString CDirectoryNode::BuildPath()
 //  Collects Query params from this and all parent nodes. If a NODE_TYPE can
 //  be used as a database parameter, it will be added to the
 //  params object.
-void CDirectoryNode::CollectQueryParams(CQueryParams& params)
+void CDirectoryNode::CollectQueryParams(CQueryParams& params) const
 {
   params.SetQueryParam(m_Type, m_strName);
 
@@ -237,7 +237,7 @@ void CDirectoryNode::CollectQueryParams(CQueryParams& params)
 
 //  Should be overloaded by a derived class.
 //  Returns the NODE_TYPE of the child nodes.
-NODE_TYPE CDirectoryNode::GetChildType()
+NODE_TYPE CDirectoryNode::GetChildType() const
 {
   return NODE_TYPE_NONE;
 }
@@ -271,7 +271,7 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
 
 //  Add an "* All ..." folder to the CFileItemList
 //  depending on the child node
-void CDirectoryNode::AddQueuingFolder(CFileItemList& items)
+void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
 {
   CFileItemPtr pItem;
 
@@ -343,7 +343,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items)
   }
 }
 
-bool CDirectoryNode::CanCache()
+bool CDirectoryNode::CanCache() const
 {
   // JM: No need to cache these views, as caching is added in the mediawindow baseclass for anything that takes
   //     longer than a second

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
@@ -69,31 +69,31 @@ namespace XFILE
       static void GetDatabaseInfo(const CStdString& strPath, CQueryParams& params);
       virtual ~CDirectoryNode();
 
-      NODE_TYPE GetType();
+      NODE_TYPE GetType() const;
 
       bool GetChilds(CFileItemList& items);
-      virtual NODE_TYPE GetChildType();
+      virtual NODE_TYPE GetChildType() const;
       virtual CStdString GetLocalizedName() const;
 
-      CDirectoryNode* GetParent();
-      bool CanCache();
+      CDirectoryNode* GetParent() const;
+      bool CanCache() const;
 
     protected:
       CDirectoryNode(NODE_TYPE Type, const CStdString& strName, CDirectoryNode* pParent);
       static CDirectoryNode* CreateNode(NODE_TYPE Type, const CStdString& strName, CDirectoryNode* pParent);
 
-      void CollectQueryParams(CQueryParams& params);
+      void CollectQueryParams(CQueryParams& params) const;
 
       const CStdString& GetName() const;
       int GetID() const;
       void RemoveParent();
 
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
 
-      CStdString BuildPath();
+      CStdString BuildPath() const;
 
     private:
-      void AddQueuingFolder(CFileItemList& items);
+      void AddQueuingFolder(CFileItemList& items) const;
 
     private:
       NODE_TYPE m_Type;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
@@ -56,6 +56,12 @@ namespace XFILE
       NODE_TYPE_SINGLES
     } NODE_TYPE;
 
+    typedef struct {
+      NODE_TYPE node;
+      int       id;
+      int       label;
+    } Node;
+
     class CDirectoryNode
     {
     public:
@@ -78,6 +84,7 @@ namespace XFILE
       void CollectQueryParams(CQueryParams& params);
 
       const CStdString& GetName() const;
+      int GetID() const;
       void RemoveParent();
 
       virtual bool GetContent(CFileItemList& items);

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
@@ -77,7 +77,7 @@ namespace XFILE
 
       void CollectQueryParams(CQueryParams& params);
 
-      const CStdString& GetName();
+      const CStdString& GetName() const;
       void RemoveParent();
 
       virtual bool GetContent(CFileItemList& items);

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
@@ -73,6 +73,7 @@ namespace XFILE
 
       bool GetChilds(CFileItemList& items);
       virtual NODE_TYPE GetChildType();
+      virtual CStdString GetLocalizedName() const;
 
       CDirectoryNode* GetParent();
       bool CanCache();

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
@@ -36,6 +36,16 @@ NODE_TYPE CDirectoryNodeAlbum::GetChildType() const
   return NODE_TYPE_SONG;
 }
 
+CStdString CDirectoryNodeAlbum::GetLocalizedName() const
+{
+  if (GetID() == -1)
+    return g_localizeStrings.Get(15102); // All Albums
+  CMusicDatabase db;
+  if (db.Open())
+    return db.GetAlbumById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeAlbum::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
@@ -31,12 +31,12 @@ CDirectoryNodeAlbum::CDirectoryNodeAlbum(const CStdString& strName, CDirectoryNo
 
 }
 
-NODE_TYPE CDirectoryNodeAlbum::GetChildType()
+NODE_TYPE CDirectoryNodeAlbum::GetChildType() const
 {
   return NODE_TYPE_SONG;
 }
 
-bool CDirectoryNodeAlbum::GetContent(CFileItemList& items)
+bool CDirectoryNodeAlbum::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeAlbum(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeAlbumCompilations::CDirectoryNodeAlbumCompilations(const CStdStrin
 
 }
 
-NODE_TYPE CDirectoryNodeAlbumCompilations::GetChildType()
+NODE_TYPE CDirectoryNodeAlbumCompilations::GetChildType() const
 {
   if (GetName()=="-1")
     return NODE_TYPE_ALBUM_COMPILATIONS_SONGS;
@@ -39,7 +39,7 @@ NODE_TYPE CDirectoryNodeAlbumCompilations::GetChildType()
   return NODE_TYPE_SONG;
 }
 
-bool CDirectoryNodeAlbumCompilations::GetContent(CFileItemList& items)
+bool CDirectoryNodeAlbumCompilations::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.cpp
@@ -39,6 +39,16 @@ NODE_TYPE CDirectoryNodeAlbumCompilations::GetChildType() const
   return NODE_TYPE_SONG;
 }
 
+CStdString CDirectoryNodeAlbumCompilations::GetLocalizedName() const
+{
+  if (GetID() == -1)
+    return g_localizeStrings.Get(15102); // All Albums
+  CMusicDatabase db;
+  if (db.Open())
+    return db.GetAlbumById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeAlbumCompilations::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeAlbumCompilations(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilations.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilationsSongs.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilationsSongs.cpp
@@ -32,7 +32,7 @@ CDirectoryNodeAlbumCompilationsSongs::CDirectoryNodeAlbumCompilationsSongs(const
 }
 
 
-bool CDirectoryNodeAlbumCompilationsSongs::GetContent(CFileItemList& items)
+bool CDirectoryNodeAlbumCompilationsSongs::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilationsSongs.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumCompilationsSongs.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeAlbumCompilationsSongs(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeAlbumRecentlyAdded::CDirectoryNodeAlbumRecentlyAdded(const CStdStr
 
 }
 
-NODE_TYPE CDirectoryNodeAlbumRecentlyAdded::GetChildType()
+NODE_TYPE CDirectoryNodeAlbumRecentlyAdded::GetChildType() const
 {
   if (GetName()=="-1")
     return NODE_TYPE_ALBUM_RECENTLY_ADDED_SONGS;
@@ -39,7 +39,7 @@ NODE_TYPE CDirectoryNodeAlbumRecentlyAdded::GetChildType()
   return NODE_TYPE_SONG;
 }
 
-bool CDirectoryNodeAlbumRecentlyAdded::GetContent(CFileItemList& items)
+bool CDirectoryNodeAlbumRecentlyAdded::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
@@ -39,6 +39,16 @@ NODE_TYPE CDirectoryNodeAlbumRecentlyAdded::GetChildType() const
   return NODE_TYPE_SONG;
 }
 
+CStdString CDirectoryNodeAlbumRecentlyAdded::GetLocalizedName() const
+{
+  if (GetID() == -1)
+    return g_localizeStrings.Get(15102); // All Albums
+  CMusicDatabase db;
+  if (db.Open())
+    return db.GetAlbumById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeAlbumRecentlyAdded::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeAlbumRecentlyAdded(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.cpp
@@ -30,7 +30,7 @@ CDirectoryNodeAlbumRecentlyAddedSong::CDirectoryNodeAlbumRecentlyAddedSong(const
 
 }
 
-bool CDirectoryNodeAlbumRecentlyAddedSong::GetContent(CFileItemList& items)
+bool CDirectoryNodeAlbumRecentlyAddedSong::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAddedSong.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeAlbumRecentlyAddedSong(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
@@ -39,6 +39,16 @@ NODE_TYPE CDirectoryNodeAlbumRecentlyPlayed::GetChildType() const
   return NODE_TYPE_SONG;
 }
 
+CStdString CDirectoryNodeAlbumRecentlyPlayed::GetLocalizedName() const
+{
+  if (GetID() == -1)
+    return g_localizeStrings.Get(15102); // All Albums
+  CMusicDatabase db;
+  if (db.Open())
+    return db.GetAlbumById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeAlbumRecentlyPlayed::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeAlbumRecentlyPlayed::CDirectoryNodeAlbumRecentlyPlayed(const CStdS
 
 }
 
-NODE_TYPE CDirectoryNodeAlbumRecentlyPlayed::GetChildType()
+NODE_TYPE CDirectoryNodeAlbumRecentlyPlayed::GetChildType() const
 {
   if (GetName()=="-1")
     return NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS;
@@ -39,7 +39,7 @@ NODE_TYPE CDirectoryNodeAlbumRecentlyPlayed::GetChildType()
   return NODE_TYPE_SONG;
 }
 
-bool CDirectoryNodeAlbumRecentlyPlayed::GetContent(CFileItemList& items)
+bool CDirectoryNodeAlbumRecentlyPlayed::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeAlbumRecentlyPlayed(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.cpp
@@ -30,7 +30,7 @@ CDirectoryNodeAlbumRecentlyPlayedSong::CDirectoryNodeAlbumRecentlyPlayedSong(con
 
 }
 
-bool CDirectoryNodeAlbumRecentlyPlayedSong::GetContent(CFileItemList& items)
+bool CDirectoryNodeAlbumRecentlyPlayedSong::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayedSong.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeAlbumRecentlyPlayedSong(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
@@ -39,6 +39,14 @@ NODE_TYPE CDirectoryNodeAlbumTop100::GetChildType() const
   return NODE_TYPE_SONG;
 }
 
+CStdString CDirectoryNodeAlbumTop100::GetLocalizedName() const
+{
+  CMusicDatabase db;
+  if (db.Open())
+    return db.GetAlbumById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeAlbumTop100::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeAlbumTop100::CDirectoryNodeAlbumTop100(const CStdString& strName, 
 
 }
 
-NODE_TYPE CDirectoryNodeAlbumTop100::GetChildType()
+NODE_TYPE CDirectoryNodeAlbumTop100::GetChildType() const
 {
   if (GetName()=="-1")
     return NODE_TYPE_ALBUM_TOP100_SONGS;
@@ -39,7 +39,7 @@ NODE_TYPE CDirectoryNodeAlbumTop100::GetChildType()
   return NODE_TYPE_SONG;
 }
 
-bool CDirectoryNodeAlbumTop100::GetContent(CFileItemList& items)
+bool CDirectoryNodeAlbumTop100::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeAlbumTop100(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.cpp
@@ -30,7 +30,7 @@ CDirectoryNodeAlbumTop100Song::CDirectoryNodeAlbumTop100Song(const CStdString& s
 
 }
 
-bool CDirectoryNodeAlbumTop100Song::GetContent(CFileItemList& items)
+bool CDirectoryNodeAlbumTop100Song::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumTop100Song.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeAlbumTop100Song(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
@@ -32,12 +32,12 @@ CDirectoryNodeArtist::CDirectoryNodeArtist(const CStdString& strName, CDirectory
 
 }
 
-NODE_TYPE CDirectoryNodeArtist::GetChildType()
+NODE_TYPE CDirectoryNodeArtist::GetChildType() const
 {
   return NODE_TYPE_ALBUM;
 }
 
-bool CDirectoryNodeArtist::GetContent(CFileItemList& items)
+bool CDirectoryNodeArtist::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
@@ -37,6 +37,16 @@ NODE_TYPE CDirectoryNodeArtist::GetChildType() const
   return NODE_TYPE_ALBUM;
 }
 
+CStdString CDirectoryNodeArtist::GetLocalizedName() const
+{
+  if (GetID() == -1)
+    return g_localizeStrings.Get(15103); // All Artists
+  CMusicDatabase db;
+  if (db.Open())
+    return db.GetArtistById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeArtist::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeArtist(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGenre.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGenre.cpp
@@ -36,6 +36,14 @@ NODE_TYPE CDirectoryNodeGenre::GetChildType() const
   return NODE_TYPE_ARTIST;
 }
 
+CStdString CDirectoryNodeGenre::GetLocalizedName() const
+{
+  CMusicDatabase db;
+  if (db.Open())
+    return db.GetGenreById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeGenre::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGenre.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGenre.cpp
@@ -31,12 +31,12 @@ CDirectoryNodeGenre::CDirectoryNodeGenre(const CStdString& strName, CDirectoryNo
 
 }
 
-NODE_TYPE CDirectoryNodeGenre::GetChildType()
+NODE_TYPE CDirectoryNodeGenre::GetChildType() const
 {
   return NODE_TYPE_ARTIST;
 }
 
-bool CDirectoryNodeGenre::GetContent(CFileItemList& items)
+bool CDirectoryNodeGenre::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGenre.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGenre.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeGenre(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGenre.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGenre.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -52,7 +52,7 @@ CDirectoryNodeOverview::CDirectoryNodeOverview(const CStdString& strName, CDirec
 
 }
 
-NODE_TYPE CDirectoryNodeOverview::GetChildType()
+NODE_TYPE CDirectoryNodeOverview::GetChildType() const
 {
   for (unsigned int i = 0; i < sizeof(OverviewChildren) / sizeof(Node); ++i)
     if (GetID() == OverviewChildren[i].id)
@@ -68,7 +68,7 @@ CStdString CDirectoryNodeOverview::GetLocalizedName() const
   return "";
 }
 
-bool CDirectoryNodeOverview::GetContent(CFileItemList& items)
+bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicDatabase;
   bool showSingles = false;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -60,6 +60,14 @@ NODE_TYPE CDirectoryNodeOverview::GetChildType()
   return NODE_TYPE_NONE;
 }
 
+CStdString CDirectoryNodeOverview::GetLocalizedName() const
+{
+  for (unsigned int i = 0; i < sizeof(OverviewChildren) / sizeof(Node); ++i)
+    if (GetID() == OverviewChildren[i].id)
+      return g_localizeStrings.Get(OverviewChildren[i].label);
+  return "";
+}
+
 bool CDirectoryNodeOverview::GetContent(CFileItemList& items)
 {
   CMusicDatabase musicDatabase;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeOverview(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
       virtual CStdString GetLocalizedName() const;
     };
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType();
       virtual bool GetContent(CFileItemList& items);
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.cpp
@@ -29,7 +29,7 @@ CDirectoryNodeRoot::CDirectoryNodeRoot(const CStdString& strName, CDirectoryNode
 
 }
 
-NODE_TYPE CDirectoryNodeRoot::GetChildType()
+NODE_TYPE CDirectoryNodeRoot::GetChildType() const
 {
   return NODE_TYPE_OVERVIEW;
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeRoot.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeRoot(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
+      virtual NODE_TYPE GetChildType() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeSingles::CDirectoryNodeSingles(const CStdString& strName, CDirecto
 
 }
 
-bool CDirectoryNodeSingles::GetContent(CFileItemList& items)
+bool CDirectoryNodeSingles::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeSingles(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeSong::CDirectoryNodeSong(const CStdString& strName, CDirectoryNode
 
 }
 
-bool CDirectoryNodeSong::GetContent(CFileItemList& items)
+bool CDirectoryNodeSong::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeSong(const CStdString& strEntryName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.cpp
@@ -30,7 +30,7 @@ CDirectoryNodeSongTop100::CDirectoryNodeSongTop100(const CStdString& strName, CD
 
 }
 
-bool CDirectoryNodeSongTop100::GetContent(CFileItemList& items)
+bool CDirectoryNodeSongTop100::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSongTop100.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeSongTop100(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
@@ -26,6 +26,11 @@
 using namespace std;
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
+Node Top100Children[] = {
+                          { NODE_TYPE_SONG_TOP100,  1, 10504 },
+                          { NODE_TYPE_ALBUM_TOP100, 2, 10505 },
+                        };
+
 CDirectoryNodeTop100::CDirectoryNodeTop100(const CStdString& strName, CDirectoryNode* pParent)
   : CDirectoryNode(NODE_TYPE_TOP100, strName, pParent)
 {
@@ -34,25 +39,20 @@ CDirectoryNodeTop100::CDirectoryNodeTop100(const CStdString& strName, CDirectory
 
 NODE_TYPE CDirectoryNodeTop100::GetChildType()
 {
-  if (GetName()=="1")
-    return NODE_TYPE_SONG_TOP100;
-  else if (GetName()=="2")
-    return NODE_TYPE_ALBUM_TOP100;
+  for (unsigned int i = 0; i < sizeof(Top100Children) / sizeof(Node); ++i)
+    if (GetID() == Top100Children[i].id)
+      return Top100Children[i].node;
 
   return NODE_TYPE_NONE;
 }
 
 bool CDirectoryNodeTop100::GetContent(CFileItemList& items)
 {
-  vector<CStdString> vecRoot;
-  vecRoot.push_back(g_localizeStrings.Get(10504));  // Top 100 Songs
-  vecRoot.push_back(g_localizeStrings.Get(10505));  // Top 100 Albums
-
-  for (int i = 0; i < (int)vecRoot.size(); ++i)
+  for (unsigned int i = 0; i < sizeof(Top100Children) / sizeof(Node); ++i)
   {
-    CFileItemPtr pItem(new CFileItem(vecRoot[i]));
+    CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(Top100Children[i].label)));
     CStdString strDir;
-    strDir.Format("%i/", i+1);
+    strDir.Format("%ld/", Top100Children[i].id);
     pItem->m_strPath += BuildPath() + strDir;
     pItem->m_bIsFolder = true;
     items.Add(pItem);

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
@@ -46,6 +46,14 @@ NODE_TYPE CDirectoryNodeTop100::GetChildType()
   return NODE_TYPE_NONE;
 }
 
+CStdString CDirectoryNodeTop100::GetLocalizedName() const
+{
+  for (unsigned int i = 0; i < sizeof(Top100Children) / sizeof(Node); ++i)
+    if (GetID() == Top100Children[i].id)
+      return g_localizeStrings.Get(Top100Children[i].label);
+  return "";
+}
+
 bool CDirectoryNodeTop100::GetContent(CFileItemList& items)
 {
   for (unsigned int i = 0; i < sizeof(Top100Children) / sizeof(Node); ++i)

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
@@ -37,7 +37,7 @@ CDirectoryNodeTop100::CDirectoryNodeTop100(const CStdString& strName, CDirectory
 
 }
 
-NODE_TYPE CDirectoryNodeTop100::GetChildType()
+NODE_TYPE CDirectoryNodeTop100::GetChildType() const
 {
   for (unsigned int i = 0; i < sizeof(Top100Children) / sizeof(Node); ++i)
     if (GetID() == Top100Children[i].id)
@@ -54,7 +54,7 @@ CStdString CDirectoryNodeTop100::GetLocalizedName() const
   return "";
 }
 
-bool CDirectoryNodeTop100::GetContent(CFileItemList& items)
+bool CDirectoryNodeTop100::GetContent(CFileItemList& items) const
 {
   for (unsigned int i = 0; i < sizeof(Top100Children) / sizeof(Node); ++i)
   {

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType();
       virtual bool GetContent(CFileItemList& items);
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeTop100(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
       virtual CStdString GetLocalizedName() const;
     };
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYear.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYear.cpp
@@ -31,12 +31,12 @@ CDirectoryNodeYear::CDirectoryNodeYear(const CStdString& strName, CDirectoryNode
 
 }
 
-NODE_TYPE CDirectoryNodeYear::GetChildType()
+NODE_TYPE CDirectoryNodeYear::GetChildType() const
 {
   return NODE_TYPE_YEAR_ALBUM;
 }
 
-bool CDirectoryNodeYear::GetContent(CFileItemList& items)
+bool CDirectoryNodeYear::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYear.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYear.cpp
@@ -36,6 +36,11 @@ NODE_TYPE CDirectoryNodeYear::GetChildType() const
   return NODE_TYPE_YEAR_ALBUM;
 }
 
+CStdString CDirectoryNodeYear::GetLocalizedName() const
+{
+  return GetName();
+}
+
 bool CDirectoryNodeYear::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYear.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYear.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYear.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYear.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeYear(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.cpp
@@ -39,6 +39,16 @@ NODE_TYPE CDirectoryNodeYearAlbum::GetChildType() const
   return NODE_TYPE_SONG;
 }
 
+CStdString CDirectoryNodeYearAlbum::GetLocalizedName() const
+{
+  if (GetID() == -1)
+    return g_localizeStrings.Get(15102); // All Albums
+  CMusicDatabase db;
+  if (db.Open())
+    return db.GetAlbumById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeYearAlbum::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeYearAlbum::CDirectoryNodeYearAlbum(const CStdString& strName, CDir
 
 }
 
-NODE_TYPE CDirectoryNodeYearAlbum::GetChildType()
+NODE_TYPE CDirectoryNodeYearAlbum::GetChildType() const
 {
   if (GetName()=="-1")
     return NODE_TYPE_YEAR_SONG;
@@ -39,7 +39,7 @@ NODE_TYPE CDirectoryNodeYearAlbum::GetChildType()
   return NODE_TYPE_SONG;
 }
 
-bool CDirectoryNodeYearAlbum::GetContent(CFileItemList& items)
+bool CDirectoryNodeYearAlbum::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeYearAlbum(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearAlbum.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearSong.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeYearSong::CDirectoryNodeYearSong(const CStdString& strName, CDirec
 
 }
 
-bool CDirectoryNodeYearSong::GetContent(CFileItemList& items)
+bool CDirectoryNodeYearSong::GetContent(CFileItemList& items) const
 {
   CMusicDatabase musicdatabase;
   if (!musicdatabase.Open())

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearSong.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeYearSong.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeYearSong(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/MusicSearchDirectory.cpp
+++ b/xbmc/filesystem/MusicSearchDirectory.cpp
@@ -25,6 +25,7 @@
 #include "FileItem.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
+#include "guilib/LocalizeStrings.h"
 
 using namespace XFILE;
 
@@ -55,6 +56,7 @@ bool CMusicSearchDirectory::GetDirectory(const CStdString& strPath, CFileItemLis
   db.Close();
   CLog::Log(LOGDEBUG, "%s (%s) took %u ms",
             __FUNCTION__, strPath.c_str(), CTimeUtils::GetTimeMS() - time);
+  items.SetLabel(g_localizeStrings.Get(137)); // Search
   return true;
 }
 

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -111,6 +111,7 @@ namespace XFILE
         items.SetContent("musicvideos");
       playlist.SetType(type);
     }
+    items.SetLabel(playlist.GetName());
     // go through and set the playlist order
     for (int i = 0; i < items.Size(); i++)
     {

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -61,6 +61,7 @@ bool CVideoDatabaseDirectory::GetDirectory(const CStdString& strPath, CFileItemL
         item->SetIconImage(strImage);
     }
   }
+  items.SetLabel(pNode->GetLocalizedName());
 
   return bResult;
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -149,30 +149,21 @@ bool CVideoDatabaseDirectory::GetLabel(const CStdString& strDirectory, CStdStrin
     return false;
 
   // get genre
-  CStdString strTemp;
   if (params.GetGenreId() != -1)
-  {
-    videodatabase.GetGenreById(params.GetGenreId(), strTemp);
-    strLabel += strTemp;
-  }
+    strLabel += videodatabase.GetGenreById(params.GetGenreId());
 
   // get country
   if (params.GetCountryId() != -1)
-  {
-    videodatabase.GetCountryById(params.GetCountryId(), strTemp);
-    strLabel += strTemp;
-  }
+    strLabel += videodatabase.GetCountryById(params.GetCountryId());
 
   // get set
   if (params.GetSetId() != -1)
-  {
-    videodatabase.GetSetById(params.GetSetId(), strTemp);
-    strLabel += strTemp;
-  }
+    strLabel += videodatabase.GetSetById(params.GetSetId());
 
   // get year
   if (params.GetYear() != -1)
   {
+    CStdString strTemp;
     strTemp.Format("%i",params.GetYear());
     if (!strLabel.IsEmpty())
       strLabel += " / ";

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -165,6 +165,11 @@ const CStdString& CDirectoryNode::GetName() const
   return m_strName;
 }
 
+int CDirectoryNode::GetID() const
+{
+  return atoi(m_strName.c_str());
+}
+
 //  Current node type
 NODE_TYPE CDirectoryNode::GetType()
 {

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -160,7 +160,7 @@ CDirectoryNode* CDirectoryNode::CreateNode(NODE_TYPE Type, const CStdString& str
 }
 
 //  Current node name
-const CStdString& CDirectoryNode::GetName()
+const CStdString& CDirectoryNode::GetName() const
 {
   return m_strName;
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -176,13 +176,13 @@ CStdString CDirectoryNode::GetLocalizedName() const
 }
 
 //  Current node type
-NODE_TYPE CDirectoryNode::GetType()
+NODE_TYPE CDirectoryNode::GetType() const
 {
   return m_Type;
 }
 
 //  Return the parent directory node or NULL, if there is no
-CDirectoryNode* CDirectoryNode::GetParent()
+CDirectoryNode* CDirectoryNode::GetParent() const
 {
   return m_pParent;
 }
@@ -195,13 +195,13 @@ void CDirectoryNode::RemoveParent()
 //  should be overloaded by a derived class
 //  to get the content of a node. Will be called
 //  by GetChilds() of a parent node
-bool CDirectoryNode::GetContent(CFileItemList& items)
+bool CDirectoryNode::GetContent(CFileItemList& items) const
 {
   return false;
 }
 
 //  Creates a videodb url
-CStdString CDirectoryNode::BuildPath()
+CStdString CDirectoryNode::BuildPath() const
 {
   CStdStringArray array;
 
@@ -228,7 +228,7 @@ CStdString CDirectoryNode::BuildPath()
 //  Collects Query params from this and all parent nodes. If a NODE_TYPE can
 //  be used as a database parameter, it will be added to the
 //  params object.
-void CDirectoryNode::CollectQueryParams(CQueryParams& params)
+void CDirectoryNode::CollectQueryParams(CQueryParams& params) const
 {
   params.SetQueryParam(m_Type, m_strName);
 
@@ -242,7 +242,7 @@ void CDirectoryNode::CollectQueryParams(CQueryParams& params)
 
 //  Should be overloaded by a derived class.
 //  Returns the NODE_TYPE of the child nodes.
-NODE_TYPE CDirectoryNode::GetChildType()
+NODE_TYPE CDirectoryNode::GetChildType() const
 {
   return NODE_TYPE_NONE;
 }
@@ -276,7 +276,7 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
 
 //  Add an "* All ..." folder to the CFileItemList
 //  depending on the child node
-void CDirectoryNode::AddQueuingFolder(CFileItemList& items)
+void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
 {
   CFileItemPtr pItem;
 
@@ -336,7 +336,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items)
   }
 }
 
-bool CDirectoryNode::CanCache()
+bool CDirectoryNode::CanCache() const
 {
   //  Only cache the directorys in the root
   //NODE_TYPE childnode=GetChildType();

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -170,6 +170,11 @@ int CDirectoryNode::GetID() const
   return atoi(m_strName.c_str());
 }
 
+CStdString CDirectoryNode::GetLocalizedName() const
+{
+  return "";
+}
+
 //  Current node type
 NODE_TYPE CDirectoryNode::GetType()
 {

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
@@ -57,6 +57,12 @@ namespace XFILE
       NODE_TYPE_COUNTRY
     } NODE_TYPE;
 
+    typedef struct {
+      NODE_TYPE node;
+      int       id;
+      int       label;
+    } Node;
+    
     class CDirectoryNode
     {
     public:
@@ -79,6 +85,7 @@ namespace XFILE
       void CollectQueryParams(CQueryParams& params);
 
       const CStdString& GetName() const;
+      int GetID() const;
       void RemoveParent();
 
       virtual bool GetContent(CFileItemList& items);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
@@ -70,31 +70,31 @@ namespace XFILE
       static void GetDatabaseInfo(const CStdString& strPath, CQueryParams& params);
       virtual ~CDirectoryNode();
 
-      NODE_TYPE GetType();
+      NODE_TYPE GetType() const;
 
       bool GetChilds(CFileItemList& items);
-      virtual NODE_TYPE GetChildType();
+      virtual NODE_TYPE GetChildType() const;
       virtual CStdString GetLocalizedName() const;
 
-      CDirectoryNode* GetParent();
+      CDirectoryNode* GetParent() const;
 
-      bool CanCache();
+      bool CanCache() const;
     protected:
       CDirectoryNode(NODE_TYPE Type, const CStdString& strName, CDirectoryNode* pParent);
       static CDirectoryNode* CreateNode(NODE_TYPE Type, const CStdString& strName, CDirectoryNode* pParent);
 
-      void CollectQueryParams(CQueryParams& params);
+      void CollectQueryParams(CQueryParams& params) const;
 
       const CStdString& GetName() const;
       int GetID() const;
       void RemoveParent();
 
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
 
-      CStdString BuildPath();
+      CStdString BuildPath() const;
 
     private:
-      void AddQueuingFolder(CFileItemList& items);
+      void AddQueuingFolder(CFileItemList& items) const;
 
     private:
       NODE_TYPE m_Type;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
@@ -74,6 +74,7 @@ namespace XFILE
 
       bool GetChilds(CFileItemList& items);
       virtual NODE_TYPE GetChildType();
+      virtual CStdString GetLocalizedName() const;
 
       CDirectoryNode* GetParent();
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
@@ -78,7 +78,7 @@ namespace XFILE
 
       void CollectQueryParams(CQueryParams& params);
 
-      const CStdString& GetName();
+      const CStdString& GetName() const;
       void RemoveParent();
 
       virtual bool GetContent(CFileItemList& items);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeActor.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeActor.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeActor::CDirectoryNodeActor(const CStdString& strName, CDirectoryNo
 
 }
 
-NODE_TYPE CDirectoryNodeActor::GetChildType()
+NODE_TYPE CDirectoryNodeActor::GetChildType() const
 {
   CQueryParams params;
   CollectQueryParams(params);
@@ -43,7 +43,7 @@ NODE_TYPE CDirectoryNodeActor::GetChildType()
   return NODE_TYPE_TITLE_TVSHOWS;
 }
 
-bool CDirectoryNodeActor::GetContent(CFileItemList& items)
+bool CDirectoryNodeActor::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeActor.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeActor.cpp
@@ -43,6 +43,14 @@ NODE_TYPE CDirectoryNodeActor::GetChildType() const
   return NODE_TYPE_TITLE_TVSHOWS;
 }
 
+CStdString CDirectoryNodeActor::GetLocalizedName() const
+{
+  CVideoDatabase db;
+  if (db.Open())
+    return db.GetPersonById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeActor::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeActor.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeActor.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeActor(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeActor.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeActor.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeCountry.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeCountry.cpp
@@ -33,8 +33,6 @@ CDirectoryNodeCountry::CDirectoryNodeCountry(const CStdString& strName, CDirecto
 
 NODE_TYPE CDirectoryNodeCountry::GetChildType()
 {
-  CQueryParams params;
-  CollectQueryParams(params);
   return NODE_TYPE_TITLE_MOVIES;
 }
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeCountry.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeCountry.cpp
@@ -36,6 +36,14 @@ NODE_TYPE CDirectoryNodeCountry::GetChildType() const
   return NODE_TYPE_TITLE_MOVIES;
 }
 
+CStdString CDirectoryNodeCountry::GetLocalizedName() const
+{
+  CVideoDatabase db;
+  if (db.Open())
+    return db.GetCountryById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeCountry::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeCountry.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeCountry.cpp
@@ -31,12 +31,12 @@ CDirectoryNodeCountry::CDirectoryNodeCountry(const CStdString& strName, CDirecto
 
 }
 
-NODE_TYPE CDirectoryNodeCountry::GetChildType()
+NODE_TYPE CDirectoryNodeCountry::GetChildType() const
 {
   return NODE_TYPE_TITLE_MOVIES;
 }
 
-bool CDirectoryNodeCountry::GetContent(CFileItemList& items)
+bool CDirectoryNodeCountry::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeCountry.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeCountry.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeCountry.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeCountry.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeCountry(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeDirector.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeDirector.cpp
@@ -43,6 +43,14 @@ NODE_TYPE CDirectoryNodeDirector::GetChildType() const
   return NODE_TYPE_TITLE_TVSHOWS;
 }
 
+CStdString CDirectoryNodeDirector::GetLocalizedName() const
+{
+  CVideoDatabase db;
+  if (db.Open())
+    return db.GetPersonById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeDirector::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeDirector.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeDirector.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeDirector::CDirectoryNodeDirector(const CStdString& strName, CDirec
 
 }
 
-NODE_TYPE CDirectoryNodeDirector::GetChildType()
+NODE_TYPE CDirectoryNodeDirector::GetChildType() const
 {
   CQueryParams params;
   CollectQueryParams(params);
@@ -43,7 +43,7 @@ NODE_TYPE CDirectoryNodeDirector::GetChildType()
   return NODE_TYPE_TITLE_TVSHOWS;
 }
 
-bool CDirectoryNodeDirector::GetContent(CFileItemList& items)
+bool CDirectoryNodeDirector::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeDirector.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeDirector.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeDirector(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeDirector.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeDirector.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeEpisodes::CDirectoryNodeEpisodes(const CStdString& strName, CDirec
 
 }
 
-bool CDirectoryNodeEpisodes::GetContent(CFileItemList& items)
+bool CDirectoryNodeEpisodes::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeEpisodes(const CStdString& strEntryName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGenre.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGenre.cpp
@@ -43,6 +43,14 @@ NODE_TYPE CDirectoryNodeGenre::GetChildType() const
   return NODE_TYPE_TITLE_TVSHOWS;
 }
 
+CStdString CDirectoryNodeGenre::GetLocalizedName() const
+{
+  CVideoDatabase db;
+  if (db.Open())
+    return db.GetGenreById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeGenre::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGenre.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGenre.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeGenre::CDirectoryNodeGenre(const CStdString& strName, CDirectoryNo
 
 }
 
-NODE_TYPE CDirectoryNodeGenre::GetChildType()
+NODE_TYPE CDirectoryNodeGenre::GetChildType() const
 {
   CQueryParams params;
   CollectQueryParams(params);
@@ -43,7 +43,7 @@ NODE_TYPE CDirectoryNodeGenre::GetChildType()
   return NODE_TYPE_TITLE_TVSHOWS;
 }
 
-bool CDirectoryNodeGenre::GetContent(CFileItemList& items)
+bool CDirectoryNodeGenre::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGenre.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGenre.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeGenre(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGenre.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeGenre.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -44,7 +44,7 @@ CDirectoryNodeMoviesOverview::CDirectoryNodeMoviesOverview(const CStdString& str
 
 }
 
-NODE_TYPE CDirectoryNodeMoviesOverview::GetChildType()
+NODE_TYPE CDirectoryNodeMoviesOverview::GetChildType() const
 {
   for (unsigned int i = 0; i < sizeof(MovieChildren) / sizeof(Node); ++i)
     if (GetID() == MovieChildren[i].id)
@@ -61,7 +61,7 @@ CStdString CDirectoryNodeMoviesOverview::GetLocalizedName() const
   return "";
 }
 
-bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items)
+bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items) const
 {
   for (unsigned int i = 0; i < sizeof(MovieChildren) / sizeof(Node); ++i)
   {

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -53,6 +53,14 @@ NODE_TYPE CDirectoryNodeMoviesOverview::GetChildType()
   return NODE_TYPE_NONE;
 }
 
+CStdString CDirectoryNodeMoviesOverview::GetLocalizedName() const
+{
+  for (unsigned int i = 0; i < sizeof(MovieChildren) / sizeof(Node); ++i)
+    if (GetID() == MovieChildren[i].id)
+      return g_localizeStrings.Get(MovieChildren[i].label);
+  return "";
+}
+
 bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items)
 {
   for (unsigned int i = 0; i < sizeof(MovieChildren) / sizeof(Node); ++i)

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -27,6 +27,17 @@
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 using namespace std;
 
+Node MovieChildren[] = {
+                        { NODE_TYPE_GENRE,        1, 135 },
+                        { NODE_TYPE_TITLE_MOVIES, 2, 369 },
+                        { NODE_TYPE_YEAR,         3, 562 },
+                        { NODE_TYPE_ACTOR,        4, 344 },
+                        { NODE_TYPE_DIRECTOR,     5, 20348 },
+                        { NODE_TYPE_STUDIO,       6, 20388 },
+                        { NODE_TYPE_SETS,         7, 20434 },
+                        { NODE_TYPE_COUNTRY,      8, 20451 },
+                       };
+
 CDirectoryNodeMoviesOverview::CDirectoryNodeMoviesOverview(const CStdString& strName, CDirectoryNode* pParent)
   : CDirectoryNode(NODE_TYPE_MOVIES_OVERVIEW, strName, pParent)
 {
@@ -35,49 +46,27 @@ CDirectoryNodeMoviesOverview::CDirectoryNodeMoviesOverview(const CStdString& str
 
 NODE_TYPE CDirectoryNodeMoviesOverview::GetChildType()
 {
-  if (GetName()=="1")
-    return NODE_TYPE_GENRE;
-  else if (GetName()=="2")
-    return NODE_TYPE_TITLE_MOVIES;
-  else if (GetName()=="3")
-    return NODE_TYPE_YEAR;
-  else if (GetName()=="4")
-    return NODE_TYPE_ACTOR;
-  else if (GetName()=="5")
-    return NODE_TYPE_DIRECTOR;
-  else if (GetName()=="6")
-    return NODE_TYPE_STUDIO;
-  else if (GetName()=="7")
-    return NODE_TYPE_SETS;
-  else if (GetName()=="8")
-    return NODE_TYPE_COUNTRY;
-
+  for (unsigned int i = 0; i < sizeof(MovieChildren) / sizeof(Node); ++i)
+    if (GetID() == MovieChildren[i].id)
+      return MovieChildren[i].node;
+  
   return NODE_TYPE_NONE;
 }
 
 bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items)
 {
-  vector<pair<const char*, int> > vecRoot;
-  vecRoot.push_back(make_pair("1", 135));  // Genres
-  vecRoot.push_back(make_pair("2", 369));  // Title
-  vecRoot.push_back(make_pair("3", 562));  // Year
-  vecRoot.push_back(make_pair("4", 344));  // Actors
-  vecRoot.push_back(make_pair("5", 20348));  // Directors
-  vecRoot.push_back(make_pair("6", 20388));  // Studios
-  CVideoDatabase db;
-  if (db.Open())
+  for (unsigned int i = 0; i < sizeof(MovieChildren) / sizeof(Node); ++i)
   {
-    if (db.HasSets())
-      vecRoot.push_back(make_pair("7", 20434));  // Sets
-    db.Close();
-  }
-  vecRoot.push_back(make_pair("8", 20451));  // Countries
-
-  CStdString path = BuildPath();
-  for (unsigned int i = 0; i < vecRoot.size(); ++i)
-  {
-    CFileItemPtr pItem(new CFileItem(path + vecRoot[i].first + "/", true));
-    pItem->SetLabel(g_localizeStrings.Get(vecRoot[i].second));
+    if (i == 6)
+    {
+      CVideoDatabase db;
+      if (db.Open() && !db.HasSets())
+        continue;
+    }
+    CStdString path;
+    path.Format("%s%ld/", BuildPath().c_str(), MovieChildren[i].id);
+    CFileItemPtr pItem(new CFileItem(path, true));
+    pItem->SetLabel(g_localizeStrings.Get(MovieChildren[i].label));
     pItem->SetCanQueue(false);
     items.Add(pItem);
   }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType();
       virtual bool GetContent(CFileItemList& items);
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeMoviesOverview(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
       virtual CStdString GetLocalizedName() const;
     };
   }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideoAlbum.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideoAlbum.cpp
@@ -36,6 +36,14 @@ NODE_TYPE CDirectoryNodeMusicVideoAlbum::GetChildType() const
   return NODE_TYPE_TITLE_MUSICVIDEOS;
 }
 
+CStdString CDirectoryNodeMusicVideoAlbum::GetLocalizedName() const
+{
+  CVideoDatabase db;
+  if (db.Open())
+    return db.GetMusicVideoAlbumById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeMusicVideoAlbum::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideoAlbum.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideoAlbum.cpp
@@ -31,12 +31,12 @@ CDirectoryNodeMusicVideoAlbum::CDirectoryNodeMusicVideoAlbum(const CStdString& s
 
 }
 
-NODE_TYPE CDirectoryNodeMusicVideoAlbum::GetChildType()
+NODE_TYPE CDirectoryNodeMusicVideoAlbum::GetChildType() const
 {
   return NODE_TYPE_TITLE_MUSICVIDEOS;
 }
 
-bool CDirectoryNodeMusicVideoAlbum::GetContent(CFileItemList& items)
+bool CDirectoryNodeMusicVideoAlbum::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideoAlbum.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideoAlbum.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeMusicVideoAlbum(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideoAlbum.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideoAlbum.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -41,7 +41,7 @@ CDirectoryNodeMusicVideosOverview::CDirectoryNodeMusicVideosOverview(const CStdS
 
 }
 
-NODE_TYPE CDirectoryNodeMusicVideosOverview::GetChildType()
+NODE_TYPE CDirectoryNodeMusicVideosOverview::GetChildType() const
 {
   for (unsigned int i = 0; i < sizeof(MusicVideoChildren) / sizeof(Node); ++i)
     if (GetID() == MusicVideoChildren[i].id)
@@ -58,7 +58,7 @@ CStdString CDirectoryNodeMusicVideosOverview::GetLocalizedName() const
   return "";
 }
 
-bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items)
+bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items) const
 {
   for (unsigned int i = 0; i < sizeof(MusicVideoChildren) / sizeof(Node); ++i)
   {

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -25,6 +25,16 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
+Node MusicVideoChildren[] = {
+                              { NODE_TYPE_GENRE,             1, 135 },
+                              { NODE_TYPE_TITLE_MOVIES,      2, 369 },
+                              { NODE_TYPE_YEAR,              3, 562 },
+                              { NODE_TYPE_ACTOR,             4, 133 },
+                              { NODE_TYPE_MUSICVIDEOS_ALBUM, 5, 132 },
+                              { NODE_TYPE_DIRECTOR,          6, 20348 },
+                              { NODE_TYPE_STUDIO,            7, 20388 },
+                            };
+
 CDirectoryNodeMusicVideosOverview::CDirectoryNodeMusicVideosOverview(const CStdString& strName, CDirectoryNode* pParent)
   : CDirectoryNode(NODE_TYPE_MUSICVIDEOS_OVERVIEW, strName, pParent)
 {
@@ -33,40 +43,20 @@ CDirectoryNodeMusicVideosOverview::CDirectoryNodeMusicVideosOverview(const CStdS
 
 NODE_TYPE CDirectoryNodeMusicVideosOverview::GetChildType()
 {
-  if (GetName()=="1")
-    return NODE_TYPE_GENRE;
-  else if (GetName()=="2")
-    return NODE_TYPE_TITLE_MUSICVIDEOS;
-  else if (GetName()=="3")
-    return NODE_TYPE_YEAR;
-  else if (GetName()=="4")
-    return NODE_TYPE_ACTOR;
-  else if (GetName()=="5")
-    return NODE_TYPE_MUSICVIDEOS_ALBUM;
-  else if (GetName()=="6")
-    return NODE_TYPE_DIRECTOR;
-  else if (GetName()=="7")
-    return NODE_TYPE_STUDIO;
+  for (unsigned int i = 0; i < sizeof(MusicVideoChildren) / sizeof(Node); ++i)
+    if (GetID() == MusicVideoChildren[i].id)
+      return MusicVideoChildren[i].node;
 
   return NODE_TYPE_NONE;
 }
 
 bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items)
 {
-  CStdStringArray vecRoot;
-  vecRoot.push_back(g_localizeStrings.Get(135));  // Genres
-  vecRoot.push_back(g_localizeStrings.Get(369));  // Title
-  vecRoot.push_back(g_localizeStrings.Get(562));  // Year
-  vecRoot.push_back(g_localizeStrings.Get(133));  // Artists
-  vecRoot.push_back(g_localizeStrings.Get(132));  // Albums
-  vecRoot.push_back(g_localizeStrings.Get(20348));  // Directors
-  vecRoot.push_back(g_localizeStrings.Get(20388));  // Studios
-
-  for (int i = 0; i < (int)vecRoot.size(); ++i)
+  for (unsigned int i = 0; i < sizeof(MusicVideoChildren) / sizeof(Node); ++i)
   {
-    CFileItemPtr pItem(new CFileItem(vecRoot[i]));
+    CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(MusicVideoChildren[i].label)));
     CStdString strDir;
-    strDir.Format("%i/", i+1);
+    strDir.Format("%ld/", MusicVideoChildren[i].id);
     pItem->m_strPath = BuildPath() + strDir;
     pItem->m_bIsFolder = true;
     pItem->SetCanQueue(false);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -50,6 +50,14 @@ NODE_TYPE CDirectoryNodeMusicVideosOverview::GetChildType()
   return NODE_TYPE_NONE;
 }
 
+CStdString CDirectoryNodeMusicVideosOverview::GetLocalizedName() const
+{
+  for (unsigned int i = 0; i < sizeof(MusicVideoChildren) / sizeof(Node); ++i)
+    if (GetID() == MusicVideoChildren[i].id)
+      return g_localizeStrings.Get(MusicVideoChildren[i].label);
+  return "";
+}
+
 bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items)
 {
   for (unsigned int i = 0; i < sizeof(MusicVideoChildren) / sizeof(Node); ++i)

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeMusicVideosOverview(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
       virtual CStdString GetLocalizedName() const;
     };
   }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType();
       virtual bool GetContent(CFileItemList& items);
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -45,7 +45,7 @@ CDirectoryNodeOverview::CDirectoryNodeOverview(const CStdString& strName, CDirec
 
 }
 
-NODE_TYPE CDirectoryNodeOverview::GetChildType()
+NODE_TYPE CDirectoryNodeOverview::GetChildType() const
 {
   for (unsigned int i = 0; i < sizeof(OverviewChildren) / sizeof(Node); ++i)
     if (GetID() == OverviewChildren[i].id)
@@ -62,7 +62,7 @@ CStdString CDirectoryNodeOverview::GetLocalizedName() const
   return "";
 }
 
-bool CDirectoryNodeOverview::GetContent(CFileItemList& items)
+bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
 {
   CVideoDatabase database;
   database.Open();

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -54,6 +54,14 @@ NODE_TYPE CDirectoryNodeOverview::GetChildType()
   return NODE_TYPE_NONE;
 }
 
+CStdString CDirectoryNodeOverview::GetLocalizedName() const
+{
+  for (unsigned int i = 0; i < sizeof(OverviewChildren) / sizeof(Node); ++i)
+    if (GetID() == OverviewChildren[i].id)
+      return g_localizeStrings.Get(OverviewChildren[i].label);
+  return "";
+}
+
 bool CDirectoryNodeOverview::GetContent(CFileItemList& items)
 {
   CVideoDatabase database;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -29,6 +29,16 @@
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 using namespace std;
 
+
+Node OverviewChildren[] = {
+                            { NODE_TYPE_MOVIES_OVERVIEW,            1, 342 },
+                            { NODE_TYPE_TVSHOWS_OVERVIEW,           2, 20343 },
+                            { NODE_TYPE_MUSICVIDEOS_OVERVIEW,       3, 20389 },
+                            { NODE_TYPE_RECENTLY_ADDED_MOVIES,      4, 20386 },
+                            { NODE_TYPE_RECENTLY_ADDED_EPISODES,    5, 20387 },
+                            { NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS, 6, 20390 },
+                          };
+
 CDirectoryNodeOverview::CDirectoryNodeOverview(const CStdString& strName, CDirectoryNode* pParent)
   : CDirectoryNode(NODE_TYPE_OVERVIEW, strName, pParent)
 {
@@ -37,18 +47,9 @@ CDirectoryNodeOverview::CDirectoryNodeOverview(const CStdString& strName, CDirec
 
 NODE_TYPE CDirectoryNodeOverview::GetChildType()
 {
-  if (GetName()=="1")
-    return NODE_TYPE_MOVIES_OVERVIEW;
-  else if (GetName()=="2")
-    return NODE_TYPE_TVSHOWS_OVERVIEW;
-  else if (GetName() == "3")
-    return NODE_TYPE_MUSICVIDEOS_OVERVIEW;
-  else if (GetName() == "4")
-    return NODE_TYPE_RECENTLY_ADDED_MOVIES;
-  else if (GetName() == "5")
-    return NODE_TYPE_RECENTLY_ADDED_EPISODES;
-  else if (GetName() == "6")
-    return NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS;
+  for (unsigned int i = 0; i < sizeof(OverviewChildren) / sizeof(Node); ++i)
+    if (GetID() == OverviewChildren[i].id)
+      return OverviewChildren[i].node;
 
   return NODE_TYPE_NONE;
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeOverview(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
       virtual CStdString GetLocalizedName() const;
     };
   }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType();
       virtual bool GetContent(CFileItemList& items);
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
@@ -31,12 +31,12 @@ CDirectoryNodeRecentlyAddedEpisodes::CDirectoryNodeRecentlyAddedEpisodes(const C
 
 }
 
-NODE_TYPE CDirectoryNodeRecentlyAddedEpisodes::GetChildType()
+NODE_TYPE CDirectoryNodeRecentlyAddedEpisodes::GetChildType() const
 {
   return NODE_TYPE_EPISODES;
 }
 
-bool CDirectoryNodeRecentlyAddedEpisodes::GetContent(CFileItemList& items)
+bool CDirectoryNodeRecentlyAddedEpisodes::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeRecentlyAddedEpisodes(const CStdString& strEntryName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
-      virtual NODE_TYPE GetChildType();
+      virtual bool GetContent(CFileItemList& items) const;
+      virtual NODE_TYPE GetChildType() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
@@ -31,12 +31,12 @@ CDirectoryNodeRecentlyAddedMovies::CDirectoryNodeRecentlyAddedMovies(const CStdS
 
 }
 
-NODE_TYPE CDirectoryNodeRecentlyAddedMovies::GetChildType()
+NODE_TYPE CDirectoryNodeRecentlyAddedMovies::GetChildType() const
 {
   return NODE_TYPE_TITLE_MOVIES;
 }
 
-bool CDirectoryNodeRecentlyAddedMovies::GetContent(CFileItemList& items)
+bool CDirectoryNodeRecentlyAddedMovies::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeRecentlyAddedMovies(const CStdString& strEntryName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
-      virtual NODE_TYPE GetChildType();
+      virtual bool GetContent(CFileItemList& items) const;
+      virtual NODE_TYPE GetChildType() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
@@ -31,12 +31,12 @@ CDirectoryNodeRecentlyAddedMusicVideos::CDirectoryNodeRecentlyAddedMusicVideos(c
 
 }
 
-NODE_TYPE CDirectoryNodeRecentlyAddedMusicVideos::GetChildType()
+NODE_TYPE CDirectoryNodeRecentlyAddedMusicVideos::GetChildType() const
 {
   return NODE_TYPE_TITLE_MUSICVIDEOS;
 }
 
-bool CDirectoryNodeRecentlyAddedMusicVideos::GetContent(CFileItemList& items)
+bool CDirectoryNodeRecentlyAddedMusicVideos::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeRecentlyAddedMusicVideos(const CStdString& strEntryName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
-      virtual NODE_TYPE GetChildType();
+      virtual bool GetContent(CFileItemList& items) const;
+      virtual NODE_TYPE GetChildType() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.cpp
@@ -29,7 +29,7 @@ CDirectoryNodeRoot::CDirectoryNodeRoot(const CStdString& strName, CDirectoryNode
 
 }
 
-NODE_TYPE CDirectoryNodeRoot::GetChildType()
+NODE_TYPE CDirectoryNodeRoot::GetChildType() const
 {
   return NODE_TYPE_OVERVIEW;
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRoot.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeRoot(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
+      virtual NODE_TYPE GetChildType() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -34,12 +34,12 @@ CDirectoryNodeSeasons::CDirectoryNodeSeasons(const CStdString& strName, CDirecto
 
 }
 
-NODE_TYPE CDirectoryNodeSeasons::GetChildType()
+NODE_TYPE CDirectoryNodeSeasons::GetChildType() const
 {
   return NODE_TYPE_EPISODES;
 }
 
-bool CDirectoryNodeSeasons::GetContent(CFileItemList& items)
+bool CDirectoryNodeSeasons::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -39,6 +39,21 @@ NODE_TYPE CDirectoryNodeSeasons::GetChildType() const
   return NODE_TYPE_EPISODES;
 }
 
+CStdString CDirectoryNodeSeasons::GetLocalizedName() const
+{
+  switch (GetID())
+  {
+  case 0:
+    return g_localizeStrings.Get(20381); // Specials
+  case -1:
+    return g_localizeStrings.Get(20366); // All Seasons
+  default:
+    CStdString season;
+    season.Format(g_localizeStrings.Get(20358), GetID()); // Season <season>
+    return season;
+  }
+}
+
 bool CDirectoryNodeSeasons::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeSeasons(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSets.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSets.cpp
@@ -36,6 +36,14 @@ NODE_TYPE CDirectoryNodeSets::GetChildType() const
   return NODE_TYPE_TITLE_MOVIES;
 }
 
+CStdString CDirectoryNodeSets::GetLocalizedName() const
+{
+  CVideoDatabase db;
+  if (db.Open())
+    return db.GetSetById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeSets::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSets.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSets.cpp
@@ -33,8 +33,6 @@ CDirectoryNodeSets::CDirectoryNodeSets(const CStdString& strName, CDirectoryNode
 
 NODE_TYPE CDirectoryNodeSets::GetChildType()
 {
-  CQueryParams params;
-  CollectQueryParams(params);
   return NODE_TYPE_TITLE_MOVIES;
 }
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSets.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSets.cpp
@@ -31,12 +31,12 @@ CDirectoryNodeSets::CDirectoryNodeSets(const CStdString& strName, CDirectoryNode
 
 }
 
-NODE_TYPE CDirectoryNodeSets::GetChildType()
+NODE_TYPE CDirectoryNodeSets::GetChildType() const
 {
   return NODE_TYPE_TITLE_MOVIES;
 }
 
-bool CDirectoryNodeSets::GetContent(CFileItemList& items)
+bool CDirectoryNodeSets::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSets.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSets.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeSets(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSets.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSets.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeStudio.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeStudio.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeStudio::CDirectoryNodeStudio(const CStdString& strName, CDirectory
 
 }
 
-NODE_TYPE CDirectoryNodeStudio::GetChildType()
+NODE_TYPE CDirectoryNodeStudio::GetChildType() const
 {
   CQueryParams params;
   CollectQueryParams(params);
@@ -43,7 +43,7 @@ NODE_TYPE CDirectoryNodeStudio::GetChildType()
   return NODE_TYPE_TITLE_TVSHOWS;
 }
 
-bool CDirectoryNodeStudio::GetContent(CFileItemList& items)
+bool CDirectoryNodeStudio::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeStudio.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeStudio.cpp
@@ -43,6 +43,14 @@ NODE_TYPE CDirectoryNodeStudio::GetChildType() const
   return NODE_TYPE_TITLE_TVSHOWS;
 }
 
+CStdString CDirectoryNodeStudio::GetLocalizedName() const
+{
+  CVideoDatabase db;
+  if (db.Open())
+    return db.GetStudioById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeStudio::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeStudio.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeStudio.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeStudio(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeStudio.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeStudio.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeTitleMovies::CDirectoryNodeTitleMovies(const CStdString& strName, 
 
 }
 
-bool CDirectoryNodeTitleMovies::GetContent(CFileItemList& items)
+bool CDirectoryNodeTitleMovies::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeTitleMovies(const CStdString& strEntryName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeTitleMusicVideos::CDirectoryNodeTitleMusicVideos(const CStdString&
 
 }
 
-bool CDirectoryNodeTitleMusicVideos::GetContent(CFileItemList& items)
+bool CDirectoryNodeTitleMusicVideos::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.h
@@ -31,7 +31,7 @@ namespace XFILE
     public:
       CDirectoryNodeTitleMusicVideos(const CStdString& strEntryName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
+      virtual bool GetContent(CFileItemList& item) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
@@ -36,6 +36,14 @@ NODE_TYPE CDirectoryNodeTitleTvShows::GetChildType() const
   return NODE_TYPE_SEASONS;
 }
 
+CStdString CDirectoryNodeTitleTvShows::GetLocalizedName() const
+{
+  CVideoDatabase db;
+  if (db.Open())
+    return db.GetTvShowTitleById(GetID());
+  return "";
+}
+
 bool CDirectoryNodeTitleTvShows::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
@@ -31,12 +31,12 @@ CDirectoryNodeTitleTvShows::CDirectoryNodeTitleTvShows(const CStdString& strName
 
 }
 
-NODE_TYPE CDirectoryNodeTitleTvShows::GetChildType()
+NODE_TYPE CDirectoryNodeTitleTvShows::GetChildType() const
 {
   return NODE_TYPE_SEASONS;
 }
 
-bool CDirectoryNodeTitleTvShows::GetContent(CFileItemList& items)
+bool CDirectoryNodeTitleTvShows::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeTitleTvShows(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType() const;
       virtual bool GetContent(CFileItemList& items) const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -39,7 +39,7 @@ CDirectoryNodeTvShowsOverview::CDirectoryNodeTvShowsOverview(const CStdString& s
 
 }
 
-NODE_TYPE CDirectoryNodeTvShowsOverview::GetChildType()
+NODE_TYPE CDirectoryNodeTvShowsOverview::GetChildType() const
 {
   if (GetName()=="0")
     return NODE_TYPE_EPISODES;
@@ -59,7 +59,7 @@ CStdString CDirectoryNodeTvShowsOverview::GetLocalizedName() const
   return "";
 }
 
-bool CDirectoryNodeTvShowsOverview::GetContent(CFileItemList& items)
+bool CDirectoryNodeTvShowsOverview::GetContent(CFileItemList& items) const
 {
   for (unsigned int i = 0; i < sizeof(TvShowChildren) / sizeof(Node); ++i)
   {

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -51,6 +51,14 @@ NODE_TYPE CDirectoryNodeTvShowsOverview::GetChildType()
   return NODE_TYPE_NONE;
 }
 
+CStdString CDirectoryNodeTvShowsOverview::GetLocalizedName() const
+{
+  for (unsigned int i = 0; i < sizeof(TvShowChildren) / sizeof(Node); ++i)
+    if (GetID() == TvShowChildren[i].id)
+      return g_localizeStrings.Get(TvShowChildren[i].label);
+  return "";
+}
+
 bool CDirectoryNodeTvShowsOverview::GetContent(CFileItemList& items)
 {
   for (unsigned int i = 0; i < sizeof(TvShowChildren) / sizeof(Node); ++i)

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -25,6 +25,14 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
+Node TvShowChildren[] = {
+                          { NODE_TYPE_GENRE,         1, 135 },
+                          { NODE_TYPE_TITLE_TVSHOWS, 2, 369 },
+                          { NODE_TYPE_YEAR,          3, 562 },
+                          { NODE_TYPE_ACTOR,         4, 344 },
+                          { NODE_TYPE_STUDIO,        5, 20388 },
+                        };
+
 CDirectoryNodeTvShowsOverview::CDirectoryNodeTvShowsOverview(const CStdString& strName, CDirectoryNode* pParent)
   : CDirectoryNode(NODE_TYPE_TVSHOWS_OVERVIEW, strName, pParent)
 {
@@ -35,34 +43,21 @@ NODE_TYPE CDirectoryNodeTvShowsOverview::GetChildType()
 {
   if (GetName()=="0")
     return NODE_TYPE_EPISODES;
-  else if (GetName()=="1")
-    return NODE_TYPE_GENRE;
-  else if (GetName()=="2")
-    return NODE_TYPE_TITLE_TVSHOWS;
-  else if (GetName()=="3")
-    return NODE_TYPE_YEAR;
-  else if (GetName()=="4")
-    return NODE_TYPE_ACTOR;
-  else if (GetName()=="5")
-    return NODE_TYPE_STUDIO;
+
+  for (unsigned int i = 0; i < sizeof(TvShowChildren) / sizeof(Node); ++i)
+    if (GetID() == TvShowChildren[i].id)
+      return TvShowChildren[i].node;
 
   return NODE_TYPE_NONE;
 }
 
 bool CDirectoryNodeTvShowsOverview::GetContent(CFileItemList& items)
 {
-  CStdStringArray vecRoot;
-  vecRoot.push_back(g_localizeStrings.Get(135));  // Genres
-  vecRoot.push_back(g_localizeStrings.Get(369));  // Title
-  vecRoot.push_back(g_localizeStrings.Get(562));  // Year
-  vecRoot.push_back(g_localizeStrings.Get(344));  // Actors
-  vecRoot.push_back(g_localizeStrings.Get(20388));// Studios
-
-  for (int i = 0; i < (int)vecRoot.size(); ++i)
+  for (unsigned int i = 0; i < sizeof(TvShowChildren) / sizeof(Node); ++i)
   {
-    CFileItemPtr pItem(new CFileItem(vecRoot[i]));
+    CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(TvShowChildren[i].label)));
     CStdString strDir;
-    strDir.Format("%i/", i+1);
+    strDir.Format("%ld/", TvShowChildren[i].id);
     pItem->m_strPath = BuildPath() + strDir;
     pItem->m_bIsFolder = true;
     pItem->SetCanQueue(false);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeTvShowsOverview(const CStdString& strName, CDirectoryNode* pParent);
     protected:
-      virtual NODE_TYPE GetChildType();
-      virtual bool GetContent(CFileItemList& items);
+      virtual NODE_TYPE GetChildType() const;
+      virtual bool GetContent(CFileItemList& items) const;
       virtual CStdString GetLocalizedName() const;
     };
   }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual NODE_TYPE GetChildType();
       virtual bool GetContent(CFileItemList& items);
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeYear.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeYear.cpp
@@ -43,6 +43,11 @@ NODE_TYPE CDirectoryNodeYear::GetChildType() const
   return NODE_TYPE_TITLE_TVSHOWS;
 }
 
+CStdString CDirectoryNodeYear::GetLocalizedName() const
+{
+  return GetName();
+}
+
 bool CDirectoryNodeYear::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeYear.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeYear.cpp
@@ -31,7 +31,7 @@ CDirectoryNodeYear::CDirectoryNodeYear(const CStdString& strName, CDirectoryNode
 
 }
 
-NODE_TYPE CDirectoryNodeYear::GetChildType()
+NODE_TYPE CDirectoryNodeYear::GetChildType() const
 {
   CQueryParams params;
   CollectQueryParams(params);
@@ -43,7 +43,7 @@ NODE_TYPE CDirectoryNodeYear::GetChildType()
   return NODE_TYPE_TITLE_TVSHOWS;
 }
 
-bool CDirectoryNodeYear::GetContent(CFileItemList& items)
+bool CDirectoryNodeYear::GetContent(CFileItemList& items) const
 {
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeYear.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeYear.h
@@ -31,8 +31,8 @@ namespace XFILE
     public:
       CDirectoryNodeYear(const CStdString& strEntryName, CDirectoryNode* pParent);
     protected:
-      virtual bool GetContent(CFileItemList& items);
-      virtual NODE_TYPE GetChildType();
+      virtual bool GetContent(CFileItemList& items) const;
+      virtual NODE_TYPE GetChildType() const;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeYear.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeYear.h
@@ -33,6 +33,7 @@ namespace XFILE
     protected:
       virtual bool GetContent(CFileItemList& items) const;
       virtual NODE_TYPE GetChildType() const;
+      virtual CStdString GetLocalizedName() const;
     };
   }
 }

--- a/xbmc/filesystem/VirtualDirectory.cpp
+++ b/xbmc/filesystem/VirtualDirectory.cpp
@@ -100,7 +100,7 @@ bool CVirtualDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
  \note The parameter \e strPath can not be a share with directory. Eg. "iso9660://dir" will return \e false.
     It must be "iso9660://".
  */
-bool CVirtualDirectory::IsSource(const CStdString& strPath) const
+bool CVirtualDirectory::IsSource(const CStdString& strPath, VECSOURCES *sources, CStdString *name) const
 {
   CStdString strPathCpy = strPath;
   strPathCpy.TrimRight("/");
@@ -113,7 +113,10 @@ bool CVirtualDirectory::IsSource(const CStdString& strPath) const
     strPathCpy.Replace("/", "\\");
 
   VECSOURCES shares;
-  GetSources(shares);
+  if (sources)
+    shares = *sources;
+  else
+    GetSources(shares);
   for (int i = 0; i < (int)shares.size(); ++i)
   {
     const CMediaSource& share = shares.at(i);
@@ -122,7 +125,12 @@ bool CVirtualDirectory::IsSource(const CStdString& strPath) const
     strShare.TrimRight("\\");
     if(URIUtils::IsDOSPath(strShare))
       strShare.Replace("/", "\\");
-    if (strShare == strPathCpy) return true;
+    if (strShare == strPathCpy)
+    {
+      if (name)
+        *name = share.strName;
+      return true;
+    }
   }
   return false;
 }

--- a/xbmc/filesystem/VirtualDirectory.h
+++ b/xbmc/filesystem/VirtualDirectory.h
@@ -43,7 +43,7 @@ namespace XFILE
       return m_vecSources.size();
     }
 
-    bool IsSource(const CStdString& strPath) const;
+    bool IsSource(const CStdString& strPath, VECSOURCES *sources = NULL, CStdString *name = NULL) const;
     bool IsInSource(const CStdString& strPath) const;
 
     inline const CMediaSource& operator [](const int index) const

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2899,8 +2899,7 @@ bool CMusicDatabase::GetAlbumsNav(const CStdString& strBaseDir, CFileItemList& i
   bool bResult = GetAlbumsByWhere(strBaseDir, strWhere, "", items);
   if (bResult && idArtist != -1)
   {
-    CStdString strArtist;
-    GetArtistById(idArtist,strArtist);
+    CStdString strArtist = GetArtistById(idArtist);
     CStdString strFanart = items.GetCachedThumb(strArtist,g_settings.GetMusicFanartFolder());
     if (CFile::Exists(strFanart))
       items.SetProperty("fanart_image",strFanart);
@@ -3086,8 +3085,7 @@ bool CMusicDatabase::GetSongsNav(const CStdString& strBaseDir, CFileItemList& it
   bool bResult = GetSongsByWhere(strBaseDir, strWhere, items);
   if (bResult && idArtist != -1)
   {
-    CStdString strArtist;
-    GetArtistById(idArtist,strArtist);
+    CStdString strArtist = GetArtistById(idArtist);
     CStdString strFanart = items.GetCachedThumb(strArtist,g_settings.GetMusicFanartFolder());
     if (CFile::Exists(strFanart))
       items.SetProperty("fanart_image",strFanart);
@@ -3520,32 +3518,19 @@ int CMusicDatabase::GetAlbumByName(const CStdString& strAlbum, const CStdString&
   return -1;
 }
 
-bool CMusicDatabase::GetGenreById(int idGenre, CStdString& strGenre)
+CStdString CMusicDatabase::GetGenreById(int id)
 {
-  strGenre = "";
-  try
-  {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+  return GetSingleValue("genre", "strGenre", PrepareSQL("idGenre=%i", id));
+}
 
-    CStdString strSQL=PrepareSQL("select strGenre from genre where genre.idGenre = %i", idGenre);
+CStdString CMusicDatabase::GetArtistById(int id)
+{
+  return GetSingleValue("artist", "strArtist", PrepareSQL("idArtist=%i", id));
+}
 
-    // run query
-    if (!m_pDS->query(strSQL.c_str())) return false;
-    int iRowsFound = m_pDS->num_rows();
-    if (iRowsFound != 1)
-    {
-      m_pDS->close();
-      return false;
-    }
-    strGenre = m_pDS->fv("genre.strGenre").get_asString();
-    return true;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
-  }
-  return false;
+CStdString CMusicDatabase::GetAlbumById(int id)
+{
+  return GetSingleValue("album", "strAlbum", PrepareSQL("idAlbum=%i", id));
 }
 
 int CMusicDatabase::GetGenreByName(const CStdString& strGenre)
@@ -3572,62 +3557,6 @@ int CMusicDatabase::GetGenreByName(const CStdString& strGenre)
     CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
   }
   return -1;
-}
-
-bool CMusicDatabase::GetArtistById(int idArtist, CStdString& strArtist)
-{
-  strArtist = "";
-  try
-  {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
-
-    CStdString strSQL=PrepareSQL("select strArtist from artist where artist.idArtist = %i", idArtist);
-
-    // run query
-    if (!m_pDS->query(strSQL.c_str())) return false;
-    int iRowsFound = m_pDS->num_rows();
-    if (iRowsFound != 1)
-    {
-      m_pDS->close();
-      return false;
-    }
-    strArtist = m_pDS->fv("artist.strArtist").get_asString();
-    return true;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
-  }
-  return false;
-}
-
-bool CMusicDatabase::GetAlbumById(int idAlbum, CStdString& strAlbum)
-{
-  strAlbum = "";
-  try
-  {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
-
-    CStdString strSQL=PrepareSQL("select strAlbum from album where album.idAlbum = %ld", idAlbum);
-
-    // run query
-    if (!m_pDS->query(strSQL.c_str())) return false;
-    int iRowsFound = m_pDS->num_rows();
-    if (iRowsFound != 1)
-    {
-      m_pDS->close();
-      return false;
-    }
-    strAlbum = m_pDS->fv("album.strAlbum").get_asString();
-    return true;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
-  }
-  return false;
 }
 
 bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const CStdString& strWhere)

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -174,9 +174,9 @@ public:
   bool GetAlbumThumb(int idAlbum, CStdString &thumb);
   bool GetArtistPath(int idArtist, CStdString &path);
 
-  bool GetGenreById(int idGenre, CStdString& strGenre);
-  bool GetArtistById(int idArtist, CStdString& strArtist);
-  bool GetAlbumById(int idAlbum, CStdString& strAlbum);
+  CStdString GetGenreById(int id);
+  CStdString GetArtistById(int id);
+  CStdString GetAlbumById(int id);
 
   int GetArtistByName(const CStdString& strArtist);
   int GetAlbumByName(const CStdString& strAlbum, const CStdString& strArtist="");

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -200,6 +200,10 @@ bool CGUIWindowMusicSongs::GetDirectory(const CStdString &strDirectory, CFileIte
   // check for .CUE files here.
   items.FilterCueItems();
 
+  CStdString label;
+  if (items.GetLabel().IsEmpty() && m_rootDir.IsSource(items.m_strPath, g_settings.GetSourcesFromType("music"), &label)) 
+    items.SetLabel(label);
+
   return true;
 }
 

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -271,6 +271,18 @@ bool CGUIWindowPictures::OnClick(int iItem)
   return false;
 }
 
+bool CGUIWindowPictures::GetDirectory(const CStdString &strDirectory, CFileItemList& items)
+{
+  if (!CGUIMediaWindow::GetDirectory(strDirectory, items))
+    return false;
+
+  CStdString label;
+  if (items.GetLabel().IsEmpty() && m_rootDir.IsSource(items.m_strPath, g_settings.GetSourcesFromType("pictures"), &label)) 
+    items.SetLabel(label);
+
+  return true;
+}
+
 bool CGUIWindowPictures::OnPlayMedia(int iItem)
 {
   if (m_vecItems->Get(iItem)->IsVideo())

--- a/xbmc/pictures/GUIWindowPictures.h
+++ b/xbmc/pictures/GUIWindowPictures.h
@@ -36,6 +36,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
 
 protected:
+  virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList& items);
   virtual void OnInfo(int item);
   virtual bool OnClick(int iItem);
   virtual void UpdateButtons();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5048,56 +5048,19 @@ bool CVideoDatabase::GetRecentlyAddedMusicVideosNav(const CStdString& strBaseDir
   return GetMusicVideosByWhere(strBaseDir, where, items);
 }
 
-bool CVideoDatabase::GetGenreById(int idGenre, CStdString& strGenre)
+CStdString CVideoDatabase::GetGenreById(int id)
 {
-  try
-  {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
-
-    CStdString strSQL=PrepareSQL("select genre.strGenre from genre where genre.idGenre=%i", idGenre);
-    m_pDS->query( strSQL.c_str() );
-
-    bool bResult = false;
-    if (!m_pDS->eof())
-    {
-      strGenre  = m_pDS->fv("genre.strGenre").get_asString();
-      bResult = true;
-    }
-    m_pDS->close();
-    return bResult;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s (%s) failed", __FUNCTION__, strGenre.c_str());
-  }
-  return false;
+  return GetSingleValue("genre", "strGenre", PrepareSQL("idGenre=%i", id));
 }
 
-bool CVideoDatabase::GetCountryById(int idCountry, CStdString& strCountry)
+CStdString CVideoDatabase::GetCountryById(int id)
 {
-  try
-  {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
+  return GetSingleValue("country", "strCountry", PrepareSQL("idCountry=%i", id));
+}
 
-    CStdString strSQL=PrepareSQL("select country.strCountry from country where country.idCountry=%i", idCountry);
-    m_pDS->query( strSQL.c_str() );
-
-    bool bResult = false;
-    if (!m_pDS->eof())
-    {
-      strCountry  = m_pDS->fv("country.strCountry").get_asString();
-      bResult = true;
-    }
-    m_pDS->close();
-    return bResult;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s (%s) failed", __FUNCTION__, strCountry.c_str());
-  }
-  return false;
+CStdString CVideoDatabase::GetSetById(int id)
+{
+  return GetSingleValue("sets", "strSet", PrepareSQL("idSet=%i", id));
 }
 
 bool CVideoDatabase::HasSets() const
@@ -5115,32 +5078,6 @@ bool CVideoDatabase::HasSets() const
   catch (...)
   {
     CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
-  }
-  return false;
-}
-
-bool CVideoDatabase::GetSetById(int idSet, CStdString& strSet)
-{
-  try
-  {
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
-
-    CStdString strSQL=PrepareSQL("select sets.strSet from sets where sets.idSet=%i", idSet);
-    m_pDS->query( strSQL.c_str() );
-
-    bool bResult = false;
-    if (!m_pDS->eof())
-    {
-      strSet  = m_pDS->fv("sets.strSet").get_asString();
-      bResult = true;
-    }
-    m_pDS->close();
-    return bResult;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s (%s) failed", __FUNCTION__, strSet.c_str());
   }
   return false;
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5063,6 +5063,26 @@ CStdString CVideoDatabase::GetSetById(int id)
   return GetSingleValue("sets", "strSet", PrepareSQL("idSet=%i", id));
 }
 
+CStdString CVideoDatabase::GetPersonById(int id)
+{
+  return GetSingleValue("actors", "strActor", PrepareSQL("idActor=%i", id));
+}
+
+CStdString CVideoDatabase::GetStudioById(int id)
+{
+  return GetSingleValue("studio", "strStudio", PrepareSQL("idStudio=%i", id));
+}
+
+CStdString CVideoDatabase::GetTvShowTitleById(int id)
+{
+  return GetSingleValue("tvshow", PrepareSQL("c%02d", VIDEODB_ID_TV_TITLE), PrepareSQL("idShow=%i", id));
+}
+
+CStdString CVideoDatabase::GetMusicVideoAlbumById(int id)
+{
+  return GetSingleValue("musicvideo", PrepareSQL("c%02d", VIDEODB_ID_MUSICVIDEO_ALBUM), PrepareSQL("idMVideo=%i", id));
+}
+
 bool CVideoDatabase::HasSets() const
 {
   try

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -354,9 +354,9 @@ public:
   bool HasMusicVideoInfo(const CStdString& strFilenameAndPath);
 
   void GetFilePathById(int idMovie, CStdString &filePath, VIDEODB_CONTENT_TYPE iType);
-  bool GetGenreById(int idGenre, CStdString& strGenre);
-  bool GetCountryById(int idCountry, CStdString& strCountry);
-  bool GetSetById(int idSet, CStdString& strSet);
+  CStdString GetGenreById(int id);
+  CStdString GetCountryById(int id);
+  CStdString GetSetById(int id);
   int GetTvShowForEpisode(int idEpisode);
 
   void GetMovieInfo(const CStdString& strFilenameAndPath, CVideoInfoTag& details, int idMovie = -1);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -357,6 +357,10 @@ public:
   CStdString GetGenreById(int id);
   CStdString GetCountryById(int id);
   CStdString GetSetById(int id);
+  CStdString GetPersonById(int id);
+  CStdString GetStudioById(int id);
+  CStdString GetTvShowTitleById(int id);
+  CStdString GetMusicVideoAlbumById(int id);
   int GetTvShowForEpisode(int idEpisode);
 
   void GetMovieInfo(const CStdString& strFilenameAndPath, CVideoInfoTag& details, int idMovie = -1);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1563,7 +1563,7 @@ void CGUIWindowVideoBase::UpdateVideoTitle(const CFileItem* pItem)
     database.GetMovieInfo("", detail, pItem->GetVideoInfoTag()->m_iDbId);
   if (iType == VIDEODB_CONTENT_MOVIE_SETS)
   {
-    database.GetSetById(params.GetSetId(),detail.m_strTitle);
+    detail.m_strTitle = database.GetSetById(params.GetSetId());
     iDbId = params.GetSetId();
   }
   if (iType == VIDEODB_CONTENT_EPISODES)

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -396,6 +396,9 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
     }
     else
     { // load info from the database
+      CStdString label;
+      if (items.GetLabel().IsEmpty() && m_rootDir.IsSource(items.m_strPath, g_settings.GetSourcesFromType("video"), &label)) 
+        items.SetLabel(label);
       LoadVideoInfo(items);
     }
   }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -654,6 +654,12 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
     pItem->m_bIsShareOrDrive = false;
     items.AddFront(pItem, 0);
   }
+  if (items.GetLabel().IsEmpty())
+  {
+    CStdString label = items.m_strPath;
+    URIUtils::RemoveSlashAtEnd(label);
+    items.SetLabel(URIUtils::GetFileName(label));
+  }
 
   int iWindow = GetID();
   CStdStringArray regexps;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -655,11 +655,7 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
     items.AddFront(pItem, 0);
   }
   if (items.GetLabel().IsEmpty())
-  {
-    CStdString label = items.m_strPath;
-    URIUtils::RemoveSlashAtEnd(label);
-    items.SetLabel(URIUtils::GetFileName(label));
-  }
+    items.SetLabel(CUtil::GetTitleFromPath(items.m_strPath, true));
 
   int iWindow = GetID();
   CStdStringArray regexps;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -654,8 +654,6 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
     pItem->m_bIsShareOrDrive = false;
     items.AddFront(pItem, 0);
   }
-  if (items.GetLabel().IsEmpty())
-    items.SetLabel(CUtil::GetTitleFromPath(items.m_strPath, true));
 
   int iWindow = GetID();
   CStdStringArray regexps;
@@ -726,6 +724,9 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory)
     Update(strParentPath);
     return false;
   }
+
+  if (items.GetLabel().IsEmpty())
+    items.SetLabel(CUtil::GetTitleFromPath(items.m_strPath, true));
 
   ClearFileItems();
   m_vecItems->Copy(items);


### PR DESCRIPTION
This patch set addresses #10313, providing localizable names of the current container foldername via the Container.Foldername infolabel.

I've done this by utilizing the label of the CFileItemList, setting it either in the directory classes (addons, videodb, musicdb) or directly by looking up the source name (files nodes) or by using GetTitleForPath.

I'm not particularly happy about the file nodes/sources lookup, but it works and will do until we get a better system at defining the hierarchy in the libraries.
