### PR TITLE
Disable multimedia keys in Windows

### DIFF
--- a/system/keymaps/appcommand.xml
+++ b/system/keymaps/appcommand.xml
@@ -1,7 +1,7 @@
 <keymap>
   <global>
     <appcommand>
-      <browser_backward>ParentDir</browser_backward>
+      <browser_back>ParentDir</browser_back>
       <browser_forward/>
       <browser_refresh/>
       <browser_stop>Stop</browser_stop>
@@ -11,10 +11,10 @@
       <volume_mute/>
       <volume_down/>
       <volume_up/>
-      <media_nexttrack>SkipNext</media_nexttrack>
-      <media_previoustrack>SkipPrevious</media_previoustrack>
-      <media_stop>Stop</media_stop>
-      <media_play_pause>Play</media_play_pause>
+      <next_track>SkipNext</next_track>
+      <prev_track>SkipPrevious</prev_track>
+      <stop>Stop</stop>
+      <play_pause>Play</play_pause>
       <launch_mail/>
       <launch_media_select>XBMC.ActivateWindow(MyMusic)</launch_media_select>
       <launch_app1>ActivateWindow(MyPrograms)</launch_app1>

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -294,7 +294,7 @@ static const ActionMapping windows[] =
 #ifdef WIN32
 static const ActionMapping appcommands[] =
 {
-  { "browser_backward",    APPCOMMAND_BROWSER_BACKWARD },
+  { "browser_back",        APPCOMMAND_BROWSER_BACKWARD },
   { "browser_forward",     APPCOMMAND_BROWSER_FORWARD },
   { "browser_refresh",     APPCOMMAND_BROWSER_REFRESH },
   { "browser_stop",        APPCOMMAND_BROWSER_STOP },
@@ -304,10 +304,10 @@ static const ActionMapping appcommands[] =
   { "volume_mute",         APPCOMMAND_VOLUME_MUTE },
   { "volume_down",         APPCOMMAND_VOLUME_DOWN },
   { "volume_up",           APPCOMMAND_VOLUME_UP },
-  { "media_nexttrack",     APPCOMMAND_MEDIA_NEXTTRACK },
-  { "media_previoustrack", APPCOMMAND_MEDIA_PREVIOUSTRACK },
-  { "media_stop",          APPCOMMAND_MEDIA_STOP },
-  { "media_play_pause",    APPCOMMAND_MEDIA_PLAY_PAUSE },
+  { "next_track",          APPCOMMAND_MEDIA_NEXTTRACK },
+  { "prev_track",          APPCOMMAND_MEDIA_PREVIOUSTRACK },
+  { "stop",                APPCOMMAND_MEDIA_STOP },
+  { "play_pause",          APPCOMMAND_MEDIA_PLAY_PAUSE },
   { "launch_mail",         APPCOMMAND_LAUNCH_MAIL },
   { "launch_media_select", APPCOMMAND_LAUNCH_MEDIA_SELECT },
   { "launch_app1",         APPCOMMAND_LAUNCH_APP1 },

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -276,6 +276,8 @@ void CAdvancedSettings::Initialize()
 
   m_jsonOutputCompact = true;
   m_jsonTcpPort = 9090;
+
+  m_enableMultimediaKeys = false;
 }
 
 bool CAdvancedSettings::Load()
@@ -872,6 +874,12 @@ bool CAdvancedSettings::Load()
     XMLUtils::GetString(pDatabase, "user", m_databaseMusic.user);
     XMLUtils::GetString(pDatabase, "pass", m_databaseMusic.pass);
     XMLUtils::GetString(pDatabase, "name", m_databaseMusic.name);
+  }
+
+  pElement = pRootElement->FirstChildElement("enablemultimediakeys");
+  if (pElement)
+  {
+    XMLUtils::GetBoolean(pRootElement, "enablemultimediakeys", m_enableMultimediaKeys);
   }
 
   // load in the GUISettings overrides:

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -288,6 +288,8 @@ class CAdvancedSettings
 
     bool m_jsonOutputCompact;
     unsigned int m_jsonTcpPort;
+
+    bool m_enableMultimediaKeys;
 };
 
 XBMC_GLOBAL(CAdvancedSettings,g_advancedSettings);

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -36,6 +36,7 @@
 #include "guilib/GUIControl.h"       // for EVENT_RESULT
 #include "powermanagement/windows/Win32PowerSyscall.h"
 #include "Shlobj.h"
+#include "settings/AdvancedSettings.h"
 
 #ifdef _WIN32
 
@@ -199,24 +200,29 @@ void DIB_InitOSKeymap()
   VK_keymap[VK_CANCEL] = XBMCK_BREAK;
   VK_keymap[VK_APPS] = XBMCK_MENU;
 
