### PR TITLE
Allow mouse actions to be mapped with an XML file

### DIFF
--- a/system/keymaps/mouse.xml
+++ b/system/keymaps/mouse.xml
@@ -1,0 +1,14 @@
+<keymap>
+  <global>
+    <mouse>
+      <leftclick>leftclick</leftclick>
+      <middleclick>middleclick</middleclick>
+      <rightclick>rightclick</rightclick>
+      <doubleclick>doubleclick</doubleclick>
+      <wheeldown>wheeldown</wheeldown>
+      <wheelup>wheelup</wheelup>
+      <mousedrag>mousedrag</mousedrag>
+      <mousemove>mousemove</mousemove>
+    </mouse>
+  </global>
+</keymap>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2919,7 +2919,7 @@ bool CApplication::ProcessMouse()
   CAction mouseaction = CButtonTranslator::GetInstance().GetAction(iWin, key);
 
   // If we couldn't find an action return false to indicate we have not
-  // handled this appcommand
+  // handled this mouse action
   if (!mouseaction.GetID())
   {
     CLog::Log(LOGDEBUG, "%s: unknown mouse command %d", __FUNCTION__, mousecommand);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2933,7 +2933,9 @@ bool CApplication::ProcessMouse()
                                   (float)g_Mouse.GetY(), 
                                   (float)g_Mouse.GetDX(), 
                                   (float)g_Mouse.GetDY());
-  if (newmouseaction.GetID() != ACTION_MOUSE_MOVE)
+
+  // Log mouse actions except for move and noop
+  if (newmouseaction.GetID() != ACTION_MOUSE_MOVE && newmouseaction.GetID() != ACTION_NOOP)
     CLog::Log(LOGDEBUG, "%s: trying mouse action %s", __FUNCTION__, mouseaction.GetName().c_str());
 
   return OnAction(newmouseaction);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2914,8 +2914,12 @@ bool CApplication::ProcessMouse()
   uint32_t mousecommand = g_Mouse.GetAction();
 
   // Retrieve the corresponding action
+  int iWin;
   CKey key(mousecommand | KEY_MOUSE, (unsigned int) 0);
-  int iWin = g_windowManager.GetActiveWindow() & WINDOW_ID_MASK;
+  if (g_windowManager.HasModalDialog())
+    iWin = g_windowManager.GetTopMostModalDialogID() & WINDOW_ID_MASK;
+  else
+    iWin = g_windowManager.GetActiveWindow() & WINDOW_ID_MASK;
   CAction mouseaction = CButtonTranslator::GetInstance().GetAction(iWin, key);
 
   // If we couldn't find an action return false to indicate we have not

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2904,6 +2904,9 @@ bool CApplication::ProcessMouse()
   if (!g_Mouse.IsActive() || !m_AppFocused)
     return false;
 
+  // Update the pointer position here so it gets updated even for ACTION_NOOP
+  m_guiPointer.SetPosition((float) g_Mouse.GetX(), (float) g_Mouse.GetY());
+
   // Reset the screensaver and idle timers
   m_idleTimer.StartZero();
   ResetScreenSaver();

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -295,6 +295,11 @@
 
 #define ACTION_PLAYER_PLAYPAUSE       227 // Play/pause. If playing it pauses, if paused it plays.
 
+// The NOOP action can be specified to disable an input event. This is
+// useful in user keyboard.xml etc to disable actions specified in the
+// system mappings.
+#define ACTION_NOOP                   999
+
 // Window ID defines to make the code a bit more readable
 #define WINDOW_INVALID                     9999
 #define WINDOW_HOME                       10000

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -76,6 +76,9 @@
 #define KEY_ASCII           0xF100 // a printable character in the range of TRUE ASCII (from 0 to 127) // FIXME make it clean and pure unicode! remove the need for KEY_ASCII
 #define KEY_UNICODE         0xF200 // another printable character whose range is not included in this KEY code
 
