### PR TITLE
removed unused CApplication::ResetPlayTime, PAPlayer::ResetTime() and IPl

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5093,12 +5093,6 @@ double CApplication::GetTotalTime() const
   return rc;
 }
 
-void CApplication::ResetPlayTime()
-{
-  if (IsPlaying() && m_pPlayer)
-    m_pPlayer->ResetTime();
-}
-
 void CApplication::StopShutdownTimer()
 {
   if (m_shutdownTimer.IsRunning())

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -191,7 +191,6 @@ public:
 
   void SeekPercentage(float percent);
   void SeekTime( double dTime = 0.0 );
-  void ResetPlayTime();
 
   void StopShutdownTimer();
   void ResetShutdownTimers();

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -133,7 +133,6 @@ public:
   virtual float GetActualFPS() { return 0.0f; };
   virtual void SeekTime(__int64 iTime = 0){};
   virtual __int64 GetTime(){ return 0;};
-  virtual void ResetTime() {};
   virtual int GetTotalTime(){ return 0;};
   virtual int GetAudioBitrate(){ return 0;}
   virtual int GetVideoBitrate(){ return 0;}

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -759,11 +759,6 @@ bool PAPlayer::ProcessPAP()
   return true;
 }
 
-void PAPlayer::ResetTime()
-{
-  m_bytesSentOut = 0;
-}
-
 __int64 PAPlayer::GetTime()
 {
   __int64  timeplus = m_BytesPerSecond ? (__int64)(((float) m_bytesSentOut / (float) m_BytesPerSecond ) * 1000.0) : 0;

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -85,7 +85,6 @@ public:
   virtual int GetSampleRate();
   virtual CStdString GetAudioCodecName();
   virtual __int64 GetTime();
-  virtual void ResetTime();
   virtual void SeekTime(__int64 iTime = 0);
   // Skip to next track/item inside the current media (if supported).
   virtual bool SkipNext();


### PR DESCRIPTION
removed unused CApplication::ResetPlayTime, PAPlayer::ResetTime() and IPlayer::ResetTime(), not used within xbmc
