### PR TITLE
IoControl

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -2111,7 +2111,10 @@ extern "C"
 #endif
     {
       void *p1 = va_arg(va, void*);
-      ret = pFile->IoControl(request, p1);
+      SNativeIoControl d;
+      d.request = request;
+      d.param   = p1;
+      ret = pFile->IoControl(IOCTRL_NATIVE, &d);
       if(ret<0)
         CLog::Log(LOGWARNING, "%s - %ld request failed with error [%d] %s", __FUNCTION__, request, errno, strerror(errno));
     }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
@@ -41,6 +41,8 @@ enum DVDStreamType
   DVDSTREAM_TYPE_BLURAY = 11,
 };
 
+#define SEEK_POSSIBLE 0x10 // flag used to check if protocol allows seeks
+
 #define DVDSTREAM_BLOCK_SIZE_FILE (2048 * 16)
 #define DVDSTREAM_BLOCK_SIZE_DVD  2048
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -116,10 +116,11 @@ __int64 CDVDInputStreamFile::GetLength()
 
 __int64 CDVDInputStreamFile::GetCachedBytes()
 {
-  if(!m_pFile)
+  SCacheStatus status;
+  if(m_pFile && m_pFile->IoControl(IOCTRL_CACHE_STATUS, &status) >= 0)
+    return status.forward;
+  else
     return -1;
-
-  return m_pFile->Seek(0, SEEK_BUFFERED);
 }
 
 BitstreamStats CDVDInputStreamFile::GetBitstreamStats() const

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -99,6 +99,10 @@ int CDVDInputStreamFile::Read(BYTE* buf, int buf_size)
 __int64 CDVDInputStreamFile::Seek(__int64 offset, int whence)
 {
   if(!m_pFile) return -1;
+
+  if(whence == SEEK_POSSIBLE)
+    return m_pFile->IoControl(IOCTRL_SEEK_POSSIBLE, NULL);
+
   __int64 ret = m_pFile->Seek(offset, whence);
 
   /* if we succeed, we are not eof anymore */

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHttp.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHttp.cpp
@@ -105,11 +105,15 @@ int CDVDInputStreamHttp::Read(BYTE* buf, int buf_size)
 
 __int64 CDVDInputStreamHttp::Seek(__int64 offset, int whence)
 {
-  __int64 ret = 0;
-  if (m_pFile) ret = m_pFile->Seek(offset, whence);
-  else return -1;
+  if(!m_pFile)
+    return -1;
 
-  m_eof = false;
+  if(whence == SEEK_POSSIBLE)
+    return m_pFile->IoControl(IOCTRL_SEEK_POSSIBLE, NULL);
+
+  __int64 ret = m_pFile->Seek(offset, whence);
+
+  if( ret >= 0 ) m_eof = false;
 
   return ret;
 }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMemory.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamMemory.cpp
@@ -95,6 +95,8 @@ __int64 CDVDInputStreamMemory::Seek(__int64 offset, int whence)
       else m_iDataPos = (int)offset;
       break;
     }
+    default:
+      return -1;
   }
   return m_iDataPos;
 }

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -518,21 +518,7 @@ int64_t CFile::Seek(int64_t iFilePosition, int iWhence)
 
   try
   {
-    if(iWhence == SEEK_POSSIBLE)
-    {
-      int64_t ret = m_pFile->Seek(iFilePosition, iWhence);
-      if(ret >= 0)
-        return ret;
-      else
-      {
-        if(m_pFile->GetLength() && m_pFile->Seek(0, SEEK_CUR) >= 0)
-          return 1;
-        else
-          return 0;
-      }
-    }
-    else
-      return m_pFile->Seek(iFilePosition, iWhence);
+    return m_pFile->Seek(iFilePosition, iWhence);
   }
 #ifndef _LINUX
   catch (const win32_exception &e)
@@ -772,6 +758,14 @@ int CFile::IoControl(EIoControl request, void* param)
   int result = -1;
   if (m_pFile)
     result = m_pFile->IoControl(request, param);
+
+  if(result == -1 && request == IOCTRL_SEEK_POSSIBLE)
+  {
+    if(m_pFile->GetLength() >= 0 && m_pFile->Seek(0, SEEK_CUR) >= 0)
+      return 1;
+    else
+      return 0;
+  }
 
   return result;
 }

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -767,6 +767,14 @@ bool CFile::SetHidden(const CStdString& fileName, bool hidden)
   return false;
 }
 
