### PR TITLE
Settings.ShowExitButton for GUIInfoManager and advancedsettings.xml

### DIFF
--- a/addons/skin.confluence/720p/DialogButtonMenu.xml
+++ b/addons/skin.confluence/720p/DialogButtonMenu.xml
@@ -135,6 +135,7 @@
 					<pulseonselect>no</pulseonselect>
 					<font>-</font>
 					<label>$LOCALIZE[13012]</label>
+					<visible>System.ShowExitButton</visible>
 				</control>
 				<control type="group" id="13">
 					<width>90</width>
@@ -225,7 +226,8 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>270</posx>
+				<include condition="System.ShowExitButton">ExitButtonOffset</include>
+				<include condition="!System.ShowExitButton">NoExitButtonOffset</include>
 				<posy>70</posy>
 				<visible>ControlGroup(13).HasFocus</visible>
 				<include>VisibleFadeEffect</include>

--- a/addons/skin.confluence/720p/includes.xml
+++ b/addons/skin.confluence/720p/includes.xml
@@ -764,4 +764,10 @@
 		<animation effect="fade" time="300">Visible</animation>
 		<animation effect="fade" time="300">Hidden</animation>
 	</include>
+	<include name="ExitButtonOffset">
+		<posx>270</posx>
+	</include>
+	<include name="NoExitButtonOffset">
+		<posx>215</posx>
+	</include>
 </includes>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -369,6 +369,7 @@ int CGUIInfoManager::TranslateSingleString(const CStdString &strCondition)
     else if (strTest.Equals("system.ismaster")) ret = SYSTEM_ISMASTER;
     else if (strTest.Equals("system.internetstate")) ret = SYSTEM_INTERNET_STATE;
     else if (strTest.Equals("system.loggedon")) ret = SYSTEM_LOGGEDON;
+    else if (strTest.Equals("system.showexitbutton")) ret = SYSTEM_SHOW_EXIT_BUTTON;
     else if (strTest.Equals("system.hasdrivef")) ret = SYSTEM_HAS_DRIVE_F;
     else if (strTest.Equals("system.hasdriveg")) ret = SYSTEM_HAS_DRIVE_G;
     else if (strTest.Equals("system.kernelversion")) ret = SYSTEM_KERNEL_VERSION;
@@ -1820,6 +1821,8 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     bReturn = g_settings.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE && g_passwordManager.bMasterUser;
   else if (condition == SYSTEM_LOGGEDON)
     bReturn = !(g_windowManager.GetActiveWindow() == WINDOW_LOGIN_SCREEN);
+  else if (condition == SYSTEM_SHOW_EXIT_BUTTON)
+    bReturn = g_advancedSettings.m_showExitButton;
   else if (condition == SYSTEM_HAS_LOGINSCREEN)
     bReturn = g_settings.UsingLoginScreen();
   else if (condition == WEATHER_IS_FETCHED)

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -141,6 +141,7 @@ class CDateTime;
 #define SYSTEM_HASLOCKS             140
 #define SYSTEM_ISMASTER             141
 #define SYSTEM_TRAYOPEN             142
+#define SYSTEM_SHOW_EXIT_BUTTON		143
 #define SYSTEM_ALARM_POS            144
 #define SYSTEM_LOGGEDON             145
 #define SYSTEM_PROFILENAME          146

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -637,6 +637,7 @@ bool CAdvancedSettings::Load()
   XMLUtils::GetBoolean(pRootElement, "fullscreen", m_startFullScreen);
 #endif
   XMLUtils::GetBoolean(pRootElement, "splash", m_splashImage);
+  XMLUtils::GetBoolean(pRootElement, "showexitbutton", m_showExitButton);
 
   XMLUtils::GetInt(pRootElement, "songinfoduration", m_songInfoDuration, 0, INT_MAX);
   XMLUtils::GetInt(pRootElement, "busydialogdelay", m_busyDialogDelay, 0, 5000);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -251,6 +251,7 @@ class CAdvancedSettings
 
     bool m_fullScreen;
     bool m_startFullScreen;
+	bool m_showExitButton; /* Ideal for appliances to hide a 'useless' button */
     bool m_splashImage;
     bool m_alwaysOnTop;  /* makes xbmc to run always on top .. osx/win32 only .. */
     int m_playlistRetries;


### PR DESCRIPTION
Added: setting to hide the exit button, useful for people running appliance based setups where exit would only confuse/complicate the user. Modifiable via the advancedsettings.xml by setting showexitbutton to false, default is true (show)
