### PR TITLE
Use a single query for playcounts/metadata in files views

### DIFF
--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -63,6 +63,33 @@ int Database::connectFull(const char *newHost, const char *newPort, const char *
   return connect(true);
 }
 
+string Database::prepare(const char *format, ...)
+{
+  string result = "";
+
+  va_list args;
+  va_start(args, format);
+  result = vprepare(format, args);
+  va_end(args);
+
+  return result;
+}
+
+string Database::vprepare(const char *format, va_list args)
+{
+  char *p = NULL;
+  string result = "";
+
+  vsprintf(p, format, args);
+
+  if ( p )
+  {
+    result = p;
+    free(p);
+  }
+
+  return result;
+}
 
 
 

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -133,7 +133,20 @@ public:
   virtual void rollback_transaction() {};
 
 /* virtual methods for formatting */
-  virtual std::string vprepare(const char *format, va_list args) { return std::string(""); };
+
+  /*! \brief Prepare a SQL statement for execution or querying using C printf nomenclature.
+   \param format - C printf compliant format string
+   \param ... - optional comma seperated list of variables for substitution in format string placeholders.
+   \return escaped and formatted string.
+   */
+  virtual std::string prepare(const char *format, ...);
+
+  /*! \brief Prepare a SQL statement for execution or querying using C printf nomenclature
+   \param format - C printf compliant format string
+   \param args - va_list of variables for substitution in format string placeholders.
+   \return escaped and formatted string.
+   */
+  virtual std::string vprepare(const char *format, va_list args);
 
   virtual bool in_transaction() {return false;};
 
@@ -283,6 +296,13 @@ public:
 //  virtual bool lookup(char *field_name, char*field_value);
 /* Refresh dataset (reopen it and set the same cursor position) */
   virtual void refresh();
+
+  /*! \brief Drop an index from the database table, provided it exists.
+   \param table - name of the table the index to be dropped is associated with
+   \param index - name of the index to be dropped
+   \return true when the index is guaranteed to no longer exist in the database.
+   */
+  virtual bool dropIndex(const char *table, const char *index) { return false; }
 
 /* Go to record No (starting with 0) */
   virtual bool seek(int pos=0);

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -93,7 +93,6 @@ private:
   void mysqlStrAccumReset(StrAccum *p);
   void mysqlStrAccumInit(StrAccum *p, char *zBase, int n, int mx);
   char *mysql_vmprintf(const char *zFormat, va_list ap);
-
 };
 
 
@@ -174,6 +173,7 @@ or insert() operations default = false) */
 /* Go to record No (starting with 0) */
   virtual bool seek(int pos=0);
 
+  virtual bool dropIndex(const char *table, const char *index);
 };
 } //namespace
 #endif

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -471,6 +471,15 @@ void SqliteDataset::fill_fields() {
 
 
 //------------- public functions implementation -----------------//
+bool SqliteDataset::dropIndex(const char *table, const char *index)
+{
+  string sql;
+
+  sql = static_cast<SqliteDatabase*>(db)->prepare("DROP INDEX IF EXISTS %s", index);
+
+  return (exec(sql) == SQLITE_OK);
+}
+
 
 int SqliteDataset::exec(const string &sql) {
   if (!handle()) throw DbErrors("No Database Connection");

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -504,6 +504,17 @@ int SqliteDataset::exec(const string &sql) {
       }
     }
   }
+  // Strip ON table from DROP INDEX statements:
+  // before: DROP INDEX foo ON table
+  // after:  DROP INDEX foo
+  size_t pos = qry.find("DROP INDEX ");
+  if ( pos != string::npos )
+  {
+    pos = qry.find(" ON ", pos+1);
+
+    if ( pos != string::npos )
+      qry = qry.substr(0, pos);
+  }
 
   if((res = db->setErr(sqlite3_exec(handle(),qry.c_str(),&callback,&exec_res,&errmsg),qry.c_str())) == SQLITE_OK)
     return res;

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -167,7 +167,7 @@ or insert() operations default = false) */
 /* Go to record No (starting with 0) */
   virtual bool seek(int pos=0);
 