+// 0xE000 -> 0xE0FF is reserved for mouse actions
+#define KEY_MOUSE           0xE000
+
 // 0xD000 -> 0xD0FF is reserved for WM_APPCOMMAND messages
 #define KEY_APPCOMMAND      0xD000
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -194,7 +194,16 @@ static const ActionMapping actions[] =
         {"yellow"            , ACTION_TELETEXT_YELLOW},
         {"blue"              , ACTION_TELETEXT_BLUE},
         {"increasepar"       , ACTION_INCREASE_PAR},
-        {"decreasepar"       , ACTION_DECREASE_PAR}};
+        {"decreasepar"       , ACTION_DECREASE_PAR},
+        { "leftclick"        , ACTION_MOUSE_LEFT_CLICK},
+        { "rightclick"       , ACTION_MOUSE_RIGHT_CLICK},
+        { "middleclick"      , ACTION_MOUSE_MIDDLE_CLICK},
+        { "doubleclick"      , ACTION_MOUSE_DOUBLE_CLICK},
+        { "wheelup"          , ACTION_MOUSE_WHEEL_UP},
+        { "wheeldown"        , ACTION_MOUSE_WHEEL_DOWN},
+        { "mousedrag"        , ACTION_MOUSE_DRAG},
+        { "mousemove"        , ACTION_MOUSE_MOVE}
+};
 
 static const ActionMapping windows[] =
        {{"home"                     , WINDOW_HOME},
@@ -290,6 +299,18 @@ static const ActionMapping windows[] =
         {"videooverlay"             , WINDOW_DIALOG_VIDEO_OVERLAY},
         {"startwindow"              , WINDOW_START},
         {"startup"                  , WINDOW_STARTUP_ANIM}};
+
+static const ActionMapping mousecommands[] =
+{
+  { "leftclick",   ACTION_MOUSE_LEFT_CLICK },
+  { "rightclick",  ACTION_MOUSE_RIGHT_CLICK },
+  { "middleclick", ACTION_MOUSE_MIDDLE_CLICK },
+  { "doubleclick", ACTION_MOUSE_DOUBLE_CLICK },
+  { "wheelup",     ACTION_MOUSE_WHEEL_UP },
+  { "wheeldown",   ACTION_MOUSE_WHEEL_DOWN },
+  { "mousedrag",   ACTION_MOUSE_DRAG },
+  { "mousemove",   ACTION_MOUSE_MOVE }
+};
 
 #ifdef WIN32
 static const ActionMapping appcommands[] =
@@ -826,7 +847,7 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
   }
   TiXmlNode* pDevice;
 
-  const char* types[] = {"gamepad", "remote", "universalremote", "keyboard", "appcommand", NULL};
+  const char* types[] = {"gamepad", "remote", "universalremote", "keyboard", "mouse", "appcommand", NULL};
   for (int i = 0; types[i]; ++i)
   {
     CStdString type(types[i]);
@@ -845,6 +866,8 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
             buttonCode = TranslateUniversalRemoteString(pButton->Value());
         else if (type == "keyboard")
             buttonCode = TranslateKeyboardButton(pButton);
+        else if (type == "mouse")
+            buttonCode = TranslateMouseCommand(pButton->Value());
         else if (type == "appcommand")
             buttonCode = TranslateAppCommand(pButton->Value());
 
@@ -1145,6 +1168,24 @@ uint32_t CButtonTranslator::TranslateAppCommand(const char *szButton)
 
   CLog::Log(LOGERROR, "%s: Can't find appcommand %s", __FUNCTION__, szButton);
 #endif
+
+  return 0;
+}
+
+uint32_t CButtonTranslator::TranslateMouseCommand(const char *szButton)
+{
+  CStdString strMouseCommand = szButton;
+  strMouseCommand.ToLower();
+
+  int j = sizeof(mousecommands)/sizeof(mousecommands[0]);
+
+  for (int i = 0; i < sizeof(mousecommands)/sizeof(mousecommands[0]); i++)
+    if (strMouseCommand.Equals(mousecommands[i].name))
+      return mousecommands[i].action | KEY_MOUSE;
+    else
+      CLog::Log(LOGDEBUG, "%s: mouse command %s != %d", __FUNCTION__, szButton, i);
+
+  CLog::Log(LOGERROR, "%s: Can't find mouse command %s", __FUNCTION__, szButton);
 
   return 0;
 }

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -1185,8 +1185,6 @@ uint32_t CButtonTranslator::TranslateMouseCommand(const char *szButton)
   for (int i = 0; i < sizeof(mousecommands)/sizeof(mousecommands[0]); i++)
     if (strMouseCommand.Equals(mousecommands[i].name))
       return mousecommands[i].action | KEY_MOUSE;
