### PR TITLE
jsonrpc: make tvshowid parameter in VideoLibrary.GetEpisodes optional

### DIFF
--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -1646,7 +1646,7 @@ namespace JSONRPC
       "\"transport\": \"Response\","
       "\"permission\": \"ReadData\","
       "\"params\": ["
-        "{ \"name\": \"tvshowid\", \"$ref\": \"Library.Id\", \"required\": true },"
+        "{ \"name\": \"tvshowid\", \"$ref\": \"Library.Id\" },"
         "{ \"name\": \"season\", \"type\": \"integer\", \"minimum\": 0, \"default\": -1 },"
         "{ \"name\": \"fields\", \"type\": \"array\", \"id\": \"Library.Fields.Episode\", \"uniqueItems\": true,"
           "\"items\": { \"type\": \"string\","

--- a/xbmc/interfaces/json-rpc/ServiceDescription.json
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.json
@@ -1621,7 +1621,7 @@
     "transport": "Response",
     "permission": "ReadData",
     "params": [
-      { "name": "tvshowid", "$ref": "Library.Id", "required": true },
+      { "name": "tvshowid", "$ref": "Library.Id" },
       { "name": "season", "type": "integer", "minimum": 0, "default": -1 },
       { "name": "fields", "type": "array", "id": "Library.Fields.Episode", "uniqueItems": true,
         "items": { "type": "string",


### PR DESCRIPTION
This change is in response to http://trac.xbmc.org/ticket/11579 as ronie tried to re-write his RandomItem script using jsonrpc but failed at this point because VideoLibrary.GetEpisodes requires a tvshowid. I only made this a pull request because I had to alter CVideoDatabase::GetEpisodesNav because that method also requires a tvshow id although it is an optional parameter. I made it truly optional for this to work but just wanted to check back in case their might be a valid reason for the current implementation.
