### PR TITLE
Python set language

### DIFF
--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -978,6 +978,24 @@ namespace PYXBMC
     
     return Py_BuildValue((char*)"ss",strSize.c_str(), strHash.c_str());
   } 
+ 
+  // setLanguage function
+  PyDoc_STRVAR(setLanguage__doc__,
+    "setLanguage(language)\n"
+    "\n"
+    "language       : string or unicode - Language string\n"
+    "\n"
+    "example:\n"
+    "  xbmc.setLanguage('English')");
+
+  PyObject* XBMC_SetLanguage(PyObject *self, PyObject *args)
+  {
+    char *cLine = NULL;
+    if (!PyArg_ParseTuple(args, (char*)"s", &cLine)) return NULL;
+    g_guiSettings.ChangeLanguage(cLine);
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
 
   // define c functions to be used in python here
   PyMethodDef xbmcMethods[] = {
@@ -1026,6 +1044,8 @@ namespace PYXBMC
 
     {(char*)"skinHasImage", (PyCFunction)XBMC_SkinHasImage, METH_VARARGS|METH_KEYWORDS, skinHasImage__doc__},
     {(char*)"subHashAndFileSize", (PyCFunction)XBMC_subHashAndFileSize, METH_VARARGS, subHashAndFileSize__doc__},
+   
+    {(char*)"setLanguage", (PyCFunction)XBMC_SetLanguage, METH_VARARGS, setLanguage__doc__},
 
     {NULL, NULL, 0, NULL}
   };

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -40,6 +40,8 @@
 #include "powermanagement/PowerManager.h"
 #include "cores/dvdplayer/DVDCodecs/Video/CrystalHD.h"
 #include "utils/PCMRemap.h"
+#include "utils/Weather.h"
+#include "LangInfo.h"
 #include "guilib/GUIFont.h" // for FONT_STYLE_* definitions
 #if defined(__APPLE__)
   #include "osx/DarwinUtils.h"
@@ -1257,6 +1259,25 @@ void CGUISettings::Clear()
   for (unsigned int i = 0; i < settingsGroups.size(); i++)
     delete settingsGroups[i];
   settingsGroups.clear();
+}
+
+void CGUISettings::ChangeLanguage(const CStdString &strLanguage)
+{
+  CStdString strLangInfoPath;
+  strLangInfoPath.Format("special://xbmc/language/%s/langinfo.xml", strLanguage.c_str());
+  g_langInfo.Load(strLangInfoPath);
+  
+  SetString("locale.language", strLanguage);
+  
+  g_charsetConverter.reset();
+  
+  CStdString strLanguagePath;
+  strLanguagePath.Format("special://xbmc/language/%s/strings.xml", strLanguage.c_str());
+  g_localizeStrings.Load(strLanguagePath);
+  
+  // also tell our weather and skin to reload as these are localized
+  g_weatherManager.Refresh();
+  g_application.getApplicationMessenger().ExecBuiltIn("ReloadSkin");
 }
 
 float square_error(float x, float y)

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -483,6 +483,7 @@ public:
   ReplayGainSettings m_replayGain;
 
   void Clear();
+  void ChangeLanguage(const CStdString &strLanguage);
 
 private:
   typedef std::map<CStdString, CSetting*>::iterator mapIter;

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -1508,30 +1508,7 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
     CStdString strLanguage = pControl->GetCurrentLabel();
     if (strLanguage != ".svn" && strLanguage != pSettingString->GetData())
     {
-      CStdString strLangInfoPath;
-      strLangInfoPath.Format("special://xbmc/language/%s/langinfo.xml", strLanguage.c_str());
-      g_langInfo.Load(strLangInfoPath);
-
-      if (g_langInfo.ForceUnicodeFont() && !g_fontManager.IsFontSetUnicode())
-      {
-        CLog::Log(LOGINFO, "Language needs a ttf font, loading first ttf font available");
-        CStdString strFontSet;
-        if (g_fontManager.GetFirstFontSetUnicode(strFontSet))
-          strLanguage = strFontSet;
-        else
-          CLog::Log(LOGERROR, "No ttf font found but needed: %s", strFontSet.c_str());
-      }
-      g_guiSettings.SetString("locale.language", strLanguage);
-
-      g_charsetConverter.reset();
-
-      CStdString strLanguagePath;
-      strLanguagePath.Format("special://xbmc/language/%s/strings.xml", strLanguage.c_str());
-      g_localizeStrings.Load(strLanguagePath);
-
-      // also tell our weather and skin to reload as these are localized
-      g_weatherManager.Refresh();
-      g_application.ReloadSkin();
+      g_guiSettings.ChangeLanguage(strLanguage);
     }
   }
   else if (strSetting.Equals("lookandfeel.skintheme"))


### PR DESCRIPTION
added xbmc.setLanguage(<language>) to xbmcmodule.cpp. it allows the xbmc language to be set from python addon.

on JMs advice, I have created CGUISettings::ChangeLanguage so that the code wouldn't be duplicated

 any objections to this? If not I will commit this in a few days