+int CFile::IoControl(EIoControl request, void* param)
+{
+  int result = -1;
+  if (m_pFile)
+    result = m_pFile->IoControl(request, param);
+
+  return result;
+}
 //*********************************************************************************************
 //*************** Stream IO for CFile objects *************************************************
 //*********************************************************************************************

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -93,7 +93,7 @@ public:
   bool SkipNext(){if (m_pFile) return m_pFile->SkipNext(); return false;}
   BitstreamStats* GetBitstreamStats() { return m_bitStreamStats; }
 
-  int IoControl(int request, void* param) { if (m_pFile) return m_pFile->IoControl(request, param); return -1; }
+  int IoControl(EIoControl request, void* param);
 
   IFile *GetImplemenation() { return m_pFile; }
 

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -107,7 +107,7 @@ bool CFileCache::Open(const CURL& url)
   }
 
   // check if source can seek
-  m_seekPossible = m_source.Seek(0, SEEK_POSSIBLE);
+  m_seekPossible = m_source.IoControl(IOCTRL_SEEK_POSSIBLE, NULL);
 
   m_readPos = 0;
   m_seekEvent.Reset();
@@ -147,7 +147,7 @@ void CFileCache::Process()
       if (m_nSeekResult != m_seekPos)
       {
         CLog::Log(LOGERROR,"%s, error %d seeking. seek returned %"PRId64, __FUNCTION__, (int)GetLastError(), m_nSeekResult);
-        m_seekPossible = m_source.Seek(0, SEEK_POSSIBLE);
+        m_seekPossible = m_source.IoControl(IOCTRL_SEEK_POSSIBLE, NULL);
       }
       else
         m_pCache->Reset(m_seekPos);
@@ -282,8 +282,6 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
     iTarget = GetLength() + iTarget;
   else if (iWhence == SEEK_CUR)
     iTarget = iCurPos + iTarget;
-  else if (iWhence == SEEK_POSSIBLE)
-    return m_seekPossible;
   else if (iWhence != SEEK_SET)
     return -1;
 
@@ -357,6 +355,9 @@ int CFileCache::IoControl(EIoControl request, void* param)
     status->forward = m_pCache->WaitForData(0, 0);
     return 0;
   }
+
+  if(request == IOCTRL_SEEK_POSSIBLE)
+    return m_seekPossible;
 
   return -1;
 }

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -284,8 +284,6 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
     iTarget = iCurPos + iTarget;
   else if (iWhence == SEEK_POSSIBLE)
     return m_seekPossible;
-  else if (iWhence == SEEK_BUFFERED)
-    return m_pCache->WaitForData(0, 0);
   else if (iWhence != SEEK_SET)
     return -1;
 
@@ -349,4 +347,16 @@ CStdString CFileCache::GetContent()
     return IFile::GetContent();
 
   return m_source.GetImplemenation()->GetContent();
+}
+
+int CFileCache::IoControl(EIoControl request, void* param)
+{
+  if(request == IOCTRL_CACHE_STATUS)
+  {
+    SCacheStatus* status = (SCacheStatus*)param;
+    status->forward = m_pCache->WaitForData(0, 0);
+    return 0;
+  }
+
+  return -1;
 }

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -55,6 +55,8 @@ namespace XFILE
     virtual int64_t       GetPosition();
     virtual int64_t       GetLength();
 
+    virtual int           IoControl(EIoControl request, void* param);
+
     IFile *GetFileImp();
 
     virtual CStdString GetContent();
@@ -62,7 +64,7 @@ namespace XFILE
   private:
     CCacheStrategy *m_pCache;
     bool      m_bDeleteCache;
-    int64_t    m_seekPossible;
+    int        m_seekPossible;
     CFile      m_source;
     CStdString    m_sourcePath;
     CEvent      m_seekEvent;

--- a/xbmc/filesystem/FileCurl.cpp
+++ b/xbmc/filesystem/FileCurl.cpp
@@ -982,8 +982,6 @@ int64_t CFileCurl::Seek(int64_t iFilePosition, int iWhence)
       else
         return -1;
       break;
-    case SEEK_POSSIBLE:
-      return m_seekable ? 1 : 0;
     default:
       return -1;
   }
