### PR TITLE
Don't destroy control objects on window deinit

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2065,6 +2065,18 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
   return bReturn;
 }
 
+/// \brief iterates through boolean conditions and compares their stored values to current values. Returns false if any condition changed value.
+const bool CGUIInfoManager::ValidateConditions(std::map<int, bool>& conditionMap) const
+{
+  for (std::map<int, bool>::iterator it = conditionMap.begin() ; it != conditionMap.end() ; it++)
+  {
+    if (g_infoManager.GetBool(it->first) != it->second)
+      return false;
+  }
+
+  return true;
+}
+
 /// \brief Examines the multi information sent and returns true or false accordingly.
 bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, const CGUIListItem *item)
 {

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1374,27 +1374,13 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
     strLabel = GetBuild();
     break;
   case SYSTEM_FREE_MEMORY:
-  case SYSTEM_FREE_MEMORY_PERCENT:
   case SYSTEM_USED_MEMORY:
-  case SYSTEM_USED_MEMORY_PERCENT:
   case SYSTEM_TOTAL_MEMORY:
-    {
-      MEMORYSTATUS stat;
-      GlobalMemoryStatus(&stat);
-      int iMemPercentFree = 100 - ((int)( 100.0f* (stat.dwTotalPhys - stat.dwAvailPhys)/stat.dwTotalPhys + 0.5f ));
-      int iMemPercentUsed = 100 - iMemPercentFree;
-
-      if (info == SYSTEM_FREE_MEMORY)
-        strLabel.Format("%luMB", (ULONG)(stat.dwAvailPhys/MB));
-      else if (info == SYSTEM_FREE_MEMORY_PERCENT)
-        strLabel.Format("%i%%", iMemPercentFree);
-      else if (info == SYSTEM_USED_MEMORY)
-        strLabel.Format("%luMB", (ULONG)((stat.dwTotalPhys - stat.dwAvailPhys)/MB));
-      else if (info == SYSTEM_USED_MEMORY_PERCENT)
-        strLabel.Format("%i%%", iMemPercentUsed);
-      else if (info == SYSTEM_TOTAL_MEMORY)
-        strLabel.Format("%luMB", (ULONG)(stat.dwTotalPhys/MB));
-    }
+    strLabel.Format("%luMB", CSysInfo::GetSystemMemory(info) / MB);
+    break;
+  case SYSTEM_FREE_MEMORY_PERCENT:
+  case SYSTEM_USED_MEMORY_PERCENT:
+    strLabel.Format("%i%%", CSysInfo::GetSystemMemory(info));
     break;
   case SYSTEM_SCREEN_MODE:
     strLabel = g_settings.m_ResInfo[g_graphicsContext.GetVideoResolution()].strMode;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2051,12 +2051,11 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
   return bReturn;
 }
 
-/// \brief iterates through boolean conditions and compares their stored values to current values. Returns false if any condition changed value.
-const bool CGUIInfoManager::ValidateConditions(std::map<int, bool>& conditionMap) const
+bool CGUIInfoManager::ValidateConditions(const std::map<int, bool>& conditionMap)
 {
-  for (std::map<int, bool>::iterator it = conditionMap.begin() ; it != conditionMap.end() ; it++)
+  for (std::map<int, bool>::const_iterator it = conditionMap.begin() ; it != conditionMap.end() ; it++)
   {
-    if (g_infoManager.GetBool(it->first) != it->second)
+    if (GetBool(it->first) != it->second)
       return false;
   }
 

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -567,6 +567,7 @@ public:
 
   int TranslateString(const CStdString &strCondition);
   bool GetBool(int condition, int contextWindow = 0, const CGUIListItem *item=NULL);
+  const bool ValidateConditions(std::map<int, bool>& map) const;
   int GetInt(int info, int contextWindow = 0) const;
   CStdString GetLabel(int info, int contextWindow = 0);
 

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -567,7 +567,8 @@ public:
 
   int TranslateString(const CStdString &strCondition);
   bool GetBool(int condition, int contextWindow = 0, const CGUIListItem *item=NULL);
-  const bool ValidateConditions(std::map<int, bool>& map) const;
+  /// \brief iterates through boolean conditions and compares their stored values to current values. Returns false if any condition changed value.
+  bool ValidateConditions(const std::map<int, bool>& map);
   int GetInt(int info, int contextWindow = 0) const;
   CStdString GetLabel(int info, int contextWindow = 0);
 

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -181,9 +181,12 @@ void CSkinInfo::LoadIncludes()
   m_includes.LoadIncludes(includesPath);
 }
 
