### PR TITLE
Allow builtin functions to be used with the mouse

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2939,11 +2939,12 @@ bool CApplication::ProcessMouse()
                                   (float)g_Mouse.GetX(), 
                                   (float)g_Mouse.GetY(), 
                                   (float)g_Mouse.GetDX(), 
-                                  (float)g_Mouse.GetDY());
+                                  (float)g_Mouse.GetDY(),
+                                  mouseaction.GetName());
 
   // Log mouse actions except for move and noop
   if (newmouseaction.GetID() != ACTION_MOUSE_MOVE && newmouseaction.GetID() != ACTION_NOOP)
-    CLog::Log(LOGDEBUG, "%s: trying mouse action %s", __FUNCTION__, mouseaction.GetName().c_str());
+    CLog::Log(LOGDEBUG, "%s: trying mouse action %s", __FUNCTION__, newmouseaction.GetName().c_str());
 
   return OnAction(newmouseaction);
 }

--- a/xbmc/guilib/Key.cpp
+++ b/xbmc/guilib/Key.cpp
@@ -193,7 +193,7 @@ CAction::CAction(int actionID, float amount1 /* = 1.0f */, float amount2 /* = 0.
   m_holdTime = 0;
 }
 
-CAction::CAction(int actionID, unsigned int state, float posX, float posY, float offsetX, float offsetY)
+CAction::CAction(int actionID, unsigned int state, float posX, float posY, float offsetX, float offsetY, const CStdString &name)
 {
   m_id = actionID;
   m_amount[0] = posX;
@@ -202,6 +202,7 @@ CAction::CAction(int actionID, unsigned int state, float posX, float posY, float
   m_amount[3] = offsetY;
   for (unsigned int i = 4; i < max_amounts; i++)
     m_amount[i] = 0;  
+  m_name = name;
   m_repeat = 0;
   m_buttonCode = 0;
   m_unicode = 0;

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -430,7 +430,7 @@ class CAction
 public:
   CAction(int actionID, float amount1 = 1.0f, float amount2 = 0.0f, const CStdString &name = "");
   CAction(int actionID, wchar_t unicode);
-  CAction(int actionID, unsigned int state, float posX, float posY, float offsetX, float offsetY);
+  CAction(int actionID, unsigned int state, float posX, float posY, float offsetX, float offsetY, const CStdString &name = "");
   CAction(int actionID, const CStdString &name, const CKey &key);
 
   /*! \brief Identifier of the action


### PR DESCRIPTION
This is a small change and I'm not sure it's really worth a pull request, but it does involve a change to CAction, so I thought I'd give everyone a chance to have a look before I push.

The change adds an optional name parameter to the CAction(int, unsigned int, float, float, float, float, const CStdString &) constructor. CApplication::ProcessMouse needs to be able to set the action name for builtin functions to work.