-
+  virtual bool dropIndex(const char *table, const char *index);
 };
 } //namespace
 #endif

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3445,10 +3445,10 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
       m_pDS->exec("ALTER table episode add c23 text");
       m_pDS->exec("ALTER table musicvideo add c23 text");
       m_pDS->exec("ALTER table tvshow add c23 text");
-      m_pDS->exec("DROP INDEX ixMovieBasePath ON movie");
-      m_pDS->exec("DROP INDEX ixMusicVideoBasePath ON musicvideo");
-      m_pDS->exec("DROP INDEX ixEpisodeBasePath ON episode");
-      m_pDS->exec("DROP INDEX ixTVShowBasePath ON tvshow");
+      m_pDS->dropIndex("movie", "ixMovieBasePath");
+      m_pDS->dropIndex("musicvideo", "ixMusicVideoBasePath");
+      m_pDS->dropIndex("episode", "ixEpisodeBasePath");
+      m_pDS->dropIndex("tvshow", "ixTVShowBasePath");
       m_pDS->exec("CREATE INDEX ixMovieBasePath ON movie ( c23(12) )");
       m_pDS->exec("CREATE INDEX ixMusicVideoBasePath ON musicvideo ( c14(12) )");
       m_pDS->exec("CREATE INDEX ixEpisodeBasePath ON episode ( c19(12) )");

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7765,3 +7765,39 @@ bool CVideoDatabase::GetItemForPath(const CStdString &content, const CStdString 
   }
   return false;
 }
+
+bool CVideoDatabase::GetItemsForPath(const CStdString &content, const CStdString &strPath, CFileItemList &items)
+{
+  CStdString path(strPath);
+  
+  if(URIUtils::IsMultiPath(path))
+    path = CMultiPathDirectory::GetFirstPath(path);
+  
+  int pathID = GetPathId(path);
+  if (pathID < 0)
+    return false;
+
+  if (content == "movies")
+  {
+    CStdString where = PrepareSQL("where c%02d=%d", VIDEODB_ID_PARENTPATHID, pathID);
+    GetMoviesByWhere("", where, "", items);
+  }
+  else if (content == "episodes")
+  {
+    CStdString where = PrepareSQL("where c%02d=%d", VIDEODB_ID_EPISODE_PARENTPATHID, pathID);
+    GetEpisodesByWhere("", where, items);
+  }
+  else if (content == "tvshows")
+  {
+    CStdString where = PrepareSQL("where c%02d=%d", VIDEODB_ID_TV_PARENTPATHID, pathID);
+    GetTvShowsByWhere("", where, items);
+  }
+  else if (content == "musicvideos")
+  {
+    CStdString where = PrepareSQL("where c%02d=%d", VIDEODB_ID_MUSICVIDEO_PARENTPATHID, pathID);
+    GetMusicVideosByWhere("", where, items);
+  }
+  for (int i = 0; i < items.Size(); i++)
+    items[i]->m_strPath = items[i]->GetVideoInfoTag()->m_basePath;
+  return items.Size() > 0;
+}

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3445,10 +3445,10 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
       m_pDS->exec("ALTER table episode add c23 text");
       m_pDS->exec("ALTER table musicvideo add c23 text");
       m_pDS->exec("ALTER table tvshow add c23 text");
