### PR TITLE
Warnings must die

### DIFF
--- a/xbmc/cores/DllLoader/coff.cpp
+++ b/xbmc/cores/DllLoader/coff.cpp
@@ -408,7 +408,7 @@ int CoffLoader::RVA2Section(unsigned long RVA)
         if ( RVA < SectionHeader[i + 1].VirtualAddress )
         {
           if ( SectionHeader[i].VirtualAddress + SectionHeader[i].VirtualSize <= RVA )
-            printf("Warning! Address outside of Section: %x!\n", RVA);
+            printf("Warning! Address outside of Section: %lx!\n", RVA);
           //                    else
           return i;
         }
@@ -416,7 +416,7 @@ int CoffLoader::RVA2Section(unsigned long RVA)
       else
       {
         if ( SectionHeader[i].VirtualAddress + SectionHeader[i].VirtualSize <= RVA )
-          printf("Warning! Address outside of Section: %x!\n", RVA);
+          printf("Warning! Address outside of Section: %lx!\n", RVA);
         //                else
         return i;
       }
@@ -516,7 +516,7 @@ void CoffLoader::PrintSymbolTable(void)
   for (SymIndex = 0; SymIndex < NumberOfSymbols; SymIndex++)
   {
     printf("%03X ", SymIndex);
-    printf("%08X ", SymTable[SymIndex].Value);
+    printf("%08lX ", SymTable[SymIndex].Value);
 
     if (SymTable[SymIndex].SectionNumber == IMAGE_SYM_ABSOLUTE)
       printf("ABS     ");
@@ -615,9 +615,9 @@ void CoffLoader::PrintFileHeader(COFF_FileHeader_t *FileHeader)
 
   printf("MachineType:            0x%04X\n", FileHeader->MachineType);
   printf("NumberOfSections:       0x%04X\n", FileHeader->NumberOfSections);
-  printf("TimeDateStamp:          0x%08X\n", FileHeader->TimeDateStamp);
-  printf("PointerToSymbolTable:   0x%08X\n", FileHeader->PointerToSymbolTable);
-  printf("NumberOfSymbols:        0x%08X\n", FileHeader->NumberOfSymbols);
+  printf("TimeDateStamp:          0x%08lX\n", FileHeader->TimeDateStamp);
+  printf("PointerToSymbolTable:   0x%08lX\n", FileHeader->PointerToSymbolTable);
+  printf("NumberOfSymbols:        0x%08lX\n", FileHeader->NumberOfSymbols);
   printf("SizeOfOptionHeader:     0x%04X\n", FileHeader->SizeOfOptionHeader);
   printf("Characteristics:        0x%04X\n", FileHeader->Characteristics);
 
@@ -677,12 +677,12 @@ void CoffLoader::PrintOptionHeader(OptionHeader_t *OptHdr)
   printf("Magic:              0x%04X\n", OptHdr->Magic);
   printf("Linker Major Ver:   0x%02X\n", VERSION_MAJOR(OptHdr->LinkVersion));
   printf("Linker Minor Ver:   0x%02X\n", VERSION_MINOR(OptHdr->LinkVersion));
-  printf("Code Size:          0x%08X\n", OptHdr->CodeSize);
-  printf("Data Size:          0x%08X\n", OptHdr->DataSize);
-  printf("BSS Size:           0x%08X\n", OptHdr->BssSize);
-  printf("Entry:              0x%08X\n", OptHdr->Entry);
-  printf("Code Base:          0x%08X\n", OptHdr->CodeBase);
-  printf("Data Base:          0x%08X\n", OptHdr->DataBase);
+  printf("Code Size:          0x%08lX\n", OptHdr->CodeSize);
+  printf("Data Size:          0x%08lX\n", OptHdr->DataSize);
+  printf("BSS Size:           0x%08lX\n", OptHdr->BssSize);
+  printf("Entry:              0x%08lX\n", OptHdr->Entry);
+  printf("Code Base:          0x%08lX\n", OptHdr->CodeBase);
+  printf("Data Base:          0x%08lX\n", OptHdr->DataBase);
   printf("\n");
 }
 
@@ -691,23 +691,23 @@ void CoffLoader::PrintWindowsHeader(WindowsHeader_t *WinHdr)
   printf("Windows Specific Option Header\n");
   printf("------------------------------------------\n\n");
 
