### PR TITLE
JSON-RPC: Adding directory parameter to AudioPlaylist.Add.  

### DIFF
--- a/xbmc/interfaces/json-rpc/FileItemHandler.h
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.h
@@ -36,6 +36,8 @@ namespace JSONRPC
     static void MakeFieldsList(const Json::Value &parameterObject, Json::Value &validFields);
 
     static bool FillFileItemList(const Json::Value &parameterObject, CFileItemList &list);
+    static bool FillDirectoryItemList(CFileItemPtr directory, CFileItemList &list);
+
   private:
     static bool ParseSortMethods(const CStdString &method, const bool &ignorethe, const CStdString &order, SORT_METHOD &sortmethod, SORT_ORDER &sortorder);
     static void Sort(CFileItemList &items, const Json::Value& parameterObject);

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -913,6 +913,7 @@ namespace JSONRPC
             "{ \"name\": \"item\", \"type\": \"object\", \"id\": \"Playlist.Audio.Item\", \"required\": true,"
                 "\"properties\": {"
                     "\"file\": { \"type\": \"string\" },"
+                    "\"directory\": { \"type\": \"string\" },"
                     "\"artistid\": { \"$ref\": \"Library.Id\" },"
                     "\"albumid\": { \"$ref\": \"Library.Id\" },"
                     "\"songid\": { \"$ref\": \"Library.Id\" },"


### PR DESCRIPTION
Added 'directory' parameter to AudioPlaylist.Add.  
Will add all music files in a directory and its' subdirectories to the audio playlist.
