### PR TITLE
Untitled

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -259,11 +259,11 @@ bool CVideoDatabase::CreateTables()
       columns += column;
     }
     columns += ")";
+    m_pDS->exec(columns.c_str());
 
     // create views
     CreateViews();
 
-    m_pDS->exec(columns.c_str());
     m_pDS->exec("CREATE UNIQUE INDEX ix_musicvideo_file_1 on musicvideo (idMVideo, idFile)");
     m_pDS->exec("CREATE UNIQUE INDEX ix_musicvideo_file_2 on musicvideo (idFile, idMVideo)");
 


### PR DESCRIPTION
Spotted a small typo in VideoDatabase.cpp that prevents XBMC to create tables on a fresh install.
