### PR TITLE
Escaped info support to builtin parameter parsing

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1303,6 +1303,9 @@ bool CUtil::TestSplitExec()
   CUtil::SplitExecFunction("SetProperty(Foo,\"\")", function, params);
   if (function != "SetProperty" || params.size() != 2 || params[0] != "Foo" || params[1] != "")
    return false;
+  CUtil::SplitExecFunction("SetProperty(foo,ba(\"ba black )\",sheep))", function, params);
+  if (function != "SetProperty" || params.size() != 2 || params[0] != "foo" || params[1] != "ba(\"ba black )\",sheep)")
+    return false;
   return true;
 }
 #endif
@@ -1343,7 +1346,6 @@ void CUtil::SplitExecFunction(const CStdString &execString, CStdString &function
       if (ch == '\"' && !escaped)
       { // finished a quote - no need to add the end quote to our string
         inQuotes = false;
-        continue;
       }
     }
     else
@@ -1351,7 +1353,6 @@ void CUtil::SplitExecFunction(const CStdString &execString, CStdString &function
       if (ch == '\"' && !escaped)
       { // start of quote - no need to add the quote to our string
         inQuotes = true;
-        continue;
       }
       if (inFunction && ch == ')')
       { // end of a function
@@ -1365,6 +1366,9 @@ void CUtil::SplitExecFunction(const CStdString &execString, CStdString &function
       { // not in a function, so a comma signfies the end of this parameter
         if (whiteSpacePos)
           parameter = parameter.Left(whiteSpacePos);
+        // trim off start and end quotes
+        if (parameter.GetLength() > 1 && parameter[0] == '\"' && parameter[parameter.GetLength() - 1] == '\"')
+          parameter = parameter.Mid(1,parameter.GetLength() - 2);
         parameters.push_back(parameter);
         parameter.Empty();
         whiteSpacePos = 0;
@@ -1392,6 +1396,9 @@ void CUtil::SplitExecFunction(const CStdString &execString, CStdString &function
     CLog::Log(LOGWARNING, "%s(%s) - end of string while searching for ) or \"", __FUNCTION__, execString.c_str());
   if (whiteSpacePos)
     parameter = parameter.Left(whiteSpacePos);
+  // trim off start and end quotes
+  if (parameter.GetLength() > 1 && parameter[0] == '\"' && parameter[parameter.GetLength() - 1] == '\"')
+    parameter = parameter.Mid(1,parameter.GetLength() - 2);
   if (!parameter.IsEmpty() || parameters.size())
     parameters.push_back(parameter);
 }

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -139,11 +139,7 @@ CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage) const
       if (infoLabel.IsEmpty())
         infoLabel = g_infoManager.GetLabel(portion.m_info, contextWindow);
       if (!infoLabel.IsEmpty())
-      {
-        label += portion.m_prefix;
-        label += infoLabel;
-        label += portion.m_postfix;
-      }
+        label += portion.GetLabel(infoLabel);
     }
     else
     { // no info, so just append the prefix
@@ -170,11 +166,7 @@ CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImag
       else
         infoLabel = g_infoManager.GetItemLabel((const CFileItem *)item, portion.m_info);
       if (!infoLabel.IsEmpty())
-      {
-        label += portion.m_prefix;
-        label += infoLabel;
-        label += portion.m_postfix;
-      }
+        label += portion.GetLabel(infoLabel);
     }
     else
     { // no info, so just append the prefix
@@ -261,6 +253,13 @@ void CGUIInfoLabel::Parse(const CStdString &label)
   work = ReplaceAddonStrings(work);
   // Step 3: Find all $INFO[info,prefix,postfix] blocks
   int pos1 = work.Find("$INFO[");
+  int pos2 = work.Find("$ESCINFO[");
+  bool escaped = false;
+  if (pos2 >= 0 && (pos1 < 0 || pos2 < pos1))
+  {
+    escaped = true;
+    pos1 = pos2;
+  }
   while (pos1 >= 0)
   {
     // output the first block (contents before first $INFO)
@@ -268,11 +267,12 @@ void CGUIInfoLabel::Parse(const CStdString &label)
       m_info.push_back(CInfoPortion(0, work.Left(pos1), ""));
 
     // ok, now decipher the $INFO block
-    int pos2 = StringUtils::FindEndBracket(work, '[', ']', pos1 + 6);
+    int len = escaped ? 9 : 6;
+    pos2 = StringUtils::FindEndBracket(work, '[', ']', pos1 + len);
     if (pos2 > pos1)
     {
       // decipher the block
-      CStdString block = work.Mid(pos1 + 6, pos2 - pos1 - 6);
+      CStdString block = work.Mid(pos1 + len, pos2 - pos1 - len);
       CStdStringArray params;
       StringUtils::SplitString(block, ",", params);
       int info = g_infoManager.TranslateString(params[0]);
@@ -281,7 +281,7 @@ void CGUIInfoLabel::Parse(const CStdString &label)
         prefix = params[1];
       if (params.size() > 2)
         postfix = params[2];
-      m_info.push_back(CInfoPortion(info, prefix, postfix));
+      m_info.push_back(CInfoPortion(info, prefix, postfix, escaped));
       // and delete it from our work string
       work = work.Mid(pos2 + 1);
     }
@@ -291,22 +291,41 @@ void CGUIInfoLabel::Parse(const CStdString &label)
       return;
     }
     pos1 = work.Find("$INFO[");
+    pos2 = work.Find("$ESCINFO[");
+    escaped = false;
+    if (pos2 >= 0 && (pos1 < 0 || pos2 < pos1))
+    {
+      escaped = true;
+      pos1 = pos2;
+    }
   }
   // add any last block
   if (!work.IsEmpty())
     m_info.push_back(CInfoPortion(0, work, ""));
 }
 
-CGUIInfoLabel::CInfoPortion::CInfoPortion(int info, const CStdString &prefix, const CStdString &postfix)
+CGUIInfoLabel::CInfoPortion::CInfoPortion(int info, const CStdString &prefix, const CStdString &postfix, bool escaped)
 {
   m_info = info;
   m_prefix = prefix;
   m_postfix = postfix;
+  m_escaped = escaped;
   // filter our prefix and postfix for comma's
   m_prefix.Replace("$COMMA", ",");
   m_postfix.Replace("$COMMA", ",");
   m_prefix.Replace("$LBRACKET", "["); m_prefix.Replace("$RBRACKET", "]");
   m_postfix.Replace("$LBRACKET", "["); m_postfix.Replace("$RBRACKET", "]");
+}
+
+CStdString CGUIInfoLabel::CInfoPortion::GetLabel(const CStdString &info) const
+{
+  CStdString label = m_prefix + info + m_postfix;
+  if (m_escaped) // escape all quotes, then quote
+  {
+    label.Replace("\"", "\\\"");
+    return "\"" + label + "\"";
+  }
+  return label;
 }
 
 CStdString CGUIInfoLabel::GetLabel(const CStdString &label, int contextWindow, bool preferImage)

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -102,10 +102,13 @@ private:
   class CInfoPortion
   {
   public:
-    CInfoPortion(int info, const CStdString &prefix, const CStdString &postfix);
+    CInfoPortion(int info, const CStdString &prefix, const CStdString &postfix, bool escaped = false);
+    CStdString GetLabel(const CStdString &info) const;
     int m_info;
     CStdString m_prefix;
     CStdString m_postfix;
+  private:
+    bool m_escaped;
   };
 
   CStdString m_fallback;


### PR DESCRIPTION
Many skinners use Skin.Property()'s as input into some other built in function, which means that skin labels (that use $INFO[]) may be passed into builtin functions as parameters.

The problem is if the label contains quotes then the builtin function parsing does weird things.

This solves this via 2 methods:
1.  We only remove quotes from parameters if they're the first and last character (ignoring whitespace) of the parameters.
2.  We introduce a new $ESCINFO[] which is identical to $INFO[] but the result is altered by first escaping any quotes, and then wraps the result in quotes.

Comments welcome - I'll commit in a couple of days if nothing obvious is discovered.
