### PR TITLE
Fix for trac ticket #11465

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6363,6 +6363,16 @@ void CVideoDatabase::CleanDatabase(IVideoInfoScannerObserver* pObserver, const v
     }
     m_pDS->close();
 
+    // Add any files that don't have a valid idPath entry to the filesToDelete list.
+    sql = "select files.idFile from files where idPath not in (select idPath from path)";
+    m_pDS->exec(sql.c_str());
+    while (!m_pDS->eof())
+    {
+      filesToDelete += m_pDS->fv("files.idFile").get_asString() + ",";
+      m_pDS->next();
+    }
+    m_pDS->close();
+
     if ( ! filesToDelete.IsEmpty() )
     {
       filesToDelete.TrimRight(",");
@@ -6501,6 +6511,7 @@ void CVideoDatabase::CleanDatabase(IVideoInfoScannerObserver* pObserver, const v
         strIds.Format("%s %i,",strIds.Mid(0),m_pDS->fv("path.idPath").get_asInt()); // mid since we cannot format the same string
       m_pDS->next();
     }
+    m_pDS->close();
     if (!strIds.IsEmpty())
     {
       strIds.TrimLeft(" ");
@@ -6510,6 +6521,8 @@ void CVideoDatabase::CleanDatabase(IVideoInfoScannerObserver* pObserver, const v
       sql = PrepareSQL("delete from tvshowlinkpath where idPath in (%s)",strIds.c_str());
       m_pDS->exec(sql.c_str());
     }
+    sql = "delete from tvshowlinkpath where idPath not in (select idPath from path)";
+    m_pDS->exec(sql.c_str());
 
     CLog::Log(LOGDEBUG, "%s: Cleaning tvshow table", __FUNCTION__);
     sql = "delete from tvshow where idShow not in (select idShow from tvshowlinkpath)";


### PR DESCRIPTION
This is to address http://trac.xbmc.org/ticket/11465 - the more detailed write up is in the ticket, short version is I've got some "dangling" entries in my video database, this adds two calls to the clean video database routine to address the issue. The code compiles, but unfortunately the HEAD branch is crashing for me right now (with or without my changes), so it's untested - although I have run the sql manually on the database and gotten the results I expected. I figured while I'm waiting for HEAD to get stable again, I could at least throw this out for feedback. Thanks!
- added "files that don't have valid path rows" to the list of files to be deleted.
- deleted "tvshowlinkpath" entries that don't have a matching path row.
- added additional database close call as I noticed one was missing.
