### PR TITLE
Add second line to the PlayEject dialog

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3558,47 +3558,9 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
 #ifdef HAS_DVD_DRIVE
   if (item.IsDiscStub())
   {
-    // Figure out Line 1 of the dialog
-    CStdString strLine1;
-    if (item.GetVideoInfoTag())
-    {
-      strLine1 = item.GetVideoInfoTag()->m_strTitle;
-    }
-    else
-    {
-      strLine1 = URIUtils::GetFileName(item.m_strPath);
-      URIUtils::RemoveExtension(strLine1);
-    }
-
-    // Figure out Line 2 of the dialog
-    CStdString strLine2;
-
-    CFile discStubFile;
-    discStubFile.Open(item.m_strPath);
-    int iSize = discStubFile.GetLength();
-    discStubFile.Close();
-
-    if (iSize > 0)
-    {
-      TiXmlDocument discStubXML;
-      if (!discStubXML.LoadFile(item.m_strPath))
-      {
-        CLog::Log(LOGERROR, "Error loading %s at line %d\n%s", item.m_strPath.c_str(),
-          discStubXML.ErrorRow(), discStubXML.ErrorDesc());
-      }
-      else
-      {
-        TiXmlElement * pRootElement = discStubXML.RootElement();
-        if (!pRootElement || strcmpi(pRootElement->Value(), "discstub") != 0)
-          CLog::Log(LOGERROR, "Error loading %s, no <discstub> node", item.m_strPath.c_str());
-        else
-          XMLUtils::GetString(pRootElement, "message", strLine2);
-      }
-    }
-
     // Display the Play Eject dialog
-    if (CGUIDialogPlayEject::ShowAndGetInput(219, 429, strLine1, strLine2))
-      MEDIA_DETECT::CAutorun::PlayDisc();
+    if (CGUIDialogPlayEject::ShowAndGetInput(item))
+      return MEDIA_DETECT::CAutorun::PlayDisc();
 
     return true;
   }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3555,16 +3555,15 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
       CUtil::ClearSubtitles();
   }
 
-#ifdef HAS_DVD_DRIVE
   if (item.IsDiscStub())
   {
+#ifdef HAS_DVD_DRIVE
     // Display the Play Eject dialog
     if (CGUIDialogPlayEject::ShowAndGetInput(item))
       return MEDIA_DETECT::CAutorun::PlayDisc();
-
+#endif
     return true;
   }
-#endif
 
   if (item.IsPlayList())
     return false;

--- a/xbmc/dialogs/GUIDialogPlayEject.cpp
+++ b/xbmc/dialogs/GUIDialogPlayEject.cpp
@@ -24,6 +24,10 @@
 #include "guilib/GUIWindowManager.h"
 #include "storage/MediaManager.h"
 #include "storage/IoSupport.h"
+#include "utils/log.h"
+#include "utils/URIUtils.h"
+#include "utils/XMLUtils.h"
+#include "video/VideoInfoTag.h"
 
 #define ID_BUTTON_PLAY      11
 #define ID_BUTTON_EJECT     10
@@ -84,26 +88,54 @@ void CGUIDialogPlayEject::OnInitWindow()
   CGUIDialogYesNo::OnInitWindow();
 }
 
-bool CGUIDialogPlayEject::ShowAndGetInput(CVariant vHeading, CVariant vLine0,
-  CVariant vLine1, CVariant vLine2, unsigned int uiAutoCloseTime /* = 0 */)
+bool CGUIDialogPlayEject::ShowAndGetInput(const CFileItem & item,
+  unsigned int uiAutoCloseTime /* = 0 */)
 {
+  // Make sure we're actually dealing with a Disc Stub
+  if (!item.IsDiscStub())
+    return false;
+
+  // Create the dialog
   CGUIDialogPlayEject * pDialog = (CGUIDialogPlayEject *)g_windowManager.
     GetWindow(WINDOW_DIALOG_PLAY_EJECT);
-
   if (!pDialog)
     return false;
 
-  pDialog->SetHeading(vHeading);
-  pDialog->SetLine(0, vLine0);
-  pDialog->SetLine(1, vLine1);
-  pDialog->SetLine(2, vLine2);
+  // Figure out Line 1 of the dialog
+  CStdString strLine1;
+  if (item.GetVideoInfoTag())
+  {
+    strLine1 = item.GetVideoInfoTag()->m_strTitle;
+  }
+  else
+  {
+    strLine1 = URIUtils::GetFileName(item.m_strPath);
+    URIUtils::RemoveExtension(strLine1);
+  }
 
+  // Figure out Line 2 of the dialog
+  CStdString strLine2;
+  TiXmlDocument discStubXML;
+  if (discStubXML.LoadFile(item.m_strPath))
+  {
+    TiXmlElement * pRootElement = discStubXML.RootElement();
+    if (!pRootElement || strcmpi(pRootElement->Value(), "discstub") != 0)
+      CLog::Log(LOGERROR, "Error loading %s, no <discstub> node", item.m_strPath.c_str());
+    else
+      XMLUtils::GetString(pRootElement, "message", strLine2);
+  }
+
+  // Setup dialog parameters
+  pDialog->SetHeading(219);
+  pDialog->SetLine(0, 429);
+  pDialog->SetLine(1, strLine1);
+  pDialog->SetLine(2, strLine2);
   pDialog->SetChoice(ID_BUTTON_PLAY - 10, 208);
   pDialog->SetChoice(ID_BUTTON_EJECT - 10, 13391);
-
   if (uiAutoCloseTime)
     pDialog->SetAutoClose(uiAutoCloseTime);
 
+  // Display the dialog
   pDialog->DoModal();
 
   return pDialog->IsConfirmed();

--- a/xbmc/dialogs/GUIDialogPlayEject.h
+++ b/xbmc/dialogs/GUIDialogPlayEject.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include "FileItem.h"
 #include "GUIDialogYesNo.h"
 #include "utils/Variant.h"
 
@@ -31,8 +32,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual void FrameMove();
 
-  static bool ShowAndGetInput(CVariant vHeading, CVariant vLine0, CVariant vLine1,
-    CVariant vLine2, unsigned int uiAutoCloseTime = 0);
+  static bool ShowAndGetInput(const CFileItem & item, unsigned int uiAutoCloseTime = 0);
 
 protected:
   virtual void OnInitWindow();


### PR DESCRIPTION
A handful of users have requested the ability to have a custom message come up with the use of Disc Stub files.  I've added this functionality with the changes in this pull request.  Basically it treats the Disc Stub file as an XML file and tries to load a message from it that it displays on the second line of the Play Eject dialog.  This should greatly help those users who have a numbered DVD collection and need more than just the title of the DVD to find the actual disc.

Thanks,
Harry
