### PR TITLE
Scraper abstraction

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -223,10 +223,10 @@ int CNfoFile::Load(const CStdString& strFile)
   XFILE::CFile file;
   if (file.Open(strFile))
   {
-    m_size = (int)file.GetLength();
+    int size = (int)file.GetLength();
     try
     {
-      m_doc = new char[m_size+1];
+      m_doc = new char[size+1];
       m_headofdoc = m_doc;
     }
     catch (...)
@@ -239,8 +239,8 @@ int CNfoFile::Load(const CStdString& strFile)
       file.Close();
       return 1;
     }
-    file.Read(m_doc, m_size);
-    m_doc[m_size] = 0;
+    file.Read(m_doc, size);
+    m_doc[size] = 0;
     file.Close();
     return 0;
   }
@@ -257,7 +257,6 @@ void CNfoFile::Close()
 
   m_strImDbUrl = "";
   m_strImDbNr = "";
-  m_size = 0;
 }
 
 void CNfoFile::AddScrapers(VECADDONS& addons,

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -37,24 +37,9 @@
 
 #include <vector>
 
-using namespace XFILE;
 using namespace std;
+using namespace XFILE;
 using namespace ADDON;
-
-//////////////////////////////////////////////////////////////////////
-// Construction/Destruction
-//////////////////////////////////////////////////////////////////////
-
-CNfoFile::CNfoFile()
-{
-  m_doc = NULL;
-  m_headofdoc = NULL;
-}
-
-CNfoFile::~CNfoFile()
-{
-  Close();
-}
 
 CNfoFile::NFOResult CNfoFile::Create(const CStdString& strPath, const ScraperPtr& info, int episode, const CStdString& strPath2)
 {

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -116,90 +116,30 @@ CNfoFile::NFOResult CNfoFile::Create(const CStdString& strPath, const ScraperPtr
   if (res == 2)
     return ERROR_NFO;
   if (bNfo)
-    return (m_strImDbUrl.size() > 0) ? COMBINED_NFO:FULL_NFO;
-
-  return   (m_strImDbUrl.size() > 0) ? URL_NFO : NO_NFO;
+    return m_scurl.m_url.empty() ? FULL_NFO : COMBINED_NFO;
+  return m_scurl.m_url.empty() ? NO_NFO : URL_NFO;
 }
 
-bool CNfoFile::DoScrape(ScraperPtr& scraper)
-{
-  vector<CStdString> extras;
-  extras.push_back(m_doc);
-  
-  CScraperUrl url;
-  CFileCurl http;
-  vector<CStdString> xml;
-  if (scraper->GetParser().HasFunction("NfoUrl"))
-    xml = scraper->Run("NfoUrl",url,http,&extras);
-
-  for (vector<CStdString>::iterator it  = xml.begin();
-                                    it != xml.end(); ++it)
-  {
-    TiXmlDocument doc;
-    doc.Parse(it->c_str());
-
-    if (doc.RootElement())
-    {
-      if (stricmp(doc.RootElement()->Value(),"error")==0)
-      {
-        CVideoInfoDownloader::ShowErrorDialog(doc.RootElement());
-        return false;
-      }
-
-      TiXmlElement* pId = doc.FirstChildElement("id");
-      if (pId && pId->FirstChild())
-        m_strImDbNr = pId->FirstChild()->Value();
-
-      TiXmlElement* url = doc.FirstChildElement("url");
-      if (url)
-      {
-        stringstream str;
-        str << *url;
-        m_strImDbUrl = str.str();
-        SetScraperInfo(scraper);
-      }
-      else if (strcmp(doc.RootElement()->Value(),"url")==0)
-      {
-        SetScraperInfo(scraper);
-        m_strImDbUrl = *it;
-      }
-    }
-  }
-  return true;
-}
-
-int CNfoFile::Scrape(ScraperPtr& scraper, const CStdString& strURL /* = "" */)
+// return value: 0 - success; 1 - no result; skip; 2 - error
+int CNfoFile::Scrape(ScraperPtr& scraper)
 {
   if (scraper->Type() != m_type)
-  {
     return 1;
-  }
-  if (!scraper->Load())
-    return 0;
-
-  // init and clear cache
   scraper->ClearCache();
 
-  vector<CStdString> extras;
-  CScraperUrl url;
-  CFileCurl http;
-  if (strURL.IsEmpty())
+  try
   {
-    if (!DoScrape(scraper))
-      return 2;
-    if (m_strImDbUrl.size() > 0)
-      return 0;
-    else
-      return 1;
+    m_scurl = scraper->NfoUrl(m_doc);
   }
-  else // we check to identify the episodeguide url
+  catch (const CScraperError &sce)
   {
-    extras.push_back(strURL);
-    vector<CStdString> result = scraper->Run("EpisodeGuideUrl",url,http,&extras);
-    if (result.empty() || result[0].IsEmpty())
-      return 1;
-    return 0;
+    CVideoInfoDownloader::ShowErrorDialog(sce);
+    return 2;
   }
+
+  if (!m_scurl.m_url.empty())
+    SetScraperInfo(scraper);
+  return m_scurl.m_url.empty() ? 1 : 0;
 }
 
 int CNfoFile::Load(const CStdString& strFile)
@@ -234,14 +174,9 @@ int CNfoFile::Load(const CStdString& strFile)
 
 void CNfoFile::Close()
 {
-  if (m_doc != NULL)
-  {
-    delete m_doc;
-    m_doc = 0;
-  }
-
-  m_strImDbUrl = "";
-  m_strImDbNr = "";
+  delete m_doc;
+  m_doc = NULL;
+  m_scurl.Clear();
 }
 
 void CNfoFile::AddScrapers(VECADDONS& addons,

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -40,8 +40,9 @@ class CScraperUrl;
 class CNfoFile
 {
 public:
-  CNfoFile();
-  virtual ~CNfoFile();
+  CNfoFile() : m_doc(NULL), m_headofdoc(NULL) {}
+  virtual ~CNfoFile() { Close(); }
+
   enum NFOResult
   {
     NO_NFO       = 0,

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -33,10 +33,6 @@
 #include "addons/Scraper.h"
 #include "utils/CharsetConverter.h"
 
-class CVideoInfoTag;
-class CScraperParser;
-class CScraperUrl;
-
 class CNfoFile
 {
 public:
@@ -71,20 +67,20 @@ public:
     return details.Load(doc.RootElement(),true);
   }
 
-  CStdString m_strImDbUrl;
-  CStdString m_strImDbNr;
   void Close();
   void SetScraperInfo(const ADDON::ScraperPtr& info) { m_info = info; }
   const ADDON::ScraperPtr& GetScraperInfo() const { return m_info; }
-private:
-  int Load(const CStdString&);
-  int Scrape(ADDON::ScraperPtr& scraper, const CStdString& strURL="");
+  const CScraperUrl &ScraperUrl() const { return m_scurl; }
+
 private:
   char* m_doc;
   char* m_headofdoc;
   ADDON::ScraperPtr m_info;
-  ADDON::TYPE       m_type;
-  bool DoScrape(ADDON::ScraperPtr& scraper);
+  ADDON::TYPE m_type;
+  CScraperUrl m_scurl;
+
+  int Load(const CStdString&);
+  int Scrape(ADDON::ScraperPtr& scraper);
   void AddScrapers(ADDON::VECADDONS& addons,
                    std::vector<ADDON::ScraperPtr>& vecScrapers);
 };

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -81,7 +81,6 @@ private:
 private:
   char* m_doc;
   char* m_headofdoc;
-  int m_size;
   ADDON::ScraperPtr m_info;
   ADDON::TYPE       m_type;
   bool DoScrape(ADDON::ScraperPtr& scraper);

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -27,16 +27,22 @@
 #include "utils/ScraperUrl.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
+#include "music/infoscanner/MusicAlbumInfo.h"
+#include "music/infoscanner/MusicArtistInfo.h"
+#include "utils/fstrcmp.h"
 #include "settings/AdvancedSettings.h"
 #include "FileItem.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
 #include "music/MusicDatabase.h"
 #include "video/VideoDatabase.h"
+#include "music/Album.h"
+#include "music/Artist.h"
 #include <sstream>
 
 using namespace std;
 using namespace XFILE;
+using namespace MUSIC_GRABBER;
 
 namespace ADDON
 {
@@ -57,7 +63,7 @@ static const ContentMapping content[] =
    {"tvshows",       CONTENT_TVSHOWS,     20343 },
    {"musicvideos",   CONTENT_MUSICVIDEOS, 20389 }};
 
-const CStdString TranslateContent(const CONTENT_TYPE &type, bool pretty/*=false*/)
+CStdString TranslateContent(const CONTENT_TYPE &type, bool pretty/*=false*/)
 {
   for (unsigned int index=0; index < sizeof(content)/sizeof(content[0]); ++index)
   {
@@ -103,10 +109,19 @@ TYPE ScraperTypeFromContent(const CONTENT_TYPE &content)
   }
 }
 
-class CAddon;
+// if the XML root is <error>, throw CScraperError with enclosed <title>/<message> values
+static void CheckScraperError(const TiXmlElement *pxeRoot)
+{
+  if (!pxeRoot || stricmp(pxeRoot->Value(), "error"))
+    return;
+  CStdString sTitle;
+  CStdString sMessage;
+  XMLUtils::GetString(pxeRoot, "title", sTitle);
+  XMLUtils::GetString(pxeRoot, "message", sMessage);
+  throw CScraperError(sTitle, sMessage);
+}
 
-CScraper::CScraper(const cp_extension_t *ext) :
-  CAddon(ext)
+CScraper::CScraper(const cp_extension_t *ext) : CAddon(ext), m_fLoaded(false)
 {
   if (ext)
   {
@@ -223,6 +238,9 @@ vector<CStdString> CScraper::Run(const CStdString& function,
                                  const vector<CStdString>* extras)
 {
   vector<CStdString> result;
+  if (!Load())
+    return result;
+
   CStdString strXML = InternalRun(function,scrURL,http,extras);
   if (strXML.IsEmpty())
   {
@@ -299,6 +317,9 @@ CStdString CScraper::InternalRun(const CStdString& function,
 
 bool CScraper::Load()
 {
+  if (m_fLoaded)
+    return true;
+
   bool result=m_parser.Load(LibPath());
   if (result)
   {
@@ -316,7 +337,10 @@ bool CScraper::Load()
       }  
       AddonPtr dep;
       if (!CAddonMgr::Get().GetAddon((*itr).first, dep))
-        return false;
+      {
+        result = false;
+        break;
+      }
       TiXmlDocument doc;
       if (dep->Type() == ADDON_SCRAPER_LIBRARY && doc.LoadFile(dep->LibPath()))
         m_parser.AddDocument(&doc);
@@ -324,7 +348,9 @@ bool CScraper::Load()
     }
   }
 
-  return result;
+  if (!result)
+    CLog::Log(LOGWARNING, "failed to load scraper XML");
+  return m_fLoaded = result;
 }
 
 bool CScraper::IsInUse() const
@@ -344,5 +370,510 @@ bool CScraper::IsInUse() const
   return false;
 }
 
-}; /* namespace ADDON */
+// pass in contents of .nfo file; returns URL (possibly empty if none found)
+// and may populate strId, or throws CScraperError on error
+CScraperUrl CScraper::NfoUrl(const CStdString &sNfoContent)
+{
+  CScraperUrl scurlRet;
+
+  // scraper function takes contents of .nfo file, returns XML (see below)
+  vector<CStdString> vcsIn;
+  vcsIn.push_back(sNfoContent);
+  CScraperUrl scurl;
+  CFileCurl fcurl;
+  vector<CStdString> vcsOut = Run("NfoUrl", scurl, fcurl, &vcsIn);
+  if (vcsOut.empty() || vcsOut[0].empty())
+    return scurlRet;
+  if (vcsOut.size() > 1)
+    CLog::Log(LOGWARNING, "%s: scraper returned multiple results; using first", __FUNCTION__);
+
+  // parse returned XML: either <error> element on error, blank on failure,
+  // or <url>...</url> or <TAG><url>...</url><id>...</id></TAG> (for any TAG) on success
+  TiXmlDocument doc;
+  doc.Parse(vcsOut[0], 0, TIXML_ENCODING_UTF8);
+  CheckScraperError(doc.RootElement());
+
+  if (doc.RootElement())
+  {
+    XMLUtils::GetString(doc.RootElement(), "id", scurlRet.strId);
+
+    TiXmlElement* pxeUrl = doc.FirstChildElement("url");
+    if (pxeUrl)
+      scurlRet.ParseElement(pxeUrl);
+    else if (!strcmp(doc.RootElement()->Value(), "url"))
+      scurlRet.ParseElement(doc.RootElement());
+  }
+  return scurlRet;
+}
+
+static bool RelevanceSortFunction(const CScraperUrl &left, const CScraperUrl &right)
+{
+  return left.relevance > right.relevance;
+}
+
+// fetch list of matching movies sorted by relevance (may be empty);
+// throws CScraperError on error; first called with fFirst set, then unset if first try fails
+std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CFileCurl &fcurl, const CStdString &sMovie,
+  bool fFirst)
+{
+  // prepare parameters for URL creation
+  CStdString sTitle, sTitleYear, sYear;
+  CUtil::CleanString(sMovie, sTitle, sTitleYear, sYear, true/*fRemoveExt*/, fFirst);
+
+  CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper "
+    "(path: '%s', content: '%s', version: '%s')", __FUNCTION__, sTitle.c_str(),
+    Name().c_str(), Path().c_str(),
+    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+
+  sTitle.ToLower();
+  if (Content() == CONTENT_MUSICVIDEOS)
+    sTitle.Replace("-"," ");
+
+  vector<CStdString> vcsIn(1);
+  g_charsetConverter.utf8To(SearchStringEncoding(), sTitle, vcsIn[0]);
+  CURL::Encode(vcsIn[0]);
+  if (!sYear.IsEmpty())
+    vcsIn.push_back(sYear);
+
+  // request a search URL from the title/filename/etc.
+  CScraperUrl scurl;
+  vector<CStdString> vcsOut = Run("CreateSearchUrl", scurl, fcurl, &vcsIn);
+  std::vector<CScraperUrl> vcscurl;
+  if (vcsOut.empty())
+  {
+    CLog::Log(LOGDEBUG, "%s: CreateSearchUrl failed", __FUNCTION__);
+    return vcscurl;
+  }
+  CLog::Log(LOGDEBUG, "%s: CreateSearchUrl returned '%s'", __FUNCTION__, vcsOut[0].c_str());
+  scurl.ParseString(vcsOut[0]);
+
+  // do the search, and parse the result into a list
+  vcsIn.clear();
+  vcsIn.push_back(scurl.m_url[0].m_url);
+  vcsOut = Run("GetSearchResults", scurl, fcurl, &vcsIn);
+
+  bool fSort(true);
+  std::set<CStdString> stsDupeCheck;
+  for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
+  {
+    TiXmlDocument doc;
+    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    if (!doc.RootElement())
+    {
+      CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
+      continue;  // might have more valid results later
+    }
+
+    CheckScraperError(doc.RootElement());
+
+    TiXmlHandle xhDoc(&doc);
+    TiXmlHandle xhResults = xhDoc.FirstChild("results");
+    if (!xhResults.Element())
+      continue;
+
+    // we need to sort if returned results don't specify 'sorted="yes"'
+    if (fSort)
+      fSort = CStdString(xhResults.Element()->Attribute("sorted")).CompareNoCase("yes") != 0;
+
+    for (TiXmlElement *pxeMovie = xhResults.FirstChild("entity").Element();
+      pxeMovie; pxeMovie = pxeMovie->NextSiblingElement())
+    {
+      CScraperUrl scurlMovie;
+      TiXmlNode *pxnTitle = pxeMovie->FirstChild("title");
+      TiXmlElement *pxeLink = pxeMovie->FirstChildElement("url");
+      if (pxnTitle && pxnTitle->FirstChild() && pxeLink && pxeLink->FirstChild())
+      {
+        scurlMovie.strTitle = pxnTitle->FirstChild()->Value();
+        XMLUtils::GetString(pxeMovie, "id", scurlMovie.strId);
+
+        for ( ; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
+          scurlMovie.ParseElement(pxeLink);
+
+        // calculate the relavance of this hit
+        CStdString sCompareTitle = scurlMovie.strTitle;
+        sCompareTitle.ToLower();
+        CStdString sMatchTitle = sMovie;
+        sMatchTitle.ToLower();
+
+        /*
+         * Identify the best match by performing a fuzzy string compare on the search term and
+         * the result. Additionally, use the year (if available) to further refine the best match.
+         * An exact match scores 1, a match off by a year scores 0.5 (release dates can vary between
+         * countries), otherwise it scores 0.
+         */
+        CStdString sCompareYear;
+        XMLUtils::GetString(pxeMovie, "year", sCompareYear);
+
+        double yearScore = 0;
+        if (!sTitleYear.empty() && !sCompareYear.empty())
+          yearScore = std::max(0.0, 1-0.5*abs(atoi(sTitleYear)-atoi(sCompareYear)));
+
+        scurlMovie.relevance = fstrcmp(sMatchTitle.c_str(), sCompareTitle.c_str(), 0.0) + yearScore;
+
+        // reconstruct a title for the user
+        if (!sCompareYear.empty())
+          scurlMovie.strTitle.AppendFormat(" (%s)", sCompareYear.c_str());
+
+        CStdString sLanguage;
+        if (XMLUtils::GetString(pxeMovie, "language", sLanguage))
+          scurlMovie.strTitle.AppendFormat(" (%s)", sLanguage.c_str());
+
+        // filter for dupes from naughty scrapers
+        if (stsDupeCheck.insert(scurlMovie.m_url[0].m_url + " " + scurlMovie.strTitle).second)
+          vcscurl.push_back(scurlMovie);
+      }
+    }
+  }
+
+  if (fSort)
+    std::sort(vcscurl.begin(), vcscurl.end(), RelevanceSortFunction);
+
+  return vcscurl;
+}
+
+// find album by artist, using fcurl for web fetches
+// returns a list of albums (empty if no match or failure)
+std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CFileCurl &fcurl, const CStdString &sAlbum,
+  const CStdString &sArtist)
+{
+  CLog::Log(LOGDEBUG, "%s: Searching for '%s - %s' using %s scraper "
+    "(path: '%s', content: '%s', version: '%s')", __FUNCTION__, sArtist.c_str(),
+    sAlbum.c_str(), Name().c_str(), Path().c_str(),
+    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+
+  // scraper function is given the album and artist as parameters and
+  // returns an XML <url> element parseable by CScraperUrl
+  std::vector<CStdString> extras(2);
+  g_charsetConverter.utf8To(SearchStringEncoding(), sAlbum, extras[0]);
+  g_charsetConverter.utf8To(SearchStringEncoding(), sArtist, extras[1]);
+  CURL::Encode(extras[0]);
+  CURL::Encode(extras[1]);
+  CScraperUrl scurl;
+  vector<CStdString> vcsOut = Run("CreateAlbumSearchUrl", scurl, fcurl, &extras);
+  if (vcsOut.size() > 1)
+    CLog::Log(LOGWARNING, "%s: scraper returned multiple results; using first", __FUNCTION__);
+
+  std::vector<CMusicAlbumInfo> vcali;
+  if (vcsOut.empty() || vcsOut[0].empty())
+    return vcali;
+  scurl.ParseString(vcsOut[0]);
+
+  // the next function is passed the contents of the returned URL, and returns
+  // an empty string on failure; on success, returns XML matches in the form:
+  // <results>
+  //  <entity>
+  //   <title>...</title>
+  //   <url>...</url> (with the usual CScraperUrl decorations like post or spoof)
+  //   <artist>...</artist>
+  //   <year>...</year>
+  //   <relevance [scale="..."]>...</relevance> (scale defaults to 1; score is divided by it)
+  //  </entity>
+  //  ...
+  // </results>
+  vcsOut = Run("GetAlbumSearchResults", scurl, fcurl);
+
+  // parse the returned XML into a vector of album objects
+  for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
+  {
+    TiXmlDocument doc;
+    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    TiXmlHandle xhDoc(&doc);
+
+    for (TiXmlElement* pxeAlbum = xhDoc.FirstChild("results").FirstChild("entity").Element();
+      pxeAlbum; pxeAlbum = pxeAlbum->NextSiblingElement())
+    {
+      CStdString sTitle;
+      if (XMLUtils::GetString(pxeAlbum, "title", sTitle))
+      {
+        CStdString sArtist;
+        CStdString sAlbumName;
+        if (XMLUtils::GetString(pxeAlbum, "artist", sArtist))
+          sAlbumName.Format("%s - %s", sArtist.c_str(), sTitle.c_str());
+        else
+          sAlbumName = sTitle;
+
+        CStdString sYear;
+        if (XMLUtils::GetString(pxeAlbum, "year", sYear))
+          sAlbumName.Format("%s (%s)", sAlbumName.c_str(), sYear.c_str());
+
+        // if no URL is provided, use the URL we got back from CreateAlbumSearchUrl
+        // (e.g., in case we only got one result back and were sent to the detail page)
+        TiXmlElement* pxeLink = pxeAlbum->FirstChildElement("url");
+        CScraperUrl scurlAlbum;
+        if (!pxeLink)
+          scurlAlbum.ParseString(scurl.m_xml);
+        for ( ; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
+          scurlAlbum.ParseElement(pxeLink);
+
+        CMusicAlbumInfo ali(sTitle, sArtist, sAlbumName, scurlAlbum);
+
+        TiXmlElement* pxeRel = pxeAlbum->FirstChildElement("relevance");
+        if (pxeRel && pxeRel->FirstChild())
+        {
+          const char* szScale = pxeRel->Attribute("scale");
+          float flScale = szScale ? float(atof(szScale)) : 1;
+          ali.SetRelevance(float(atof(pxeRel->FirstChild()->Value())) / flScale);
+        }
+
+        vcali.push_back(ali);
+      }
+    }
+  }
+  return vcali;
+}
+
+// find artist, using fcurl for web fetches
+// returns a list of artists (empty if no match or failure)
+std::vector<CMusicArtistInfo> CScraper::FindArtist(CFileCurl &fcurl,
+  const CStdString &sArtist)
+{
+  CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper "
+    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__, sArtist.c_str(),
+    Name().c_str(), Path().c_str(),
+    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+
+  // scraper function is given the artist as parameter and
+  // returns an XML <url> element parseable by CScraperUrl
+  std::vector<CStdString> extras(1);
+  g_charsetConverter.utf8To(SearchStringEncoding(), sArtist, extras[0]);
+  CURL::Encode(extras[0]);
+  CScraperUrl scurl;
+  vector<CStdString> vcsOut = Run("CreateArtistSearchUrl", scurl, fcurl, &extras);
+
+  std::vector<CMusicArtistInfo> vcari;
+  if (vcsOut.empty() || vcsOut[0].empty())
+    return vcari;
+  scurl.ParseString(vcsOut[0]);
+
+  // the next function is passed the contents of the returned URL, and returns
+  // an empty string on failure; on success, returns XML matches in the form:
+  // <results>
+  //  <entity>
+  //   <title>...</title>
+  //   <year>...</year>
+  //   <genre>...</genre>
+  //   <url>...</url> (with the usual CScraperUrl decorations like post or spoof)
+  //  </entity>
+  //  ...
+  // </results>
+  vcsOut = Run("GetArtistSearchResults", scurl, fcurl);
+
+  // parse the returned XML into a vector of artist objects
+  for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
+  {
+    TiXmlDocument doc;
+    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    if (!doc.RootElement())
+    {
+      CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
+      return vcari;
+    }
+    TiXmlHandle xhDoc(&doc);
+    for (TiXmlElement* pxeArtist = xhDoc.FirstChild("results").FirstChild("entity").Element();
+      pxeArtist; pxeArtist = pxeArtist->NextSiblingElement())
+    {
+      TiXmlNode* pxnTitle = pxeArtist->FirstChild("title");
+      if (pxnTitle && pxnTitle->FirstChild())
+      {
+        CScraperUrl scurlArtist;
+
+        TiXmlElement* pxeLink = pxeArtist->FirstChildElement("url");
+        if (!pxeLink)
+          scurlArtist.ParseString(scurl.m_xml);
+        for ( ; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
+          scurlArtist.ParseElement(pxeLink);
+
+        CMusicArtistInfo ari(pxnTitle->FirstChild()->Value(), scurlArtist);
+        XMLUtils::GetString(pxeArtist, "genre", ari.GetArtist().strGenre);
+        XMLUtils::GetString(pxeArtist, "year", ari.GetArtist().strBorn);
+
+        vcari.push_back(ari);
+      }
+    }
+  }
+  return vcari;
+}
+
+// fetch list of episodes from URL (from video database)
+EPISODELIST CScraper::GetEpisodeList(XFILE::CFileCurl &fcurl, const CScraperUrl &scurl)
+{
+  CLog::Log(LOGDEBUG, "%s: Searching '%s' using %s scraper "
+    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
+    scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
+    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+
+  EPISODELIST vcep;
+  if (scurl.m_url.empty())
+    return vcep;
+
+  vector<CStdString> vcsIn;
+  vcsIn.push_back(scurl.m_url[0].m_url);
+  vector<CStdString> vcsOut = Run("GetEpisodeList", scurl, fcurl, &vcsIn);
+
+  // parse the XML response
+  for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
+  {
+    TiXmlDocument doc;
+    doc.Parse(*i);
+    if (!doc.RootElement())
+    {
+      CLog::Log(LOGERROR, "%s: Unable to parse XML",__FUNCTION__);
+      continue;
+    }
+
+    TiXmlHandle xhDoc(&doc);
+    for (TiXmlElement *pxeMovie = xhDoc.FirstChild("episodeguide").FirstChild("episode").
+      Element(); pxeMovie; pxeMovie = pxeMovie->NextSiblingElement())
+    {
+      EPISODE ep;
+      TiXmlElement *pxeLink = pxeMovie->FirstChildElement("url");
+      if (pxeLink && XMLUtils::GetInt(pxeMovie, "season", ep.key.first) &&
+        XMLUtils::GetInt(pxeMovie, "epnum", ep.key.second))
+      {
+        CScraperUrl &scurlEp(ep.cScraperUrl);
+        if (!XMLUtils::GetString(pxeMovie, "title", scurlEp.strTitle))
+            scurlEp.strTitle = g_localizeStrings.Get(416);
+        XMLUtils::GetString(pxeMovie, "id", scurlEp.strId);
+
+        for ( ; pxeLink && pxeLink->FirstChild(); pxeLink = pxeLink->NextSiblingElement("url"))
+          scurlEp.ParseElement(pxeLink);
+
+        // date must be the format of yyyy-mm-dd
+        ep.cDate.SetValid(FALSE);
+        CStdString sDate;
+        if (XMLUtils::GetString(pxeMovie, "aired", sDate) && sDate.length() == 10)
+        {
+          tm tm;
+          if (strptime(sDate, "%Y-%m-%d", &tm))
+            ep.cDate.SetDate(tm.tm_year, tm.tm_mon + 1, tm.tm_mday);
+        }
+        vcep.push_back(ep);
+      }
+    }
+  }
+
+  // find minimum in each season
+  map<int, int> mpMin;
+  for (EPISODELIST::const_iterator i = vcep.begin(); i != vcep.end(); ++i)
+  {
+    map<int, int>::iterator iMin = mpMin.find(i->key.first);
+    if (iMin == mpMin.end())
+      mpMin.insert(i->key);
+    else if (i->key.second < iMin->second)
+      iMin->second = i->key.second;
+  }
+
+  // correct episode numbers
+  for (EPISODELIST::iterator i = vcep.begin(); i != vcep.end(); ++i)
+  {
+    i->key.second -= mpMin[i->key.first];
+    if (mpMin[i->key.first] > 0)
+      ++i->key.second;
+  }
+
+  return vcep;
+}
+
+// takes URL; returns true and populates video details on success, false otherwise
+bool CScraper::GetVideoDetails(XFILE::CFileCurl &fcurl, const CScraperUrl &scurl,
+  bool fMovie/*else episode*/, CVideoInfoTag &video)
+{
+  CLog::Log(LOGDEBUG, "%s: Reading %s '%s' using %s scraper "
+    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
+    fMovie ? "movie" : "episode", scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
+    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+
+  video.Reset();
+  CStdString sFunc = fMovie ? "GetDetails" : "GetEpisodeDetails";
+  vector<CStdString> vcsIn;
+  vcsIn.push_back(scurl.strId);
+  vcsIn.push_back(scurl.m_url[0].m_url);
+  vector<CStdString> vcsOut = Run(sFunc, scurl, fcurl, &vcsIn);
+
+  // parse XML output
+  bool fRet(false);
+  for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
+  {
+    TiXmlDocument doc;
+    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    if (!doc.RootElement())
+    {
+      CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
+      continue;
+    }
+
+    TiXmlHandle xhDoc(&doc);
+    TiXmlElement *pxeDetails = xhDoc.FirstChild("details").Element();
+    if (!pxeDetails)
+    {
+      CLog::Log(LOGERROR, "%s: Invalid XML file (want <details>)", __FUNCTION__);
+      continue;
+    }
+    video.Load(pxeDetails, true/*fChain*/);
+    fRet = true;  // but don't exit in case of chaining
+  }
+  return fRet;
+}
+
+// takes a URL; returns true and populates album on success, false otherwise
+bool CScraper::GetAlbumDetails(CFileCurl &fcurl, const CScraperUrl &scurl, CAlbum &album)
+{
+  CLog::Log(LOGDEBUG, "%s: Reading '%s' using %s scraper "
+    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
+    scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
+    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+
+  vector<CStdString> vcsOut = Run("GetAlbumDetails", scurl, fcurl);
+
+  // parse the returned XML into an album object (see CAlbum::Load for details)
+  bool fRet(false);
+  for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
+  {
+    TiXmlDocument doc;
+    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    if (!doc.RootElement())
+    {
+      CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
+      return false;
+    }
+    fRet = album.Load(doc.RootElement(), i != vcsOut.begin());
+  }
+  return fRet;
+}
+
+// takes a URL (one returned from FindArtist), the original search string, and
+// returns true and populates artist on success, false on failure
+bool CScraper::GetArtistDetails(CFileCurl &fcurl, const CScraperUrl &scurl,
+  const CStdString &sSearch, CArtist &artist)
+{
+  CLog::Log(LOGDEBUG, "%s: Reading '%s' ('%s') using %s scraper "
+    "(file: '%s', content: '%s', version: '%s')", __FUNCTION__,
+    scurl.m_url[0].m_url.c_str(), sSearch.c_str(), Name().c_str(), Path().c_str(),
+    ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+
+  // pass in the original search string for chaining to search other sites
+  vector<CStdString> vcIn;
+  vcIn.push_back(sSearch);
+  CURL::Encode(vcIn[0]);
+
+  vector<CStdString> vcsOut = Run("GetArtistDetails", scurl, fcurl, &vcIn);
+
+  // ok, now parse the xml file
+  bool fRet(false);
+  for (vector<CStdString>::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
+  {
+    TiXmlDocument doc;
+    doc.Parse(*i, 0, TIXML_ENCODING_UTF8);
+    if (!doc.RootElement())
+    {
+      CLog::Log(LOGERROR, "%s: Unable to parse XML", __FUNCTION__);
+      return false;
+    }
+
+    fRet = artist.Load(doc.RootElement(), i != vcsOut.begin());
+  }
+  return fRet;
+}
+
+}
 

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -42,75 +42,75 @@ class CScraperUrl;
 
 namespace ADDON
 {
-  class CScraper;
-  typedef boost::shared_ptr<CScraper> ScraperPtr;
+class CScraper;
+typedef boost::shared_ptr<CScraper> ScraperPtr;
 
-  const CStdString   TranslateContent(const CONTENT_TYPE &content, bool pretty=false);
-        CONTENT_TYPE TranslateContent(const CStdString &string);
-        TYPE         ScraperTypeFromContent(const CONTENT_TYPE &content);
+const CStdString TranslateContent(const CONTENT_TYPE &content, bool pretty=false);
+CONTENT_TYPE TranslateContent(const CStdString &string);
+TYPE ScraperTypeFromContent(const CONTENT_TYPE &content);
 
-  class CScraper : public CAddon
-  {
-  public:
-    CScraper(const AddonProps &props) : CAddon(props) { }
-    CScraper(const cp_extension_t *ext);
-    virtual ~CScraper() {}
-    virtual AddonPtr Clone(const AddonPtr &self) const;
+class CScraper : public CAddon
+{
+public:
+  CScraper(const AddonProps &props) : CAddon(props) { }
+  CScraper(const cp_extension_t *ext);
+  virtual ~CScraper() {}
+  virtual AddonPtr Clone(const AddonPtr &self) const;
 
-    /*! \brief Set the scraper settings for a particular path from an XML string
-     Loads the default and user settings (if not already loaded) and, if the given XML string is non-empty,
-     overrides the user settings with the XML.
-     \param content Content type of the path
-     \param xml string of XML with the settings.  If non-empty this overrides any saved user settings.
-     \return true if settings are available, false otherwise
-     \sa GetPathSettings
-     */
-    bool SetPathSettings(CONTENT_TYPE content, const CStdString& xml);
+  /*! \brief Set the scraper settings for a particular path from an XML string
+   Loads the default and user settings (if not already loaded) and, if the given XML string is non-empty,
+   overrides the user settings with the XML.
+   \param content Content type of the path
+   \param xml string of XML with the settings.  If non-empty this overrides any saved user settings.
+   \return true if settings are available, false otherwise
+   \sa GetPathSettings
+   */
+  bool SetPathSettings(CONTENT_TYPE content, const CStdString& xml);
 
-    /*! \brief Get the scraper settings for a particular path in the form of an XML string
-     Loads the default and user settings (if not already loaded) and returns the user settings in the
-     form or an XML string
-     \return a string containing the XML settings
-     \sa SetPathSettings
-     */
-    CStdString GetPathSettings();
+  /*! \brief Get the scraper settings for a particular path in the form of an XML string
+   Loads the default and user settings (if not already loaded) and returns the user settings in the
+   form or an XML string
+   \return a string containing the XML settings
+   \sa SetPathSettings
+   */
+  CStdString GetPathSettings();
 
-    /*! \brief Clear any previously cached results for this scraper
-     Any previously cached files are cleared if they have been cached for longer than the specified
-     cachepersistence.
-     */
-    void ClearCache();
-    bool Load();
+  /*! \brief Clear any previously cached results for this scraper
+   Any previously cached files are cleared if they have been cached for longer than the specified
+   cachepersistence.
+   */
+  void ClearCache();
+  bool Load();
 
-    CONTENT_TYPE Content() const { return m_pathContent; }
-    const CStdString& Framework() const { return m_framework; }
-    const CStdString& Language() const { return m_language; }
-    bool RequiresSettings() const { return m_requiressettings; }
-    bool Supports(const CONTENT_TYPE &content) const;
+  CONTENT_TYPE Content() const { return m_pathContent; }
+  const CStdString& Framework() const { return m_framework; }
+  const CStdString& Language() const { return m_language; }
+  bool RequiresSettings() const { return m_requiressettings; }
+  bool Supports(const CONTENT_TYPE &content) const;
 
-    std::vector<CStdString> Run(const CStdString& function,
-                                const CScraperUrl& url,
-                                XFILE::CFileCurl& http,
-                                const std::vector<CStdString>* extras=NULL);
-    CScraperParser& GetParser() { return m_parser; }
+  std::vector<CStdString> Run(const CStdString& function,
+                              const CScraperUrl& url,
+                              XFILE::CFileCurl& http,
+                              const std::vector<CStdString>* extras=NULL);
+  CScraperParser& GetParser() { return m_parser; }
 
-    bool IsInUse() const;
+  bool IsInUse() const;
 
-  private:
-    CScraper(const CScraper&, const AddonPtr&);
+private:
+  CScraper(const CScraper&, const AddonPtr&);
 
-    CStdString InternalRun(const CStdString& function,
-                           const CScraperUrl& url,
-                           XFILE::CFileCurl& http,
-                           const std::vector<CStdString>* extras);
+  CStdString InternalRun(const CStdString& function,
+                         const CScraperUrl& url,
+                         XFILE::CFileCurl& http,
+                         const std::vector<CStdString>* extras);
 
-    CStdString m_framework;
-    CStdString m_language;
-    bool m_requiressettings;
-    CDateTimeSpan m_persistence;
-    CONTENT_TYPE m_pathContent;
-    CScraperParser m_parser;
-  };
+  CStdString m_framework;
+  CStdString m_language;
+  bool m_requiressettings;
+  CDateTimeSpan m_persistence;
+  CONTENT_TYPE m_pathContent;
+  CScraperParser m_parser;
+};
 
-}; /* namespace ADDON */
+}
 

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -21,7 +21,19 @@
  */
 #include "addons/Addon.h"
 #include "XBDateTime.h"
+#include "utils/ScraperUrl.h"
 #include "utils/ScraperParser.h"
+#include "video/Episode.h"
+
+class CAlbum;
+class CArtist;
+class CVideoInfoTag;
+
+namespace MUSIC_GRABBER
+{
+class CMusicAlbumInfo;
+class CMusicArtistInfo;
+}
 
 typedef enum
 {
@@ -45,14 +57,29 @@ namespace ADDON
 class CScraper;
 typedef boost::shared_ptr<CScraper> ScraperPtr;
 
-const CStdString TranslateContent(const CONTENT_TYPE &content, bool pretty=false);
+CStdString TranslateContent(const CONTENT_TYPE &content, bool pretty=false);
 CONTENT_TYPE TranslateContent(const CStdString &string);
 TYPE ScraperTypeFromContent(const CONTENT_TYPE &content);
+
+// thrown as exception to show error dialog
+class CScraperError
+{
+public:
+  CScraperError(const CStdString &sTitle, const CStdString &sMessage) :
+    m_sTitle(sTitle), m_sMessage(sMessage) {}
+
+  const CStdString &Title() const { return m_sTitle; }
+  const CStdString &Message() const { return m_sMessage; }
+
+private:
+  CStdString m_sTitle;
+  CStdString m_sMessage;
+};
 
 class CScraper : public CAddon
 {
 public:
-  CScraper(const AddonProps &props) : CAddon(props) { }
+  CScraper(const AddonProps &props) : CAddon(props), m_fLoaded(false) {}
   CScraper(const cp_extension_t *ext);
   virtual ~CScraper() {}
   virtual AddonPtr Clone(const AddonPtr &self) const;
@@ -80,31 +107,48 @@ public:
    cachepersistence.
    */
   void ClearCache();
-  bool Load();
 
   CONTENT_TYPE Content() const { return m_pathContent; }
-  const CStdString& Framework() const { return m_framework; }
   const CStdString& Language() const { return m_language; }
   bool RequiresSettings() const { return m_requiressettings; }
   bool Supports(const CONTENT_TYPE &content) const;
 
-  std::vector<CStdString> Run(const CStdString& function,
-                              const CScraperUrl& url,
-                              XFILE::CFileCurl& http,
-                              const std::vector<CStdString>* extras=NULL);
-  CScraperParser& GetParser() { return m_parser; }
-
   bool IsInUse() const;
+
+  // scraper media functions
+  CScraperUrl NfoUrl(const CStdString &sNfoContent);
+
+  std::vector<CScraperUrl> FindMovie(XFILE::CFileCurl &fcurl,
+    const CStdString &sMovie, bool fFirst);
+  std::vector<MUSIC_GRABBER::CMusicAlbumInfo> FindAlbum(XFILE::CFileCurl &fcurl,
+    const CStdString &sAlbum, const CStdString &sArtist = "");
+  std::vector<MUSIC_GRABBER::CMusicArtistInfo> FindArtist(
+    XFILE::CFileCurl &fcurl, const CStdString &sArtist);
+  EPISODELIST GetEpisodeList(XFILE::CFileCurl &fcurl, const CScraperUrl &scurl);
+
+  bool GetVideoDetails(XFILE::CFileCurl &fcurl, const CScraperUrl &scurl,
+    bool fMovie/*else episode*/, CVideoInfoTag &video);
+  bool GetAlbumDetails(XFILE::CFileCurl &fcurl, const CScraperUrl &scurl,
+    CAlbum &album);
+  bool GetArtistDetails(XFILE::CFileCurl &fcurl, const CScraperUrl &scurl,
+    const CStdString &sSearch, CArtist &artist);
 
 private:
   CScraper(const CScraper&, const AddonPtr&);
+  CStdString SearchStringEncoding() const
+    { return m_parser.GetSearchStringEncoding(); }
 
+  bool Load();
+  std::vector<CStdString> Run(const CStdString& function,
+                              const CScraperUrl& url,
+                              XFILE::CFileCurl& http,
+                              const std::vector<CStdString>* extras = NULL);
   CStdString InternalRun(const CStdString& function,
                          const CScraperUrl& url,
                          XFILE::CFileCurl& http,
                          const std::vector<CStdString>* extras);
 
-  CStdString m_framework;
+  bool m_fLoaded;
   CStdString m_language;
   bool m_requiressettings;
   CDateTimeSpan m_persistence;

--- a/xbmc/music/infoscanner/MusicAlbumInfo.cpp
+++ b/xbmc/music/infoscanner/MusicAlbumInfo.cpp
@@ -34,7 +34,8 @@ CMusicAlbumInfo::CMusicAlbumInfo(const CStdString& strAlbumInfo, const CScraperU
   m_bLoaded = false;
 }
 
-CMusicAlbumInfo::CMusicAlbumInfo(const CStdString& strAlbum, const CStdString& strArtist, const CStdString& strAlbumInfo, const CScraperUrl& strAlbumURL)
+CMusicAlbumInfo::CMusicAlbumInfo(const CStdString& strAlbum, const CStdString& strArtist,
+  const CStdString& strAlbumInfo, const CScraperUrl& strAlbumURL)
 {
   m_album.strAlbum = strAlbum;
   m_album.strArtist = strArtist;
@@ -52,44 +53,12 @@ void CMusicAlbumInfo::SetAlbum(CAlbum& album)
   m_bLoaded = true;
 }
 
-bool CMusicAlbumInfo::Parse(const TiXmlElement* album, bool bChained)
+bool CMusicAlbumInfo::Load(XFILE::CFileCurl& http, const ADDON::ScraperPtr& scraper)
 {
-  if (!m_album.Load(album,bChained))
-    return false;
-
-  if (m_strTitle2.IsEmpty())
+  bool fSuccess = scraper->GetAlbumDetails(http, m_albumURL, m_album);
+  if (fSuccess && m_strTitle2.empty())
     m_strTitle2 = m_album.strAlbum;
-
-  SetLoaded();
-
-  return true;
-}
-
-bool CMusicAlbumInfo::Load(XFILE::CFileCurl& http,
-                           const ADDON::ScraperPtr& scraper)
-{
-  // load our scraper xml
-  if (!scraper->Load())
-    return false;
-
-  vector<CStdString> xml = scraper->Run("GetAlbumDetails",GetAlbumURL(),http);
-
-  bool ret=true;
-  for (vector<CStdString>::iterator it  = xml.begin();
-                                    it != xml.end(); ++it)
-  {
-    // ok, now parse the xml file
-    TiXmlDocument doc;
-    doc.Parse(it->c_str(),0,TIXML_ENCODING_UTF8);
-    if (!doc.RootElement())
-    {
-      CLog::Log(LOGERROR, "%s: Unable to parse xml",__FUNCTION__);
-      return false;
-    }
-
-    ret = Parse(doc.RootElement(),it!=xml.begin());
-  }
-
-  return ret;
+  SetLoaded(fSuccess);
+  return fSuccess;
 }
 

--- a/xbmc/music/infoscanner/MusicAlbumInfo.cpp
+++ b/xbmc/music/infoscanner/MusicAlbumInfo.cpp
@@ -23,19 +23,8 @@
 #include "addons/Scraper.h"
 #include "utils/log.h"
 
-using namespace MUSIC_GRABBER;
 using namespace std;
-
-CMusicAlbumInfo::CMusicAlbumInfo(void)
-{
-  m_strTitle2 = "";
-  m_bLoaded = false;
-  m_relevance = -1;
-}
-
-CMusicAlbumInfo::~CMusicAlbumInfo(void)
-{
-}
+using namespace MUSIC_GRABBER;
 
 CMusicAlbumInfo::CMusicAlbumInfo(const CStdString& strAlbumInfo, const CScraperUrl& strAlbumURL)
 {
@@ -55,52 +44,12 @@ CMusicAlbumInfo::CMusicAlbumInfo(const CStdString& strAlbum, const CStdString& s
   m_bLoaded = false;
 }
 
-const CAlbum& CMusicAlbumInfo::GetAlbum() const
-{
-  return m_album;
-}
-
-CAlbum& CMusicAlbumInfo::GetAlbum()
-{
-  return m_album;
-}
-
 void CMusicAlbumInfo::SetAlbum(CAlbum& album)
 {
   m_album = album;
   m_album.m_strDateOfRelease.Format("%i", album.iYear);
   m_strTitle2 = "";
   m_bLoaded = true;
-}
-
-const VECSONGS &CMusicAlbumInfo::GetSongs() const
-{
-  return m_album.songs;
-}
-
-void CMusicAlbumInfo::SetSongs(VECSONGS &songs)
-{
-  m_album.songs = songs;
-}
-
-void CMusicAlbumInfo::SetTitle(const CStdString& strTitle)
-{
-  m_album.strAlbum = strTitle;
-}
-
-const CScraperUrl& CMusicAlbumInfo::GetAlbumURL() const
-{
-  return m_albumURL;
-}
-
-const CStdString& CMusicAlbumInfo::GetTitle2() const
-{
-  return m_strTitle2;
-}
-
-const CStdString& CMusicAlbumInfo::GetDateOfRelease() const
-{
-  return m_album.m_strDateOfRelease;
 }
 
 bool CMusicAlbumInfo::Parse(const TiXmlElement* album, bool bChained)
@@ -111,11 +60,10 @@ bool CMusicAlbumInfo::Parse(const TiXmlElement* album, bool bChained)
   if (m_strTitle2.IsEmpty())
     m_strTitle2 = m_album.strAlbum;
 
-  SetLoaded(true);
+  SetLoaded();
 
   return true;
 }
-
 
 bool CMusicAlbumInfo::Load(XFILE::CFileCurl& http,
                            const ADDON::ScraperPtr& scraper)
@@ -145,12 +93,3 @@ bool CMusicAlbumInfo::Load(XFILE::CFileCurl& http,
   return ret;
 }
 
-void CMusicAlbumInfo::SetLoaded(bool bOnOff)
-{
-  m_bLoaded = bOnOff;
-}
-
-bool CMusicAlbumInfo::Loaded() const
-{
-  return m_bLoaded;
-}

--- a/xbmc/music/infoscanner/MusicAlbumInfo.h
+++ b/xbmc/music/infoscanner/MusicAlbumInfo.h
@@ -35,30 +35,32 @@ namespace MUSIC_GRABBER
 class CMusicAlbumInfo
 {
 public:
-  CMusicAlbumInfo(void);
+  CMusicAlbumInfo() : m_bLoaded(false), m_relevance(-1) {}
   CMusicAlbumInfo(const CStdString& strAlbumInfo, const CScraperUrl& strAlbumURL);
   CMusicAlbumInfo(const CStdString& strAlbum, const CStdString& strArtist, const CStdString& strAlbumInfo, const CScraperUrl& strAlbumURL);
-  virtual ~CMusicAlbumInfo(void);
-  bool Loaded() const;
-  void SetLoaded(bool bOnOff);
+  virtual ~CMusicAlbumInfo() {}
+
+  bool Loaded() const { return m_bLoaded; }
+  void SetLoaded() { m_bLoaded = true; }
+  const CAlbum &GetAlbum() const { return m_album; }
+  CAlbum& GetAlbum() { return m_album; }
   void SetAlbum(CAlbum& album);
-  const CAlbum &GetAlbum() const;
-  CAlbum& GetAlbum();
-  void SetSongs(VECSONGS &songs);
-  const VECSONGS &GetSongs() const;
-  const CStdString& GetTitle2() const;
-  const CStdString& GetDateOfRelease() const;
-  const CScraperUrl& GetAlbumURL() const;
+  const VECSONGS &GetSongs() const { return m_album.songs; }
+  const CStdString& GetTitle2() const { return m_strTitle2; }
+  void SetTitle(const CStdString& strTitle) { m_album.strAlbum = strTitle; }
+  const CScraperUrl& GetAlbumURL() const { return m_albumURL; }
   float GetRelevance() const { return m_relevance; }
-  void SetTitle(const CStdString& strTitle);
   void SetRelevance(float relevance) { m_relevance = relevance; }
+
   bool Load(XFILE::CFileCurl& http, const ADDON::ScraperPtr& scraper);
   bool Parse(const TiXmlElement* album, bool bChained=false);
+
 protected:
+  bool m_bLoaded;
   CAlbum m_album;
   float m_relevance;
   CStdString m_strTitle2;
   CScraperUrl m_albumURL;
-  bool m_bLoaded;
 };
+
 }

--- a/xbmc/music/infoscanner/MusicAlbumInfo.h
+++ b/xbmc/music/infoscanner/MusicAlbumInfo.h
@@ -41,7 +41,7 @@ public:
   virtual ~CMusicAlbumInfo() {}
 
   bool Loaded() const { return m_bLoaded; }
-  void SetLoaded() { m_bLoaded = true; }
+  void SetLoaded(bool bLoaded) { m_bLoaded = bLoaded; }
   const CAlbum &GetAlbum() const { return m_album; }
   CAlbum& GetAlbum() { return m_album; }
   void SetAlbum(CAlbum& album);
@@ -53,7 +53,6 @@ public:
   void SetRelevance(float relevance) { m_relevance = relevance; }
 
   bool Load(XFILE::CFileCurl& http, const ADDON::ScraperPtr& scraper);
-  bool Parse(const TiXmlElement* album, bool bChained=false);
 
 protected:
   bool m_bLoaded;

--- a/xbmc/music/infoscanner/MusicArtistInfo.cpp
+++ b/xbmc/music/infoscanner/MusicArtistInfo.cpp
@@ -40,43 +40,9 @@ void CMusicArtistInfo::SetArtist(const CArtist& artist)
   m_bLoaded = true;
 }
 
-bool CMusicArtistInfo::Parse(const TiXmlElement* artist, bool bChained)
+bool CMusicArtistInfo::Load(CFileCurl& http, const ADDON::ScraperPtr& scraper,
+  const CStdString &strSearch)
 {
-  if (!m_artist.Load(artist,bChained))
-    return false;
-
-  SetLoaded();
-
-  return true;
-}
-
-bool CMusicArtistInfo::Load(CFileCurl& http, const ADDON::ScraperPtr& scraper)
-{
-  // load our scraper xml
-  if (!scraper->Load())
-    return false;
-
-  vector<CStdString> extras;
-  extras.push_back(m_strSearch);
-
-  vector<CStdString> xml = scraper->Run("GetArtistDetails",GetArtistURL(),http,&extras);
-
-  bool ret=true;
-  for (vector<CStdString>::iterator it  = xml.begin();
-                                    it != xml.end(); ++it)
-  {
-    // ok, now parse the xml file
-    TiXmlDocument doc;
-    doc.Parse(it->c_str(),0,TIXML_ENCODING_UTF8);
-    if (!doc.RootElement())
-    {
-      CLog::Log(LOGERROR, "%s: Unable to parse xml",__FUNCTION__);
-      return false;
-    }
-
-    ret = Parse(doc.RootElement(),it!=xml.begin());
-  }
-
-  return ret;
+  return m_bLoaded = scraper->GetArtistDetails(http, m_artistURL, strSearch, m_artist);
 }
 

--- a/xbmc/music/infoscanner/MusicArtistInfo.cpp
+++ b/xbmc/music/infoscanner/MusicArtistInfo.cpp
@@ -23,18 +23,9 @@
 #include "addons/Scraper.h"
 #include "utils/log.h"
 
-using namespace MUSIC_GRABBER;
-using namespace XFILE;
 using namespace std;
-
-CMusicArtistInfo::CMusicArtistInfo(void)
-{
-  m_bLoaded = false;
-}
-
-CMusicArtistInfo::~CMusicArtistInfo(void)
-{
-}
+using namespace XFILE;
+using namespace MUSIC_GRABBER;
 
 CMusicArtistInfo::CMusicArtistInfo(const CStdString& strArtist, const CScraperUrl& strArtistURL)
 {
@@ -43,25 +34,10 @@ CMusicArtistInfo::CMusicArtistInfo(const CStdString& strArtist, const CScraperUr
   m_bLoaded = false;
 }
 
-const CArtist& CMusicArtistInfo::GetArtist() const
-{
-  return m_artist;
-}
-
-CArtist& CMusicArtistInfo::GetArtist()
-{
-  return m_artist;
-}
-
 void CMusicArtistInfo::SetArtist(const CArtist& artist)
 {
   m_artist = artist;
   m_bLoaded = true;
-}
-
-const CScraperUrl& CMusicArtistInfo::GetArtistURL() const
-{
-  return m_artistURL;
 }
 
 bool CMusicArtistInfo::Parse(const TiXmlElement* artist, bool bChained)
@@ -69,7 +45,7 @@ bool CMusicArtistInfo::Parse(const TiXmlElement* artist, bool bChained)
   if (!m_artist.Load(artist,bChained))
     return false;
 
-  SetLoaded(true);
+  SetLoaded();
 
   return true;
 }
@@ -104,12 +80,3 @@ bool CMusicArtistInfo::Load(CFileCurl& http, const ADDON::ScraperPtr& scraper)
   return ret;
 }
 
-void CMusicArtistInfo::SetLoaded(bool bOnOff)
-{
-  m_bLoaded = bOnOff;
-}
-
-bool CMusicArtistInfo::Loaded() const
-{
-  return m_bLoaded;
-}

--- a/xbmc/music/infoscanner/MusicArtistInfo.h
+++ b/xbmc/music/infoscanner/MusicArtistInfo.h
@@ -34,15 +34,15 @@ namespace MUSIC_GRABBER
 class CMusicArtistInfo
 {
 public:
-  CMusicArtistInfo(void);
+  CMusicArtistInfo() : m_bLoaded(false) {}
   CMusicArtistInfo(const CStdString& strArtist, const CScraperUrl& strArtistURL);
-  virtual ~CMusicArtistInfo(void);
-  bool Loaded() const;
-  void SetLoaded(bool bOnOff);
+  virtual ~CMusicArtistInfo() {}
+  bool Loaded() const { return m_bLoaded; }
+  void SetLoaded() { m_bLoaded = true; }
   void SetArtist(const CArtist& artist);
-  const CArtist& GetArtist() const;
-  CArtist& GetArtist();
-  const CScraperUrl& GetArtistURL() const;
+  const CArtist& GetArtist() const { return m_artist; }
+  CArtist& GetArtist() { return m_artist; }
+  const CScraperUrl& GetArtistURL() const { return m_artistURL; }
   bool Load(XFILE::CFileCurl& http, const ADDON::ScraperPtr& scraper);
   bool Parse(const TiXmlElement* artist, bool bChained=false);
   CStdString m_strSearch;

--- a/xbmc/music/infoscanner/MusicArtistInfo.h
+++ b/xbmc/music/infoscanner/MusicArtistInfo.h
@@ -49,7 +49,6 @@ public:
 protected:
   CArtist m_artist;
   CScraperUrl m_artistURL;
-  CScraperParser m_parser;
   bool m_bLoaded;
 };
 }

--- a/xbmc/music/infoscanner/MusicArtistInfo.h
+++ b/xbmc/music/infoscanner/MusicArtistInfo.h
@@ -43,9 +43,9 @@ public:
   const CArtist& GetArtist() const { return m_artist; }
   CArtist& GetArtist() { return m_artist; }
   const CScraperUrl& GetArtistURL() const { return m_artistURL; }
-  bool Load(XFILE::CFileCurl& http, const ADDON::ScraperPtr& scraper);
-  bool Parse(const TiXmlElement* artist, bool bChained=false);
-  CStdString m_strSearch;
+  bool Load(XFILE::CFileCurl& http, const ADDON::ScraperPtr& scraper,
+    const CStdString &strSearch);
+
 protected:
   CArtist m_artist;
   CScraperUrl m_artistURL;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -846,7 +846,7 @@ bool CMusicInfoScanner::DownloadAlbumInfo(const CStdString& strPath, const CStdS
     }
     else if (result == CNfoFile::URL_NFO || result == CNfoFile::COMBINED_NFO)
     {
-      CScraperUrl scrUrl(nfoReader.m_strImDbUrl);
+      CScraperUrl scrUrl(nfoReader.ScraperUrl());
       CMusicAlbumInfo album("nfo",scrUrl);
       info = nfoReader.GetScraperInfo();
       CLog::Log(LOGDEBUG,"-- nfo-scraper: %s",info->Name().c_str());
@@ -1075,7 +1075,7 @@ bool CMusicInfoScanner::DownloadArtistInfo(const CStdString& strPath, const CStd
     }
     else if (result == CNfoFile::URL_NFO || result == CNfoFile::COMBINED_NFO)
     {
-      CScraperUrl scrUrl(nfoReader.m_strImDbUrl);
+      CScraperUrl scrUrl(nfoReader.ScraperUrl());
       CMusicArtistInfo artist("nfo",scrUrl);
       info = nfoReader.GetScraperInfo();
       CLog::Log(LOGDEBUG,"-- nfo-scraper: %s",info->Name().c_str());
@@ -1162,10 +1162,7 @@ bool CMusicInfoScanner::DownloadArtistInfo(const CStdString& strPath, const CStd
     }
   }
 
-  scraper.GetArtist(iSelectedArtist).m_strSearch = strArtist;
-  CURL::Encode(scraper.GetArtist(iSelectedArtist).m_strSearch);
-  scraper.LoadArtistInfo(iSelectedArtist);
-
+  scraper.LoadArtistInfo(iSelectedArtist, strArtist);
   while (!scraper.Completed())
   {
     if (m_bStop)

--- a/xbmc/music/infoscanner/MusicInfoScraper.h
+++ b/xbmc/music/infoscanner/MusicInfoScraper.h
@@ -37,7 +37,7 @@ public:
   void FindAlbumInfo(const CStdString& strAlbum, const CStdString& strArtist = "");
   void LoadAlbumInfo(int iAlbum);
   void FindArtistInfo(const CStdString& strArtist);
-  void LoadArtistInfo(int iArtist);
+  void LoadArtistInfo(int iArtist, const CStdString &strSearch);
   bool Completed();
   bool Succeeded();
   void Cancel();
@@ -77,6 +77,7 @@ protected:
   std::vector<CMusicArtistInfo> m_vecArtists;
   CStdString m_strAlbum;
   CStdString m_strArtist;
+  CStdString m_strSearch;
   int m_iAlbum;
   int m_iArtist;
   bool m_bSucceeded;

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -861,7 +861,7 @@ bool CGUIWindowMusicBase::FindArtistInfo(const CStdString& strArtist, CMusicArti
   while (needsRefresh || bCanceled);
 
   m_musicdatabase.GetArtistInfo(idArtist,artist.GetArtist());
-  artist.SetLoaded(true);
+  artist.SetLoaded();
   return true;
 }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -817,7 +817,7 @@ bool CGUIWindowMusicBase::FindAlbumInfo(const CStdString& strAlbum, const CStdSt
   if (idAlbum != -1)
     m_musicdatabase.GetAlbumInfo(idAlbum,album.GetAlbum(),&album.GetAlbum().songs);
 
-  album.SetLoaded();
+  album.SetLoaded(true);
   return true;
 }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -817,7 +817,7 @@ bool CGUIWindowMusicBase::FindAlbumInfo(const CStdString& strAlbum, const CStdSt
   if (idAlbum != -1)
     m_musicdatabase.GetAlbumInfo(idAlbum,album.GetAlbum(),&album.GetAlbum().songs);
 
-  album.SetLoaded(true);
+  album.SetLoaded();
   return true;
 }
 

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -398,16 +398,6 @@ const CStdString CScraperParser::Parse(const CStdString& strTag,
   return tmp;
 }
 
-bool CScraperParser::HasFunction(const CStdString& strTag)
-{
-  TiXmlElement* pChildElement = m_pRootElement->FirstChildElement(strTag.c_str());
-
-  if (!pChildElement)
-    return false;
-
-  return true;
-}
-
 void CScraperParser::Clean(CStdString& strDirty)
 {
   int i=0;

--- a/xbmc/utils/ScraperParser.h
+++ b/xbmc/utils/ScraperParser.h
@@ -49,10 +49,10 @@ public:
 
   void Clear();
   const CStdString GetFilename() { return m_strFile; }
-  const CStdString GetSearchStringEncoding() { return m_SearchStringEncoding; }
+  CStdString GetSearchStringEncoding() const
+    { return m_SearchStringEncoding; }
   const CStdString Parse(const CStdString& strTag,
                          ADDON::CScraper* scraper);
-  bool HasFunction(const CStdString& strTag);
 
   void AddDocument(const TiXmlDocument* doc);
 

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -281,6 +281,8 @@ bool CScraperUrl::DownloadThumbnail(const CStdString &thumb, const CScraperUrl::
   return false;
 }
 
+// XML format is of strUrls is:
+// <TAG><url>...</url>...</TAG> (parsed by ParseElement) or <url>...</url> (ditto)
 bool CScraperUrl::ParseEpisodeGuide(CStdString strUrls)
 {
   if (strUrls.IsEmpty())
@@ -298,15 +300,11 @@ bool CScraperUrl::ParseEpisodeGuide(CStdString strUrls)
     TiXmlElement *link = docHandle.FirstChild("episodeguide").Element();
     if (link->FirstChildElement("url"))
     {
-      link = link->FirstChildElement("url");
-      while (link)
-      {
+      for (link = link->FirstChildElement("url"); link; link = link->NextSiblingElement("url"))
         ParseElement(link);
-        link = link->NextSiblingElement("url");
-      }
     }
     else if (link->FirstChild() && link->FirstChild()->Value())
-      ParseString(link->FirstChild()->Value());
+      ParseElement(link);
   }
   else
     return false;

--- a/xbmc/video/Episode.h
+++ b/xbmc/video/Episode.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "utils/ScraperUrl.h"
+
+// single episode information
+struct EPISODE
+{
+  std::pair<int,int> key;
+  CDateTime cDate;
+  CScraperUrl cScraperUrl;
+};
+
+typedef std::vector<EPISODE> EPISODELIST;
+

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -27,7 +27,6 @@
 #include "utils/ScraperParser.h"
 #include "NfoFile.h"
 #include "dialogs/GUIDialogProgress.h"
-#include "utils/fstrcmp.h"
 #include "dialogs/GUIDialogOK.h"
 #include "Application.h"
 #include "guilib/GUIWindowManager.h"
@@ -35,366 +34,37 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 
-using namespace HTML;
 using namespace std;
+using namespace HTML;
 
 #ifndef __GNUC__
 #pragma warning (disable:4018)
 #endif
 
-//////////////////////////////////////////////////////////////////////
-// Construction/Destruction
-//////////////////////////////////////////////////////////////////////
-CVideoInfoDownloader::CVideoInfoDownloader(const ADDON::ScraperPtr &scraper)
-{
-  m_info = scraper;
-}
-
-CVideoInfoDownloader::~CVideoInfoDownloader()
-{
-}
-
+// return value: 0 = we failed, -1 = we failed and reported an error, 1 = success
 int CVideoInfoDownloader::InternalFindMovie(const CStdString &strMovie,
                                             MOVIELIST& movielist,
-                                            bool& sortMovieList,
                                             bool cleanChars /* = true */)
 {
-  movielist.clear();
-
-  CScraperUrl scrURL;
-
-  CStdString strName = strMovie;
-  CStdString movieTitle, movieTitleAndYear, movieYear;
-  CUtil::CleanString(strName, movieTitle, movieTitleAndYear, movieYear, true, cleanChars);
-
-  movieTitle.ToLower();
-
-  if (m_info->Content() == CONTENT_MUSICVIDEOS)
-    movieTitle.Replace("-"," ");
-
-  CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper (path: '%s', content: '%s', version: '%s')",
-    __FUNCTION__, movieTitle.c_str(), m_info->Name().c_str(), m_info->Path().c_str(),
-    ADDON::TranslateContent(m_info->Content()).c_str(), m_info->Version().c_str());
-
-  if (m_info->GetParser().HasFunction("CreateSearchUrl"))
+  try
   {
-    GetURL(strMovie, movieTitle, movieYear, scrURL);
+    if (!(movielist = m_info->FindMovie(m_http, strMovie, cleanChars)).empty())
+      return 1;
   }
-  else if (m_info->Content() == CONTENT_MUSICVIDEOS)
+  catch (const ADDON::CScraperError &sce)
   {
-    if (!m_info->GetParser().HasFunction("FileNameScrape"))
-      return 0;
-
-    CScraperUrl scrURL("filenamescrape");
-    URIUtils::RemoveExtension(strName);
-    scrURL.strTitle = strName;
-    movielist.push_back(scrURL);
+    ShowErrorDialog(sce);
     return 1;
   }
-  if (scrURL.m_xml.IsEmpty())
-    return 0;
-
-  vector<CStdString> extras;
-  extras.push_back(scrURL.m_url[0].m_url);
-
-  vector<CStdString> xml = m_info->Run("GetSearchResults",scrURL,m_http,&extras);
-
-  bool haveValidResults = false;
-  for (vector<CStdString>::iterator it  = xml.begin();
-                                    it != xml.end(); ++it)
-  {
-    // ok, now parse the xml file
-    TiXmlDocument doc;
-    doc.Parse(it->c_str(),0,TIXML_ENCODING_UTF8);
-    if (!doc.RootElement())
-    {
-      CLog::Log(LOGERROR, "%s: Unable to parse xml",__FUNCTION__);
-      continue;  // might have more valid results later
-    }
-
-    if (stricmp(doc.RootElement()->Value(),"error")==0)
-    {
-      ShowErrorDialog(doc.RootElement());
-      return -1; // scraper has reported an error
-    }
-
-    TiXmlHandle docHandle( &doc );
-    TiXmlElement *movie = docHandle.FirstChild("results").Element();
-    if (!movie)
-      continue;
-
-    haveValidResults = true;
-
-    movie = docHandle.FirstChild( "results" ).FirstChild( "entity" ).Element();
-    while (movie)
-    {
-      // is our result already sorted correctly when handed over from scraper? if so, do not let xbmc sort it
-      if (sortMovieList)
-      {
-        TiXmlElement* results = docHandle.FirstChild("results").Element();
-        if (results)
-        {
-          CStdString szSorted = results->Attribute("sorted");
-          sortMovieList = (szSorted.CompareNoCase("yes") != 0);
-        }
-      }
-
-      TiXmlNode *title = movie->FirstChild("title");
-      TiXmlElement *link = movie->FirstChildElement("url");
-      TiXmlNode *year = movie->FirstChild("year");
-      TiXmlNode* id = movie->FirstChild("id");
-      TiXmlNode* language = movie->FirstChild("language");
-      if (title && title->FirstChild() && link && link->FirstChild())
-      {
-        CScraperUrl url;
-        url.strTitle = title->FirstChild()->Value();
-        while (link && link->FirstChild())
-        {
-          url.ParseElement(link);
-          link = link->NextSiblingElement("url");
-        }
-        if (id && id->FirstChild())
-          url.strId = id->FirstChild()->Value();
-
-        // calculate the relavance of this hit
-        CStdString compareTitle = url.strTitle;
-        compareTitle.ToLower();
-        CStdString matchTitle = movieTitle;
-        matchTitle.ToLower();
-        // see if we need to add year information
-        CStdString compareYear;
-        if (year && year->FirstChild())
-          compareYear = year->FirstChild()->Value();
-
-        /*
-         * Identify the best match by performing a fuzzy string compare on the search term and
-         * the result. Additionally, use the year (if available) to further refine the best match.
-         * An exact match scores 1, a match off by a year scores 0.5 (release dates can vary between
-         * countries), otherwise it scores 0.
-         */
-        double yearScore = 0;
-        if (!movieYear.IsEmpty() && !compareYear.IsEmpty())
-          yearScore = std::max(0.0, 1-0.5*abs(atoi(movieYear)-atoi(compareYear)));
-        url.relevance = fstrcmp(matchTitle.c_str(), compareTitle.c_str(), 0.0) + yearScore;
-
-        // reconstruct a title for the user
-        CStdString title = url.strTitle;
-        if (!compareYear.IsEmpty())
-          title.AppendFormat(" (%s)", compareYear.c_str());
-        if (language && language->FirstChild())
-          title.AppendFormat(" (%s)", language->FirstChild()->Value());
-        url.strTitle = title;
-        // filter for dupes from naughty scrapers
-        MOVIELIST::iterator iter=movielist.begin();
-        while (iter != movielist.end())
-        {
-          if (iter->m_url[0].m_url.Equals(url.m_url[0].m_url) &&
-              iter->strTitle.Equals(url.strTitle))
-            break;
-          ++iter;
-        }
-        if (iter == movielist.end())
-          movielist.push_back(url);
-      }
-      movie = movie->NextSiblingElement();
-    }
-  }
-  return haveValidResults ? 1 : 0;
+  return 0;
 }
 
-bool CVideoInfoDownloader::RelevanceSortFunction(const CScraperUrl &left,
-                                                 const CScraperUrl &right)
+void CVideoInfoDownloader::ShowErrorDialog(const ADDON::CScraperError &sce)
 {
-  return left.relevance > right.relevance;
-}
-
-void CVideoInfoDownloader::ShowErrorDialog(const TiXmlElement* element)
-{
-  const TiXmlElement* title = element->FirstChildElement("title");
-  CStdString strTitle;
-  if (title && title->FirstChild() && title->FirstChild()->Value())
-    strTitle = title->FirstChild()->Value();
-  const TiXmlElement* message = element->FirstChildElement("message");
-  CStdString strMessage;
-  if (message && message->FirstChild() && message->FirstChild()->Value())
-    strMessage = message->FirstChild()->Value();
-  CGUIDialogOK* dialog = (CGUIDialogOK*)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
-  dialog->SetHeading(strTitle);
-  dialog->SetLine(0,strMessage);
-  g_application.getApplicationMessenger().DoModal(dialog,WINDOW_DIALOG_OK);
-}
-
-bool CVideoInfoDownloader::InternalGetEpisodeList(const CScraperUrl& url,
-                                                  EPISODELIST& details)
-{
-  EPISODELIST temp;
-  vector<CStdString> extras;
-  if (url.m_url.empty())
-    return false;
-  extras.push_back(url.m_url[0].m_url);
-  vector<CStdString> xml = m_info->Run("GetEpisodeList",url,m_http,&extras);
-
-  for (vector<CStdString>::iterator it  = xml.begin();
-                                    it != xml.end(); ++it)
-  {
-    // ok, now parse the xml file
-    TiXmlDocument doc;
-    doc.Parse(it->c_str());
-    if (!doc.RootElement())
-    {
-      CLog::Log(LOGERROR, "%s: Unable to parse xml",__FUNCTION__);
-      return false;
-    }
-
-    TiXmlHandle docHandle( &doc );
-    TiXmlElement *movie = docHandle.FirstChild( "episodeguide" ).FirstChild( "episode" ).Element();
-
-    while (movie)
-    {
-      TiXmlNode *title = movie->FirstChild("title");
-      TiXmlElement *link = movie->FirstChildElement("url");
-      TiXmlNode *epnum = movie->FirstChild("epnum");
-      TiXmlNode *season = movie->FirstChild("season");
-      TiXmlNode* id = movie->FirstChild("id");
-      TiXmlNode *aired = movie->FirstChild("aired");
-      if (link && link->FirstChild() && epnum && epnum->FirstChild() && season && season->FirstChild())
-      {
-        CScraperUrl url2;
-        if (title && title->FirstChild())
-          url2.strTitle = title->FirstChild()->Value();
-        else
-          url2.strTitle = g_localizeStrings.Get(416);
-
-        while (link && link->FirstChild())
-        {
-          url2.ParseElement(link);
-          link = link->NextSiblingElement("url");
-        }
-
-        if (id && id->FirstChild())
-          url2.strId = id->FirstChild()->Value();
-        pair<int,int> key(atoi(season->FirstChild()->Value()),atoi(epnum->FirstChild()->Value()));
-        EPISODE newEpisode;
-        newEpisode.key = key;
-        newEpisode.cDate.SetValid(FALSE);
-        if (aired && aired->FirstChild())
-        {
-          const char *dateStr = aired->FirstChild()->Value();
-          // date must be the format of yyyy-mm-dd
-          if (strlen(dateStr)==10)
-          {
-            char year[5];
-            char month[3];
-            memcpy(year,dateStr,4);
-            year[4] = '\0';
-            memcpy(month,dateStr+5,2);
-            month[2] = '\0';
-            newEpisode.cDate.SetDate(atoi(year),atoi(month),atoi(dateStr+8));
-          }
-        }
-        newEpisode.cScraperUrl = url2;
-        temp.push_back(newEpisode);
-      }
-      movie = movie->NextSiblingElement();
-    }
-  }
-
-  // find minimum in each season
-  map<int,int> min;
-  for (EPISODELIST::iterator iter=temp.begin(); iter != temp.end(); ++iter )
-  {
-    if ((signed int) min.size() == (iter->key.first -1))
-      min.insert(iter->key);
-    else if (iter->key.second < min[iter->key.first])
-      min[iter->key.first] = iter->key.second;
-  }
-  // correct episode numbers
-  for (EPISODELIST::iterator iter=temp.begin(); iter != temp.end(); ++iter )
-  {
-    int episode=iter->key.second - min[iter->key.first];
-    if (min[iter->key.first] > 0)
-      episode++;
-    pair<int,int> key(iter->key.first,episode);
-    EPISODE newEpisode;
-    newEpisode.key = key;
-    newEpisode.cDate = iter->cDate;
-    newEpisode.cScraperUrl = iter->cScraperUrl;
-    details.push_back(newEpisode);
-  }
-
-  return true;
-}
-
-bool CVideoInfoDownloader::InternalGetDetails(const CScraperUrl& url,
-                                              CVideoInfoTag& movieDetails,
-                                              const CStdString& strFunction)
-{
-  if (url.m_xml.Equals("filenamescrape"))
-    return ScrapeFilename(movieDetails.m_strFileNameAndPath,movieDetails);
-
-  vector<CStdString> extras;
-  extras.push_back(url.strId);
-  extras.push_back(url.m_url[0].m_url);
-  vector<CStdString> xml = m_info->Run(strFunction,url,m_http,&extras);
-  for (vector<CStdString>::iterator it  = xml.begin();
-                                    it != xml.end(); ++it)
-  {
-    // ok, now parse the xml file
-    TiXmlDocument doc;
-    doc.Parse(it->c_str(),0,TIXML_ENCODING_UTF8);
-    if (!doc.RootElement())
-    {
-      CLog::Log(LOGERROR, "%s: Unable to parse xml",__FUNCTION__);
-      return false;
-    }
-
-    ParseDetails(doc, movieDetails);
-  }
-
-  return true;
-}
-
-bool CVideoInfoDownloader::ParseDetails(TiXmlDocument &doc,
-                                        CVideoInfoTag &movieDetails)
-{
-  TiXmlHandle docHandle( &doc );
-  TiXmlElement *details = docHandle.FirstChild( "details" ).Element();
-
-  if (!details)
-  {
-    CLog::Log(LOGERROR, "%s: Invalid xml file",__FUNCTION__);
-    return false;
-  }
-
-  // set chaining to true here as this is called by our scrapers
-  movieDetails.Load(details, true);
-
-  return true;
-}
-
-void CVideoInfoDownloader::RemoveAllAfter(char* szMovie, const char* szSearch)
-{
-  char* pPtr = strstr(szMovie, szSearch);
-  if (pPtr) *pPtr = 0;
-}
-
-void CVideoInfoDownloader::GetURL(const CStdString &movieFile,
-                                  const CStdString &movieName,
-                                  const CStdString &movieYear,
-                                  CScraperUrl& scrURL)
-{
-  // convert to the encoding requested by the parser
-  vector<CStdString> extras;
-  extras.push_back(movieName);
-  g_charsetConverter.utf8To(m_info->GetParser().GetSearchStringEncoding(), movieName, extras[0]);
-  CURL::Encode(extras[0]);
-  if (!movieYear.IsEmpty())
-    extras.push_back(movieYear);
-
-  scrURL.Clear();
-  vector<CStdString> xml = m_info->Run("CreateSearchUrl",scrURL,m_http,&extras);
-  if (!xml.empty())
-    scrURL.ParseString(xml[0]);
+  CGUIDialogOK *pdlg = (CGUIDialogOK *)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
+  pdlg->SetHeading(sce.Title());
+  pdlg->SetLine(0, sce.Message());
+  g_application.getApplicationMessenger().DoModal(pdlg, WINDOW_DIALOG_OK);
 }
 
 // threaded functions
@@ -442,10 +112,6 @@ int CVideoInfoDownloader::FindMovie(const CStdString &strMovie,
 {
   //CLog::Log(LOGDEBUG,"CVideoInfoDownloader::FindMovie(%s)", strMovie.c_str());
 
-  // load our scraper xml
-  if (!m_info->Load())
-    return 0;
-
   if (pProgress)
   { // threaded version
     m_state = FIND_MOVIE;
@@ -465,26 +131,19 @@ int CVideoInfoDownloader::FindMovie(const CStdString &strMovie,
       Sleep(1);
     }
     // transfer to our movielist
-    movieList.clear();
-    for (unsigned int i=0; i < m_movieList.size(); i++)
-      movieList.push_back(m_movieList[i]);
-    m_movieList.clear();
+    m_movieList.swap(movieList);
     int found=m_found;
     CloseThread();
     return found;
   }
 
   // unthreaded
-  bool sortList = true;
-  int success = InternalFindMovie(strMovie, movieList, sortList);
+  int success = InternalFindMovie(strMovie, movieList);
   // NOTE: this might be improved by rescraping if the match quality isn't high?
-  if (success && !movieList.size())
+  if (success && movieList.empty())
   { // no results. try without cleaning chars like '.' and '_'
-    success = InternalFindMovie(strMovie, movieList, sortList, false);
+    success = InternalFindMovie(strMovie, movieList, false);
   }
-  // sort our movie list by fuzzy match
-  if (sortList)
-    std::sort(movieList.begin(), movieList.end(), RelevanceSortFunction);
   return success;
 }
 
@@ -495,9 +154,6 @@ bool CVideoInfoDownloader::GetDetails(const CScraperUrl &url,
   //CLog::Log(LOGDEBUG,"CVideoInfoDownloader::GetDetails(%s)", url.m_strURL.c_str());
   m_url = url;
   m_movieDetails = movieDetails;
-  // load our scraper xml
-  if (!m_info->Load())
-    return false;
 
   // fill in the defaults
   movieDetails.Reset();
@@ -523,7 +179,7 @@ bool CVideoInfoDownloader::GetDetails(const CScraperUrl &url,
     return true;
   }
   else  // unthreaded
-    return InternalGetDetails(url, movieDetails);
+    return m_info->GetVideoDetails(m_http, url, true/*fMovie*/, movieDetails);
 }
 
 bool CVideoInfoDownloader::GetEpisodeDetails(const CScraperUrl &url,
@@ -533,10 +189,6 @@ bool CVideoInfoDownloader::GetEpisodeDetails(const CScraperUrl &url,
   //CLog::Log(LOGDEBUG,"CVideoInfoDownloader::GetDetails(%s)", url.m_strURL.c_str());
   m_url = url;
   m_movieDetails = movieDetails;
-
-  // load our scraper xml
-  if (!m_info->Load())
-    return false;
 
   // fill in the defaults
   movieDetails.Reset();
@@ -562,7 +214,7 @@ bool CVideoInfoDownloader::GetEpisodeDetails(const CScraperUrl &url,
     return true;
   }
   else  // unthreaded
-    return InternalGetDetails(url, movieDetails, "GetEpisodeDetails");
+    return m_info->GetVideoDetails(m_http, url, false/*fMovie*/, movieDetails);
 }
 
 bool CVideoInfoDownloader::GetEpisodeList(const CScraperUrl& url,
@@ -572,10 +224,6 @@ bool CVideoInfoDownloader::GetEpisodeList(const CScraperUrl& url,
   //CLog::Log(LOGDEBUG,"CVideoInfoDownloader::GetDetails(%s)", url.m_strURL.c_str());
   m_url = url;
   m_episode = movieDetails;
-
-  // load our scraper xml
-  if (!m_info->Load())
-    return false;
 
   // fill in the defaults
   movieDetails.clear();
@@ -601,7 +249,7 @@ bool CVideoInfoDownloader::GetEpisodeList(const CScraperUrl& url,
     return true;
   }
   else  // unthreaded
-    return InternalGetEpisodeList(url, movieDetails);
+    return !(movieDetails = m_info->GetEpisodeList(m_http, url)).empty();
 }
 
 void CVideoInfoDownloader::CloseThread()
@@ -611,30 +259,5 @@ void CVideoInfoDownloader::CloseThread()
   m_http.Reset();
   m_state = DO_NOTHING;
   m_found = 0;
-}
-
-bool CVideoInfoDownloader::ScrapeFilename(const CStdString& strFileName,
-                                          CVideoInfoTag& details)
-{
-  CScraperUrl url;
-  vector<CStdString> extras;
-  extras.push_back(strFileName);
-  URIUtils::RemoveExtension(extras[0]);
-  extras[0].Replace("_"," ");
-  vector<CStdString> result = m_info->Run("FileNameScrape",url,m_http,&extras);
-  if (!result.empty())
-  {
-    CLog::Log(LOGDEBUG,"scraper: FileNameScrape returned %s", result[0].c_str());
-    TiXmlDocument doc;
-    doc.Parse(result[0].c_str());
-    if (doc.RootElement())
-    {
-      CNfoFile file;
-      if (file.GetDetails(details,result[0].c_str()))
-        return true;
-    }
-  }
-
-  return false;
 }
 

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -32,13 +32,18 @@
 class TiXmlDocument;
 class CGUIDialogProgress;
 
+namespace ADDON
+{
+class CScraperError;
+}
+
 typedef std::vector<CScraperUrl> MOVIELIST;
 
 class CVideoInfoDownloader : public CThread
 {
 public:
-  CVideoInfoDownloader(const ADDON::ScraperPtr &scraper);
-  virtual ~CVideoInfoDownloader();
+  CVideoInfoDownloader(const ADDON::ScraperPtr &scraper) : m_info(scraper) {}
+  virtual ~CVideoInfoDownloader() {}
 
   // threaded lookup functions
 
@@ -53,29 +58,16 @@ public:
   bool GetEpisodeDetails(const CScraperUrl& url, CVideoInfoTag &movieDetails, CGUIDialogProgress *pProgress = NULL);
   bool GetEpisodeList(const CScraperUrl& url, EPISODELIST& details, CGUIDialogProgress *pProgress = NULL);
 
-  static void ShowErrorDialog(const TiXmlElement* element);
+  static void ShowErrorDialog(const ADDON::CScraperError &sce);
+
 protected:
-  void RemoveAllAfter(char* szMovie, const char* szSearch);
-  int InternalFindMovie(const CStdString& strMovie, MOVIELIST& movielist, bool& sortMovieList, bool cleanChars = true);
-  bool InternalGetDetails(const CScraperUrl& url, CVideoInfoTag& movieDetails, const CStdString& strFunction="GetDetails");
-  bool InternalGetEpisodeList(const CScraperUrl& url, EPISODELIST& details);
-  bool ParseDetails(TiXmlDocument &doc, CVideoInfoTag &movieDetails);
-  void GetURL(const CStdString &movieFile, const CStdString &movieName, const CStdString &movieYear, CScraperUrl& strURL);
-  bool ScrapeFilename(const CStdString& strFileName, CVideoInfoTag& details);
-
-  static bool RelevanceSortFunction(const CScraperUrl& left, const CScraperUrl &right);
-
-  XFILE::CFileCurl m_http;
-
-  // threaded stuff
-  void Process();
-  void CloseThread();
-
   enum LOOKUP_STATE { DO_NOTHING = 0,
                       FIND_MOVIE = 1,
                       GET_DETAILS = 2,
                       GET_EPISODE_LIST = 3,
                       GET_EPISODE_DETAILS = 4 };
+
+  XFILE::CFileCurl m_http;
   CStdString        m_strMovie;
   MOVIELIST         m_movieList;
   CVideoInfoTag     m_movieDetails;
@@ -84,5 +76,11 @@ protected:
   LOOKUP_STATE      m_state;
   int               m_found;
   ADDON::ScraperPtr m_info;
+
+  // threaded stuff
+  void Process();
+  void CloseThread();
+
+  int InternalFindMovie(const CStdString& strMovie, MOVIELIST& movielist, bool cleanChars = true);
 };
 

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -24,23 +24,15 @@
 #include "threads/Thread.h"
 #include "VideoInfoTag.h"
 #include "addons/Scraper.h"
+#include "Episode.h"
 #include "XBDateTime.h"
 #include "filesystem/FileCurl.h"
 
-// forward definitions
+// forward declarations
 class TiXmlDocument;
 class CGUIDialogProgress;
 
 typedef std::vector<CScraperUrl> MOVIELIST;
-
-typedef struct
-{
-  std::pair<int,int> key;
-  CDateTime cDate;
-  CScraperUrl cScraperUrl;
-} EPISODE;
-
-typedef std::vector<EPISODE> EPISODELIST;
 
 class CVideoInfoDownloader : public CThread
 {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1704,10 +1704,7 @@ namespace VIDEO
       }
       else if (result != CNfoFile::NO_NFO && result != CNfoFile::ERROR_NFO)
       {
-        CScraperUrl url(m_nfoReader.m_strImDbUrl);
-        scrUrl = url;
-
-        scrUrl.strId  = m_nfoReader.m_strImDbNr;
+        scrUrl = m_nfoReader.ScraperUrl();
         info = m_nfoReader.GetScraperInfo();
 
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Fetching url '%s' using %s scraper (content: '%s')",

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -26,7 +26,6 @@
 #include "VideoInfoDownloader.h"
 #include "XBDateTime.h"
 
-class CIMDB;
 class CRegExp;
 
 namespace VIDEO


### PR DESCRIPTION
Scraper abstraction: provide an encapsulation.

To eventually allow scrapers to be written in Python or other languages, first the scraper interface itself (CScraper) was changed to define several language-agnostic methods (in particular, with no reference to XML): FindMovie, FindAlbum, etc., replacing the old Run (now internal).

Most XML parsing has been moved into CScraper, which for now functions as both a general scraper interface and the implementation for XML scrapers (in future may split into IScraper / CXMLScraper).

CScraper now ensures its scraper is loaded by itself; loading is an implementation detail that clients should not have to worry about.

Note: This change incorporates https://github.com/xbmc/xbmc/commit/652f59e9e5097006009168a88e5f7517d276317b (year search update), and uses spaces (not tabs).
