### PR TITLE
Simplify keyboard handling

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -26,6 +26,7 @@
 #include "settings/Settings.h"
 #include "guilib/Key.h"
 #include "input/XBMC_keysym.h"
+#include "input/XBMC_keytable.h"
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
 #include "FileItem.h"
@@ -1036,89 +1037,22 @@ uint32_t CButtonTranslator::TranslateUniversalRemoteString(const char *szButton)
 uint32_t CButtonTranslator::TranslateKeyboardString(const char *szButton)
 {
   uint32_t buttonCode = 0;
-  if (strlen(szButton) == 1)
-  { // single character
-    buttonCode = (uint32_t)toupper(szButton[0]) | KEY_VKEY;
-    // FIXME It is a printable character, printable should be ASCII not VKEY! Till now it works, but how (long)?
-    // FIXME support unicode: additional parameter necessary since unicode can not be embedded into key/action-ID.
+  XBMCKEYTABLE keytable;
+
+  // Look up the key name
+  if (KeyTableLookupName(szButton, &keytable))
+  {
+    buttonCode = keytable.vkey;
   }
+
+  // The lookup failed i.e. the key name wasn't found
   else
-  { // for keys such as return etc. etc.
+  {
     CStdString strKey = szButton;
     strKey.ToLower();
 
-    if (strKey.Equals("return")) buttonCode = 0x0D;
-    else if (strKey.Equals("enter")) buttonCode = 0x6C;
-    else if (strKey.Equals("escape")) buttonCode = 0x1B;
-    else if (strKey.Equals("esc")) buttonCode = 0x1B;
-    else if (strKey.Equals("tab")) buttonCode = 0x09;
-    else if (strKey.Equals("space")) buttonCode = 0x20;
-    else if (strKey.Equals("left")) buttonCode = 0x25;
-    else if (strKey.Equals("right")) buttonCode = 0x27;
-    else if (strKey.Equals("up")) buttonCode = 0x26;
-    else if (strKey.Equals("down")) buttonCode = 0x28;
-    else if (strKey.Equals("insert")) buttonCode = 0x2D;
-    else if (strKey.Equals("delete")) buttonCode = 0x2E;
-    else if (strKey.Equals("home")) buttonCode = 0x24;
-    else if (strKey.Equals("end")) buttonCode = 0x23;
-    else if (strKey.Equals("f1")) buttonCode = 0x70;
-    else if (strKey.Equals("f2")) buttonCode = 0x71;
-    else if (strKey.Equals("f3")) buttonCode = 0x72;
-    else if (strKey.Equals("f4")) buttonCode = 0x73;
-    else if (strKey.Equals("f5")) buttonCode = 0x74;
-    else if (strKey.Equals("f6")) buttonCode = 0x75;
-    else if (strKey.Equals("f7")) buttonCode = 0x76;
-    else if (strKey.Equals("f8")) buttonCode = 0x77;
-    else if (strKey.Equals("f9")) buttonCode = 0x78;
-    else if (strKey.Equals("f10")) buttonCode = 0x79;
-    else if (strKey.Equals("f11")) buttonCode = 0x7A;
-    else if (strKey.Equals("f12")) buttonCode = 0x7B;
-    else if (strKey.Equals("numpadzero") || strKey.Equals("zero")) buttonCode = 0x60;
-    else if (strKey.Equals("numpadone") || strKey.Equals("one")) buttonCode = 0x61;
-    else if (strKey.Equals("numpadtwo") || strKey.Equals("two")) buttonCode = 0x62;
-    else if (strKey.Equals("numpadthree") || strKey.Equals("three")) buttonCode = 0x63;
-    else if (strKey.Equals("numpadfour") || strKey.Equals("four")) buttonCode = 0x64;
-    else if (strKey.Equals("numpadfive") || strKey.Equals("five")) buttonCode = 0x65;
-    else if (strKey.Equals("numpadsix") || strKey.Equals("six")) buttonCode = 0x66;
-    else if (strKey.Equals("numpadseven") || strKey.Equals("seven")) buttonCode = 0x67;
-    else if (strKey.Equals("numpadeight") || strKey.Equals("eight")) buttonCode = 0x68;
-    else if (strKey.Equals("numpadnine") || strKey.Equals("nine")) buttonCode = 0x69;
-    else if (strKey.Equals("numpadtimes")) buttonCode = 0x6A;
-    else if (strKey.Equals("numpadplus")) buttonCode = 0x6B;
-    else if (strKey.Equals("numpadminus")) buttonCode = 0x6D;
-    else if (strKey.Equals("numpadperiod")) buttonCode = 0x6E;
-    else if (strKey.Equals("numpaddivide")) buttonCode = 0x6F;
-    else if (strKey.Equals("pageup")) buttonCode = 0x21;
-    else if (strKey.Equals("pagedown")) buttonCode = 0x22;
-    else if (strKey.Equals("printscreen")) buttonCode = 0x2A;
-    else if (strKey.Equals("backspace")) buttonCode = 0x08;
-    else if (strKey.Equals("menu")) buttonCode = 0x5D;
-    else if (strKey.Equals("pause")) buttonCode = 0x13;
-    else if (strKey.Equals("leftshift")) buttonCode = 0xA0;
-    else if (strKey.Equals("rightshift")) buttonCode = 0xA1;
-    else if (strKey.Equals("leftctrl")) buttonCode = 0xA2;
-    else if (strKey.Equals("rightctrl")) buttonCode = 0xA3;
-    else if (strKey.Equals("leftalt")) buttonCode = 0xA4;
-    else if (strKey.Equals("rightalt")) buttonCode = 0xA5;
-    else if (strKey.Equals("leftwindows")) buttonCode = 0x5B;
-    else if (strKey.Equals("rightwindows")) buttonCode = 0x5C;
-    else if (strKey.Equals("capslock")) buttonCode = 0x20;
-    else if (strKey.Equals("numlock")) buttonCode = 0x90;
-    else if (strKey.Equals("scrolllock")) buttonCode = 0x91;
-    else if (strKey.Equals("semicolon") || strKey.Equals("colon")) buttonCode = 0xBA;
-    else if (strKey.Equals("equals") || strKey.Equals("plus")) buttonCode = 0xBB;
-    else if (strKey.Equals("comma") || strKey.Equals("lessthan")) buttonCode = 0xBC;
-    else if (strKey.Equals("minus") || strKey.Equals("underline")) buttonCode = 0xBD;
-    else if (strKey.Equals("period") || strKey.Equals("greaterthan")) buttonCode = 0xBE;
-    else if (strKey.Equals("forwardslash") || strKey.Equals("questionmark")) buttonCode = 0xBF;
-    else if (strKey.Equals("leftquote") || strKey.Equals("tilde")) buttonCode = 0xC0;
-    else if (strKey.Equals("opensquarebracket") || strKey.Equals("openbrace")) buttonCode = 0xEB;
-    else if (strKey.Equals("backslash") || strKey.Equals("pipe")) buttonCode = 0xEC;
-    else if (strKey.Equals("closesquarebracket") || strKey.Equals("closebrace")) buttonCode = 0xED;
-    else if (strKey.Equals("quote") || strKey.Equals("doublequote")) buttonCode = 0xEE;
-
     // Multimedia keys
-    else if (strKey.Equals("browser_back"))        buttonCode = XBMCK_BROWSER_BACK;
+    if (strKey.Equals("browser_back"))        buttonCode = XBMCK_BROWSER_BACK;
     else if (strKey.Equals("browser_forward"))     buttonCode = XBMCK_BROWSER_FORWARD;
     else if (strKey.Equals("browser_refresh"))     buttonCode = XBMCK_BROWSER_REFRESH;
     else if (strKey.Equals("browser_stop"))        buttonCode = XBMCK_BROWSER_STOP;
@@ -1140,9 +1074,10 @@ uint32_t CButtonTranslator::TranslateKeyboardString(const char *szButton)
     else if (strKey.Equals("launch_media_center")) buttonCode = 0xB9;
     else
       CLog::Log(LOGERROR, "Keyboard Translator: Can't find button %s", strKey.c_str());
-
-    buttonCode |= KEY_VKEY;
   }
+
+  buttonCode |= KEY_VKEY;
+
   return buttonCode;
 }
 

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -28,6 +28,7 @@
 #include "KeyboardLayoutConfiguration.h"
 #include "windowing/XBMC_events.h"
 #include "utils/TimeUtils.h"
+#include "input/XBMC_keytable.h"
 
 #if defined(_LINUX) && !defined(__APPLE__)
 #include <X11/Xlib.h>
@@ -42,46 +43,6 @@ struct XBMC_KeyMapping
   BYTE  VKey;
   char  Ascii;
   WCHAR Unicode;
-};
-
-// Convert control keypresses e.g. ctrl-A from 0x01 to 0x41
-static XBMC_KeyMapping g_mapping_ctrlkeys[] =
-{ {0x30, 0x60, XBMCK_0, XBMCK_0}
-, {0x31, 0x61, XBMCK_1, XBMCK_1}
-, {0x32, 0x62, XBMCK_2, XBMCK_2}
-, {0x33, 0x63, XBMCK_3, XBMCK_3}
-, {0x34, 0x64, XBMCK_4, XBMCK_4}
-, {0x35, 0x65, XBMCK_5, XBMCK_5}
-, {0x36, 0x66, XBMCK_6, XBMCK_6}
-, {0x37, 0x67, XBMCK_7, XBMCK_7}
-, {0x38, 0x68, XBMCK_8, XBMCK_8}
-, {0x39, 0x69, XBMCK_9, XBMCK_9}
-, {0x61, 0x41, XBMCK_a, XBMCK_a}
-, {0x62, 0x42, XBMCK_b, XBMCK_b}
-, {0x63, 0x43, XBMCK_c, XBMCK_c}
-, {0x64, 0x44, XBMCK_d, XBMCK_d}
-, {0x65, 0x45, XBMCK_e, XBMCK_e}
-, {0x66, 0x46, XBMCK_f, XBMCK_f}
-, {0x67, 0x47, XBMCK_g, XBMCK_g}
-, {0x68, 0x48, XBMCK_h, XBMCK_h}
-, {0x69, 0x49, XBMCK_i, XBMCK_i}
-, {0x6a, 0x4a, XBMCK_j, XBMCK_j}
-, {0x6b, 0x4b, XBMCK_k, XBMCK_k}
-, {0x6c, 0x4c, XBMCK_l, XBMCK_l}
-, {0x6d, 0x4d, XBMCK_m, XBMCK_m}
-, {0x6e, 0x4e, XBMCK_n, XBMCK_n}
-, {0x6f, 0x4f, XBMCK_o, XBMCK_o}
-, {0x70, 0x50, XBMCK_p, XBMCK_p}
-, {0x71, 0x51, XBMCK_q, XBMCK_q}
-, {0x72, 0x52, XBMCK_r, XBMCK_r}
-, {0x73, 0x53, XBMCK_s, XBMCK_s}
-, {0x74, 0x54, XBMCK_t, XBMCK_t}
-, {0x75, 0x55, XBMCK_u, XBMCK_u}
-, {0x76, 0x56, XBMCK_v, XBMCK_v}
-, {0x77, 0x57, XBMCK_w, XBMCK_w}
-, {0x78, 0x58, XBMCK_x, XBMCK_x}
-, {0x79, 0x59, XBMCK_y, XBMCK_y}
-, {0x7a, 0x5a, XBMCK_z, XBMCK_z}
 };
 
 // based on the evdev mapped scancodes in /user/share/X11/xkb/keycodes
@@ -171,339 +132,6 @@ static XBMC_KeyMapping g_mapping_ubuntu[] =
 , { 117, 0x5d } // right click
 };
 
