### PR TITLE
Add new parameter to LoadProfile built-in function. Parameter its "quick"

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -271,14 +271,15 @@ int CBuiltins::Execute(const CStdString& execString)
   else if (execute.Equals("loadprofile"))
   {
     int index = g_settings.GetProfileIndex(parameter);
-    bool prompt = (params.size() == 2 && params[1].Equals("prompt"));
+    bool prompt = ((params.size() > 1 && params[1].Equals("prompt")) || (params.size() > 2 && params[2].Equals("prompt")));	
+	bool quick = ((params.size() > 2 && params[2].Equals("quick")) || (params.size() > 1 && params[1].Equals("quick")));
     bool bCanceled;
     if (index >= 0
         && (g_settings.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE
             || g_passwordManager.IsProfileLockUnlocked(index,bCanceled,prompt)))
     {
 
-      CGUIWindowLoginScreen::LoadProfile(index);
+      CGUIWindowLoginScreen::LoadProfile(index,quick);
     }
   }
   else if (execute.Equals("mastermode"))

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -261,7 +261,7 @@ CFileItemPtr CGUIWindowLoginScreen::GetCurrentListItem(int offset)
   return m_vecItems->Get(item);
 }
 
-void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
+void CGUIWindowLoginScreen::LoadProfile(unsigned int profile, bool quick)
 {
   if (profile != 0 || !g_settings.IsMasterUser())
   {
@@ -279,7 +279,7 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
   g_settings.UpdateCurrentProfileDate();
   g_settings.SaveProfiles(PROFILES_FILE);
 
-  if (g_settings.GetLastUsedProfileIndex() != profile)
+  if (g_settings.GetLastUsedProfileIndex() != profile && !quick)
   {
     g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
     g_playlistPlayer.ClearPlaylist(PLAYLIST_MUSIC);
@@ -290,7 +290,10 @@ void CGUIWindowLoginScreen::LoadProfile(unsigned int profile)
 #ifdef HAS_PYTHON
   g_pythonParser.m_bLogin = true;
 #endif
-  g_windowManager.ChangeActiveWindow(g_SkinInfo->GetFirstWindow());
+  if(!quick)
+  {
+    g_windowManager.ChangeActiveWindow(g_SkinInfo->GetFirstWindow());
+  }
 
   g_application.UpdateLibraries();
 }

--- a/xbmc/windows/GUIWindowLoginScreen.h
+++ b/xbmc/windows/GUIWindowLoginScreen.h
@@ -38,7 +38,7 @@ public:
   virtual bool HasListItems() const { return true; };
   virtual CFileItemPtr GetCurrentListItem(int offset = 0);
   int GetViewContainerID() const { return m_viewControl.GetCurrentControl(); };
-  static void LoadProfile(unsigned int profile);
+  static void LoadProfile(unsigned int profile, bool quick=false);
 
 protected:
   virtual void OnInitWindow();


### PR DESCRIPTION
Add new parameter to LoadProfile built-in function. Parameter its "quick", if that parameter is used, LoadProfile wont clean playlist nor change active window.

So new function remains as LoadProfile(profileName,prompt,quick),LoadProfile(profileName,quick prompt),LoadProfile(profileName,quick), LoadProfile(profileName,prompt) and LoadProfile(profileName)

Every combination has been tested and works as expected. 
I know noone asked for this change, i made it for my own use, but if someone else thinks it may be usefull....

Difference between quick and default behaviour it's that quick doesnt clean playlist nor changes active window to "firstWindow()"

Thanks cptspiff for coding tips and help =).

_Excuse me for opening another pull request, but old one went out of control (i think also a little bug/strange behaviour on git), now made a proper branch so i wont commit on it again_
Old one link: https://github.com/xbmc/xbmc/pull/169
