### PR TITLE
Removed unnecessary announcement and used the window messaging instead

### DIFF
--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -72,11 +72,6 @@ void CGUIWindowHome::Announce(EAnnouncementFlag flag, const char *sender, const 
     if (strcmp(message, "NewPlayCount") == 0)
       ra_flag |= Totals;
   }
-  else if (flag & System)
-  {
-    if (strcmp(message, "ProfileChange") == 0)
-      ra_flag |= (Video | Audio | Totals);
-  }
 
   // add the job immediatedly if the home window is active
   // otherwise defer it to the next initialisation
@@ -92,4 +87,26 @@ void CGUIWindowHome::AddRecentlyAddedJobs(int flag)
   if (flag != 0)
     CJobManager::GetInstance().AddJob(new CRecentlyAddedJob(flag), NULL);
   m_updateRA = 0;
+}
+
+bool CGUIWindowHome::OnMessage(CGUIMessage& message)
+{
+  switch ( message.GetMessage() )
+  {
+  case GUI_MSG_NOTIFY_ALL:
+    if (message.GetParam1() == GUI_MSG_WINDOW_RESET)
+    {
+      if (IsActive())
+        AddRecentlyAddedJobs(Video | Audio | Totals);
+      else
+        m_updateRA |= (Video | Audio | Totals);
+      return true;
+    }
+    break;
+
+  default:
+    break;
+  }
+
+  return CGUIWindow::OnMessage(message);
 }

--- a/xbmc/windows/GUIWindowHome.h
+++ b/xbmc/windows/GUIWindowHome.h
@@ -34,6 +34,8 @@ public:
   virtual void OnInitWindow();
   virtual void Announce(ANNOUNCEMENT::EAnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
 
+  virtual bool OnMessage(CGUIMessage& message);
+
 private:
   int m_updateRA; // flag for which recently added items needs to be queried
   void AddRecentlyAddedJobs(int flag);

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -30,11 +30,12 @@
 #include "interfaces/python/XBPython.h"
 #endif
 #include "interfaces/Builtins.h"
-#include "interfaces/AnnouncementManager.h"
 #include "utils/Weather.h"
 #include "network/Network.h"
 #include "addons/Skin.h"
 #include "settings/Profile.h"
+#include "guilib/GUIMessage.h"
+#include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogOK.h"
 #include "settings/Settings.h"
@@ -292,6 +293,4 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   g_windowManager.ChangeActiveWindow(g_SkinInfo->GetFirstWindow());
 
   g_application.UpdateLibraries();
-
-  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::System, "xbmc", "ProfileChange");
 }


### PR DESCRIPTION
This removes the unnecessary announcement in favour of sending a window message instead.

The reason for this is that profile change for an external client does not need to be announced, its essentially the same as if the application quit (atleast on TCP clients).

While a profile logout and login announcement might be interesting if we had system wide announcers the truth is we don't have that and we might never do. As such I vote on removing the need to add that as an announcement. We could and probably should announce OnQuit when we do logout though, but since we disconnect the network services thats kindof implied.
