### PR TITLE
Implements trac ticket #10796 - splits out view state by skin

### DIFF
--- a/xbmc/GUIViewState.cpp
+++ b/xbmc/GUIViewState.cpp
@@ -411,7 +411,8 @@ void CGUIViewState::LoadViewState(const CStdString &path, int windowID)
   if (db.Open())
   {
     CViewState state;
-    if (db.GetViewState(path, windowID, state))
+    if (db.GetViewState(path, windowID, state, g_guiSettings.GetString("lookandfeel.skin")) ||
+        db.GetViewState(path, windowID, state, ""))
     {
       SetViewAsControl(state.m_viewMode);
       SetSortMethod(state.m_sortMethod);
@@ -429,7 +430,7 @@ void CGUIViewState::SaveViewToDb(const CStdString &path, int windowID, CViewStat
     CViewState state(m_currentViewAsControl, GetSortMethod(), m_sortOrder);
     if (viewState)
       *viewState = state;
-    db.SetViewState(path, windowID, state);
+    db.SetViewState(path, windowID, state, g_guiSettings.GetString("lookandfeel.skin"));
     db.Close();
     if (viewState)
       g_settings.Save();

--- a/xbmc/ViewDatabase.h
+++ b/xbmc/ViewDatabase.h
@@ -30,13 +30,13 @@ public:
   virtual ~CViewDatabase(void);
   virtual bool Open();
 
-  bool GetViewState(const CStdString &path, int windowID, CViewState &state);
-  bool SetViewState(const CStdString &path, int windowID, const CViewState &state);
+  bool GetViewState(const CStdString &path, int windowID, CViewState &state, const CStdString &skin);
+  bool SetViewState(const CStdString &path, int windowID, const CViewState &state, const CStdString &skin);
   bool ClearViewStates(int windowID);
 
 protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 3; };
+  virtual int GetMinVersion() const { return 4; };
   const char *GetBaseDBName() const { return "ViewModes"; };
 };


### PR DESCRIPTION
This was all done by spiff, I just got it working on the current master and tested that it works.

In the database code, it was trying to update any current entries in ViewModes to add the skin name to these. However, the current skin is not accessible from that code anymore (g_guiSettings) and I couldn't change the signature to add the skin name.

However, the code now tries to look up the view mode for the current skin, and if it can't find it then falls back to the first entry it can find for the same window and path. Hence, this effectively gives the same result without updating the existing table entries.
