### PR TITLE
Add multimedia key handing

### DIFF
--- a/addons/script.module.pysqlite/lib/pysqlite2/__init__.py
+++ b/addons/script.module.pysqlite/lib/pysqlite2/__init__.py
@@ -3,6 +3,14 @@
 # this will only be allowed if the script is greater that version 1.0
 
 import warnings
+import re
+
+# Credit gnud on stackoverflow:
+#  see http://stackoverflow.com/questions/1714027/version-number-comparison/1714190#1714190
+def xbmcVerCmp(version1, version2):
+    def normalize(v):
+        return [int(x) for x in re.sub(r'(\.0+)*$','', v).split(".")]
+    return cmp(normalize(version1), normalize(version2))
 
 # Not sure why this might fail but ....
 try:
@@ -10,11 +18,11 @@ try:
     xbmcapiversion = __main__.__xbmcapiversion__
 except:
     xbmcapiversion = "1.0"
-    warnings.warn("For some reason the module'" + std(__name__) + "' couldn't get access to '__main__'. This may prevent certain backward compatility modes from operating correctly.")
+    warnings.warn("For some reason the module '" + str(__name__) + "' couldn't get access to '__main__'. This may prevent certain backward compatility modes from operating correctly.")
 
 # if the xbmcapiversion is either not set (because trying to get it failed or 
 #  the script was invoked in an odd manner from xbmc) ...
-if (float(xbmcapiversion) <= 1.0):
+if (xbmcVerCmp(xbmcapiversion,"1.0") <= 0):
     # then import sqlite3 in place of dbapi2
     try:
         import sqlite3 as dbapi2

