### PR TITLE
Python callback error handling fix

### DIFF
--- a/xbmc/interfaces/python/xbmcmodule/pyutil.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/pyutil.cpp
@@ -24,6 +24,7 @@
 #include <wchar.h>
 #include <vector>
 #include "addons/Skin.h"
+#include "utils/log.h"
 #include "tinyXML/tinyxml.h"
 #include "utils/CharsetConverter.h"
 #include "threads/CriticalSection.h"
@@ -197,7 +198,22 @@ void _PyXBMC_MakePendingCalls()
     g_callQueue.erase(iter);
     lock.Leave();
     if (p.func)
+    {
       p.func(p.args);
+
+      // Since the callback is likely to make it into python, and since
+      // not all of the callback functions handle errors, the error state
+      // may remain set from the previous call. As a result subsequent calls
+      // to callback functions exhibit odd behavior difficult to debug.
+      if (PyErr_Occurred())
+      {
+        CLog::Log(LOGERROR,"Exception in python script callback execution");
+
+        // This clears the python error state and prints it to the log
+        PyErr_Print();
+      }
+
+    }
     //(*((*iter).first))((*iter).second);
     lock.Enter();
     iter = g_callQueue.begin();


### PR DESCRIPTION
This fixes a problem where a python error in one callback method can effect the execution of subsequent callbacks, as the error state in the interpreter wasn't being cleared.

IMO, If there are plans for a 10.2 this should be backported.
