### PR TITLE
Multiscript Python Deadlock Fix

### DIFF
--- a/xbmc/interfaces/python/xbmcmodule/pythreadstate.h
+++ b/xbmc/interfaces/python/xbmcmodule/pythreadstate.h
@@ -56,6 +56,8 @@ class CPyThreadState
       }
     }
 
+    PyThreadState* GetState() { return m_threadState; }
+
   private:
     PyThreadState* m_threadState;
 };

--- a/xbmc/interfaces/python/xbmcmodule/pythreadstate.h
+++ b/xbmc/interfaces/python/xbmcmodule/pythreadstate.h
@@ -56,8 +56,6 @@ class CPyThreadState
       }
     }
 
-    PyThreadState* GetState() { return m_threadState; }
-
   private:
     PyThreadState* m_threadState;
 };

--- a/xbmc/interfaces/python/xbmcmodule/pyutil.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/pyutil.cpp
@@ -80,17 +80,13 @@ namespace PYXBMC
 
   void PyXBMCGUILock()
   {
-    if (iPyXBMCGUILockRef == 0) g_graphicsContext.Lock();
-    iPyXBMCGUILockRef++;
+    CPyThreadState tsg;
+    g_graphicsContext.Lock();
   }
 
   void PyXBMCGUIUnlock()
   {
-    if (iPyXBMCGUILockRef > 0)
-    {
-      iPyXBMCGUILockRef--;
-      if (iPyXBMCGUILockRef == 0) g_graphicsContext.Unlock();
-    }
+    g_graphicsContext.Unlock();
   }
 
   void PyXBMCWaitForThreadMessage(int message, int param1, int param2)

--- a/xbmc/interfaces/python/xbmcmodule/window.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/window.cpp
@@ -60,8 +60,7 @@ namespace PYXBMC
   // used by Dialog to to create a new dialogWindow
   bool Window_CreateNewWindow(Window* pWindow, bool bAsDialog)
   {
-    CPyThreadState tsg;
-    CSingleLock lock(g_graphicsContext);
+    GIL_SAFE_SINGLELOCK(g_graphicsContext);
 
     if (pWindow->iWindowId != -1)
     {
@@ -102,7 +101,7 @@ namespace PYXBMC
           pWindow->pWindow = new CGUIPythonWindowXMLDialog(id,pWindow->sXMLFileName,pWindow->sFallBackPath);
         else
           pWindow->pWindow = new CGUIPythonWindowXML(id,pWindow->sXMLFileName,pWindow->sFallBackPath);
-        ((CGUIPythonWindowXML*)pWindow->pWindow)->SetCallbackWindow(tsg.GetState(), (PyObject*)pWindow);
+        ((CGUIPythonWindowXML*)pWindow->pWindow)->SetCallbackWindow(PyThreadState_Get(), (PyObject*)pWindow);
       }
       else
       {
@@ -110,7 +109,7 @@ namespace PYXBMC
           pWindow->pWindow = new CGUIPythonWindowDialog(id);
         else
           pWindow->pWindow = new CGUIPythonWindow(id);
-        ((CGUIPythonWindow*)pWindow->pWindow)->SetCallbackWindow(tsg.GetState(), (PyObject*)pWindow);
+        ((CGUIPythonWindow*)pWindow->pWindow)->SetCallbackWindow(PyThreadState_Get(), (PyObject*)pWindow);
       }
 
       g_windowManager.Add(pWindow->pWindow);


### PR DESCRIPTION
This is the third rewrite of this fix. As a result I deleted the old PR comment since it doesn't apply anymore.

According to the docs, the Python thread state should be released whenever native code that's called from python has the potential to block. Trying to get a global lock on the g_graphicsContext constitutes a potential blocking action (which also happens when PyXBMCGUILock is called). 

This changes PyXBMCGUILock to release the GIL before attempting to get the lock on the g_graphicsContext and restoring it once the g_graphicsContext lock has been obtained. 

Other explicit g_graphicsContext locking are now accompanied by an instantiation of the CPyThreadState guard class.

Also, there was a problem with PyXBMCGUILock/Unlock in that there was a potential race condition between the counter and the lock. This fix addresses that problem also.