--- a/lib/cpluff/libcpluff/pinfo.c
+++ b/lib/cpluff/libcpluff/pinfo.c
@@ -194,7 +194,7 @@ CP_C_API cp_plugin_info_t * cp_get_plugin_info(cp_context_t *context, const char
 		// Lookup plug-in information
 		if (id != NULL) {
 			if ((node = hash_lookup(context->env->plugins, id)) == NULL) {
-				cpi_warnf(context, N_("Could not return information about unknown plug-in %s."), id);
+				//cpi_warnf(context, N_("Could not return information about unknown plug-in %s."), id);
 				status = CP_ERR_UNKNOWN;
 				break;
 			}

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DllLibass.h
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DllLibass.h
@@ -152,9 +152,9 @@ public:
     virtual void ass_free_track(ASS_Track* track)
         { return ::ass_free_track(track); }
     virtual void ass_set_fonts(ASS_Renderer *priv, const char *default_font, const char *default_family, int fc, const char *config, int update)
-#ifndef _ARMEL
+#ifdef LIBASS_VERSION
         { return ::ass_set_fonts(priv, default_font, default_family, fc, config, update); }
-#else /* Libass version on armel is too old. */
+#else /* Legacy version. */
         { ::ass_set_fonts(priv, default_font, default_family); return; }
 #endif
     virtual void ass_set_style_overrides(ASS_Library* priv, char** list)
@@ -170,9 +170,9 @@ public:
     virtual void ass_set_message_cb(ASS_Library *priv
                                    , void (*msg_cb)(int level, const char *fmt, va_list args, void *data)
                                    , void *data)
-#ifndef _ARMEL
+#ifdef LIBASS_VERSION
         { return ::ass_set_message_cb(priv, msg_cb, data); }
-#else /* Libass version on armel is too old. */
+#else /* Legacy version. */
         { return; }
 #endif
 

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -55,7 +55,7 @@ bool CRecentlyAddedJob::UpdateVideo()
 
   if (videodatabase.GetRecentlyAddedMoviesNav("videodb://1/", items, NUM_ITEMS))
   {  
-    for (i; i < NUM_ITEMS; ++i)
+    for (i; i < items.Size(); ++i)
     {
       CFileItemPtr item = items.Get(i);
       CStdString   value;
@@ -94,7 +94,7 @@ bool CRecentlyAddedJob::UpdateVideo()
  
   if (videodatabase.GetRecentlyAddedEpisodesNav("videodb://1/", TVShowItems, NUM_ITEMS))
   {  
-    for (i; i < NUM_ITEMS; ++i)
+    for (i; i < TVShowItems.Size(); ++i)
     {    
       CFileItemPtr item          = TVShowItems.Get(i);
       int          EpisodeSeason = item->GetVideoInfoTag()->m_iSeason;
@@ -155,7 +155,7 @@ bool CRecentlyAddedJob::UpdateMusic()
   
   if (musicdatabase.GetRecentlyAddedAlbumSongs("musicdb://", musicItems, NUM_ITEMS))
   { 
-    for (i; i < NUM_ITEMS; ++i)
+    for (i; i < musicItems.Size(); ++i)
     {  
       CFileItemPtr item = musicItems.Get(i);
       CStdString   value;
@@ -201,7 +201,7 @@ bool CRecentlyAddedJob::UpdateMusic()
   
   if (musicdatabase.GetRecentlyAddedAlbums(albums, NUM_ITEMS))
   { 
-    for (i; i < NUM_ITEMS; ++i)
+    for (i; i < (int)albums.size(); ++i)
     {
       CStdString value;
       CStdString strPath;

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -55,7 +55,7 @@ bool CRecentlyAddedJob::UpdateVideo()
 
   if (videodatabase.GetRecentlyAddedMoviesNav("videodb://1/", items, NUM_ITEMS))
   {  
-    for (i; i < items.Size(); ++i)
+    for (; i < items.Size(); ++i)
     {
       CFileItemPtr item = items.Get(i);
       CStdString   value;
@@ -74,7 +74,7 @@ bool CRecentlyAddedJob::UpdateVideo()
       home->SetProperty("LatestMovie." + value + ".Fanart"      , item->GetCachedFanart());
     }
   } 
-  for (i; i < NUM_ITEMS; ++i)
+  for (; i < NUM_ITEMS; ++i)
   {
     CStdString value;
     value.Format("%i", i + 1);
@@ -94,7 +94,7 @@ bool CRecentlyAddedJob::UpdateVideo()
  
   if (videodatabase.GetRecentlyAddedEpisodesNav("videodb://1/", TVShowItems, NUM_ITEMS))
   {  
-    for (i; i < TVShowItems.Size(); ++i)
+    for (; i < TVShowItems.Size(); ++i)
     {    
       CFileItemPtr item          = TVShowItems.Get(i);
       int          EpisodeSeason = item->GetVideoInfoTag()->m_iSeason;
@@ -118,7 +118,7 @@ bool CRecentlyAddedJob::UpdateVideo()
       home->SetProperty("LatestEpisode." + value + ".Fanart"        , item->GetCachedFanart());
     }
   } 
-  for (i; i < NUM_ITEMS; ++i)
+  for (; i < NUM_ITEMS; ++i)
   {
     CStdString value;
     value.Format("%i", i + 1);
@@ -155,7 +155,7 @@ bool CRecentlyAddedJob::UpdateMusic()
   
   if (musicdatabase.GetRecentlyAddedAlbumSongs("musicdb://", musicItems, NUM_ITEMS))
   { 
-    for (i; i < musicItems.Size(); ++i)
+    for (; i < musicItems.Size(); ++i)
     {  
       CFileItemPtr item = musicItems.Get(i);
       CStdString   value;
@@ -182,7 +182,7 @@ bool CRecentlyAddedJob::UpdateMusic()
       home->SetProperty("LatestSong." + value + ".Fanart"  , item->GetCachedFanart());
     }
   }
-  for (i; i < NUM_ITEMS; ++i)
+  for (; i < NUM_ITEMS; ++i)
   {
     CStdString value;
     value.Format("%i", i + 1);
@@ -201,7 +201,7 @@ bool CRecentlyAddedJob::UpdateMusic()
   
   if (musicdatabase.GetRecentlyAddedAlbums(albums, NUM_ITEMS))
   { 
-    for (i; i < (int)albums.size(); ++i)
+    for (; i < (int)albums.size(); ++i)
     {
       CStdString value;
       CStdString strPath;
@@ -226,7 +226,7 @@ bool CRecentlyAddedJob::UpdateMusic()
       home->SetProperty("LatestAlbum." + value + ".Fanart"  , CFileItem::GetCachedThumb(strArtist,g_settings.GetMusicFanartFolder()));
     }
   }
-  for (i; i < NUM_ITEMS; ++i)
+  for (; i < NUM_ITEMS; ++i)
   {
     CStdString value;
     value.Format("%i", i + 1);

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -77,11 +77,6 @@ void CGUIWindowHome::Announce(EAnnouncementFlag flag, const char *sender, const 
     if (strcmp(message, "NewPlayCount") == 0)
       ra_flag |= Totals;
   }
-  else if (flag & System)
-  {
-    if (strcmp(message, "ProfileChange") == 0)
-      ra_flag |= (Video | Audio | Totals);
-  }
 
   // add the job immediatedly if the home window is active
   // otherwise defer it to the next initialisation
@@ -97,4 +92,26 @@ void CGUIWindowHome::AddRecentlyAddedJobs(int flag)
   if (flag != 0)
     CJobManager::GetInstance().AddJob(new CRecentlyAddedJob(flag), NULL);
   m_updateRA = 0;
+}
+
+bool CGUIWindowHome::OnMessage(CGUIMessage& message)
+{
+  switch ( message.GetMessage() )
+  {
+  case GUI_MSG_NOTIFY_ALL:
+    if (message.GetParam1() == GUI_MSG_WINDOW_RESET)
+    {
+      if (IsActive())
+        AddRecentlyAddedJobs(Video | Audio | Totals);
+      else
+        m_updateRA |= (Video | Audio | Totals);
+      return true;
+    }
+    break;
+
+  default:
+    break;
+  }
+
+  return CGUIWindow::OnMessage(message);
 }

--- a/xbmc/windows/GUIWindowHome.h
+++ b/xbmc/windows/GUIWindowHome.h
@@ -34,6 +34,8 @@ public:
   virtual void OnInitWindow();
   virtual void Announce(ANNOUNCEMENT::EAnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
 
+  virtual bool OnMessage(CGUIMessage& message);
+
 private:
   int m_updateRA; // flag for which recently added items needs to be queried
   void AddRecentlyAddedJobs(int flag);

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -30,11 +30,12 @@
 #include "interfaces/python/XBPython.h"
 #endif
 #include "interfaces/Builtins.h"
-#include "interfaces/AnnouncementManager.h"
 #include "utils/Weather.h"
 #include "network/Network.h"
 #include "addons/Skin.h"
 #include "settings/Profile.h"
+#include "guilib/GUIMessage.h"
+#include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogOK.h"
 #include "settings/Settings.h"
@@ -292,6 +293,4 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   g_windowManager.ChangeActiveWindow(g_SkinInfo->GetFirstWindow());
 
   g_application.UpdateLibraries();
-
-  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::System, "xbmc", "ProfileChange");
 }


### PR DESCRIPTION
This patch adds support for the multimedia keys on a multimedia keyboard. At the moment these are unrecognised and ignored. This has been tested on Win32: it may not work on Linux/OSX because I had to change a Win32 specific file (WinEventsWin32.cpp) to add the extra keys to VK_keymap. Something similar may be needed for Linux and OSX.
Further tidying up of the key handling code will be done imminently.