-  printf("Image Base:         0x%08X\n", WinHdr->ImageBase);
-  printf("Section Alignment:  0x%08X\n", WinHdr->SectionAlignment);
-  printf("File Alignment:     0x%08X\n", WinHdr->FileAlignment);
+  printf("Image Base:         0x%08lX\n", WinHdr->ImageBase);
+  printf("Section Alignment:  0x%08lX\n", WinHdr->SectionAlignment);
+  printf("File Alignment:     0x%08lX\n", WinHdr->FileAlignment);
   printf("OS Version:         %d.%08d\n", BIGVERSION_MAJOR(WinHdr->OSVer), BIGVERSION_MINOR(WinHdr->OSVer));
   printf("Image Version:      %d.%08d\n", BIGVERSION_MAJOR(WinHdr->ImgVer), BIGVERSION_MINOR(WinHdr->ImgVer));
   printf("SubSystem Version:  %d.%08d\n", BIGVERSION_MAJOR(WinHdr->SubSysVer), BIGVERSION_MINOR(WinHdr->SubSysVer));
-  printf("Size of Image:      0x%08X\n", WinHdr->SizeOfImage);
-  printf("Size of Headers:    0x%08X\n", WinHdr->SizeOfHeaders);
-  printf("Checksum:           0x%08X\n", WinHdr->CheckSum);
+  printf("Size of Image:      0x%08lX\n", WinHdr->SizeOfImage);
+  printf("Size of Headers:    0x%08lX\n", WinHdr->SizeOfHeaders);
+  printf("Checksum:           0x%08lX\n", WinHdr->CheckSum);
   printf("Subsystem:          0x%04X\n", WinHdr->Subsystem);
   printf("DLL Flags:          0x%04X\n", WinHdr->DLLFlags);
-  printf("Sizeof Stack Resv:  0x%08X\n", WinHdr->SizeOfStackReserve);
-  printf("Sizeof Stack Comm:  0x%08X\n", WinHdr->SizeOfStackCommit);
-  printf("Sizeof Heap Resv:   0x%08X\n", WinHdr->SizeOfHeapReserve);
-  printf("Sizeof Heap Comm:   0x%08X\n", WinHdr->SizeOfHeapCommit);
-  printf("Loader Flags:       0x%08X\n", WinHdr->LoaderFlags);
-  printf("Num Directories:    %d\n", WinHdr->NumDirectories);
+  printf("Sizeof Stack Resv:  0x%08lX\n", WinHdr->SizeOfStackReserve);
+  printf("Sizeof Stack Comm:  0x%08lX\n", WinHdr->SizeOfStackCommit);
+  printf("Sizeof Heap Resv:   0x%08lX\n", WinHdr->SizeOfHeapReserve);
+  printf("Sizeof Heap Comm:   0x%08lX\n", WinHdr->SizeOfHeapCommit);
+  printf("Loader Flags:       0x%08lX\n", WinHdr->LoaderFlags);
+  printf("Num Directories:    %ld\n", WinHdr->NumDirectories);
   printf("\n");
 }
 
@@ -720,15 +720,15 @@ void CoffLoader::PrintSection(SectionHeader_t *ScnHdr, char* data)
   printf("Section: %s\n", SectionName);
   printf("------------------------------------------\n\n");
 
-  printf("Virtual Size:       0x%08X\n", ScnHdr->VirtualSize);
-  printf("Virtual Address:    0x%08X\n", ScnHdr->VirtualAddress);
-  printf("Sizeof Raw Data:    0x%08X\n", ScnHdr->SizeOfRawData);
-  printf("Ptr To Raw Data:    0x%08X\n", ScnHdr->PtrToRawData);
-  printf("Ptr To Relocations: 0x%08X\n", ScnHdr->PtrToRelocations);
-  printf("Ptr To Line Nums:   0x%08X\n", ScnHdr->PtrToLineNums);
+  printf("Virtual Size:       0x%08lX\n", ScnHdr->VirtualSize);
+  printf("Virtual Address:    0x%08lX\n", ScnHdr->VirtualAddress);
+  printf("Sizeof Raw Data:    0x%08lX\n", ScnHdr->SizeOfRawData);
+  printf("Ptr To Raw Data:    0x%08lX\n", ScnHdr->PtrToRawData);
+  printf("Ptr To Relocations: 0x%08lX\n", ScnHdr->PtrToRelocations);
+  printf("Ptr To Line Nums:   0x%08lX\n", ScnHdr->PtrToLineNums);
   printf("Num Relocations:    0x%04X\n", ScnHdr->NumRelocations);
   printf("Num Line Numbers:   0x%04X\n", ScnHdr->NumLineNumbers);
