### PR TITLE
changed: upgrade memory based cache to filebased after having been full f

### DIFF
--- a/xbmc/filesystem/CacheCircular.h
+++ b/xbmc/filesystem/CacheCircular.h
@@ -43,6 +43,7 @@ public:
 
     virtual int64_t Seek(int64_t pos) ;
     virtual void Reset(int64_t pos) ;
+    virtual int64_t GetCacheStart() { return m_beg; }
 
 protected:
     uint64_t          m_beg;       /**< index in file (not buffer) of beginning of valid data */

--- a/xbmc/filesystem/CacheMemBuffer.h
+++ b/xbmc/filesystem/CacheMemBuffer.h
@@ -47,6 +47,7 @@ public:
 
     virtual int64_t Seek(int64_t iFilePosition) ;
     virtual void Reset(int64_t iSourcePosition) ;
+    virtual int64_t GetCacheStart() { return m_nStartPosition; }
 
 protected:
     int64_t m_nStartPosition;

--- a/xbmc/filesystem/CacheStrategy.h
+++ b/xbmc/filesystem/CacheStrategy.h
@@ -57,6 +57,7 @@ public:
   virtual void EndOfInput(); // mark the end of the input stream so that Read will know when to return EOF
   virtual bool IsEndOfInput();
   virtual void ClearEndOfInput();
+  virtual int64_t GetCacheStart() = 0;
 
   CEvent m_space;
 protected:
@@ -80,6 +81,8 @@ public:
   virtual int64_t Seek(int64_t iFilePosition);
   virtual void Reset(int64_t iSourcePosition);
   virtual void EndOfInput();
+
+  virtual int64_t GetCacheStart() { return m_nStartPosition; }
 
   int64_t  GetAvailableRead();
 


### PR DESCRIPTION
changed: upgrade memory based cache to filebased after having been full for 2 seconds without anything reading out of it

By starting out with a memory based cache, then replacing that with a file based one on need we avoid the rather large overhead a file based cache introduces. However it can currently not discern the difference between paused playback on a really fast network, and on a slow one. So if you play over http from local network for example and pause playback. The whole file will be downloaded to local disk at maximum network speed.

I'm hesitant to this feature. I suspect it must be possible to turn on and off. On embedded system we may not have diskspace enough to do this. And currently i don't think the file based cache handles the situation of running out of space well at all.

Comments are very welcome to how we should handle a feature like this.
