### PR TITLE
Fix crash in CDVDAudio::Finish()

### DIFF
--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -238,7 +238,7 @@ void CDVDAudio::Finish()
   if(silence > 0 && m_iBufferSize > 0)
   {
     CLog::Log(LOGDEBUG, "CDVDAudio::Drain - adding %d bytes of silence, buffer size: %d, chunk size: %d", silence, m_iBufferSize, m_dwPacketSize);
-    m_pBuffer = (BYTE*)realloc(m_pBuffer, m_dwPacketSize);
+    m_pBuffer = (BYTE*)realloc(m_pBuffer, m_iBufferSize + silence);
     memset(m_pBuffer+m_iBufferSize, 0, silence);
     m_iBufferSize += silence;
   }


### PR DESCRIPTION
Fix buggy realloc() in CDVDAudio::Finish() which causes memory corruption.

This would occur just after messages like this in the debug log:
DEBUG: CDVDAudio::Drain - adding 1536 bytes of silence, buffer size: 6144, chunk size: 3840

In the original code, the realloc() would change the buffer to 3840 bytes, then the memset below would clear bytes 6144-7680 in the buffer. Changing the realloc() to m_iBufferSize + silence fixes the crash.