-  printf("Characteristics:    0x%08X\n", ScnHdr->Characteristics);
+  printf("Characteristics:    0x%08lX\n", ScnHdr->Characteristics);
   if (ScnHdr->Characteristics & IMAGE_SCN_CNT_CODE)
     printf("                    IMAGE_SCN_CNT_CODE\n");
   if (ScnHdr->Characteristics & IMAGE_SCN_CNT_DATA)

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDStateSerializer.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDStateSerializer.cpp
@@ -94,7 +94,7 @@ bool CDVDStateSerializer::DVDToXMLState( std::string &xmlstate, const dvd_state_
           }
 
           { TiXmlElement eValue("tv_usec");
-            sprintf(buffer, "%ld", state->registers.GPRM_time[i].tv_usec);
+            sprintf(buffer, "%ld", (long int)state->registers.GPRM_time[i].tv_usec);
             eValue.InsertEndChild( TiXmlText( buffer ) );
             eTime.InsertEndChild( eValue ) ;
           }
@@ -251,7 +251,7 @@ bool CDVDStateSerializer::XMLToDVDState( dvd_state_t *state, const std::string &
 
       text = TiXmlHandle( element ).FirstChildElement("time").FirstChildElement("tv_usec").FirstChild().Text();
       if( text )
-        sscanf(text->Value(), "%ld", &state->registers.GPRM_time[index].tv_usec);
+        sscanf(text->Value(), "%ld", (long int*)&state->registers.GPRM_time[index].tv_usec);
     }
     element = element->NextSiblingElement("gprm");
   }

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -61,7 +61,7 @@ using namespace std;
 #ifndef HAS_DVD_DRIVE
 extern "C"
 {
-  void cdio_warn(const char* msg, ...) { CLog::Log(LOGWARNING, msg); }
+  void cdio_warn(const char* msg, ...) { CLog::Log(LOGWARNING, "%s", msg); }
 }
 #endif
 

--- a/xbmc/music/karaoke/karaokelyricscdg.cpp
+++ b/xbmc/music/karaoke/karaokelyricscdg.cpp
@@ -614,10 +614,10 @@ bool CKaraokeLyricsCDG::Load()
   
   if ( buggy_commands == 0 )
 	CLog::Log( LOGDEBUG, "CDG loader: CDG file %s has been loading successfully, %d useful packets, %dKb used",
-				m_cdgFile.c_str(), m_cdgStream.size(), m_cdgStream.size() * sizeof(CDGPacket) / 1024 );
+				m_cdgFile.c_str(), (int)m_cdgStream.size(), (int)(m_cdgStream.size() * sizeof(CDGPacket) / 1024) );
  else
 	CLog::Log( LOGDEBUG, "CDG loader: CDG file %s was damaged, %d errors ignored, %d useful packets, %dKb used",
-				m_cdgFile.c_str(), buggy_commands, m_cdgStream.size(), m_cdgStream.size() * sizeof(CDGPacket) / 1024 );
+				m_cdgFile.c_str(), buggy_commands, (int)m_cdgStream.size(), (int)(m_cdgStream.size() * sizeof(CDGPacket) / 1024) );
 
   return true;
 }

--- a/xbmc/network/osx/ZeroconfBrowserOSX.cpp
+++ b/xbmc/network/osx/ZeroconfBrowserOSX.cpp
@@ -43,8 +43,7 @@ namespace
                                                             kCFStringEncodingUTF8);
     char *buffer = new char[buf_len];
     assert(buffer);
-    Boolean bool2 = CFStringGetCString(cfstr, buffer, buf_len, kCFStringEncodingUTF8);
-    assert(bool2);
+    assert(CFStringGetCString(cfstr, buffer, buf_len, kCFStringEncodingUTF8));
     CStdString myString(buffer);
     delete[] buffer;
     return myString;
@@ -150,7 +149,7 @@ void CZeroconfBrowserOSX::BrowserCallback(CFNetServiceBrowserRef browser, CFOpti
     }
   } else
   {
-    CLog::Log(LOGERROR, "CZeroconfBrowserOSX::BrowserCallback returned (domain = %d, error = %ld)\n", error->domain, error->error);
+    CLog::Log(LOGERROR, "CZeroconfBrowserOSX::BrowserCallback returned (domain = %d, error = %ld)\n", (int)error->domain, error->error);
   }
 }
 
