### PR TITLE
fixes #9684: show a warning notification if starting webserver, eventserver or jsonrpc tcp server fails

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2283,6 +2283,11 @@
   <string id="33082">Path to script</string>
   <string id="33083">Enable custom script button</string>
 
+  <string id="33100">Failed to start</string>
+  <string id="33101">Webserver</string>
+  <string id="33102">Event Server</string>
+  <string id="33103">Remote communication server</string>
+
   <!-- translators: no need to add these to your language files -->
   <string id="34000">Lame</string>
   <string id="34001">Vorbis</string>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1195,7 +1195,7 @@ bool CApplication::Initialize()
   return true;
 }
 
-void CApplication::StartWebServer()
+bool CApplication::StartWebServer()
 {
 #ifdef HAS_WEB_SERVER
   if (g_guiSettings.GetBool("services.webserver") && m_network.IsAvailable())
@@ -1206,12 +1206,14 @@ void CApplication::StartWebServer()
     if (webPort < 1024 && geteuid() != 0)
     {
         CLog::Log(LOGERROR, "Cannot start Web Server as port is smaller than 1024 and user is not root");
-        return;
+        return false;
     }
 #endif
 
+    bool started = false;
     if (m_WebServer.Start(webPort, g_guiSettings.GetString("services.webserverusername"), g_guiSettings.GetString("services.webserverpassword")))
     {
+      started = true;
       // publish web frontend and API services
 #ifdef HAS_WEB_INTERFACE
       CZeroconf::GetInstance()->PublishService("servers.webserver", "_http._tcp", "XBMC Web Server", webPort);
@@ -1227,8 +1229,12 @@ void CApplication::StartWebServer()
     if (g_settings.m_HttpApiBroadcastLevel >= 1)
       getApplicationMessenger().HttpApi("broadcastlevel; StartUp;1");
 #endif
+
+    return started;
   }
 #endif
+
+  return true;
 }
 
 void CApplication::StopWebServer()
@@ -1250,7 +1256,7 @@ void CApplication::StopWebServer()
 #endif
 }
 
-void CApplication::StartJSONRPCServer()
+bool CApplication::StartJSONRPCServer()
 {
 #ifdef HAS_JSONRPC
   if (g_guiSettings.GetBool("services.esenabled"))
@@ -1258,9 +1264,16 @@ void CApplication::StartJSONRPCServer()
     CJSONRPC::Initialize();
 
     if (CTCPServer::StartServer(g_advancedSettings.m_jsonTcpPort, g_guiSettings.GetBool("services.esallinterfaces")))
+    {
       CZeroconf::GetInstance()->PublishService("servers.jsonrpc", "_xbmc-jsonrpc._tcp", "XBMC JSONRPC", g_advancedSettings.m_jsonTcpPort);
+      return true;
+    }
+    else
+      return false;
   }
 #endif
+
+  return true;
 }
 
 void CApplication::StopJSONRPCServer(bool bWait)
@@ -1290,21 +1303,23 @@ void CApplication::StopUPnP(bool bWait)
 #endif
 }
 
-void CApplication::StartEventServer()
+bool CApplication::StartEventServer()
 {
 #ifdef HAS_EVENT_SERVER
   CEventServer* server = CEventServer::GetInstance();
   if (!server)
   {
     CLog::Log(LOGERROR, "ES: Out of memory");
-    return;
+    return false;
   }
   if (g_guiSettings.GetBool("services.esenabled"))
   {
     CLog::Log(LOGNOTICE, "ES: Starting event server");
     server->StartServer();
+    return true;
   }
 #endif
+  return true;
 }
 
 bool CApplication::StopEventServer(bool bWait, bool promptuser)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -103,9 +103,9 @@ public:
 
   void StartServices();
   void StopServices();
-  void StartWebServer();
+  bool StartWebServer();
   void StopWebServer();
-  void StartJSONRPCServer();
+  bool StartJSONRPCServer();
   void StopJSONRPCServer(bool bWait);
   void StartUPnP();
   void StopUPnP(bool bWait);
@@ -113,7 +113,7 @@ public:
   void StopUPnPRenderer();
   void StartUPnPServer();
   void StopUPnPServer();
-  void StartEventServer();
+  bool StartEventServer();
   bool StopEventServer(bool bWait, bool promptuser);
   void RefreshEventServer();
   void StartDbusServer();

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1135,7 +1135,8 @@ int CBuiltins::Execute(const CStdString& execString)
     g_settings.LoadMasterForLogin();
     g_passwordManager.bMasterUser = false;
     g_windowManager.ActivateWindow(WINDOW_LOGIN_SCREEN);
-    g_application.StartEventServer(); // event server could be needed in some situations
+    if (!g_application.StartEventServer()) // event server could be needed in some situations
+      g_application.m_guiDialogKaiToast.QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
   }
   else if (execute.Equals("pagedown"))
   {

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -26,6 +26,7 @@
 #include "libscrobbler/librefmscrobbler.h"
 #include "utils/RssReader.h"
 #include "utils/log.h"
+#include "guilib/LocalizeStrings.h"
 
 using namespace std;
 
@@ -269,19 +270,22 @@ void CNetwork::StartServices()
   g_application.StartTimeServer();
 #endif
 #ifdef HAS_WEB_SERVER
-  g_application.StartWebServer();
+  if (!g_application.StartWebServer())
+    g_application.m_guiDialogKaiToast.QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33101), g_localizeStrings.Get(33100));
 #endif
 #ifdef HAS_UPNP
   g_application.StartUPnP();
 #endif
 #ifdef HAS_EVENT_SERVER