-void CSkinInfo::ResolveIncludes(TiXmlElement *node)
+void CSkinInfo::ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
 {
-  m_includes.ResolveIncludes(node);
+  if(xmlIncludeConditions)
+    xmlIncludeConditions->clear();
+
+  m_includes.ResolveIncludes(node, xmlIncludeConditions);
 }
 
 int CSkinInfo::GetStartWindow() const

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -93,7 +93,7 @@ public:
    */
   static bool TranslateResolution(const CStdString &name, RESOLUTION_INFO &res);
 
-  void ResolveIncludes(TiXmlElement *node);
+  void ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
 
   float GetEffectsSlowdown() const { return m_effectsSlowDown; };
 

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -91,6 +91,9 @@ bool CGUIDialogContextMenu::OnMessage(CGUIMessage &message)
 
 void CGUIDialogContextMenu::OnInitWindow()
 {
+  m_posX = m_coordX;
+  m_posY = m_coordY;
+  SetupButtons();
   m_clickedButton = -1;
   // set initial control focus
   m_lastControlID = BUTTON_START;
@@ -604,15 +607,24 @@ CMediaSource *CGUIDialogContextMenu::GetShare(const CStdString &type, const CFil
 
 void CGUIDialogContextMenu::OnWindowLoaded()
 {
+  m_coordX = m_posX;
+  m_coordY = m_posY;
   CGUIDialog::OnWindowLoaded();
-  SetInitialVisibility();
-  SetupButtons();
 }
 
-void CGUIDialogContextMenu::OnWindowUnload()
+void CGUIDialogContextMenu::OnDeinitWindow(int nextWindowID)
 {
+  //we can't be sure that controls are removed on window unload
+  //we have to remove them to be sure that they won't stay for next use of context menu
+  for (unsigned int i = 0; i < m_buttons.size(); i++)
+  {
+    const CGUIControl *control = GetControl(BUTTON_START + i);
+    if (control)
+      RemoveControl(control);
+  }
+
   m_buttons.clear();
-  CGUIDialog::OnWindowUnload();
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 CStdString CGUIDialogContextMenu::GetDefaultShareNameByType(const CStdString &strType)

--- a/xbmc/dialogs/GUIDialogContextMenu.h
+++ b/xbmc/dialogs/GUIDialogContextMenu.h
@@ -147,7 +147,7 @@ protected:
   void SetupButtons();
 
   /*! \brief Position the context menu in the middle of the focused control.
-   If no control is available it is positioned in the middle of the screen.
+   If no control is available it is positioned in the middle of th escreen.
    */
   void PositionAtCurrentFocus();
 
@@ -155,13 +155,14 @@ protected:
   float GetHeight();
   virtual void OnInitWindow();
   virtual void OnWindowLoaded();
-  virtual void OnWindowUnload();
+  virtual void OnDeinitWindow(int nextWindowID);
   static CStdString GetDefaultShareNameByType(const CStdString &strType);
   static void SetDefault(const CStdString &strType, const CStdString &strDefault);
   static void ClearDefault(const CStdString &strType);
   static CMediaSource *GetShare(const CStdString &type, const CFileItem *item);
 
 private:
+  float m_coordX, m_coordY;
   int m_clickedButton;
   CContextButtons m_buttons;
 };

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -944,7 +944,6 @@ void CGUIBaseContainer::SetStaticContent(const vector<CGUIListItemPtr> &items)
   m_staticUpdateTime = 0;
   m_staticItems.clear();
   m_staticItems.assign(items.begin(), items.end());
-  UpdateVisibility();
 }
 
 void CGUIBaseContainer::SetRenderOffset(const CPoint &offset)

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -784,6 +784,12 @@ void CGUIBaseContainer::UpdateVisibility(const CGUIListItem *item)
   }
 }
 
+void CGUIBaseContainer::SetInitialVisibility()
+{
+  UpdateVisibility();
+  CGUIControl::SetInitialVisibility();
+}
+
 void CGUIBaseContainer::CalculateLayout()
 {
   CGUIListItemLayout *oldFocusedLayout = m_focusedLayout;

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -56,6 +56,7 @@ public:
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
+  virtual void SetInitialVisibility();
 
   virtual unsigned int GetRows() const;
 

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -161,21 +161,21 @@ bool CGUIIncludes::HasIncludeFile(const CStdString &file) const
   return false;
 }
 