-    else
-      CLog::Log(LOGDEBUG, "%s: mouse command %s != %d", __FUNCTION__, szButton, i);
 
   CLog::Log(LOGERROR, "%s: Can't find mouse command %s", __FUNCTION__, szButton);
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -45,7 +45,8 @@ typedef struct
 } ActionMapping;
 
 static const ActionMapping actions[] =
-       {{"left"              , ACTION_MOVE_LEFT },
+{
+        {"left"              , ACTION_MOVE_LEFT },
         {"right"             , ACTION_MOVE_RIGHT},
         {"up"                , ACTION_MOVE_UP   },
         {"down"              , ACTION_MOVE_DOWN },
@@ -195,14 +196,19 @@ static const ActionMapping actions[] =
         {"blue"              , ACTION_TELETEXT_BLUE},
         {"increasepar"       , ACTION_INCREASE_PAR},
         {"decreasepar"       , ACTION_DECREASE_PAR},
-        { "leftclick"        , ACTION_MOUSE_LEFT_CLICK},
-        { "rightclick"       , ACTION_MOUSE_RIGHT_CLICK},
-        { "middleclick"      , ACTION_MOUSE_MIDDLE_CLICK},
-        { "doubleclick"      , ACTION_MOUSE_DOUBLE_CLICK},
-        { "wheelup"          , ACTION_MOUSE_WHEEL_UP},
-        { "wheeldown"        , ACTION_MOUSE_WHEEL_DOWN},
-        { "mousedrag"        , ACTION_MOUSE_DRAG},
-        { "mousemove"        , ACTION_MOUSE_MOVE}
+
+        // Mouse actions
+        {"leftclick"         , ACTION_MOUSE_LEFT_CLICK},
+        {"rightclick"        , ACTION_MOUSE_RIGHT_CLICK},
+        {"middleclick"       , ACTION_MOUSE_MIDDLE_CLICK},
+        {"doubleclick"       , ACTION_MOUSE_DOUBLE_CLICK},
+        {"wheelup"           , ACTION_MOUSE_WHEEL_UP},
+        {"wheeldown"         , ACTION_MOUSE_WHEEL_DOWN},
+        {"mousedrag"         , ACTION_MOUSE_DRAG},
+        {"mousemove"         , ACTION_MOUSE_MOVE},
+
+        // Do nothing action
+        { "noop"             , ACTION_NOOP}
 };
 
 static const ActionMapping windows[] =
@@ -900,9 +906,6 @@ bool CButtonTranslator::TranslateActionString(const char *szAction, int &action)
   strAction.ToLower();
   if (CBuiltins::HasCommand(strAction)) 
     action = ACTION_BUILT_IN_FUNCTION;
-
-  if (strAction.Equals("noop"))
-    return true;
 
   for (unsigned int index=0;index < sizeof(actions)/sizeof(actions[0]);++index)
   {

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -106,6 +106,8 @@ private:
   static uint32_t TranslateKeyboardString(const char *szButton);
   static uint32_t TranslateKeyboardButton(TiXmlElement *pButton);
 
+  static uint32_t TranslateMouseCommand(const char *szButton);
+
   static uint32_t TranslateAppCommand(const char *szButton);
 
   void MapWindowActions(TiXmlNode *pWindow, int wWindowID);

--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -254,9 +254,10 @@ bool CMouseStat::MovedPastThreshold() const
   return (m_mouseState.dx * m_mouseState.dx + m_mouseState.dy * m_mouseState.dy >= MOUSE_MINIMUM_MOVEMENT * MOUSE_MINIMUM_MOVEMENT);
 }
 
-CAction CMouseStat::GetAction() const
+uint32_t CMouseStat::GetAction() const
 {
   int actionID = ACTION_MOUSE_MOVE;
+
   if (bClick[MOUSE_LEFT_BUTTON])
     actionID = ACTION_MOUSE_LEFT_CLICK;
   else if (bClick[MOUSE_RIGHT_BUTTON])
@@ -272,5 +273,15 @@ CAction CMouseStat::GetAction() const
   else if (m_mouseState.dz < 0)
     actionID = ACTION_MOUSE_WHEEL_DOWN;
 
-  return CAction(actionID, (unsigned int)bHold[MOUSE_LEFT_BUTTON], (float)m_mouseState.x, (float)m_mouseState.y, (float)m_mouseState.dx, (float)m_mouseState.dy);
+  return actionID;
 }
+
+int CMouseStat::GetHold(int ButtonID)
+{
+  switch (ButtonID)
+  { case MOUSE_LEFT_BUTTON:
+      return bHold[MOUSE_LEFT_BUTTON];
+  }
+  return false;
+}
+

--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -276,7 +276,7 @@ uint32_t CMouseStat::GetAction() const
   return actionID;
 }
 
