### PR TITLE
missing mac address on Windows

### DIFF
--- a/xbmc/network/windows/NetworkWin32.cpp
+++ b/xbmc/network/windows/NetworkWin32.cpp
@@ -75,8 +75,9 @@ bool CNetworkInterfaceWin32::IsConnected()
 
 CStdString CNetworkInterfaceWin32::GetMacAddress()
 {
-  CStdString result = "";
-  result = CStdString((char*)m_adapter.Address);
+  CStdString result;
+  unsigned char* mAddr = m_adapter.Address;
+  result.Format("%02X:%02X:%02X:%02X:%02X:%02X", mAddr[0], mAddr[1], mAddr[2], mAddr[3], mAddr[4], mAddr[5]);
   return result;
 }
 

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -88,7 +88,7 @@ CSysData::INTERNET_STATE CSysInfoJob::GetInternetState()
 
 CStdString CSysInfoJob::GetMACAddress()
 {
-#if defined(HAS_LINUX_NETWORK)
+#if defined(HAS_LINUX_NETWORK) || defined(HAS_WIN32_NETWORK)
   CNetworkInterface* iface = g_application.getNetwork().GetFirstConnectedInterface();
   if (iface)
     return iface->GetMacAddress();


### PR DESCRIPTION
On Windows, the network tab of system info doesn't show the user's mac address. I traced this problem to CNetworkInterfaceWin32::GetMacAddress() not being implemented. This patch fixes the problem by implementing the missing function.