@@ -230,7 +229,7 @@ bool CZeroconfBrowserOSX::doAddServiceType(const CStdString& fcr_service_type)
     CFNetServiceBrowserUnscheduleFromRunLoop(p_browser, m_runloop, kCFRunLoopCommonModes);         
     CFRelease(p_browser);
     p_browser = NULL;
-    CLog::Log(LOGERROR, "CFNetServiceBrowserSearchForServices returned (domain = %d, error = %ld)\n", error.domain, error.error);
+    CLog::Log(LOGERROR, "CFNetServiceBrowserSearchForServices returned (domain = %d, error = %ld)\n", (int)error.domain, error.error);
   } else
   {
     //store the browser

--- a/xbmc/network/osx/ZeroconfOSX.cpp
+++ b/xbmc/network/osx/ZeroconfOSX.cpp
@@ -79,7 +79,7 @@ bool CZeroconfOSX::doPublishService(const std::string& fcr_identifier,
     CFNetServiceSetClient(netService, NULL, NULL);
     CFRelease(netService);
     netService = NULL;
-    CLog::Log(LOGERROR, "CZeroconfOSX::doPublishService CFNetServiceRegister returned (domain = %d, error = %ld)\n", error.domain, error.error);
+    CLog::Log(LOGERROR, "CZeroconfOSX::doPublishService CFNetServiceRegister returned (domain = %d, error = %ld)\n", (int)error.domain, error.error);
   } else
   {
     CSingleLock lock(m_data_guard);
@@ -121,7 +121,7 @@ void CZeroconfOSX::registerCallback(CFNetServiceRef theService, CFStreamError* e
         CLog::Log(LOGERROR, "CZeroconfOSX::registerCallback name collision occured");
         break;
       default:
-        CLog::Log(LOGERROR, "CZeroconfOSX::registerCallback returned (domain = %d, error = %ld)\n", error->domain, error->error);
+        CLog::Log(LOGERROR, "CZeroconfOSX::registerCallback returned (domain = %d, error = %ld)\n", (int)error->domain, error->error);
         break;
     }
     p_this->cancelRegistration(theService);

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -1302,13 +1302,13 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
       g_guiSettings.SetString("audiooutput.audiodevice", pControl->GetCurrentLabel());
 #endif
   }
-#if defined(_LINUX)
+#if defined(_LINUX) && !defined(__arm__)
   else if (strSetting.Equals("audiooutput.passthroughdevice"))
   {
     CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(pSettingControl->GetID());
-#if defined(_LINUX) && !defined(__APPLE__)
+#if !defined(__APPLE__)
       g_guiSettings.SetString("audiooutput.passthroughdevice", m_DigitalAudioSinkMap[pControl->GetCurrentLabel()]);
-#elif !defined(__arm__)
+#else
       g_guiSettings.SetString("audiooutput.passthroughdevice", pControl->GetCurrentLabel());
 #endif
   }

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -131,7 +131,7 @@ __thread CThread* pLocalThread = NULL;
 #endif
 void CThread::term_handler (int signum)
 {
-  CLog::Log(LOGERROR,"thread 0x%lx (%lu) got signal %d. calling OnException and terminating thread abnormally.", pthread_self(), pthread_self(), signum);
+  CLog::Log(LOGERROR,"thread 0x%lx (%lu) got signal %d. calling OnException and terminating thread abnormally.", (long unsigned int)pthread_self(), (long unsigned int)pthread_self(), signum);
   if (LOCAL_THREAD)
   {
     LOCAL_THREAD->m_bStop = TRUE;

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -279,11 +279,10 @@ static void logicalToVisualBiDi(const CStdStringA& strSource, CStdStringA& strDe
       // Apperently a string can get longer during this transformation
       // so make sure we allocate the maximum possible character utf8
       // can generate atleast, should cover all bases
-      char *result = strDest.GetBuffer(len*4);
+      strDest.GetBuffer(len*4);
 
       // Convert back from Unicode to the charset
-      int len2 = fribidi_unicode_to_charset(fribidiCharset, visual, len, result);
-      ASSERT(len2 <= len*4);
+      ASSERT(fribidi_unicode_to_charset(fribidiCharset, visual, len, result) <= len*4);
       strDest.ReleaseBuffer();
 
       resultString += strDest;


### PR DESCRIPTION
Kill about 75 warnings. Some are fixed by using the right format specifier in logging. Others by forcing a cast to the specific format specifier in logging. A few restructures and such.

ACKs from all platforms in case I opps somewhere.