@@ -1388,4 +1386,12 @@ bool CFileCurl::GetMimeType(const CURL &url, CStdString &content, CStdString use
    CLog::Log(LOGDEBUG, "CFileCurl::GetMimeType - %s -> failed", url.Get().c_str());
    content = "";
    return false;
+}
+
+int CFileCurl::IoControl(EIoControl request, void* param)
+{
+  if(request == IOCTRL_SEEK_POSSIBLE)
+    return m_seekable ? 1 : 0;
+
+  return -1;
 }

--- a/xbmc/filesystem/FileCurl.h
+++ b/xbmc/filesystem/FileCurl.h
@@ -51,6 +51,7 @@ namespace XFILE
       virtual bool ReadString(char *szLine, int iLineLength)     { return m_state->ReadString(szLine, iLineLength); }
       virtual unsigned int Read(void* lpBuf, int64_t uiBufSize)  { return m_state->Read(lpBuf, uiBufSize); }
       virtual CStdString GetMimeType()                           { return m_state->m_httpheader.GetMimeType(); }
+      virtual int IoControl(EIoControl request, void* param);
 
       bool Post(const CStdString& strURL, const CStdString& strPostData, CStdString& strHTML);
       bool Get(const CStdString& strURL, CStdString& strHTML);

--- a/xbmc/filesystem/FileDAAP.cpp
+++ b/xbmc/filesystem/FileDAAP.cpp
@@ -215,9 +215,6 @@ int64_t CFileDAAP::Seek(int64_t iFilePosition, int iWhence)
 {
   CSingleLock lock(g_DaapClient);
 
-  if(iWhence == SEEK_POSSIBLE)
-    return 1; //m_curl.Seek(iFilePosition, iWhence);
-
   int requestid = ++m_thisHost->request_id;
 
   char hash[33] = {0};
@@ -248,5 +245,13 @@ bool CFileDAAP::Exists(const CURL& url)
 
 int CFileDAAP::Stat(const CURL& url, struct __stat64* buffer)
 {
+  return -1;
+}
+
+int CFileDAAP::IoControl(EIoControl request, void* param)
+{
+  if(request == IOCTRL_SEEK_POSSIBLE)
+    return 1;
+
   return -1;
 }

--- a/xbmc/filesystem/FileDAAP.h
+++ b/xbmc/filesystem/FileDAAP.h
@@ -77,6 +77,7 @@ public:
   virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
   virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
   virtual void Close();
+  virtual int  IoControl(EIoControl request, void* param);
 
 protected:
 

--- a/xbmc/filesystem/FileHD.cpp
+++ b/xbmc/filesystem/FileHD.cpp
@@ -317,10 +317,14 @@ void CFileHD::Flush()
   ::FlushFileBuffers(m_hFile);
 }
 
-int CFileHD::IoControl(int request, void* param)
+int CFileHD::IoControl(EIoControl request, void* param)
 {
 #ifdef _LINUX
-  return ioctl((*m_hFile).fd, request, param);
+  if(request == IOCTRL_NATIVE && param)
+  {
+    IoControlNative* s = (IoControlNative*)param;
+    return ioctl((*m_hFile).fd, s->request, s->param);
+  }
 #endif
   return -1;
 }

--- a/xbmc/filesystem/FileHD.h
+++ b/xbmc/filesystem/FileHD.h
@@ -57,7 +57,7 @@ public:
   virtual bool Rename(const CURL& url, const CURL& urlnew);
   virtual bool SetHidden(const CURL& url, bool hidden);
 
-  virtual int IoControl(int request, void* param);
+  virtual int IoControl(EIoControl request, void* param);
 protected:
   CStdString GetLocal(const CURL &url); /* crate a properly format path from an url */
   AUTOPTR::CAutoPtrHandle m_hFile;