-void CGUIIncludes::ResolveIncludes(TiXmlElement *node)
+void CGUIIncludes::ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
 {
   if (!node)
     return;
-  ResolveIncludesForNode(node);
+  ResolveIncludesForNode(node, xmlIncludeConditions);
 
   TiXmlElement *child = node->FirstChildElement();
   while (child)
   {
-    ResolveIncludes(child);
+    ResolveIncludes(child, xmlIncludeConditions);
     child = child->NextSiblingElement();
   }
 }
 
-void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node)
+void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
 {
   // we have a node, find any <include file="fileName">tagName</include> tags and replace
   // recursively with their real includes
@@ -212,7 +212,13 @@ void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node)
     const char *condition = include->Attribute("condition");
     if (condition)
     { // check this condition
-      if (!g_infoManager.GetBool(g_infoManager.TranslateString(condition)))
+      int conditionID = g_infoManager.TranslateString(condition);
+      bool value = g_infoManager.GetBool(conditionID);
+
+      if (xmlIncludeConditions)
+        (*xmlIncludeConditions)[conditionID] = value;
+
+      if (!value)
       {
         include = include->NextSiblingElement("include");
         continue;

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -44,10 +44,9 @@ public:
    "bar" from the include file "foo".
    \param node an XML Element - all child elements are traversed.
    */
-  void ResolveIncludes(TiXmlElement *node);
-
+  void ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
 private:
-  void ResolveIncludesForNode(TiXmlElement *node);
+  void ResolveIncludesForNode(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
   CStdString ResolveConstant(const CStdString &constant) const;
   bool HasIncludeFile(const CStdString &includeFile) const;
   std::map<CStdString, TiXmlElement> m_includes;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -584,8 +584,7 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
   start = CurrentHostCounter();
 #endif
   // use forceLoad to determine if xml file need loading
-  if (!forceLoad && m_loadOnDemand)
-    forceLoad = m_loadOnDemand;
+  forceLoad |= m_loadOnDemand;
 
   // if window is loaded (not cleared before) and we aren't forced to load
   // we will have to load it only if include conditions values were changed

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -133,8 +133,8 @@ bool CGUIWindow::Load(TiXmlDocument &xmlDoc)
   // be done with respect to the correct aspect ratio
   g_graphicsContext.SetScalingResolution(m_coordsRes, m_needsScaling);
 
-  // Resolve any includes that may be present
-  g_SkinInfo->ResolveIncludes(pRootElement);
+  // Resolve any includes that may be present and save conditions used to do it
+  g_SkinInfo->ResolveIncludes(pRootElement, &m_xmlIncludeConditions);
   // now load in the skin file
   SetDefaults();
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -649,7 +649,7 @@ bool CGUIWindow::Initialize()
 {
   if (!g_windowManager.Initialized())
     return false;     // can't load if we have no skin yet
-  return Load(GetProperty("xmlfile"));
+  return OnMessage(CGUIMessage(GUI_MSG_WINDOW_INIT, 0, 0));
 }
 
 void CGUIWindow::SetInitialVisibility()

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -38,6 +38,7 @@
 #include "utils/log.h"
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
+#include "utils/SystemInfo.h"
 #include "input/ButtonTranslator.h"
 #include "utils/XMLUtils.h"
 
@@ -627,7 +628,8 @@ void CGUIWindow::FreeResources(bool forceUnload /*= FALSE */)
   CGUIControlGroup::FreeResources();
   //g_TextureManager.Dump();
   // unload the skin
-  if (m_loadOnDemand || forceUnload) ClearAll();
+  if (m_loadOnDemand || forceUnload || !CSysInfo::FreeMemoryTest())
+    ClearAll();
 }
 
 void CGUIWindow::DynamicResourceAlloc(bool bOnOff)

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -289,6 +289,8 @@ protected:
   bool m_manualRunActions;
 
   int m_exclusiveMouseControl; ///< \brief id of child control that wishes to receive all mouse events \sa GUI_MSG_EXCLUSIVE_MOUSE
+
+  std::map<int, bool> m_xmlIncludeConditions; ///< \brief used to store conditions used to resolve includes for this window
 };
 
 #endif

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -252,6 +252,7 @@ protected:
   RESOLUTION_INFO m_coordsRes; // resolution that the window coordinates are in.
   bool m_needsScaling;
   bool m_windowLoaded;  // true if the window's xml file has been loaded
+  bool m_windowInited;  // true if the window is inited
   bool m_loadOnDemand;  // true if the window should be loaded only as needed
   bool m_isDialog;      // true if we have a dialog, false otherwise.
   bool m_dynamicResourceAlloc;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -186,6 +186,8 @@ void CAdvancedSettings::Initialize()
   m_dvdThumbs = "folder.jpg|Folder.jpg|folder.JPG|Folder.JPG";
   m_fanartImages = "fanart.jpg|fanart.png";
 
+  m_bDestroyWindowControls = false; // use this feature by default - it has positive influence on performance (assuming that there is enough virtual memory)
+
   m_bMusicLibraryHideAllItems = false;
   m_bMusicLibraryAllItemsOnBottom = false;
   m_bMusicLibraryAlbumsSortByArtistThenYear = false;
@@ -812,6 +814,8 @@ bool CAdvancedSettings::Load()
   TiXmlElement* pFanart = pRootElement->FirstChildElement("fanart");
   if (pFanart)
     GetCustomExtensions(pFanart,m_fanartImages);
+
+  XMLUtils::GetBoolean(pRootElement, "destroywindowcontrols", m_bDestroyWindowControls);
 
   // music filename->tag filters
   TiXmlElement* filters = pRootElement->FirstChildElement("musicfilenamefilters");

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -187,6 +187,7 @@ void CAdvancedSettings::Initialize()
   m_fanartImages = "fanart.jpg|fanart.png";
 
   m_bDestroyWindowControls = false; // use this feature by default - it has positive influence on performance (assuming that there is enough virtual memory)
+  m_iFreeMemoryThreshold = 200 * 1024 * 1024; // by default set threshold on 200MB
 
   m_bMusicLibraryHideAllItems = false;
   m_bMusicLibraryAllItemsOnBottom = false;
@@ -816,6 +817,7 @@ bool CAdvancedSettings::Load()
     GetCustomExtensions(pFanart,m_fanartImages);
 
   XMLUtils::GetBoolean(pRootElement, "destroywindowcontrols", m_bDestroyWindowControls);
+  XMLUtils::GetInt(pRootElement, "freememorythreshold", m_iFreeMemoryThreshold);
 
   // music filename->tag filters
   TiXmlElement* filters = pRootElement->FirstChildElement("musicfilenamefilters");

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -817,7 +817,7 @@ bool CAdvancedSettings::Load()
     GetCustomExtensions(pFanart,m_fanartImages);
 
   XMLUtils::GetBoolean(pRootElement, "destroywindowcontrols", m_bDestroyWindowControls);
-  XMLUtils::GetInt(pRootElement, "freememorythreshold", m_iFreeMemoryThreshold);
+  XMLUtils::GetUInt(pRootElement, "freememorythreshold", m_iFreeMemoryThreshold);
 
   // music filename->tag filters
   TiXmlElement* filters = pRootElement->FirstChildElement("musicfilenamefilters");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -193,6 +193,7 @@ class CAdvancedSettings
     CStdString m_fanartImages;
 
     bool m_bDestroyWindowControls;
+    int m_iFreeMemoryThreshold;
 
     bool m_bMusicLibraryHideAllItems;
     int m_iMusicLibraryRecentlyAddedItems;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -192,6 +192,8 @@ class CAdvancedSettings
     CStdString m_dvdThumbs;
     CStdString m_fanartImages;
 
+    bool m_bDestroyWindowControls;
+
     bool m_bMusicLibraryHideAllItems;
     int m_iMusicLibraryRecentlyAddedItems;
     bool m_bMusicLibraryAllItemsOnBottom;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -193,7 +193,7 @@ class CAdvancedSettings
     CStdString m_fanartImages;
 
     bool m_bDestroyWindowControls;
-    int m_iFreeMemoryThreshold;
+    unsigned int m_iFreeMemoryThreshold;
 
     bool m_bMusicLibraryHideAllItems;
     int m_iMusicLibraryRecentlyAddedItems;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -276,7 +276,7 @@ bool CSysInfo::GetDiskSpace(const CStdString drive,int& iTotal, int& iTotalFree,
   return bRet;
 }
 
-const unsigned long CSysInfo::GetSystemMemory(const int& info)
+unsigned long long CSysInfo::GetSystemMemory(const int& info)
 {
   switch(info)
   {
@@ -304,7 +304,7 @@ const unsigned long CSysInfo::GetSystemMemory(const int& info)
   }
 }
 
-const bool CSysInfo::FreeMemoryTest()
+bool CSysInfo::FreeMemoryTest()
 {
   return GetSystemMemory(SYSTEM_FREE_MEMORY) >= g_advancedSettings.m_iFreeMemoryThreshold;
 }

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -32,6 +32,7 @@
 #include "Application.h"
 #include "windowing/WindowingFactory.h"
 #include "settings/Settings.h"
+#include "settings/AdvancedSettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "CPUInfo.h"
 #include "utils/TimeUtils.h"
@@ -303,6 +304,10 @@ const unsigned long CSysInfo::GetSystemMemory(const int& info)
   }
 }
 