-      m_pDS->exec("DROP INDEX ixMovieBasePath");
-      m_pDS->exec("DROP INDEX ixMusicVideoBasePath");
-      m_pDS->exec("DROP INDEX ixEpisodeBasePath");
-      m_pDS->exec("DROP INDEX ixTVShowBasePath");
+      m_pDS->exec("DROP INDEX ixMovieBasePath ON movie");
+      m_pDS->exec("DROP INDEX ixMusicVideoBasePath ON musicvideo");
+      m_pDS->exec("DROP INDEX ixEpisodeBasePath ON episode");
+      m_pDS->exec("DROP INDEX ixTVShowBasePath ON tvshow");
       m_pDS->exec("CREATE INDEX ixMovieBasePath ON movie ( c23(12) )");
       m_pDS->exec("CREATE INDEX ixMusicVideoBasePath ON musicvideo ( c14(12) )");
       m_pDS->exec("CREATE INDEX ixEpisodeBasePath ON episode ( c19(12) )");

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7405,13 +7405,7 @@ void CVideoDatabase::ImportFromXML(const CStdString &path)
       { // check the scraper exists, if so store the path
         AddonPtr addon;
         CStdString uuid;
-
-        if (!XMLUtils::GetString(path,"scraperID",uuid))
-        { // support pre addons exports
-          XMLUtils::GetString(path, "scraperpath", uuid);
-          uuid = URIUtils::GetFileName(uuid);
-        }
-
+        XMLUtils::GetString(path,"scraperID",uuid);
         if (CAddonMgr::Get().GetAddon(uuid, addon))
         {
           SScanSettings settings;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3495,6 +3495,42 @@ void CVideoDatabase::UpdateBasePath(const char *table, const char *id, int colum
   m_pDS2->close();
 }
 
+bool CVideoDatabase::GetPlayCounts(CFileItemList &items)
+{
+  int pathID = GetPathId(items.m_strPath);
+  if (pathID < 0)
+    return false; // path (and thus files) aren't in the database
+
+  try
+  {
+    // error!
+    if (NULL == m_pDB.get()) return false;
+    if (NULL == m_pDS.get()) return false;
+
+    // TODO: also test a single query for the above and below
+    CStdString sql = PrepareSQL("select strFilename,playCount from files where idPath=%i", pathID);
+    if (RunQuery(sql) <= 0)
+      return false;
+
+    items.SetFastLookup(true); // note: it's possibly quicker the other way around (map on db returned items)?
+    while (!m_pDS->eof())
+    {
+      CStdString path;
+      ConstructPath(path, items.m_strPath, m_pDS->fv(0).get_asString());
+      CFileItemPtr item = items.Get(path);
+      if (item)
+        item->GetVideoInfoTag()->m_playCount = m_pDS->fv(1).get_asInt();
+      m_pDS->next();
+    }
+    return true;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
+  }
+  return false;
+}
+
 int CVideoDatabase::GetPlayCount(const CFileItem &item)
 {
   int id = GetFileId(item);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3445,10 +3445,10 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
       m_pDS->exec("ALTER table episode add c23 text");
       m_pDS->exec("ALTER table musicvideo add c23 text");
       m_pDS->exec("ALTER table tvshow add c23 text");
-      m_pDS->exec("DROP INDEX IF EXISTS ixMovieBasePath");
-      m_pDS->exec("DROP INDEX IF EXISTS ixMusicVideoBasePath");
-      m_pDS->exec("DROP INDEX IF EXISTS ixEpisodeBasePath");
-      m_pDS->exec("DROP INDEX IF EXISTS ixTVShowBasePath");
+      m_pDS->exec("DROP INDEX ixMovieBasePath");
+      m_pDS->exec("DROP INDEX ixMusicVideoBasePath");
+      m_pDS->exec("DROP INDEX ixEpisodeBasePath");
+      m_pDS->exec("DROP INDEX ixTVShowBasePath");
       m_pDS->exec("CREATE INDEX ixMovieBasePath ON movie ( c23(12) )");
       m_pDS->exec("CREATE INDEX ixMusicVideoBasePath ON musicvideo ( c14(12) )");
       m_pDS->exec("CREATE INDEX ixEpisodeBasePath ON episode ( c19(12) )");

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -555,7 +555,7 @@ public:
   void CleanDatabase(VIDEO::IVideoInfoScannerObserver* pObserver=NULL, const std::vector<int>* paths=NULL);
 
   /*! \brief Add a file to the database, if necessary
-   If the file is already in the database, we simply return it's id.
+   If the file is already in the database, we simply return its id.
    \param url - full path of the file to add.
    \return id of the file, -1 if it could not be added.
    */
@@ -569,7 +569,7 @@ public:
   int AddFile(const CFileItem& item);
 
   /*! \brief Add a path to the database, if necessary
-   If the path is already in the database, we simply return it's id.
+   If the path is already in the database, we simply return its id.
    \param strPath the path to add
    \return id of the file, -1 if it could not be added.
    */

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -59,7 +59,7 @@ namespace VIDEO
 
 // these defines are based on how many columns we have and which column certain data is going to be in
 // when we do GetDetailsForMovie()
-#define VIDEODB_MAX_COLUMNS 23
+#define VIDEODB_MAX_COLUMNS 24
 #define VIDEODB_DETAILS_FILEID			1
 #define VIDEODB_DETAILS_FILE			VIDEODB_MAX_COLUMNS + 2
 #define VIDEODB_DETAILS_PATH			VIDEODB_MAX_COLUMNS + 3
@@ -118,6 +118,7 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_FANART = 20,
   VIDEODB_ID_COUNTRY = 21,
   VIDEODB_ID_BASEPATH = 22,
+  VIDEODB_ID_PARENTPATHID = 23,
   VIDEODB_ID_MAX
 } VIDEODB_IDS;
 
@@ -149,7 +150,8 @@ const struct SDbTableOffsets
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strTrailer) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_fanart.m_xml) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strCountry) },
-  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) }
+  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) },
+  { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_parentPathID) }
 };
 
 typedef enum // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