-int CMouseStat::GetHold(int ButtonID)
+int CMouseStat::GetHold(int ButtonID) const
 {
   switch (ButtonID)
   { case MOUSE_LEFT_BUTTON:

--- a/xbmc/input/MouseStat.h
+++ b/xbmc/input/MouseStat.h
@@ -78,11 +78,11 @@ public:
   MOUSE_STATE GetState() const { return m_pointerState; };
   uint32_t GetAction() const;
 
-  int GetHold(int ButtonID);
-  inline int GetX(void) { return m_mouseState.x; }
-  inline int GetY(void) { return m_mouseState.y; }
-  inline int GetDX(void) { return m_mouseState.dx; }
-  inline int GetDY(void) { return m_mouseState.dy; }
+  int GetHold(int ButtonID) const;
+  inline int GetX(void) const { return m_mouseState.x; }
+  inline int GetY(void) const { return m_mouseState.y; }
+  inline int GetDX(void) const { return m_mouseState.dx; }
+  inline int GetDY(void) const { return m_mouseState.dy; }
 
 private:
   /*! \brief Holds information regarding a particular mouse button state

--- a/xbmc/input/MouseStat.h
+++ b/xbmc/input/MouseStat.h
@@ -76,7 +76,13 @@ public:
   void SetState(MOUSE_STATE state) { m_pointerState = state; };
   void SetEnabled(bool enabled = true);
   MOUSE_STATE GetState() const { return m_pointerState; };
-  CAction GetAction() const;
+  uint32_t GetAction() const;
+
+  int GetHold(int ButtonID);
+  inline int GetX(void) { return m_mouseState.x; }
+  inline int GetY(void) { return m_mouseState.y; }
+  inline int GetDX(void) { return m_mouseState.dx; }
+  inline int GetDY(void) { return m_mouseState.dy; }
 
 private:
   /*! \brief Holds information regarding a particular mouse button state


### PR DESCRIPTION
This patch allows mouse actions to be configured in the same way as keyboard actions.

NB this is a first pass at the problem and it's intended mostly to solicit feedback. I didn't want to spend too long on it in case there are fundamental problems with this approach. I have checked that the mouse still works as expected, and I've checked that:

&lt;keymap&gt;
  &lt;fullscreenvideo&gt;
    &lt;mouse&gt;
      &lt;leftclick&gt;Pause&lt;/leftclick&gt;
    &lt;/mouse&gt;
  &lt;/fullscreenvideo&gt;
&lt;/keymap&gt;

does indeed configure a left click to pause the video (I tested this because it's a feature that has been asked for in the forum). If feedback is favourable I will tidy up the code and thoroughly test it.