-  VK_keymap[VK_BROWSER_BACK]        = XBMCK_BROWSER_BACK;
-  VK_keymap[VK_BROWSER_FORWARD]     = XBMCK_BROWSER_FORWARD;
-  VK_keymap[VK_BROWSER_REFRESH]     = XBMCK_BROWSER_REFRESH;
-  VK_keymap[VK_BROWSER_STOP]        = XBMCK_BROWSER_STOP;
-  VK_keymap[VK_BROWSER_SEARCH]      = XBMCK_BROWSER_SEARCH;
-  VK_keymap[VK_BROWSER_FAVORITES]   = XBMCK_BROWSER_FAVORITES;
-  VK_keymap[VK_BROWSER_HOME]        = XBMCK_BROWSER_HOME;
-  VK_keymap[VK_VOLUME_MUTE]         = XBMCK_VOLUME_MUTE;
-  VK_keymap[VK_VOLUME_DOWN]         = XBMCK_VOLUME_DOWN;
-  VK_keymap[VK_VOLUME_UP]           = XBMCK_VOLUME_UP;
-  VK_keymap[VK_MEDIA_NEXT_TRACK]    = XBMCK_MEDIA_NEXT_TRACK;
-  VK_keymap[VK_MEDIA_PREV_TRACK]    = XBMCK_MEDIA_PREV_TRACK;
-  VK_keymap[VK_MEDIA_STOP]          = XBMCK_MEDIA_STOP;
-  VK_keymap[VK_MEDIA_PLAY_PAUSE]    = XBMCK_MEDIA_PLAY_PAUSE;
-  VK_keymap[VK_LAUNCH_MAIL]         = XBMCK_LAUNCH_MAIL;
-  VK_keymap[VK_LAUNCH_MEDIA_SELECT] = XBMCK_LAUNCH_MEDIA_SELECT;
-  VK_keymap[VK_LAUNCH_APP1]         = XBMCK_LAUNCH_APP1;
-  VK_keymap[VK_LAUNCH_APP2]         = XBMCK_LAUNCH_APP2;
+  // Only include the multimedia keys if they have been enabled in the
+  // advanced settings
+  if (g_advancedSettings.m_enableMultimediaKeys)
+  {
+    VK_keymap[VK_BROWSER_BACK]        = XBMCK_BROWSER_BACK;
+    VK_keymap[VK_BROWSER_FORWARD]     = XBMCK_BROWSER_FORWARD;
+    VK_keymap[VK_BROWSER_REFRESH]     = XBMCK_BROWSER_REFRESH;
+    VK_keymap[VK_BROWSER_STOP]        = XBMCK_BROWSER_STOP;
+    VK_keymap[VK_BROWSER_SEARCH]      = XBMCK_BROWSER_SEARCH;
+    VK_keymap[VK_BROWSER_FAVORITES]   = XBMCK_BROWSER_FAVORITES;
+    VK_keymap[VK_BROWSER_HOME]        = XBMCK_BROWSER_HOME;
+    VK_keymap[VK_VOLUME_MUTE]         = XBMCK_VOLUME_MUTE;
+    VK_keymap[VK_VOLUME_DOWN]         = XBMCK_VOLUME_DOWN;
+    VK_keymap[VK_VOLUME_UP]           = XBMCK_VOLUME_UP;
+    VK_keymap[VK_MEDIA_NEXT_TRACK]    = XBMCK_MEDIA_NEXT_TRACK;
+    VK_keymap[VK_MEDIA_PREV_TRACK]    = XBMCK_MEDIA_PREV_TRACK;
+    VK_keymap[VK_MEDIA_STOP]          = XBMCK_MEDIA_STOP;
+    VK_keymap[VK_MEDIA_PLAY_PAUSE]    = XBMCK_MEDIA_PLAY_PAUSE;
+    VK_keymap[VK_LAUNCH_MAIL]         = XBMCK_LAUNCH_MAIL;
+    VK_keymap[VK_LAUNCH_MEDIA_SELECT] = XBMCK_LAUNCH_MEDIA_SELECT;
+    VK_keymap[VK_LAUNCH_APP1]         = XBMCK_LAUNCH_APP1;
+    VK_keymap[VK_LAUNCH_APP2]         = XBMCK_LAUNCH_APP2;
+  }
 
   Arrows_keymap[3] = (XBMCKey)0x25;
   Arrows_keymap[2] = (XBMCKey)0x26;


### PR DESCRIPTION
In Windows, pressing a multimedia key generates both a keypress and an appcommand. XBMC processes both, so the command is executed twice. This patch disables the multimedia keys in Windows and adds an advancedsettings.xml setting to enable them again. Since every multimedia key generates a matching appcommand, the multimedia key presses still produce the desired result.

Also change the appcommand tag names in appcommand.xml to match the multimedia key names in keyboard.xml.