@@ -172,6 +174,7 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_TV_STUDIOS = 14,
   VIDEODB_ID_TV_SORTTITLE = 15,
   VIDEODB_ID_TV_BASEPATH = 16,
+  VIDEODB_ID_TV_PARENTPATHID = 17,
   VIDEODB_ID_TV_MAX
 } VIDEODB_TV_IDS;
 
@@ -193,7 +196,8 @@ const struct SDbTableOffsets DbTvShowOffsets[] =
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strMPAARating)},
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strStudio)},
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strSortTitle)},
-  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) }
+  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) },
+  { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_parentPathID) }
 };
 
 typedef enum // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
@@ -218,6 +222,7 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_EPISODE_SORTEPISODE = 16,
   VIDEODB_ID_EPISODE_BOOKMARK = 17,
   VIDEODB_ID_EPISODE_BASEPATH = 18,
+  VIDEODB_ID_EPISODE_PARENTPATHID = 19,
   VIDEODB_ID_EPISODE_MAX
 } VIDEODB_EPISODE_IDS;
 
@@ -241,7 +246,8 @@ const struct SDbTableOffsets DbEpisodeOffsets[] =
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iSpecialSortSeason) },
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iSpecialSortEpisode) },
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iBookmarkId) },
-  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) }
+  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) },
+  { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_parentPathID) }
 };
 
 typedef enum // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)
@@ -261,6 +267,7 @@ typedef enum // this enum MUST match the offset struct further down!! and make s
   VIDEODB_ID_MUSICVIDEO_GENRE = 11,
   VIDEODB_ID_MUSICVIDEO_TRACK = 12,
   VIDEODB_ID_MUSICVIDEO_BASEPATH = 13,
+  VIDEODB_ID_MUSICVIDEO_PARENTPATHID = 14,
   VIDEODB_ID_MUSICVIDEO_MAX
 } VIDEODB_MUSICVIDEO_IDS;
 
@@ -279,7 +286,8 @@ const struct SDbTableOffsets DbMusicVideoOffsets[] =
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strArtist) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strGenre) },
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iTrack) },
-  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) }
+  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) },
+  { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_parentPathID) }
 };
 
 #define COMPARE_PERCENTAGE     0.90f // 90%