+const bool CSysInfo::FreeMemoryTest()
+{
+  return GetSystemMemory(SYSTEM_FREE_MEMORY) >= g_advancedSettings.m_iFreeMemoryThreshold;
+}
 CStdString CSysInfo::GetXBVerInfo()
 {
   return "CPU: " + g_cpuInfo.getCPUModel();

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -275,6 +275,34 @@ bool CSysInfo::GetDiskSpace(const CStdString drive,int& iTotal, int& iTotalFree,
   return bRet;
 }
 
+const unsigned long CSysInfo::GetSystemMemory(const int& info)
+{
+  switch(info)
+  {
+    case SYSTEM_FREE_MEMORY:
+    case SYSTEM_FREE_MEMORY_PERCENT:
+    case SYSTEM_USED_MEMORY:
+    case SYSTEM_USED_MEMORY_PERCENT:
+    case SYSTEM_TOTAL_MEMORY:
+      MEMORYSTATUS stat;
+      GlobalMemoryStatus(&stat);
+
+      if (info == SYSTEM_FREE_MEMORY)
+        return stat.dwAvailPhys;
+      else if (info == SYSTEM_FREE_MEMORY_PERCENT)
+        return 100ul - ((unsigned long)( 100.0f* (stat.dwTotalPhys - stat.dwAvailPhys)/stat.dwTotalPhys + 0.5f ));
+      else if (info == SYSTEM_USED_MEMORY)
+        return stat.dwTotalPhys - stat.dwAvailPhys;
+      else if (info == SYSTEM_USED_MEMORY_PERCENT)
+        return ((unsigned long)( 100.0f* (stat.dwTotalPhys - stat.dwAvailPhys)/stat.dwTotalPhys + 0.5f ));
+      else if (info == SYSTEM_TOTAL_MEMORY)
+        return stat.dwTotalPhys;
+
+    default:
+      return 0; // wrong info
+  }
+}
+
 CStdString CSysInfo::GetXBVerInfo()
 {
   return "CPU: " + g_cpuInfo.getCPUModel();

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -104,6 +104,7 @@ public:
   static CStdString GetKernelVersion();
   CStdString GetXBVerInfo();
   bool GetDiskSpace(const CStdString drive,int& iTotal, int& iTotalFree, int& iTotalUsed, int& iPercentFree, int& iPercentUsed);
+  static const unsigned long GetSystemMemory(const int& info);
   CStdString GetHddSpaceInfo(int& percent, int drive, bool shortText=false);
   CStdString GetHddSpaceInfo(int drive, bool shortText=false);
 

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -104,8 +104,8 @@ public:
   static CStdString GetKernelVersion();
   CStdString GetXBVerInfo();
   bool GetDiskSpace(const CStdString drive,int& iTotal, int& iTotalFree, int& iTotalUsed, int& iPercentFree, int& iPercentUsed);
-  static const unsigned long GetSystemMemory(const int& info);
-  static const bool FreeMemoryTest();
+  static unsigned long long GetSystemMemory(const int& info);
+  static bool FreeMemoryTest();
   CStdString GetHddSpaceInfo(int& percent, int drive, bool shortText=false);
   CStdString GetHddSpaceInfo(int drive, bool shortText=false);
 

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -105,6 +105,7 @@ public:
   CStdString GetXBVerInfo();
   bool GetDiskSpace(const CStdString drive,int& iTotal, int& iTotalFree, int& iTotalUsed, int& iPercentFree, int& iPercentUsed);
   static const unsigned long GetSystemMemory(const int& info);
+  static const bool FreeMemoryTest();
   CStdString GetHddSpaceInfo(int& percent, int drive, bool shortText=false);
   CStdString GetHddSpaceInfo(int drive, bool shortText=false);
 


### PR DESCRIPTION
Window's controls are being deleted on window deinit. This results in loading xml, resolving includes, parsing resolved xml and creating controls everytime user activate window.

This will allow to keep controls objects in memory on window deinit (if system has enough free memory).

pros: 
- skipping unnecessary I/O operations (loading xml file) 
- better user experience (faster UI)

cons:
- higher memory usage - it's not significent increase but this could be issue for some platforms (f.e. ipod/ipad) - in my commits I have this feature turned on by default - there could be some #ifdef to change default setting for some platforms

notes:
- skinners should be noticed to use ReloadSkin() builtin exclusively to refresh window