-  g_application.StartEventServer();
+  if (!g_application.StartEventServer())
+    g_application.m_guiDialogKaiToast.QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
 #endif
 #ifdef HAS_DBUS_SERVER
   g_application.StartDbusServer();
 #endif
 #ifdef HAS_JSONRPC
-  g_application.StartJSONRPCServer();
+  if (!g_application.StartJSONRPCServer())
+    g_application.m_guiDialogKaiToast.QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33103), g_localizeStrings.Get(33100));
 #endif
 #ifdef HAS_ZEROCONF
   g_application.StartZeroconf();

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -696,7 +696,8 @@ void CGUIWindowSettingsCategory::UpdateSettings()
       if ( remoteMode != APPLE_REMOTE_DISABLED )
       {
         g_guiSettings.SetBool("services.esenabled", true);
-        g_application.StartEventServer();
+        if (!g_application.StartEventServer())
+          g_application.m_guiDialogKaiToast.QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
       }
 
       // if XBMC helper is running, prompt user before effecting change
@@ -1330,7 +1331,11 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
       ValidatePortNumber(pSettingControl, "8080", "80");
     g_application.StopWebServer();
     if (g_guiSettings.GetBool("services.webserver"))
-      g_application.StartWebServer();
+      if (!g_application.StartWebServer())
+      {
+        CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(33101), "", g_localizeStrings.Get(33100), "");
+        g_guiSettings.SetBool("services.webserver", false);
+      }
   }
   else if (strSetting.Equals("services.webserverusername") || strSetting.Equals("services.webserverpassword"))
   {
@@ -1685,7 +1690,15 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
   {
 #ifdef HAS_EVENT_SERVER
     if (g_guiSettings.GetBool("services.esenabled"))
-      g_application.StartEventServer();
+    {
+      if (!g_application.StartEventServer())
+      {
+        CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(33102), "", g_localizeStrings.Get(33100), "");
+        g_guiSettings.SetBool("services.esenabled", false);
+        CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
+        if (pControl) pControl->SetEnabled(false);
+      }
+    }
     else
     {
       if (!g_application.StopEventServer(true, true))
@@ -1696,10 +1709,15 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
       }
     }
 #endif
+#ifdef HAS_JSONRPC
     if (g_guiSettings.GetBool("services.esenabled"))
-      g_application.StartJSONRPCServer();
+    {
+      if (!g_application.StartJSONRPCServer())
+        CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(33103), "", g_localizeStrings.Get(33100), "");
+    }
     else
       g_application.StopJSONRPCServer(false);
+#endif
   }
   else if (strSetting.Equals("services.esport"))
   {
@@ -1707,7 +1725,10 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
     ValidatePortNumber(pSettingControl, "9777", "9777");
     //restart eventserver without asking user
     if (g_application.StopEventServer(true, false))
-      g_application.StartEventServer();
+    {
+      if (!g_application.StartEventServer())
+        CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(33102), "", g_localizeStrings.Get(33100), "");
+    }
 #if defined(__APPLE__) && !defined(__arm__)
     //reconfigure XBMCHelper for port changes
     XBMCHelper::GetInstance().Configure();
@@ -1720,7 +1741,10 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
     if (g_guiSettings.GetBool("services.esenabled"))
     {
       if (g_application.StopEventServer(true, true))
-        g_application.StartEventServer();
+      {
+        if (!g_application.StartEventServer())
+          CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(33102), "", g_localizeStrings.Get(33100), "");
+      }
       else
       {
         g_guiSettings.SetBool("services.esenabled", true);
@@ -1729,10 +1753,15 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
       }
     }
 #endif
+#ifdef HAS_JSONRPC
     if (g_guiSettings.GetBool("services.esenabled"))
-      g_application.StartJSONRPCServer();
+    {
+      if (!g_application.StartJSONRPCServer())
+        CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(33103), "", g_localizeStrings.Get(33100), "");
+    }
     else
       g_application.StopJSONRPCServer(false);
+#endif
   }
   else if (strSetting.Equals("services.esinitialdelay") ||
            strSetting.Equals("services.escontinuousdelay"))


### PR DESCRIPTION
This fixes the bug ticket at http://trac.xbmc.org/ticket/9684. As described in my last comment of that ticket it contains two types of notifications:
1. if the user just manually edited the setting for the webserver or eventserver and it fails to start a CGUIDialogOK dialog will be displayed and the setting will be automatically disabled after the user clicked OK.
2. if one of the servers fails to start on XBMC startup a warning notification will be shown.

I'd like some comments on whether this is a good idea or not and maybe someone can come up with some better strings for the warning notifications as I'm no good when it comes to find the right words.