@@ -694,13 +702,22 @@ private:
    */
   void UpdateBasePath(const char *table, const char *id, int column, bool shows = false);
 
+  /*! \brief Update routine for base path id of videos
+   Only required for videodb version < 52
+   \param table the table to update
+   \param id the primary id in the given table
+   \param column the column of the basepath
+   \param idColumn the column of the parent path id to update
+   */
+  void UpdateBasePathID(const char *table, const char *id, int column, int idColumn);
+
   /*! \brief Determine whether the path is using lookup using folders
    \param path the path to check
    \param shows whether this path is from a tvshow (defaults to false)
    */
   bool LookupByFolders(const CStdString &path, bool shows = false);
 
-  virtual int GetMinVersion() const { return 51; };
+  virtual int GetMinVersion() const { return 52; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -552,6 +552,13 @@ public:
    */
   int AddFile(const CFileItem& item);
 
+  /*! \brief Add a path to the database, if necessary
+   If the path is already in the database, we simply return it's id.
+   \param strPath the path to add
+   \return id of the file, -1 if it could not be added.
+   */
+  int AddPath(const CStdString& strPath);
+
   void ExportToXML(const CStdString &path, bool singleFiles = false, bool images=false, bool actorThumbs=false, bool overwrite=false);
   bool ExportSkipEntry(const CStdString &nfoFile);
   void ExportActorThumbs(const CStdString &path, const CVideoInfoTag& tag, bool singleFiles, bool overwrite=false);
@@ -608,7 +615,6 @@ protected:
    */
   int GetFileId(const CStdString& url);
 
-  int AddPath(const CStdString& strPath);
   int AddToTable(const CStdString& table, const CStdString& firstField, const CStdString& secondField, const CStdString& value);
   int AddGenre(const CStdString& strGenre1);
   int AddActor(const CStdString& strActor, const CStdString& strThumb);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -457,6 +457,14 @@ public:
    */
   bool GetItemForPath(const CStdString &content, const CStdString &path, CFileItem &item);
 
+  /*! \brief Get videos of the given content type from the given path
+   \param content the content type to fetch.
+   \param path the path to fetch videos from.
+   \param items the returned items
+   \return true if items are found, false otherwise.
+   */
+  bool GetItemsForPath(const CStdString &content, const CStdString &path, CFileItemList &items);
+
   /*! \brief Check whether a given scraper is in use.
    \param scraperID the scraper to check for.
    \return true if the scraper is in use, false otherwise.

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -328,23 +328,29 @@ public:
   /*! \brief Increment the playcount of an item
    Increments the playcount and updates the last played date
    \param item CFileItem to increment the playcount for
-   \sa GetPlayCount, SetPlayCount
+   \sa GetPlayCount, SetPlayCount, GetPlayCounts
    */
   void IncrementPlayCount(const CFileItem &item);
 
   /*! \brief Get the playcount of an item
    \param item CFileItem to get the playcount for
    \return the playcount of the item, or -1 on error
-   \sa SetPlayCount, IncrementPlayCount
+   \sa SetPlayCount, IncrementPlayCount, GetPlayCounts
    */
   int GetPlayCount(const CFileItem &item);
 
   /*! \brief Update the last played time of an item
    Updates the last played date
    \param item CFileItem to update the last played time for
-   \sa GetPlayCount, SetPlayCount, IncrementPlayCount
+   \sa GetPlayCount, SetPlayCount, IncrementPlayCount, GetPlayCounts
    */
   void UpdateLastPlayed(const CFileItem &item);
+
+  /*! \brief Get the playcount of a list of items
+   \param items CFileItemList to fetch the playcounts for
+   \sa GetPlayCount, SetPlayCount, IncrementPlayCount
+   */
+  bool GetPlayCounts(CFileItemList &items);
 
   void UpdateMovieTitle(int idMovie, const CStdString& strNewMovieTitle, VIDEODB_CONTENT_TYPE iType=VIDEODB_CONTENT_MOVIES);
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -688,6 +688,12 @@ private:
    */
   void UpdateBasePath(const char *table, const char *id, int column, bool shows = false);
 
+  /*! \brief Determine whether the path is using lookup using folders
+   \param path the path to check
+   \param shows whether this path is from a tvshow (defaults to false)
+   */
+  bool LookupByFolders(const CStdString &path, bool shows = false);
+
   virtual int GetMinVersion() const { return 51; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1060,7 +1060,8 @@ namespace VIDEO
     long lResult = -1;
 
     CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
-    movieDetails.m_basePath = pItem->GetBaseMoviePath(videoFolder);
+    if (movieDetails.m_basePath.IsEmpty())
+      movieDetails.m_basePath = pItem->GetBaseMoviePath(videoFolder);
 
     if (content == CONTENT_MOVIES)
     {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1062,6 +1062,7 @@ namespace VIDEO
     CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
     if (movieDetails.m_basePath.IsEmpty())
       movieDetails.m_basePath = pItem->GetBaseMoviePath(videoFolder);
+    movieDetails.m_parentPathID = m_database.AddPath(URIUtils::GetParentPath(movieDetails.m_basePath));
 
     if (content == CONTENT_MOVIES)
     {

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -79,6 +79,7 @@ void CVideoInfoTag::Reset()
   m_playCount = 0;
   m_fEpBookmark = 0;
   m_basePath = "";
+  m_parentPathID = -1;
 }
 
 bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathInfo)
@@ -305,6 +306,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar << m_strShowLink;
     ar << m_fEpBookmark;
     ar << m_basePath;
+    ar << m_parentPathID;
   }
   else
   {
@@ -371,6 +373,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar >> m_strShowLink;
     ar >> m_fEpBookmark;
     ar >> m_basePath;
+    ar >> m_parentPathID;
   }
 }
 

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -51,6 +51,7 @@ public:
   bool IsEmpty() const;
 
   CStdString m_basePath; // the base path of the video, for folder-based lookups
