### PR TITLE
Quick load profile function

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -181,6 +181,7 @@ const BUILT_IN commands[] = {
   { "Control.Message",            true,   "Send a given message to a control within a given window" },
   { "SendClick",                  true,   "Send a click message from the given control to the given window" },
   { "LoadProfile",                true,   "Load the specified profile (note; if locks are active it won't work)" },
+  { "LoadProfileFast",            true,   "Load the specified profile without cleaning playlist and keeping current window active(note; if locks are active it won't work)" },
   { "SetProperty",                true,   "Sets a window property for the current focused window/dialog (key,value)" },
   { "ClearProperty",              true,   "Clears a window property for the current focused window/dialog (key,value)" },
   { "PlayWith",                   true,   "Play the selected item with the specified core" },
@@ -279,6 +280,19 @@ int CBuiltins::Execute(const CStdString& execString)
     {
 
       CGUIWindowLoginScreen::LoadProfile(index);
+    }
+  }
+  else if (execute.Equals("loadprofilefast"))
+  {
+    int index = g_settings.GetProfileIndex(parameter);
+    bool prompt = (params.size() == 2 && params[1].Equals("prompt"));
+    bool bCanceled;
+    if (index >= 0
+        && (g_settings.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE
+            || g_passwordManager.IsProfileLockUnlocked(index,bCanceled,prompt)))
+    {
+
+      CGUIWindowLoginScreen::FastLoadProfile(index);
     }
   }
   else if (execute.Equals("mastermode"))

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -294,3 +294,30 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 
   g_application.UpdateLibraries();
 }
+
+
+void CGUIWindowLoginScreen::FastLoadProfile(unsigned int profile)
+{
+  if (profile != 0 || !g_settings.IsMasterUser())
+  {
+    g_application.getNetwork().NetworkMessage(CNetwork::SERVICES_DOWN,1);
+    g_settings.LoadProfile(profile);
+  }
+  else
+  {
+    CGUIWindow* pWindow = g_windowManager.GetWindow(WINDOW_HOME);
+    if (pWindow)
+      pWindow->ResetControlStates();
+  }
+  g_application.getNetwork().NetworkMessage(CNetwork::SERVICES_UP,1);
+
+  g_settings.UpdateCurrentProfileDate();
+  g_settings.SaveProfiles(PROFILES_FILE);
+  
+  g_weatherManager.Refresh();
+#ifdef HAS_PYTHON
+  g_pythonParser.m_bLogin = true;
+#endif
+
+  g_application.UpdateLibraries();
+}

--- a/xbmc/windows/GUIWindowLoginScreen.h
+++ b/xbmc/windows/GUIWindowLoginScreen.h
@@ -39,6 +39,7 @@ public:
   virtual CFileItemPtr GetCurrentListItem(int offset = 0);
   int GetViewContainerID() const { return m_viewControl.GetCurrentControl(); };
   static void LoadProfile(unsigned int profile);
+  static void FastLoadProfile(unsigned int profile);
 
 protected:
   virtual void OnInitWindow();


### PR DESCRIPTION
Hello,

First contribution here so it would be nice if you could review it (has been tested during 3 days on my own build).

Basically it adds a new function, its the same than LoadProfile(..) one but its LoadProfileFast(..), it will change profile settings and others, but wont clear playlist nor open main "FirstWindow". I made it for self-use and i think it could be usefull for people which uses profiles only to change settings, but not as real profiles (aka, not different databases, nor real users).

Usage its, on "keyboard.xml" (any xml inside keymaps i guess):
<f1>LoadProfileFast(FullSVSync)</f1>
<f2>LoadProfileFast(NoFullVSync)</f2>
<f3>LoadProfileFast(Master user)</f3>

Also wanted to dont update <lastloaded>0</lastloaded>, on profiles.xml, but since i didnt manage to 
(tried removing
- g_settings.UpdateCurrentProfileDate();
- g_settings.SaveProfiles(PROFILES_FILE);
  and didnt work, so i better leave it on), if someone wants it, put profiles.xml to read-only.

PS: If you pull it, if posible, please change commit comment to "adds a new function, its the same than LoadProfile(..) one but its LoadProfileFast(..), it will change profile settings and others, but wont clear playlist nor open main "FirstWindow", First time i use github and cant find how to edit commit.

*if PS is not possible, patch file can be found on: http://www.mediafire.com/?84nal70j7ya5x83
