### PR TITLE
add iOrder to actorlink* tables to be able to list actors by appearance

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -614,14 +614,14 @@ protected:
   int AddMusicVideo(const CStdString& strFilenameAndPath);
 
   // link functions - these two do all the work
-  void AddLinkToActor(const char *table, int actorID, const char *secondField, int secondID, const CStdString &role);
+  void AddLinkToActor(const char *table, int actorID, const char *secondField, int secondID, const CStdString &role, int order);
   void AddToLinkTable(const char *table, const char *firstField, int firstID, const char *secondField, int secondID);
 
   void AddSetToMovie(int idMovie, int idSet);
 
-  void AddActorToMovie(int idMovie, int idActor, const CStdString& strRole);
-  void AddActorToTvShow(int idTvShow, int idActor, const CStdString& strRole);
-  void AddActorToEpisode(int idEpisode, int idActor, const CStdString& strRole);
+  void AddActorToMovie(int idMovie, int idActor, const CStdString& strRole, int order);
+  void AddActorToTvShow(int idTvShow, int idActor, const CStdString& strRole, int order);
+  void AddActorToEpisode(int idEpisode, int idActor, const CStdString& strRole, int order);
   void AddArtistToMusicVideo(int lMVideo, int idArtist);
 
   void AddDirectorToMovie(int idMovie, int idDirector);
@@ -681,7 +681,7 @@ private:
    */
   void UpdateBasePath(const char *table, const char *id, int column, bool shows = false);
 
-  virtual int GetMinVersion() const { return 50; };
+  virtual int GetMinVersion() const { return 51; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 


### PR DESCRIPTION
This commit adds a field "iOrder" to the actorlinkmovie, actorlinktvshow and actorlinkepisode tables. This allows to define the order of the actors and how they will be listed in the user interface. The advantage of this is that the actors are listed in the same order as they are on e.g. IMDb or other scraper sites which usually sort the actors by importance (e.g. Bruce Willis is the first actor in the list for Die Hard and not some no-name actor which plays a minor role). Currently the list is ordered by idActor which again is ordered by the time the actor was added to the database.

This commit solves two trac tickets:
- http://trac.xbmc.org/ticket/5341
- http://trac.xbmc.org/ticket/9700

I tested it for actors loaded from an NFO but I didn't test it with XBMC's scrapers as I don't use them so I'd appreciate it if someone could test this with an internal scraper and report back.

Furthermore I'd be grateful if someone could look at the database update logic as I've never done this before.

There's a drawback: Movies, tv shows and episodes already in the database don't get an order and therefor don't show nicely (just same as before) with these changes. A user would have to remove his library and re-scrape all the info for it to work on all movies.

As usual I'm open for any suggestion/ideas.
Thanks