+  int m_parentPathID;      // the parent path id where the base path of the video lies
   CStdString m_strDirector;
   CStdString m_strWritingCredits;
   CStdString m_strGenre;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -437,7 +437,9 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
       pItem->m_bIsFolder = item.m_bIsFolder;
     }
     else
-    { // set the watched overlay and clean the label
+    { // set the watched overlay (note: items in a folder with content set that aren't in the db
+      //                                won't get picked up here - in the future all items will be returned)
+      // and clean the label
       if (pItem->HasVideoInfoTag())
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pItem->GetVideoInfoTag()->m_playCount > 0);
       if (clean)

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -419,6 +419,9 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
                 !items.IsVirtualDirectoryRoot() &&
                 m_stackingAvailable);
 
+  if (content.IsEmpty())
+    m_database.GetPlayCounts(items);
+
   for (int i = 0; i < items.Size(); i++)
   {
     CFileItemPtr pItem = items[i];
@@ -434,10 +437,9 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
       pItem->m_bIsFolder = item.m_bIsFolder;
     }
     else
-    { // grab the playcount and clean the label
-      int playCount = m_database.GetPlayCount(*pItem);
-      if (playCount >= 0)
-        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, playCount > 0);
+    { // set the watched overlay and clean the label
+      if (pItem->HasVideoInfoTag())
+        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pItem->GetVideoInfoTag()->m_playCount > 0);
       if (clean)
         pItem->CleanString();
     }


### PR DESCRIPTION
The commits below speed up retrieval of metadata during files mode in the video library by using a single query (or 2) based on the path being retrieved, rather than a separate query per item.

Speed up is reasonably significant with many items in a folder, and is generally faster even when only 1 item exists in the folder.

Please review for sanity - will commit in a day or two if no issues pop up.
