### PR TITLE
Fixed deadlock when starting LiveTV through myth://

### DIFF
--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -43,7 +43,7 @@
 #include <signal.h>
 #include <cmyth_local.h>
 
-pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
 typedef struct {
 	int version;


### PR DESCRIPTION
libcmyth now uses a recursive mutex to allow the thread holding the connection lock to get passed another lock.

elupus already reviewed this "workaround" when I posted a previous pull request. It's the easiest way to resolve the problem without introducing a number of locked and unlocked methods within libcmyth.
