### PR TITLE
NFO Fanart Patch

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -491,11 +491,24 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie)
   XMLUtils::GetString(movie, "trailer", m_strTrailer);
   XMLUtils::GetString(movie, "basepath", m_basePath);
 
+  int iThumbCount= m_strPictureURL.m_url.size();
+  CStdString sXmlAdd;
+
   const TiXmlElement* thumb = movie->FirstChildElement("thumb");
   while (thumb)
   {
     m_strPictureURL.ParseElement(thumb);
+	sXmlAdd<<*thumb;
     thumb = thumb->NextSiblingElement("thumb");
+  }
+
+  // if there are thumbs in the nfo, we should place them on top of the list
+  if ((iThumbCount!=m_strPictureURL.m_url.size()) && (m_strPictureURL.m_url.size()>1) && (iThumbCount>0) )
+  {
+    rotate(m_strPictureURL.m_url.begin(), m_strPictureURL.m_url.begin()+iThumbCount, m_strPictureURL.m_url.end());   
+    // rebuild xml string for database
+    sXmlAdd+=m_strPictureURL.m_xml;
+    m_strPictureURL.m_xml=sXmlAdd;
   }
 
   XMLUtils::GetAdditiveString(movie,"genre",g_advancedSettings.m_videoItemSeparator,m_strGenre);
@@ -613,6 +626,10 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie)
   const TiXmlElement *fanart = movie->FirstChildElement("fanart");
   if (fanart)
   {
+    // we need to replace the scraper results with the nfo results
+    // combining them does not work properly, as the scraper result
+    // might contain an url attribut which prevents to load a filesystem file
+    m_fanart.m_xml.clear();
     m_fanart.m_xml << *fanart;
     m_fanart.Unpack();
   }


### PR DESCRIPTION
This patch covers to topics with using fanart and Thumbs in NFOs

Bug: Fanart: Fanart given in nfos are not used if a scraper(s) already found fanart
Thumbs: Thumbs given in nfos are not priorized against scraper results, so it is not possible to provide thumbs in nfos as they are added after the scraper thumb results
