### PR TITLE
Fix URIUtils::IsDVD function logic

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -472,7 +472,7 @@ bool URIUtils::IsDVD(const CStdString& strFile)
 {
 #if defined(_WIN32)
   if(strFile.Mid(1) == ":\\"
-  && strFile.Mid(1) == ":")
+  || strFile.Mid(1) == ":")
     return true;
 
   if((GetDriveType(strFile.c_str()) == DRIVE_CDROM) || strFile.Left(6).Equals("dvd://"))

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -471,9 +471,9 @@ bool URIUtils::IsHD(const CStdString& strFileName)
 bool URIUtils::IsDVD(const CStdString& strFile)
 {
 #if defined(_WIN32)
-  if(strFile.Mid(1) != ":\\"
-  && strFile.Mid(1) != ":")
-    return false;
+  if(strFile.Mid(1) == ":\\"
+  && strFile.Mid(1) == ":")
+    return true;
 
   if((GetDriveType(strFile.c_str()) == DRIVE_CDROM) || strFile.Left(6).Equals("dvd://"))
     return true;


### PR DESCRIPTION
The logic in the URIUtils::IsDVD function is slightly off, so I've put together this pull request to fix it.

The original logic in that function checked to see if the file name was NOT "X:" or "X:\" (where X could be any letter) and return false if it's not.  However, this prevents any of the other checks later in the function from ever being reached.  The correct logic should be to check if the file name IS "X:" or "X:\" and if it is return true, otherwise continue running the rest of the function.

Thanks,
Harry
