### PR TITLE
Allow scrollbar to use navigation if nib can't move in given direction

### DIFF
--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -94,45 +94,51 @@ bool CGUIScrollBar::OnAction(const CAction &action)
   case ACTION_MOVE_LEFT:
     if (m_orientation == HORIZONTAL)
     {
-      Move( -1);
-      return true;
+      if(Move( -1))
+        return true;
     }
     break;
 
   case ACTION_MOVE_RIGHT:
     if (m_orientation == HORIZONTAL)
     {
-      Move(1);
-      return true;
+      if(Move(1))
+        return true;
     }
     break;
   case ACTION_MOVE_UP:
     if (m_orientation == VERTICAL)
     {
-      Move(-1);
-      return true;
+      if(Move(-1))
+        return true;
     }
     break;
 
   case ACTION_MOVE_DOWN:
     if (m_orientation == VERTICAL)
     {
-      Move(1);
-      return true;
+      if(Move(1))
+        return true;
     }
     break;
   }
   return CGUIControl::OnAction(action);
 }
 
-void CGUIScrollBar::Move(int numSteps)
+bool CGUIScrollBar::Move(int numSteps)
 {
+  if (numSteps < 0 && m_offset == 0) // we are at the beginning - can't scroll up/left anymore
+    return false;
+  if (numSteps > 0 && m_offset == m_numItems - m_pageSize) // we are at the end - we can't scroll down/right anymore
+    return false;
+
   m_offset += numSteps * m_pageSize;
   if (m_offset > m_numItems - m_pageSize) m_offset = m_numItems - m_pageSize;
   if (m_offset < 0) m_offset = 0;
   CGUIMessage message(GUI_MSG_NOTIFY_ALL, GetParentID(), GetID(), GUI_MSG_PAGE_CHANGE, m_offset);
   SendWindowMessage(message);
   SetInvalid();
+  return true;
 }
 
 void CGUIScrollBar::SetRange(int pageSize, int numItems)

--- a/xbmc/guilib/GUIScrollBarControl.h
+++ b/xbmc/guilib/GUIScrollBarControl.h
@@ -66,7 +66,7 @@ protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual void UpdateColors();
   void UpdateBarSize();
-  virtual void Move(int iNumSteps);
+  bool Move(int iNumSteps);
   virtual void SetFromPosition(const CPoint &point);
 
   CGUITexture m_guiBackground;

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -23,6 +23,7 @@
 #include "utils/CharsetConverter.h"
 #include "GUIInfoManager.h"
 #include "tinyXML/tinyxml.h"
+#include "utils/MathUtils.h"
 
 using namespace std;
 
@@ -210,7 +211,7 @@ void CGUITextBox::Render()
 
   if (m_pageControl)
   {
-    CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), m_pageControl, offset);
+    CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), m_pageControl, MathUtils::round_int(m_scrollOffset / m_itemHeight));
     SendWindowMessage(msg);
   }
   CGUIControl::Render();


### PR DESCRIPTION
First commit deals with rare situation where textbox is scrolled to bottom and scroll bar used as page control doesn't reflect it:

now: http://wojtek.piechowiak.eu/mich/xbmc/screenshot006.png
with my change: http://wojtek.piechowiak.eu/mich/xbmc/screenshot008.png

Second commit allow usage of navigation tags if scrollbar can't be scrolled anymore in given direction (we can use onup/ondown in vertical mode and onleft/onright in horizontal mode). First commit is needed to correctly detect that we can't scroll down anymore.

On the attached screenshots You can see use scenario of this - there is horizontal list with buttons, pressing down will focus scrollbar - it would be intuitive for user that returning to buttons will be done by pressing up.
