### PR TITLE
Auto Rip and Eject a CD

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1334,7 +1334,7 @@
   <string id="14082">Show EXIF picture information</string>
   <string id="14083">Use a fullscreen window rather than true fullscreen</string>
   <string id="14084">Queue songs on selection</string>
-  <string id="14085">Play audio CDs automatically</string>
+  <string id="14085"></string>
   <string id="14086">Playback</string>
   <string id="14087">DVDs</string>
   <string id="14088">Play DVDs automatically</string>
@@ -1345,6 +1345,9 @@
   <string id="14093">Security</string>
   <string id="14094">Input devices</string>
   <string id="14095">Power saving</string>
+  <string id="14096">Rip and Eject</string>
+  <string id="14097">Audio CD Insert Action</string>
+  <string id="14098">Play</string>
 
   <string id="15015">Remove</string>
   <string id="15016">Games</string>

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -315,7 +315,13 @@ void CGUISettings::Initialize()
   AddString(scr, "scrobbler.librefmpass", 15219, "", EDIT_CONTROL_MD5_INPUT, false, 15219);
 
   CSettingsCategory* acd = AddCategory(3, "audiocds", 620);
-  AddBool(acd, "audiocds.autorun", 14085, false);
+  map<int,int> autocd;
+  autocd.insert(make_pair(16018, AUTOCD_NONE));
+  autocd.insert(make_pair(14098, AUTOCD_PLAY));
+#ifdef HAS_CDDA_RIPPER
+  autocd.insert(make_pair(14096, AUTOCD_RIP));
+#endif
+  AddInt(acd,"audiocds.autoaction",14097,AUTOCD_NONE, autocd, SPIN_CONTROL_TEXT);
   AddBool(acd, "audiocds.usecddb", 227, true);
   AddSeparator(acd, "audiocds.sep1");
   AddPath(acd,"audiocds.recordingpath",20000,"select writable folder",BUTTON_CONTROL_PATH_INPUT,false,657);

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -63,6 +63,11 @@ class TiXmlElement;
 #define KARAOKE_COLOR_START  0
 #define KARAOKE_COLOR_END    4
 
+// CDDA Autoaction defines
+#define AUTOCD_NONE              0
+#define AUTOCD_PLAY              1
+#define AUTOCD_RIP               2
+
 // CDDA ripper defines
 #define CDDARIP_ENCODER_LAME     0
 #define CDDARIP_ENCODER_VORBIS   1

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -476,7 +476,7 @@ std::vector<CStdString> CMediaManager::GetDiskUsage()
 
 void CMediaManager::OnStorageAdded(const CStdString &label, const CStdString &path)
 {
-  if (g_guiSettings.GetBool("audiocds.autorun") || g_guiSettings.GetBool("dvds.autorun"))
+  if (g_guiSettings.GetInt("audiocds.autoaction") != AUTOCD_NONE || g_guiSettings.GetBool("dvds.autorun"))
     CJobManager::GetInstance().AddJob(new CAutorunMediaJob(label, path), this, CJob::PRIORITY_HIGH);
   else
     g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13021), label, TOAST_DISPLAY_TIME, false);


### PR DESCRIPTION
This is a pull request for the patch I had submitted on Trac - http://trac.xbmc.org/ticket/9885.  

This adds the ability to Rip and Eject a CD automatically when inserted. Very useful when dealing with a sizable CD collection.
