### PR TITLE
Allow service addons to specify when they want to start (startup or after login)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1185,7 +1185,7 @@ bool CApplication::Initialize()
   CCrystalHD::GetInstance();
 #endif
 
-  CAddonMgr::Get().StartServices();
+  CAddonMgr::Get().StartServices(false);
 
   CLog::Log(LOGNOTICE, "initialize done");
 
@@ -3366,7 +3366,7 @@ void CApplication::Stop(int exitCode)
   g_mediaManager.Stop();
 
   // Stop services before unloading Python
-  CAddonMgr::Get().StopServices();
+  CAddonMgr::Get().StopServices(false);
 
 /* Python resource freeing must be done after skin has been unloaded, not before
    some windows still need it when deinitializing during skin unloading. */

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -686,7 +686,7 @@ bool CAddonMgr::LoadAddonDescriptionFromMemory(const TiXmlElement *root, AddonPt
   return addon != NULL;
 }
 
-bool CAddonMgr::StartServices()
+bool CAddonMgr::StartServices(const bool beforelogin)
 {
   CLog::Log(LOGDEBUG, "ADDON: Starting service addons.");
 
@@ -699,13 +699,17 @@ bool CAddonMgr::StartServices()
   {
     boost::shared_ptr<CService> service = boost::dynamic_pointer_cast<CService>(*it);
     if (service)
-      ret &= service->Start();
+    {
+      if ( (beforelogin && service->GetStartOption() == CService::STARTUP)
+        || (!beforelogin && service->GetStartOption() == CService::LOGIN) )
+        ret &= service->Start();
+    }
   }
 
   return ret;
 }
 
-void CAddonMgr::StopServices()
+void CAddonMgr::StopServices(const bool onlylogin)
 {
   CLog::Log(LOGDEBUG, "ADDON: Stopping service addons.");
 
@@ -717,7 +721,11 @@ void CAddonMgr::StopServices()
   {
     boost::shared_ptr<CService> service = boost::dynamic_pointer_cast<CService>(*it);
     if (service)
-      service->Stop();
+    {
+      if ( (onlylogin && service->GetStartOption() == CService::LOGIN)
+        || (!onlylogin) )
+        service->Stop();
+    }
   }
 }
 

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -159,10 +159,10 @@ namespace ADDON
     /*! \brief Start all services addons.
         \return True is all addons are started, false otherwise
     */
-    bool StartServices();
+    bool StartServices(const bool beforelogin);
     /*! \brief Stop all services addons.
     */
-    void StopServices();
+    void StopServices(const bool onlylogin);
 
   private:
     void LoadAddons(const CStdString &path, 

--- a/xbmc/addons/Service.cpp
+++ b/xbmc/addons/Service.cpp
@@ -31,14 +31,18 @@ namespace ADDON
 {
 
 CService::CService(const cp_extension_t *ext)
-  : CAddon(ext), m_type(UNKNOWN)
+  : CAddon(ext), m_type(UNKNOWN), m_startOption(LOGIN)
 {
   BuildServiceType();
+
+  CStdString start = CAddonMgr::Get().GetExtValue(ext->configuration, "@start");
+  if (start.Equals("startup"))
+    m_startOption = STARTUP;
 }
 
 
 CService::CService(const AddonProps &props)
-  : CAddon(props), m_type(UNKNOWN)
+  : CAddon(props), m_type(UNKNOWN), m_startOption(LOGIN)
 {
   BuildServiceType();
 }
@@ -50,7 +54,7 @@ bool CService::Start()
   {
 #ifdef HAS_PYTHON
   case PYTHON:
-    ret = (g_pythonParser.evalFile(LibPath(),this->shared_from_this()) != -1);
+    ret = (g_pythonParser.evalFile(LibPath(), this->shared_from_this()) != -1);
     break;
 #endif
 

--- a/xbmc/addons/Service.h
+++ b/xbmc/addons/Service.h
@@ -34,17 +34,25 @@ namespace ADDON
       PYTHON
     };
 
+    enum START_OPTION
+    {
+      STARTUP,
+      LOGIN
+    };
+
     CService(const cp_extension_t *ext);
     CService(const AddonProps &props);
 
     bool Start();
     bool Stop();
     TYPE GetServiceType() { return m_type; }
+    START_OPTION GetStartOption() { return m_startOption; }
 
   protected:
     void BuildServiceType();
 
   private:
     TYPE m_type;
+    START_OPTION m_startOption;
   };
 }

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1124,6 +1124,8 @@ int CBuiltins::Execute(const CStdString& execString)
       videoScan->Close(true);
     }
 
+    ADDON::CAddonMgr::Get().StopServices(true);
+
     g_application.getNetwork().NetworkMessage(CNetwork::SERVICES_DOWN,1);
     g_settings.LoadMasterForLogin();
     g_passwordManager.bMasterUser = false;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -57,6 +57,7 @@
 #include "utils/URIUtils.h"
 #include "input/MouseStat.h"
 #include "filesystem/File.h"
+#include "addons/AddonManager.h"
 
 using namespace std;
 using namespace XFILE;
@@ -950,6 +951,8 @@ bool CSettings::LoadProfile(unsigned int index)
 
     CUtil::DeleteMusicDatabaseDirectoryCache();
     CUtil::DeleteVideoDatabaseDirectoryCache();
+
+    ADDON::CAddonMgr::Get().StartServices(false);
 
     return true;
   }


### PR DESCRIPTION
Addon makers needs to add a "start" tag to the "xbmc.service" end-point:

``` xml
<extension point="xbmc.service"
             library="default.py" start="login|startup">
```
