### PR TITLE
Allow controling visibility of cast/plot controls in DIalogVideoInfo and tracks/review, discography/biography in DialogMusicInfo

### DIFF
--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -230,50 +230,49 @@ void CGUIDialogMusicInfo::Update()
   if (m_bArtistInfo)
   {
     CONTROL_ENABLE(CONTROL_BTN_GET_FANART);
-    if (m_bViewReview)
+
+    SetLabel(CONTROL_TEXTAREA, m_artist.strBiography);
+    CGUIMessage message(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, m_albumSongs);
+    OnMessage(message);
+
+    if (GetControl(CONTROL_BTN_TRACKS)) // if no CONTROL_BTN_TRACKS found - allow skinner full visibility control over CONTROL_TEXTAREA and CONTROL_LIST
     {
-      SET_CONTROL_VISIBLE(CONTROL_TEXTAREA);
-      SET_CONTROL_HIDDEN(CONTROL_LIST);
-      SetLabel(CONTROL_TEXTAREA, m_artist.strBiography);
-      SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 21888);
-    }
-    else
-    {
-      SET_CONTROL_VISIBLE(CONTROL_LIST);
-      if (GetControl(CONTROL_LIST))
+      if (m_bViewReview)
       {
-        SET_CONTROL_HIDDEN(CONTROL_TEXTAREA);
-        CGUIMessage message(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, m_albumSongs);
-        OnMessage(message);
+        SET_CONTROL_VISIBLE(CONTROL_TEXTAREA);
+        SET_CONTROL_HIDDEN(CONTROL_LIST);
+        SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 21888);
       }
       else
-        CLog::Log(LOGERROR, "Out of date skin - needs list with id %i", CONTROL_LIST);
-      SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 21887);
+      {
+        SET_CONTROL_VISIBLE(CONTROL_LIST);
+        SET_CONTROL_HIDDEN(CONTROL_TEXTAREA);
+        SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 21887);
+      }
     }
   }
   else
   {
     CONTROL_DISABLE(CONTROL_BTN_GET_FANART);
 
-    if (m_bViewReview)
+    SetLabel(CONTROL_TEXTAREA, m_album.strReview);
+    CGUIMessage message(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, m_albumSongs);
+    OnMessage(message);
+
+    if (GetControl(CONTROL_BTN_TRACKS)) // if no CONTROL_BTN_TRACKS found - allow skinner full visibility control over CONTROL_TEXTAREA and CONTROL_LIST
     {
-      SET_CONTROL_VISIBLE(CONTROL_TEXTAREA);
-      SET_CONTROL_HIDDEN(CONTROL_LIST);
-      SetLabel(CONTROL_TEXTAREA, m_album.strReview);
-      SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 182);
-    }
-    else
-    {
-      SET_CONTROL_VISIBLE(CONTROL_LIST);
-      if (GetControl(CONTROL_LIST))
+      if (m_bViewReview)
       {
-        SET_CONTROL_HIDDEN(CONTROL_TEXTAREA);
-        CGUIMessage message(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, m_albumSongs);
-        OnMessage(message);
+        SET_CONTROL_VISIBLE(CONTROL_TEXTAREA);
+        SET_CONTROL_HIDDEN(CONTROL_LIST);
+        SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 182);
       }
       else
-        CLog::Log(LOGERROR, "Out of date skin - needs list with id %i", CONTROL_LIST);
-      SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 183);
+      {
+        SET_CONTROL_VISIBLE(CONTROL_LIST);
+        SET_CONTROL_HIDDEN(CONTROL_TEXTAREA);
+        SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 183);
+      }
     }
   }
   // update the thumbnail

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -345,26 +345,29 @@ void CGUIDialogVideoInfo::Update()
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, m_castList);
   OnMessage(msg);
 
-  if (m_bViewReview)
+  if (GetControl(CONTROL_BTN_TRACKS)) // if no CONTROL_BTN_TRACKS found - allow skinner full visibility control over CONTROL_TEXTAREA and CONTROL_LIST
   {
-    if (!m_movieItem->GetVideoInfoTag()->m_strArtist.IsEmpty())
+    if (m_bViewReview)
     {
-      SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 133);
+      if (!m_movieItem->GetVideoInfoTag()->m_strArtist.IsEmpty())
+      {
+        SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 133);
+      }
+      else
+      {
+        SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 206);
+      }
+
+      SET_CONTROL_HIDDEN(CONTROL_LIST);
+      SET_CONTROL_VISIBLE(CONTROL_TEXTAREA);
     }
     else
     {
-      SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 206);
+      SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 207);
+
+      SET_CONTROL_HIDDEN(CONTROL_TEXTAREA);
+      SET_CONTROL_VISIBLE(CONTROL_LIST);
     }
-
-    SET_CONTROL_HIDDEN(CONTROL_LIST);
-    SET_CONTROL_VISIBLE(CONTROL_TEXTAREA);
-  }
-  else
-  {
-    SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 207);
-
-    SET_CONTROL_HIDDEN(CONTROL_TEXTAREA);
-    SET_CONTROL_VISIBLE(CONTROL_LIST);
   }
 
   // Check for resumability


### PR DESCRIPTION
This patch allow skinner to control visibility of container/textarea control pairs in DialogVideoInfo and DialogMusicInfo. "Backward compatibility" is preserved - if dialog has control with ID=5 (this ID was defined to be toggle, switching visibility between container and textarea) it will act as it did before. If there is no control with ID=5 visibility is controlled by skinner.

Here is topic on forum about it: http://forum.xbmc.org/showthread.php?t=101343

Diffs are a bit messy - but mechanism is simple:

<pre>if (GetControl(CONTROL_BTN_TRACKS)) // if no CONTROL_BTN_TRACKS found - allow skinner full visibility control over CONTROL_TEXTAREA and CONTROL_LIST</pre>

dialog will control visibility of textarea/container only if this control (toggle) is found
