### PR TITLE
Fix crash caused by a second reference count for CServices. 

### DIFF
--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -21,6 +21,9 @@
 */
 #include "boost/shared_ptr.hpp"
 #include "utils/StdString.h"
+
+#include <boost/enable_shared_from_this.hpp>
+
 #include <set>
 #include <map>
 
@@ -73,7 +76,7 @@ namespace ADDON
   typedef std::map<CStdString, CStdString> InfoMap;
   class AddonProps;
 
-  class IAddon
+  class IAddon : public boost::enable_shared_from_this<IAddon>
   {
   public:
     virtual ~IAddon() {};

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -50,7 +50,7 @@ bool CService::Start()
   {
 #ifdef HAS_PYTHON
   case PYTHON:
-    ret = (g_pythonParser.evalFile(LibPath(),ADDON::AddonPtr(this)) != -1);
+    ret = (g_pythonParser.evalFile(LibPath(),this->shared_from_this()) != -1);
     break;
 #endif
 


### PR DESCRIPTION
This is to fix a problem with a split/second reference count for Addon's that are also Services. We need to borrow the single reference count rather than create a new/second one.
