### PR TITLE
Fix for mixed provider plugins and "Auto play next"

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -968,7 +968,7 @@ bool CGUIMediaWindow::OnClick(int iItem)
       if (CAddonMgr::Get().GetAddon(url.GetHostName(),addon))
       {
         PluginPtr plugin = boost::dynamic_pointer_cast<CPluginSource>(addon);
-        if (plugin && plugin->Provides(CPluginSource::AUDIO))
+        if (plugin && plugin->Provides(CPluginSource::AUDIO) && pItem->IsAudio())
         {
           iPlaylist = PLAYLIST_MUSIC;
           autoplay = g_guiSettings.GetBool("musicplayer.autoplaynextitem");


### PR DESCRIPTION
Fix "automatically play next" so that it's only applied to audio in an addon. Currently if an addon provides both audio and video, this setting is used to queue up audio AND video, rather than just audio (as the setting appears under music only). 

This change just checks that an item is audio before queuing. 

[An alternative change would be to remove the plugin->provide test as well so that only audio is queued up (regardless of the provider type in addon).  However this may affect current addons]. 