--- a/xbmc/filesystem/FileSFTP.cpp
+++ b/xbmc/filesystem/FileSFTP.cpp
@@ -475,9 +475,6 @@ void CFileSFTP::Close()
 
 int64_t CFileSFTP::Seek(int64_t iFilePosition, int iWhence)
 {
-  if(iWhence == SEEK_POSSIBLE)
-    return 1;
-
   if (m_session && m_sftp_handle)
   {
     uint64_t position = 0;
@@ -570,4 +567,13 @@ int64_t CFileSFTP::GetPosition()
   CLog::Log(LOGERROR, "SFTPFile: Can't get position without a filehandle");
   return 0;
 }
+
+int CFileSFTP::IoControl(EIoControl request, void* param)
+{
+  if(request == IOCTRL_SEEK_POSSIBLE)
+    return 1;
+
+  return -1;
+}
+
 #endif

--- a/xbmc/filesystem/FileSFTP.h
+++ b/xbmc/filesystem/FileSFTP.h
@@ -103,7 +103,7 @@ namespace XFILE
     virtual int64_t GetLength();
     virtual int64_t GetPosition();
     virtual int     GetChunkSize() {return 1;};
-
+    virtual int     IoControl(EIoControl request, void* param);
   private:
     CStdString m_file;
     CSFTPSessionPtr m_session;

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -39,7 +39,6 @@
 #include <sys/stat.h>
 
 #define SEEK_POSSIBLE 0x10 // flag used to check if protocol allows seeks
-#define SEEK_BUFFERED 0x11 // how many bytes forward is buffered
 
 namespace XFILE
 {
@@ -50,8 +49,14 @@ struct SNativeIoControl
   void* param;
 };
 
+struct SCacheStatus
+{
+  uint64_t forward;  /**< number of bytes cached forward of current position */
+};
+
 typedef enum {
   IOCTRL_NATIVE        = 1, /**< SNativeIoControl structure, containing what should be passed to native ioctrl */
+  IOCTRL_CACHE_STATUS  = 3, /**< SCacheStatus structure */
 } EIoControl;
 
 class IFile

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -44,6 +44,16 @@
 namespace XFILE
 {
 
+struct SNativeIoControl
+{
+  int   request;
+  void* param;
+};
+
+typedef enum {
+  IOCTRL_NATIVE        = 1, /**< SNativeIoControl structure, containing what should be passed to native ioctrl */
+} EIoControl;
+
 class IFile
 {
 public:
@@ -78,7 +88,7 @@ public:
   virtual bool Rename(const CURL& url, const CURL& urlnew) { return false; }
   virtual bool SetHidden(const CURL& url, bool hidden) { return false; }
 
-  virtual int IoControl(int request, void* param) { return -1; }
+  virtual int IoControl(EIoControl request, void* param) { return -1; }
 
   virtual CStdString GetContent()                            { return "application/octet-stream"; }
 };

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -38,8 +38,6 @@
 #include <stdint.h>
 #include <sys/stat.h>
 
-#define SEEK_POSSIBLE 0x10 // flag used to check if protocol allows seeks
-
 namespace XFILE
 {
 
@@ -56,6 +54,7 @@ struct SCacheStatus
 
 typedef enum {
   IOCTRL_NATIVE        = 1, /**< SNativeIoControl structure, containing what should be passed to native ioctrl */
+  IOCTRL_SEEK_POSSIBLE = 2, /**< return 0 if known not to work, 1 if it should work */
   IOCTRL_CACHE_STATUS  = 3, /**< SCacheStatus structure */
 } EIoControl;
 

--- a/xbmc/filesystem/MythFile.cpp
+++ b/xbmc/filesystem/MythFile.cpp
@@ -465,14 +465,6 @@ int64_t CMythFile::Seek(int64_t pos, int whence)
 {
   CLog::Log(LOGDEBUG, "%s - seek to pos %"PRId64", whence %d", __FUNCTION__, pos, whence);
 
-  if(whence == SEEK_POSSIBLE)
-  {
-    if(m_recorder)
-      return 0;
-    else
-      return 1;
-  }
-
   int64_t result;
   if(m_recorder)
     result = -1; //m_dll->livetv_seek(m_recorder, pos, whence);
@@ -714,4 +706,16 @@ bool CMythFile::GetCutList(cmyth_commbreaklist_t& commbreaklist)
     return true;
   }
   return false;
+}
+
+int CMythFile::IoControl(EIoControl request, void* param)
+{
+  if(request == IOCTRL_SEEK_POSSIBLE)
+  {
+    if(m_recorder)
+      return 0;
+    else
+      return 1;
+  }
+  return -1;
 }

--- a/xbmc/filesystem/MythFile.h
+++ b/xbmc/filesystem/MythFile.h
@@ -80,6 +80,7 @@ public:
   virtual bool           GetCommBreakList(cmyth_commbreaklist_t& commbreaklist);
   virtual bool           GetCutList(cmyth_commbreaklist_t& commbreaklist);
 
+  virtual int            IoControl(EIoControl request, void* param);
 protected:
   virtual void OnEvent(int event, const std::string& data);
 

--- a/xbmc/filesystem/SAPFile.cpp
+++ b/xbmc/filesystem/SAPFile.cpp
@@ -130,8 +130,6 @@ int64_t CSAPFile::Seek(int64_t iFilePosition, int iWhence)
     case SEEK_END:
       m_stream.seekg((int)iFilePosition, ios_base::end);
       break;
-    case SEEK_POSSIBLE:
-      return 1;
     default:
       return -1;
   }
@@ -171,3 +169,10 @@ bool CSAPFile::Rename(const CURL& url, const CURL& urlnew)
   return false;
 }
 