-// Set the vkey value for non-printing keys that do not have vkey or
-// ascii equivalent.
-// OSX defines unicode values for non-printing keys which breaks the
-// key parser, set m_wUnicode
-static XBMC_KeyMapping g_mapping_npc[] =
-{ { XBMCK_BACKSPACE, 0x08 }
-, { XBMCK_TAB, 0x09 }
-, { XBMCK_RETURN, 0x0d }
-, { XBMCK_ESCAPE, 0x1b }
-, { XBMCK_SPACE, 0x20, ' ', L' ' }
-, { XBMCK_MENU, 0x5d }
-, { XBMCK_KP0, 0x60 }
-, { XBMCK_KP1, 0x61 }
-, { XBMCK_KP2, 0x62 }
-, { XBMCK_KP3, 0x63 }
-, { XBMCK_KP4, 0x64 }
-, { XBMCK_KP5, 0x65 }
-, { XBMCK_KP6, 0x66 }
-, { XBMCK_KP7, 0x67 }
-, { XBMCK_KP8, 0x68 }
-, { XBMCK_KP9, 0x69 }
-, { XBMCK_KP_ENTER, 0x6C }
-, { XBMCK_UP, 0x26 }
-, { XBMCK_DOWN, 0x28 }
-, { XBMCK_LEFT, 0x25 }
-, { XBMCK_RIGHT, 0x27 }
-, { XBMCK_INSERT, 0x2D }
-, { XBMCK_DELETE, 0x2E }
-, { XBMCK_HOME, 0x24 }
-, { XBMCK_END, 0x23 }
-, { XBMCK_F1, 0x70 }
-, { XBMCK_F2, 0x71 }
-, { XBMCK_F3, 0x72 }
-, { XBMCK_F4, 0x73 }
-, { XBMCK_F5, 0x74 }
-, { XBMCK_F6, 0x75 }
-, { XBMCK_F7, 0x76 }
-, { XBMCK_F8, 0x77 }
-, { XBMCK_F9, 0x78 }
-, { XBMCK_F10, 0x79 }
-, { XBMCK_F11, 0x7a }
-, { XBMCK_F12, 0x7b }
-, { XBMCK_KP_PERIOD, 0x6e }
-, { XBMCK_KP_MULTIPLY, 0x6a }
-, { XBMCK_KP_MINUS, 0x6d }
-, { XBMCK_KP_PLUS, 0x6b }
-, { XBMCK_KP_DIVIDE, 0x6f }
-, { XBMCK_PAGEUP, 0x21 }
-, { XBMCK_PAGEDOWN, 0x22 }
-, { XBMCK_PRINT, 0x2a }
-, { XBMCK_LSHIFT, 0xa0 }
-, { XBMCK_RSHIFT, 0xa1 }
-, { XBMCK_BROWSER_BACK,        XBMCK_BROWSER_BACK }
-, { XBMCK_BROWSER_FORWARD,     XBMCK_BROWSER_FORWARD }
-, { XBMCK_BROWSER_REFRESH,     XBMCK_BROWSER_REFRESH }
-, { XBMCK_BROWSER_STOP,        XBMCK_BROWSER_STOP }
-, { XBMCK_BROWSER_SEARCH,      XBMCK_BROWSER_SEARCH }
-, { XBMCK_BROWSER_FAVORITES,   XBMCK_BROWSER_FAVORITES }
-, { XBMCK_BROWSER_HOME,        XBMCK_BROWSER_HOME }
-, { XBMCK_VOLUME_MUTE,         XBMCK_VOLUME_MUTE }
-, { XBMCK_VOLUME_DOWN,         XBMCK_VOLUME_DOWN }
-, { XBMCK_VOLUME_UP,           XBMCK_VOLUME_UP }
-, { XBMCK_MEDIA_NEXT_TRACK,    XBMCK_MEDIA_NEXT_TRACK }
-, { XBMCK_MEDIA_PREV_TRACK,    XBMCK_MEDIA_PREV_TRACK }
-, { XBMCK_MEDIA_STOP,          XBMCK_MEDIA_STOP }
-, { XBMCK_MEDIA_PLAY_PAUSE,    XBMCK_MEDIA_PLAY_PAUSE }
-, { XBMCK_LAUNCH_MAIL,         XBMCK_LAUNCH_MAIL }
-, { XBMCK_LAUNCH_MEDIA_SELECT, XBMCK_LAUNCH_MEDIA_SELECT }
-, { XBMCK_LAUNCH_APP1,         XBMCK_LAUNCH_APP1 }
-, { XBMCK_LAUNCH_APP2,         XBMCK_LAUNCH_APP2 }
-};
-
-#define NUM_KEYNAMES 0x100
-static const char *keynames[NUM_KEYNAMES] =
-{
-  NULL,                 // 0x0
-  NULL,                 // 0x1
-  NULL,                 // 0x2
-  NULL,                 // 0x3
-  NULL,                 // 0x4
-  NULL,                 // 0x5
-  NULL,                 // 0x6
-  NULL,                 // 0x7
-  "backspace",          // 0x8
-  "tab",                // 0x9
-  NULL,                 // 0xA
-  NULL,                 // 0xB
-  NULL,                 // 0xC
-  "return",             // 0xD
-  NULL,                 // 0xE
-  NULL,                 // 0xF
-  NULL,                 // 0x10
-  NULL,                 // 0x11
-  NULL,                 // 0x12
-  NULL,                 // 0x13
-  NULL,                 // 0x14
-  NULL,                 // 0x15
-  NULL,                 // 0x16
-  NULL,                 // 0x17
-  NULL,                 // 0x18
-  NULL,                 // 0x19
-  NULL,                 // 0x1A
-  "escape",             // 0x1B
-  NULL,                 // 0x1C
-  NULL,                 // 0x1D
-  NULL,                 // 0x1E
-  NULL,                 // 0x1F
-  "space",              // 0x20
-  "pageup",             // 0x21
-  "pagedown",           // 0x22
-  "end",                // 0x23
-  "home",               // 0x24
-  "left",               // 0x25
-  "up",                 // 0x26
-  "right",              // 0x27
-  "down",               // 0x28
-  NULL,                 // 0x29
-  "printscreen",        // 0x2A
-  NULL,                 // 0x2B
-  NULL,                 // 0x2C
-  "insert",             // 0x2D
-  "delete",             // 0x2E
-  NULL,                 // 0x2F
-  NULL,                 // 0x30
-  NULL,                 // 0x31
-  NULL,                 // 0x32
-  NULL,                 // 0x33
-  NULL,                 // 0x34
-  NULL,                 // 0x35
-  NULL,                 // 0x36
-  NULL,                 // 0x37
-  NULL,                 // 0x38
-  NULL,                 // 0x39
-  NULL,                 // 0x3A
-  NULL,                 // 0x3B
-  NULL,                 // 0x3C
-  NULL,                 // 0x3D
-  NULL,                 // 0x3E
-  NULL,                 // 0x3F
-  NULL,                 // 0x40
-  "A",                  // 0x41
-  "B",                  // 0x42
-  "C",                  // 0x43
-  "D",                  // 0x44
-  "E",                  // 0x45
-  "F",                  // 0x46
-  "G",                  // 0x47
-  "H",                  // 0x48
-  "I",                  // 0x49
-  "J",                  // 0x4A
-  "K",                  // 0x4B
-  "L",                  // 0x4C
-  "M",                  // 0x4D
-  "N",                  // 0x4E
-  "O",                  // 0x4F
-  "P",                  // 0x50
-  "Q",                  // 0x51
-  "R",                  // 0x52
-  "S",                  // 0x53
-  "T",                  // 0x54
-  "U",                  // 0x55
-  "V",                  // 0x56
-  "W",                  // 0x57
-  "X",                  // 0x58
-  "Y",                  // 0x59
-  "Z",                  // 0x5A
-  NULL,                 // 0x5B
-  NULL,                 // 0x5C
-  "menu",               // 0x5D
-  NULL,                 // 0x5E
-  NULL,                 // 0x5F
-  "0",                  // 0x60
-  "1",                  // 0x61
-  "2",                  // 0x62
-  "3",                  // 0x63
-  "4",                  // 0x64
-  "5",                  // 0x65
-  "6",                  // 0x66
-  "7",                  // 0x67
-  "8",                  // 0x68
-  "9",                  // 0x69
-  NULL,                 // 0x6A
-  NULL,                 // 0x6B
-  "enter",              // 0x6C
-  NULL,                 // 0x6D
-  NULL,                 // 0x6E
-  NULL,                 // 0x6F
-  "f1",                 // 0x70
-  "f2",                 // 0x71
-  "f3",                 // 0x72
-  "f4",                 // 0x73
-  "f5",                 // 0x74
-  "f6",                 // 0x75
-  "f7",                 // 0x76
-  "f8",                 // 0x77
-  "f9",                 // 0x78
-  "f10",                // 0x79
-  "f11",                // 0x7A
-  "f12",                // 0x7B
-  NULL,                 // 0x7C
-  NULL,                 // 0x7D
-  NULL,                 // 0x7E
-  NULL,                 // 0x7F
-  NULL,                 // 0x80
-  NULL,                 // 0x81
-  NULL,                 // 0x82
-  NULL,                 // 0x83
-  NULL,                 // 0x84
-  NULL,                 // 0x85
-  NULL,                 // 0x86
-  NULL,                 // 0x87
-  NULL,                 // 0x88
-  NULL,                 // 0x89
-  NULL,                 // 0x8A
-  NULL,                 // 0x8B
-  NULL,                 // 0x8C
-  NULL,                 // 0x8D
-  NULL,                 // 0x8E
-  NULL,                 // 0x8F
-  NULL,                 // 0x90
-  NULL,                 // 0x91
-  NULL,                 // 0x92
-  NULL,                 // 0x93
-  NULL,                 // 0x94
-  NULL,                 // 0x95
-  NULL,                 // 0x96
-  NULL,                 // 0x97
-  NULL,                 // 0x98
-  NULL,                 // 0x99
-  NULL,                 // 0x9A
-  NULL,                 // 0x9B
-  NULL,                 // 0x9C
-  NULL,                 // 0x9D
-  NULL,                 // 0x9E
-  NULL,                 // 0x9F
-  "lshift",             // 0xA0
-  "rshift",             // 0xA1
-  "lcontrol",           // 0xA2
-  "rcontrol",           // 0xA3
-  "lalt",               // 0xA4
-  "ralt",               // 0xA5
-  "browser_back",       // 0xA6
-  "browser_forward",    // 0xA7
-  "browser_refresh",    // 0xA8
-  "browser_stop",       // 0xA9
-  "browser_search",     // 0xAA
-  "browser_favorites",  // 0xAB
-  "browser_home",       // 0xAC
-  "volume_mute",        // 0xAD
-  "volume_down",        // 0xAE
-  "volume_up",          // 0xAF
-  "next_track",         // 0xB0
-  "prev_track",         // 0xB1
-  "stop",               // 0xB2
-  "play_pause",         // 0xB3
-  "launch_mail",        // 0xB4
-  "launch_media_select",// 0xB5
-  "launch_app1_pc_icon",// 0xB6
-  "launch_app2_pc_icon",// 0xB7
-  NULL,                 // 0xB8
-  NULL,                 // 0xB9
-  "semicolon",          // 0xBA
-  "equals",             // 0xBB
-  "comma",              // 0xBC
-  "minus",              // 0xBD
-  "period",             // 0xBE
-  "slash",              // 0xBF
-  "leftquote",          // 0xC0
-  NULL,                 // 0xC1
-  NULL,                 // 0xC2
-  NULL,                 // 0xC3
-  NULL,                 // 0xC4
-  NULL,                 // 0xC5
-  NULL,                 // 0xC6
-  NULL,                 // 0xC7
-  NULL,                 // 0xC8
-  NULL,                 // 0xC9
-  NULL,                 // 0xCA
-  NULL,                 // 0xCB
-  NULL,                 // 0xCC
-  NULL,                 // 0xCD
-  NULL,                 // 0xCE
-  NULL,                 // 0xCF
-  NULL,                 // 0xD0
-  NULL,                 // 0xD1
-  NULL,                 // 0xD2
-  NULL,                 // 0xD3
-  NULL,                 // 0xD4
-  NULL,                 // 0xD5
-  NULL,                 // 0xD6
-  NULL,                 // 0xD7
-  NULL,                 // 0xD8
-  NULL,                 // 0xD9
-  NULL,                 // 0xDA
-  NULL,                 // 0xDB
-  NULL,                 // 0xDC
-  NULL,                 // 0xDD
-  NULL,                 // 0xDE
-  NULL,                 // 0xDF
-  NULL,                 // 0xE0
-  NULL,                 // 0xE1
-  NULL,                 // 0xE2
-  NULL,                 // 0xE3
-  NULL,                 // 0xE4
-  NULL,                 // 0xE5
-  NULL,                 // 0xE6
-  NULL,                 // 0xE7
-  NULL,                 // 0xE8
-  NULL,                 // 0xE9
-  NULL,                 // 0xEA
-  "opensquarebracket",  // 0xEB
-  "backslash",          // 0xEC
-  "closesquarebracket", // 0xED
-  "'",                  // 0xEE
-  NULL,                 // 0xEF
-  NULL,                 // 0xF0
-  NULL,                 // 0xF1
-  NULL,                 // 0xF2
-  NULL,                 // 0xF3
-  NULL,                 // 0xF4
-  NULL,                 // 0xF5
-  NULL,                 // 0xF6
-  NULL,                 // 0xF7
-  NULL,                 // 0xF8
-  NULL,                 // 0xF9
-  NULL,                 // 0xFA
-  NULL,                 // 0xFB
-  NULL,                 // 0xFC
-  NULL,                 // 0xFD
-  NULL,                 // 0xFE
-  NULL                  // 0xFF
-};
-
 static bool LookupKeyMapping(BYTE* VKey, char* Ascii, WCHAR* Unicode, int source, XBMC_KeyMapping* map, int count)
 {
   for(int i = 0; i < count; i++)
@@ -579,6 +207,7 @@ const CKey CKeyboardStat::ProcessKeyDown(XBMC_keysym& keysym)
   char ascii;
   uint32_t modifiers;
   unsigned int held;
+  XBMCKEYTABLE keytable;
 
   ascii = 0;
   vkey = 0;
@@ -597,80 +226,33 @@ const CKey CKeyboardStat::ProcessKeyDown(XBMC_keysym& keysym)
   if (keysym.mod & XBMCKMOD_SUPER)
     modifiers |= CKey::MODIFIER_SUPER;
 
-  CLog::Log(LOGDEBUG, "SDLKeyboard: scancode: %d, sym: %d, unicode: %d, modifier: %x", keysym.scancode, keysym.sym, keysym.unicode, keysym.mod);
+  CLog::Log(LOGDEBUG, "SDLKeyboard: scancode: %02x, sym: %04x, unicode: %04x, modifier: %x", keysym.scancode, keysym.sym, keysym.unicode, keysym.mod);
 
-  if ((keysym.unicode >= 'A' && keysym.unicode <= 'Z') ||
-    (keysym.unicode >= 'a' && keysym.unicode <= 'z'))
+  // For control key combinations, e.g. ctrl-P, the UNICODE gets set
+  // to 1 for ctrl-A, 2 for ctrl-B etc. To get round this, if the
+  // control key is down lookup by sym
+  if (modifiers & CKey::MODIFIER_CTRL && KeyTableLookupSym(keysym.sym, &keytable))
   {
-    ascii = (char)keysym.unicode;
-    vkey = toupper(ascii);
+    unicode = keytable.unicode;
+    ascii   = keytable.ascii;
+    vkey    = keytable.vkey;
   }
-  else if (keysym.unicode >= '0' && keysym.unicode <= '9')
+
+  // For printing keys look up the unicode
+  else if (KeyTableLookupUnicode(keysym.unicode, &keytable))
   {
-    ascii = (char)keysym.unicode;
-    vkey = 0x60 + ascii - '0'; // xbox keyboard routine appears to return 0x60->69 (unverified). Ideally this "fixing"
-    // should be done in xbox routine, not in the sdl/directinput routines.
-    // we should just be using the unicode/ascii value in all routines (perhaps with some
-    // headroom for modifier keys?)
+    ascii = keytable.ascii;
+    vkey = keytable.vkey;
   }
+
+  // For non-printing keys look up the sym
+  else if (KeyTableLookupSym(keysym.sym, &keytable))
+  {
+    vkey = keytable.vkey;
+  }
+
   else
   {
-    // see comment above about the weird use of vkey here...
-    if (keysym.unicode == ')') { vkey = 0x60; ascii = ')'; }
-    else if (keysym.unicode == '!') { vkey = 0x61; ascii = '!'; }
-    else if (keysym.unicode == '@') { vkey = 0x62; ascii = '@'; }
-    else if (keysym.unicode == '#') { vkey = 0x63; ascii = '#'; }
-    else if (keysym.unicode == '$') { vkey = 0x64; ascii = '$'; }
-    else if (keysym.unicode == '%') { vkey = 0x65; ascii = '%'; }
-    else if (keysym.unicode == '^') { vkey = 0x66; ascii = '^'; }
-    else if (keysym.unicode == '&') { vkey = 0x67; ascii = '&'; }
-    else if (keysym.unicode == '*') { vkey = 0x68; ascii = '*'; }
-    else if (keysym.unicode == '(') { vkey = 0x69; ascii = '('; }
-    else if (keysym.unicode == ':') { vkey = 0xba; ascii = ':'; }
-    else if (keysym.unicode == ';') { vkey = 0xba; ascii = ';'; }
-    else if (keysym.unicode == '=') { vkey = 0xbb; ascii = '='; }
-    else if (keysym.unicode == '+') { vkey = 0xbb; ascii = '+'; }
-    else if (keysym.unicode == '<') { vkey = 0xbc; ascii = '<'; }
-    else if (keysym.unicode == ',') { vkey = 0xbc; ascii = ','; }
-    else if (keysym.unicode == '-') { vkey = 0xbd; ascii = '-'; }
-    else if (keysym.unicode == '_') { vkey = 0xbd; ascii = '_'; }
-    else if (keysym.unicode == '>') { vkey = 0xbe; ascii = '>'; }
-    else if (keysym.unicode == '.') { vkey = 0xbe; ascii = '.'; }
-    else if (keysym.unicode == '?') { vkey = 0xbf; ascii = '?'; } // 0xbf is OEM 2 Why is it assigned here?
-    else if (keysym.unicode == '/') { vkey = 0xbf; ascii = '/'; }
-    else if (keysym.unicode == '~') { vkey = 0xc0; ascii = '~'; }
-    else if (keysym.unicode == '`') { vkey = 0xc0; ascii = '`'; }
-    else if (keysym.unicode == '{') { vkey = 0xeb; ascii = '{'; }
-    else if (keysym.unicode == '[') { vkey = 0xeb; ascii = '['; } // 0xeb is not defined by MS. Why is it assigned here?
-    else if (keysym.unicode == '|') { vkey = 0xec; ascii = '|'; }
-    else if (keysym.unicode == '\\') { vkey = 0xec; ascii = '\\'; }
-    else if (keysym.unicode == '}') { vkey = 0xed; ascii = '}'; }
-    else if (keysym.unicode == ']') { vkey = 0xed; ascii = ']'; } // 0xed is not defined by MS. Why is it assigned here?
-    else if (keysym.unicode == '"') { vkey = 0xee; ascii = '"'; }
-    else if (keysym.unicode == '\'') { vkey = 0xee; ascii = '\''; }
-
-    // For control key combinations, e.g. ctrl-P, the UNICODE gets set
-    // to 1 for ctrl-A, 2 for ctrl-B etc. This mapping sets the UNICODE
-    // back to 'a', 'b', etc.
-    // It isn't clear to me if this applies to Linux and Mac as well as
-    // Windows.
-    if (modifiers & CKey::MODIFIER_CTRL)
-    {
-      if (!vkey && !ascii)
-        LookupKeyMapping(&vkey, NULL, &unicode
-                       , keysym.sym
-                       , g_mapping_ctrlkeys
-                       , sizeof(g_mapping_ctrlkeys)/sizeof(g_mapping_ctrlkeys[0]));
-    }
-
-    /* Check for standard non printable keys */
-    if (!vkey && !ascii)
-      LookupKeyMapping(&vkey, NULL, &unicode
-                     , keysym.sym
-                     , g_mapping_npc
-                     , sizeof(g_mapping_npc)/sizeof(g_mapping_npc[0]));
-
-
     if (!vkey && !ascii)
     {
       /* Check for linux defined non printable keys */
@@ -716,7 +298,7 @@ const CKey CKeyboardStat::ProcessKeyDown(XBMC_keysym& keysym)
   // Create and return a CKey
 
   CKey key(vkey, unicode, ascii, modifiers, held);
-    
+
   return key;
 }
 
@@ -733,6 +315,7 @@ void CKeyboardStat::ProcessKeyUp(void)
 CStdString CKeyboardStat::GetKeyName(int KeyID)
 { int keyid;
   CStdString keyname;
+  XBMCKEYTABLE keytable;
 
   keyname.clear();
 
@@ -748,15 +331,12 @@ CStdString CKeyboardStat::GetKeyName(int KeyID)
     keyname.append("win-");
 
 // Now get the key name
-  
-  keyid = KeyID & 0x0FFF;
-  if (keyid > NUM_KEYNAMES)
-    keyname.AppendFormat("%i", keyid);
-  else if (!keynames[keyid])
-    keyname.AppendFormat("%i", keyid);
-  else
-    keyname.append(keynames[keyid]);
 
+  keyid = KeyID & 0xFF;
+  if (KeyTableLookupVKeyName(keyid, &keytable))
+    keyname.append(keytable.keyname);
+  else
+    keyname.AppendFormat("%i", keyid);
   keyname.AppendFormat(" (%02x)", KeyID);
 
   return keyname;

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -23,7 +23,7 @@
 
 // The array of XBMCKEYTABLEs used in XBMC.
 // scancode, sym, unicode, ascii, vkey, keyname
-XBMCKEYTABLE XBMCKeyTable[] =
+static const XBMCKEYTABLE XBMCKeyTable[] =
 { { 0x0E, 0x0008, 0x0000, 0x00, 0x08, "backspace" }
 , { 0x0f, 0x0009, 0x0009, 0x09, 0x09, "tab" }
 , { 0x1c, 0x000d, 0x000d, 0x0d, 0x0d, "return" }

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -1,0 +1,275 @@
+/*
+ *      Copyright (C) 2007-2010 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "input/XBMC_keytable.h"
+
+// The array of XBMCKEYTABLEs used in XBMC.
+// scancode, sym, unicode, ascii, vkey, keyname
+XBMCKEYTABLE XBMCKeyTable[] =
+{ { 0x0E, 0x0008, 0x0000, 0x00, 0x08, "backspace" }
+, { 0x0f, 0x0009, 0x0009, 0x09, 0x09, "tab" }
+, { 0x1c, 0x000d, 0x000d, 0x0d, 0x0d, "return" }
+, { 0x0b, 0x001b, 0x001b, 0x1b, 0x1b, "escape" }
+, { 0x0b,      0,      0,    0, 0x1b, "esc" } // Allowed abbreviation for "escape"
+, { 0x45, 0x0013,      0,    0, 0x13, "pause" }
+, { 0x39, 0x0020, 0x0020, 0x20, 0x20, "space" }
+
+// Number keys on the main keyboard
+, { 0x0b, 0x0030,    '0',  '0', 0x30, "zero" }
+, { 0x02, 0x0031,    '1',  '1', 0x31, "one" }
+, { 0x03, 0x0032,    '2',  '2', 0x32, "two" }
+, { 0x04, 0x0033,    '3',  '3', 0x33, "three" }
+, { 0x05, 0x0034,    '4',  '4', 0x34, "four" }
+, { 0x06, 0x0035,    '5',  '5', 0x35, "five" }
+, { 0x07, 0x0036,    '6',  '6', 0x36, "six" }
+, { 0x08, 0x0037,    '7',  '7', 0x37, "seven" }
+, { 0x09, 0x0038,    '8',  '8', 0x38, "eight" }
+, { 0x0a, 0x0039,    '9',  '9', 0x39, "nine" }
+
+// Shifted number keys on a US keyboard
+, { 0x0b, 0x0030,    ')',  ')', 0x30, "zero" }
+, { 0x02, 0x0031,    '!',  '!', 0x31, "one" }
+, { 0x03, 0x0032,    '@',  '@', 0x32, "two" }
+, { 0x04, 0x0033,    '#',  '#', 0x33, "three" }
+, { 0x05, 0x0034,    '$',  '$', 0x34, "four" }
+, { 0x06, 0x0035,    '%',  '%', 0x35, "five" }
+, { 0x07, 0x0036,    '^',  '^', 0x36, "six" }
+, { 0x08, 0x0037,    '&',  '&', 0x37, "seven" }
+, { 0x09, 0x0038,    '*',  '*', 0x38, "eight" }
+, { 0x0a, 0x0039,    '(',  '(', 0x39, "nine" }
+
+// A to Z - note that upper case A-Z don't have a matching name or
+// vkey. Only the lower case a-z are used in key mappings.
+, { 0x1e, 0x0061,    'A',  'A', 0x41, NULL }
+, { 0x30, 0x0062,    'B',  'B', 0x42, NULL }
+, { 0x2e, 0x0063,    'C',  'C', 0x43, NULL }
+, { 0x20, 0x0064,    'D',  'D', 0x44, NULL }
+, { 0x12, 0x0065,    'E',  'E', 0x45, NULL }
+, { 0x21, 0x0066,    'F',  'F', 0x46, NULL }
+, { 0x22, 0x0067,    'G',  'G', 0x47, NULL }
+, { 0x23, 0x0068,    'H',  'H', 0x48, NULL }
+, { 0x17, 0x0069,    'I',  'I', 0x49, NULL }
+, { 0x24, 0x006A,    'J',  'J', 0x4A, NULL }
+, { 0x25, 0x006B,    'K',  'K', 0x4B, NULL }
+, { 0x26, 0x006C,    'L',  'L', 0x4C, NULL }
+, { 0x32, 0x006D,    'M',  'M', 0x4D, NULL }
+, { 0x31, 0x006E,    'N',  'N', 0x4E, NULL }
+, { 0x18, 0x006F,    'O',  'O', 0x4F, NULL }
+, { 0x19, 0x0070,    'P',  'P', 0x50, NULL }
+, { 0x10, 0x0071,    'Q',  'Q', 0x51, NULL }
+, { 0x13, 0x0072,    'R',  'R', 0x52, NULL }
+, { 0x1f, 0x0073,    'S',  'S', 0x53, NULL }
+, { 0x14, 0x0074,    'T',  'T', 0x54, NULL }
+, { 0x16, 0x0075,    'U',  'U', 0x55, NULL }
+, { 0x2f, 0x0076,    'V',  'V', 0x56, NULL }
+, { 0x11, 0x0077,    'W',  'W', 0x57, NULL }
+, { 0x2d, 0x0078,    'X',  'X', 0x58, NULL }
+, { 0x15, 0x0079,    'Y',  'Y', 0x59, NULL }
+, { 0x2c, 0x007A,    'Z',  'Z', 0x5A, NULL }
+
+, { 0x1e, 0x0061,    'a',  'a', 0x41, "a" }
+, { 0x30, 0x0062,    'b',  'b', 0x42, "b" }
+, { 0x2e, 0x0063,    'c',  'c', 0x43, "c" }
+, { 0x20, 0x0064,    'd',  'd', 0x44, "d" }
+, { 0x12, 0x0065,    'e',  'e', 0x45, "e" }
+, { 0x21, 0x0066,    'f',  'f', 0x46, "f" }
+, { 0x22, 0x0067,    'g',  'g', 0x47, "g" }
+, { 0x23, 0x0068,    'h',  'h', 0x48, "h" }
+, { 0x17, 0x0069,    'i',  'i', 0x49, "i" }
+, { 0x24, 0x006a,    'j',  'j', 0x4a, "j" }
+, { 0x25, 0x006b,    'k',  'k', 0x4b, "k" }
+, { 0x26, 0x006c,    'l',  'l', 0x4c, "l" }
+, { 0x32, 0x006d,    'm',  'm', 0x4d, "m" }
+, { 0x31, 0x006e,    'n',  'n', 0x4e, "n" }
+, { 0x18, 0x006f,    'o',  'o', 0x4f, "o" }
+, { 0x19, 0x0070,    'p',  'p', 0x50, "p" }
+, { 0x10, 0x0071,    'q',  'q', 0x51, "q" }
+, { 0x13, 0x0072,    'r',  'r', 0x52, "r" }
+, { 0x1f, 0x0073,    's',  's', 0x53, "s" }
+, { 0x14, 0x0074,    't',  't', 0x54, "t" }
+, { 0x16, 0x0075,    'u',  'u', 0x55, "u" }
+, { 0x2f, 0x0076,    'v',  'v', 0x56, "v" }
+, { 0x11, 0x0077,    'w',  'w', 0x57, "w" }
+, { 0x2d, 0x0078,    'x',  'x', 0x58, "x" }
+, { 0x15, 0x0079,    'y',  'y', 0x59, "y" }
+, { 0x2c, 0x007a,    'z',  'z', 0x5a, "z" }
+
+// Numeric keypad
+, { 0x52, 0x0100,    '0',  '0', 0x60, "numpadzero"}
+, { 0x4f, 0x0101,    '1',  '1', 0x61, "numpadone"}
+, { 0x50, 0x0102,    '2',  '2', 0x62, "numpadtwo"}
+, { 0x51, 0x0103,    '3',  '3', 0x63, "numpadthree"}
+, { 0x4b, 0x0104,    '4',  '4', 0x64, "numpadfour"}
+, { 0x4c, 0x0105,    '5',  '5', 0x65, "numpadfive"}
+, { 0x4d, 0x0106,    '6',  '6', 0x66, "numpadsix"}
+, { 0x47, 0x0107,    '7',  '7', 0x67, "numpadseven"}
+, { 0x48, 0x0108,    '8',  '8', 0x68, "numpadeight"}
+, { 0x49, 0x0109,    '9',  '9', 0x69, "numpadnine"}
+, { 0x53, 0x010a,    '.',  '.', 0x6e, "numpadperiod"}
+, { 0x35, 0x010b,    '/',  '/', 0x6f, "numpaddivide"}
+, { 0x37, 0x010c,    '*',  '*', 0x6a, "numpadtimes"}
+, { 0x4a, 0x010d,    '-',  '-', 0x6d, "numpadminus"}
+, { 0x4e, 0x010e,    '+',  '+', 0x6b, "numpadplus"}
+, { 0x1c, 0x010f,      0,    0, 0x6c, "enter"}
+
+// Misc printing characters
+, { 0x28, 0x0027,   '\'', '\'', 0xEE, "quote" }
+, { 0x28, 0x0027,    '"',  '"', 0xEE, "doublequote" }
+, { 0x33, 0x002c,    ',',  ',', 0xBC, "comma" }
+, { 0x33, 0x002c,    '<',  '<', 0xBC, "lessthan" }
+, { 0x0c, 0x002d,    '-',  '-', 0xBD, "minus" }
+, { 0x0c, 0x002d,    '_',  '_', 0xBD, "underline" }
+, { 0x34, 0x002e,    '.',  '.', 0xBE, "period" }
+, { 0x34, 0x002e,    '>',  '>', 0xBE, "greaterthan" }
+, { 0x35, 0x002f,    '/',  '/', 0xBF, "forwardslash" }
+, { 0x35, 0x002f,    '?',  '?', 0xBF, "questionmark" }
+, { 0x27, 0x003b,    ';',  ';', 0xBA, "semicolon" }
+, { 0x27, 0x003b,    ':',  ':', 0xBA, "colon" }
+, { 0x56, 0x003c,   '\\', '\\', 0xEC, "backslash" }
+, { 0x56, 0x003c,    '|',  '|', 0xEC, "pipe" }
+, { 0x0d, 0x003d,    '=',  '=', 0xBB, "equals" }
+, { 0x0d, 0x003d,    '+',  '+', 0xBB, "plus" }
+, { 0x1a, 0x005b,    '[',  '[', 0xEB, "opensquarebracket" }
+, { 0x1a, 0x005b,    '{',  '{', 0xEB, "openbrace" }
+, { 0x1b, 0x005d,    ']',  ']', 0xED, "closesquarebracket" }
+, { 0x1b, 0x005d,    '}',  '}', 0xED, "closebrace" }
+, { 0x29, 0x0060,    '`',  '`', 0xC0, "leftquote" }
+, { 0x29, 0x0060,    '~',  '~', 0xC0, "tilde" }
+
+// Function keys
+, { 0x3b, 0x011a,      0,    0, 0x70, "f1"}
+, { 0x3c, 0x011b,      0,    0, 0x71, "f2"}
+, { 0x3d, 0x011c,      0,    0, 0x72, "f3"}
+, { 0x3e, 0x011d,      0,    0, 0x73, "f4"}
+, { 0x3f, 0x011e,      0,    0, 0x74, "f5"}
+, { 0x40, 0x011f,      0,    0, 0x75, "f6"}
+, { 0x41, 0x0120,      0,    0, 0x76, "f7"}
+, { 0x42, 0x0121,      0,    0, 0x77, "f8"}
+, { 0x43, 0x0122,      0,    0, 0x78, "f9"}
+, { 0x44, 0x0123,      0,    0, 0x79, "f10"}
+, { 0x57, 0x0124,      0,    0, 0x7a, "f11"}
+, { 0x58, 0x0125,      0,    0, 0x7b, "f12"}
+, { 0x5b, 0x0126,      0,    0, 0x7c, "f13"}
+, { 0x5c, 0x0127,      0,    0, 0x7d, "f14"}
+, { 0x5d, 0x0128,      0,    0, 0x7e, "f15"}
+
+// Misc non-printing keys
+, { 0x48, 0x0111,      0,    0, 0x26, "up" }
+, { 0x50, 0x0112,      0,    0, 0x28, "down" }
+, { 0x4d, 0x0113,      0,    0, 0x27, "right" }
+, { 0x4b, 0x0114,      0,    0, 0x25, "left" }
+, { 0x52, 0x0115,      0,    0, 0x2d, "insert" }
+, { 0x53, 0x007f,      0,    0, 0x2e, "delete" }
+, { 0x47, 0x0116,      0,    0, 0x24, "home" }
+, { 0x4f, 0x0117,      0,    0, 0x23, "end" }
+, { 0x49, 0x0118,      0,    0, 0x21, "pageup" }
+, { 0x51, 0x0119,      0,    0, 0x22, "pagedown" }
+, { 0x45, 0x012c,      0,    0, 0x90, "numlock" }
+, { 0x3a, 0x012d,      0,    0, 0x20, "capslock" }
+, { 0x46, 0x012e,      0,    0, 0x91, "scrolllock" }
+, { 0x36, 0x012f,      0,    0, 0xA1, "rightshift" }
+, { 0x2a, 0x0130,      0,    0, 0xA0, "leftshift" }
+, { 0x1d, 0x0131,      0,    0, 0xA3, "rightctrl" }
+, { 0x1d, 0x0132,      0,    0, 0xA2, "leftctrl" }
+, { 0x38, 0x0134,      0,    0, 0xA4, "leftalt" }
+, { 0x5b, 0x0137,      0,    0, 0x5B, "leftwindows" }
+, { 0x5c, 0x0138,      0,    0, 0x5C, "rightwindows" }
+, { 0x37, 0x013c,      0,    0, 0x2A, "printscreen" }
+, { 0x5d, 0x013f,      0,    0, 0x5D, "menu" }
+};
+
+static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);
+
+bool KeyTableLookupName(const char* keyname, XBMCKEYTABLE* keytable)
+{
+  // If the name being searched for is null or "" there will be no match
+  if (!keyname)
+    return false;
+  if (keyname[0] == '\0')
+    return false;
+
+  // Look up the key name in XBMCKeyTable
+  for (int i = 0; i < XBMCKeyTableSize; i++)
+  { if (XBMCKeyTable[i].keyname)
+    { if (strcmp(keyname, XBMCKeyTable[i].keyname) == 0)
+      { *keytable = XBMCKeyTable[i];
+        return true;
+      }
+    }
+  }
+
+  // The name wasn't found
+  return false;
+}
+
+bool KeyTableLookupSym(uint16_t sym, XBMCKEYTABLE* keytable)
+{
+  // If the sym being searched for is zero there will be no match
+  if (sym == 0)
+    return false;
+
+  // Look up the sym in XBMCKeyTable
+  for (int i = 0; i < XBMCKeyTableSize; i++)
+  { if (sym == XBMCKeyTable[i].sym)
+    { *keytable = XBMCKeyTable[i];
+      return true;
+    }
+  }
+
+  // The name wasn't found
+  return false;
+}
+
+bool KeyTableLookupUnicode(uint16_t unicode, XBMCKEYTABLE* keytable)
+{
+  // If the unicode being searched for is zero there will be no match
+  if (unicode == 0)
+    return false;
+
+  // Look up the unicode in XBMCKeyTable
+  for (int i = 0; i < XBMCKeyTableSize; i++)
+  { if (unicode == XBMCKeyTable[i].unicode)
+    { *keytable = XBMCKeyTable[i];
+      return true;
+    }
+  }
+
+  // The name wasn't found
+  return false;
+}
+
+bool KeyTableLookupVKeyName(uint32_t vkey, XBMCKEYTABLE* keytable)
+{
+  // If the vkey being searched for is zero there will be no match
+  if (vkey == 0)
+    return false;
+
+  // Look up the vkey in XBMCKeyTable
+  for (int i = 0; i < XBMCKeyTableSize; i++)
+  { if (vkey == XBMCKeyTable[i].vkey && XBMCKeyTable[i].keyname)
+    { *keytable = XBMCKeyTable[i];
+      return true;
+    }
+  }
+
+  // The name wasn't found
+  return false;
+}

--- a/xbmc/input/XBMC_keytable.h
+++ b/xbmc/input/XBMC_keytable.h
@@ -1,0 +1,64 @@
+/*
+ *      Copyright (C) 2007-2010 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#ifndef _XBMC_keytable_h
+#define _XBMC_keytable_h
+
+typedef struct _XBMCKEYTABLE
+{
+
+  // The scancode is the key scan code returned by the keyboard driver.
+  // The only use for this is to detect some multimedia keys that do
+  // not set the sym member in Linux.
+  uint8_t scancode;
+
+  // The sym is a value that identifies which key was pressed. Note
+  // that it specifies the key not the character so it is unaffected by
+  // shift, control, etc.
+  uint16_t sym;
+
+  // If the keypress generates a printing character the unicode and
+  // ascii member variables contain the character generated. If the
+  // key is a non-printing character, e.g. a function or arrow key,
+  // the unicode and ascii member variables are zero.
+  uint16_t unicode;
+  char     ascii;
+
+  // The following two member variables are used to specify the
+  // action/function assigned to a key.
+  // The keynames are used as tags in keyboard.xml. When reading keyboard.xml
+  // TranslateKeyboardString uses the keyname to look up the vkey, and
+  // this is used in the mapping table.
+  uint32_t    vkey;
+  const char* keyname;
+
+} XBMCKEYTABLE;
+
+// The array of XBMCKEYTABLEs used in XBMC.
+// This array is initialised in KeyboardStat.cpp.
+extern XBMCKEYTABLE XBMCKeyTable[];
+
+bool KeyTableLookupName(const char* keyname, XBMCKEYTABLE* keytable);
+bool KeyTableLookupSym(uint16_t sym, XBMCKEYTABLE* keytable);
+bool KeyTableLookupUnicode(uint16_t unicode, XBMCKEYTABLE* keytable);
+bool KeyTableLookupVKeyName(uint32_t vkey, XBMCKEYTABLE* keytable);
+
+#endif /* _XBMC_keytable_h */

--- a/xbmc/input/XBMC_keytable.h
+++ b/xbmc/input/XBMC_keytable.h
@@ -22,7 +22,7 @@
 #ifndef _XBMC_keytable_h
 #define _XBMC_keytable_h
 
-typedef struct _XBMCKEYTABLE
+typedef struct struct_XBMCKEYTABLE
 {
 
   // The scancode is the key scan code returned by the keyboard driver.
@@ -51,10 +51,6 @@ typedef struct _XBMCKEYTABLE
   const char* keyname;
 
 } XBMCKEYTABLE;
-
-// The array of XBMCKEYTABLEs used in XBMC.
-// This array is initialised in KeyboardStat.cpp.
-extern XBMCKEYTABLE XBMCKeyTable[];
 
 bool KeyTableLookupName(const char* keyname, XBMCKEYTABLE* keytable);
 bool KeyTableLookupSym(uint16_t sym, XBMCKEYTABLE* keytable);


### PR DESCRIPTION
This is to tidy up and simplify the keyboard handling. I have replaced the massive if ... else if ... blocks with a single table that holds all the required data for keypresses. Keys can be processed simply by looking up the desired value in this table. This considerably streamlines the code.

This is still a work in progress (I can't do the multimedia keys at the moment because my multimedia keyboard is broken!) and I have only tested on Windows. At the moment what I'm after is comments on this approach and whether I should go ahead and complete the work and test on Linux. Note that I can't test on OSX.