+int CSAPFile::IoControl(EIoControl request, void* param)
+{
+  if(request == IOCTRL_SEEK_POSSIBLE)
+    return 1;
+
+  return -1;
+}

--- a/xbmc/filesystem/SAPFile.h
+++ b/xbmc/filesystem/SAPFile.h
@@ -44,6 +44,8 @@ public:
 
   virtual bool Delete(const CURL& url);
   virtual bool Rename(const CURL& url, const CURL& urlnew);
+
+  virtual int  IoControl(EIoControl request, void* param);
 protected:
   std::stringstream m_stream;
   int               m_len;

--- a/xbmc/filesystem/VTPFile.cpp
+++ b/xbmc/filesystem/VTPFile.cpp
@@ -140,10 +140,6 @@ unsigned int CVTPFile::Read(void* buffer, int64_t size)
 int64_t CVTPFile::Seek(int64_t pos, int whence)
 {
   CLog::Log(LOGDEBUG, "CVTPFile::Seek - seek to pos %"PRId64", whence %d", pos, whence);
-
-  if(whence == SEEK_POSSIBLE)
-    return 0;
-
   return -1;
 }
 
@@ -221,4 +217,12 @@ bool CVTPFile::SelectChannel(unsigned int channel)
     return true;
   else
     return false;
+}
+
+int CVTPFile::IoControl(EIoControl request, void* param)
+{
+  if(request == IOCTRL_SEEK_POSSIBLE)
+    return 0;
+
+  return -1;
 }

--- a/xbmc/filesystem/VTPFile.h
+++ b/xbmc/filesystem/VTPFile.h
@@ -59,7 +59,7 @@ public:
   virtual int            GetStartTime()              { return 0; }
   virtual bool           UpdateItem(CFileItem& item) { return false; }
 
-
+  virtual int            IoControl(EIoControl request, void* param);
 protected:
   CVTPSession* m_session;
   SOCKET       m_socket;

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -964,8 +964,6 @@ int64_t iso9660::Seek(HANDLE hFile, int64_t lOffset, int whence)
     // end += pos
     pContext->m_dwFilePos = pContext->m_dwFileSize + lOffset;
     break;
-  case SEEK_POSSIBLE:
-    return 1;
   default:
     return -1;
   }

--- a/xbmc/win32/WINFileSMB.cpp
+++ b/xbmc/win32/WINFileSMB.cpp
@@ -314,7 +314,7 @@ void CWINFileSMB::Flush()
   ::FlushFileBuffers(m_hFile);
 }
 
-int CWINFileSMB::IoControl(int request, void* param)
+int CWINFileSMB::IoControl(EIoControl request, void* param)
 { 
   return -1;
 }

--- a/xbmc/win32/WINFileSMB.h
+++ b/xbmc/win32/WINFileSMB.h
@@ -54,7 +54,7 @@ public:
   virtual bool Rename(const CURL& url, const CURL& urlnew);
   virtual bool SetHidden(const CURL& url, bool hidden);
 
-  virtual int IoControl(int request, void* param);
+  virtual int IoControl(EIoControl request, void* param);
 protected:
   CStdString GetLocal(const CURL &url); /* crate a properly format path from an url */
   AUTOPTR::CAutoPtrHandle m_hFile;


### PR DESCRIPTION
This extends the IoControl interface we already have in IFile to handle both the SEEK_POSSIBLE and the SEEK_BUFFERED features. They where always abit funky to have in the seek function.

The SEEK_BUFFERED change ended up abit large. I have not changed how dvdplayer does things internally, it's mapped to the new API instead so that should probably be changed.

The point here is that using an IoControl system will make it easier for filesystem plugins to support abit more advanced stuff instead of us extending the IFile interface all the time.

There is probably some more stuff in IFile that could/should be moved to the IoControl interface. With that said, there is nothing wrong with having porcelain in CFile to make it's usage easier. But on the low level side it seems like a better approach.
