### PR TITLE
Dirty region based rendering (updated from GSOC 2010)

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1840B797139968DB007C848B /* JSONVariantWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1840B794139968DB007C848B /* JSONVariantWriter.cpp */; };
 		18ACF8E313597B0000B67371 /* RecentlyAddedJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ACF8E113597B0000B67371 /* RecentlyAddedJob.cpp */; };
 		4D5D2E131301753F006ABC13 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D5D2E121301753F006ABC13 /* CFNetwork.framework */; };
+		7C0A7D4013A3539700AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7D3E13A3539700AFC2BD /* GUIWindowDebugInfo.cpp */; };
 		7C99B73F133D372300FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B73D133D372300FC2B16 /* CacheCircular.cpp */; };
 		7C99B7AA134072CD00FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */; };
 		7CBC8954139385470046CB82 /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC8950139385470046CB82 /* DirtyRegionSolvers.cpp */; };
@@ -930,6 +931,8 @@
 		18ACF8E113597B0000B67371 /* RecentlyAddedJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RecentlyAddedJob.cpp; sourceTree = "<group>"; };
 		18ACF8E213597B0000B67371 /* RecentlyAddedJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecentlyAddedJob.h; sourceTree = "<group>"; };
 		4D5D2E121301753F006ABC13 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		7C0A7D3E13A3539700AFC2BD /* GUIWindowDebugInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowDebugInfo.cpp; sourceTree = "<group>"; };
+		7C0A7D3F13A3539700AFC2BD /* GUIWindowDebugInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowDebugInfo.h; sourceTree = "<group>"; };
 		7C99B73D133D372300FC2B16 /* CacheCircular.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheCircular.cpp; sourceTree = "<group>"; };
 		7C99B73E133D372300FC2B16 /* CacheCircular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheCircular.h; sourceTree = "<group>"; };
 		7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -5216,6 +5219,8 @@
 			children = (
 				F56C77B9131EC154000AD0F6 /* GUIMediaWindow.cpp */,
 				F56C77BA131EC154000AD0F6 /* GUIMediaWindow.h */,
+				7C0A7D3E13A3539700AFC2BD /* GUIWindowDebugInfo.cpp */,
+				7C0A7D3F13A3539700AFC2BD /* GUIWindowDebugInfo.h */,
 				F56C77BB131EC154000AD0F6 /* GUIWindowFileManager.cpp */,
 				F56C77BC131EC154000AD0F6 /* GUIWindowFileManager.h */,
 				F56C77BD131EC154000AD0F6 /* GUIWindowHome.cpp */,
@@ -6696,6 +6701,7 @@
 				1840B797139968DB007C848B /* JSONVariantWriter.cpp in Sources */,
 				7CBC8954139385470046CB82 /* DirtyRegionSolvers.cpp in Sources */,
 				7CBC8955139385470046CB82 /* DirtyRegionTracker.cpp in Sources */,
+				7C0A7D4013A3539700AFC2BD /* GUIWindowDebugInfo.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		4D5D2E131301753F006ABC13 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D5D2E121301753F006ABC13 /* CFNetwork.framework */; };
 		7C99B73F133D372300FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B73D133D372300FC2B16 /* CacheCircular.cpp */; };
 		7C99B7AA134072CD00FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */; };
+		7CBC8954139385470046CB82 /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC8950139385470046CB82 /* DirtyRegionSolvers.cpp */; };
+		7CBC8955139385470046CB82 /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC8952139385470046CB82 /* DirtyRegionTracker.cpp */; };
 		C807119F135DB842002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807119D135DB842002F601B /* InputOperations.cpp */; };
 		C8EC5D51136954E400CCC10D /* XBMC_keytable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8EC5D4F136954E400CCC10D /* XBMC_keytable.cpp */; };
 		F54D9E0712B65FFF006870F9 /* libc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F54D9E0612B65FFF006870F9 /* libc.dylib */; };
@@ -932,6 +934,11 @@
 		7C99B73E133D372300FC2B16 /* CacheCircular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheCircular.h; sourceTree = "<group>"; };
 		7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
 		7C99B7A9134072CD00FC2B16 /* GUIDialogPlayEject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDialogPlayEject.h; sourceTree = "<group>"; };
+		7CBC894F139385470046CB82 /* DirtyRegion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegion.h; sourceTree = "<group>"; };
+		7CBC8950139385470046CB82 /* DirtyRegionSolvers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirtyRegionSolvers.cpp; sourceTree = "<group>"; };
+		7CBC8951139385470046CB82 /* DirtyRegionSolvers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionSolvers.h; sourceTree = "<group>"; };
+		7CBC8952139385470046CB82 /* DirtyRegionTracker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirtyRegionTracker.cpp; sourceTree = "<group>"; };
+		7CBC8953139385470046CB82 /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
 		8D576316048677EA00EA77CD /* XBMC.frappliance */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XBMC.frappliance; sourceTree = BUILT_PRODUCTS_DIR; };
 		A192FD47135E46C800D92E9B /* IOSAudioRingBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IOSAudioRingBuffer.h; path = AudioRenderers/IOSAudioRingBuffer.h; sourceTree = "<group>"; };
 		C807119D135DB842002F601B /* InputOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InputOperations.cpp; sourceTree = "<group>"; };
@@ -4191,6 +4198,11 @@
 				F56C74A2131EC152000AD0F6 /* D3DResource.h */,
 				F56C74A3131EC152000AD0F6 /* DDSImage.h */,
 				F56C74A4131EC152000AD0F6 /* DirectXGraphics.h */,
+				7CBC894F139385470046CB82 /* DirtyRegion.h */,
+				7CBC8950139385470046CB82 /* DirtyRegionSolvers.cpp */,
+				7CBC8951139385470046CB82 /* DirtyRegionSolvers.h */,
+				7CBC8952139385470046CB82 /* DirtyRegionTracker.cpp */,
+				7CBC8953139385470046CB82 /* DirtyRegionTracker.h */,
 				F56C74A5131EC152000AD0F6 /* FrameBufferObject.h */,
 				F56C74A6131EC152000AD0F6 /* Geometry.h */,
 				F56C74A7131EC152000AD0F6 /* GraphicContext.h */,
@@ -6682,6 +6694,8 @@
 				18404DFB1396C43B00863BBA /* Slingbox.cpp in Sources */,
 				1840B796139968DB007C848B /* JSONVariantParser.cpp in Sources */,
 				1840B797139968DB007C848B /* JSONVariantWriter.cpp in Sources */,
+				7CBC8954139385470046CB82 /* DirtyRegionSolvers.cpp in Sources */,
+				7CBC8955139385470046CB82 /* DirtyRegionTracker.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		4D5D2E1E1301758F006ABC13 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */; };
 		7C99B6E9133D36E200FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */; };
 		7C99B7BE1340730000FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */; };
+		7CBC896A139385740046CB82 /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC8966139385740046CB82 /* DirtyRegionSolvers.cpp */; };
+		7CBC896B139385740046CB82 /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC8968139385740046CB82 /* DirtyRegionTracker.cpp */; };
 		C80711AD135DB85F002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C80711AB135DB85F002F601B /* InputOperations.cpp */; };
 		C8EC5D26136953E100CCC10D /* XBMC_keytable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8EC5D24136953E100CCC10D /* XBMC_keytable.cpp */; };
 		F54D9E8112B713F8006870F9 /* libc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F54D9E8012B713F8006870F9 /* libc.dylib */; };
@@ -933,6 +935,11 @@
 		7C99B6E8133D36E200FC2B16 /* CacheCircular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheCircular.h; sourceTree = "<group>"; };
 		7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
 		7C99B7BD1340730000FC2B16 /* GUIDialogPlayEject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIDialogPlayEject.h; sourceTree = "<group>"; };
+		7CBC8965139385740046CB82 /* DirtyRegion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegion.h; sourceTree = "<group>"; };
+		7CBC8966139385740046CB82 /* DirtyRegionSolvers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirtyRegionSolvers.cpp; sourceTree = "<group>"; };
+		7CBC8967139385740046CB82 /* DirtyRegionSolvers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionSolvers.h; sourceTree = "<group>"; };
+		7CBC8968139385740046CB82 /* DirtyRegionTracker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirtyRegionTracker.cpp; sourceTree = "<group>"; };
+		7CBC8969139385740046CB82 /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
 		8D576316048677EA00EA77CD /* XBMC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XBMC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C80711AB135DB85F002F601B /* InputOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InputOperations.cpp; sourceTree = "<group>"; };
 		C80711AC135DB85F002F601B /* InputOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InputOperations.h; sourceTree = "<group>"; };
@@ -4552,6 +4559,11 @@
 				F56C8485131F42E9000AD0F6 /* D3DResource.h */,
 				F56C8486131F42E9000AD0F6 /* DDSImage.h */,
 				F56C8487131F42E9000AD0F6 /* DirectXGraphics.h */,
+				7CBC8965139385740046CB82 /* DirtyRegion.h */,
+				7CBC8966139385740046CB82 /* DirtyRegionSolvers.cpp */,
+				7CBC8967139385740046CB82 /* DirtyRegionSolvers.h */,
+				7CBC8968139385740046CB82 /* DirtyRegionTracker.cpp */,
+				7CBC8969139385740046CB82 /* DirtyRegionTracker.h */,
 				F56C8488131F42E9000AD0F6 /* FrameBufferObject.h */,
 				F56C8489131F42E9000AD0F6 /* Geometry.h */,
 				F56C848A131F42E9000AD0F6 /* GraphicContext.h */,
@@ -6699,6 +6711,8 @@
 				18404DD61396C3F300863BBA /* Slingbox.cpp in Sources */,
 				1840B77A1399616D007C848B /* JSONVariantParser.cpp in Sources */,
 				1840B77B1399616D007C848B /* JSONVariantWriter.cpp in Sources */,
+				7CBC896A139385740046CB82 /* DirtyRegionSolvers.cpp in Sources */,
+				7CBC896B139385740046CB82 /* DirtyRegionTracker.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		18ACF8FD13597B5700B67371 /* RecentlyAddedJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ACF8FB13597B5700B67371 /* RecentlyAddedJob.cpp */; };
 		3255316612B2D02400837CD2 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3255316512B2D02400837CD2 /* CoreAudio.framework */; };
 		4D5D2E1E1301758F006ABC13 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */; };
+		7C0A7D2E13A3537800AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7D2C13A3537800AFC2BD /* GUIWindowDebugInfo.cpp */; };
 		7C99B6E9133D36E200FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */; };
 		7C99B7BE1340730000FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */; };
 		7CBC896A139385740046CB82 /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC8966139385740046CB82 /* DirtyRegionSolvers.cpp */; };
@@ -931,6 +932,8 @@
 		18ACF8FC13597B5700B67371 /* RecentlyAddedJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecentlyAddedJob.h; sourceTree = "<group>"; };
 		3255316512B2D02400837CD2 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		7C0A7D2C13A3537800AFC2BD /* GUIWindowDebugInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowDebugInfo.cpp; sourceTree = "<group>"; };
+		7C0A7D2D13A3537800AFC2BD /* GUIWindowDebugInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowDebugInfo.h; sourceTree = "<group>"; };
 		7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheCircular.cpp; sourceTree = "<group>"; };
 		7C99B6E8133D36E200FC2B16 /* CacheCircular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheCircular.h; sourceTree = "<group>"; };
 		7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -5586,6 +5589,8 @@
 			children = (
 				F56C87A6131F42EC000AD0F6 /* GUIMediaWindow.cpp */,
 				F56C87A7131F42EC000AD0F6 /* GUIMediaWindow.h */,
+				7C0A7D2C13A3537800AFC2BD /* GUIWindowDebugInfo.cpp */,
+				7C0A7D2D13A3537800AFC2BD /* GUIWindowDebugInfo.h */,
 				F56C87A8131F42EC000AD0F6 /* GUIWindowFileManager.cpp */,
 				F56C87A9131F42EC000AD0F6 /* GUIWindowFileManager.h */,
 				F56C87AA131F42EC000AD0F6 /* GUIWindowHome.cpp */,
@@ -6713,6 +6718,7 @@
 				1840B77B1399616D007C848B /* JSONVariantWriter.cpp in Sources */,
 				7CBC896A139385740046CB82 /* DirtyRegionSolvers.cpp in Sources */,
 				7CBC896B139385740046CB82 /* DirtyRegionTracker.cpp in Sources */,
+				7C0A7D2E13A3537800AFC2BD /* GUIWindowDebugInfo.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -500,6 +500,8 @@
 		43EA4297136C1D9E002C82A5 /* RenderCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F56579AD13060D1E0085ED7F /* RenderCapture.cpp */; };
 		43EA429B136C1E2F002C82A5 /* xbmcvfsmodule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 189047D11301DEAB00C11012 /* xbmcvfsmodule.cpp */; };
 		43EA42B0136C2274002C82A5 /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807114B135DB5CC002F601B /* InputOperations.cpp */; };
+		7C0A7CB613A3365E00AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7CB413A3365E00AFC2BD /* GUIWindowDebugInfo.cpp */; };
+		7C0A7CB713A3365E00AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7CB413A3365E00AFC2BD /* GUIWindowDebugInfo.cpp */; };
 		7C2D6AE40F35453E00DD2E85 /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
 		7C45DBE910F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
 		7C45DBEA10F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
@@ -2370,6 +2372,8 @@
 		6E97BDC10DA2B620003A2A89 /* EventServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventServer.h; sourceTree = "<group>"; };
 		6E97BDC30DA2B620003A2A89 /* Fanart.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fanart.h; sourceTree = "<group>"; };
 		6E97BDC40DA2B620003A2A89 /* Socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Socket.h; sourceTree = "<group>"; };
+		7C0A7CB413A3365E00AFC2BD /* GUIWindowDebugInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowDebugInfo.cpp; sourceTree = "<group>"; };
+		7C0A7CB513A3365E00AFC2BD /* GUIWindowDebugInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowDebugInfo.h; sourceTree = "<group>"; };
 		7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpecialProtocol.cpp; sourceTree = "<group>"; };
 		7C2D6AE30F35453E00DD2E85 /* SpecialProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialProtocol.h; sourceTree = "<group>"; };
 		7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DAVDirectory.cpp; sourceTree = "<group>"; };
@@ -4661,6 +4665,8 @@
 			children = (
 				E38E17F00D25F9FA00618676 /* GUIMediaWindow.cpp */,
 				E38E17F10D25F9FA00618676 /* GUIMediaWindow.h */,
+				7C0A7CB413A3365E00AFC2BD /* GUIWindowDebugInfo.cpp */,
+				7C0A7CB513A3365E00AFC2BD /* GUIWindowDebugInfo.h */,
 				E38E18030D25F9FA00618676 /* GUIWindowFileManager.cpp */,
 				E38E18040D25F9FA00618676 /* GUIWindowFileManager.h */,
 				E38E18090D25F9FA00618676 /* GUIWindowHome.cpp */,
@@ -8028,6 +8034,7 @@
 				1840B75313993DA0007C848B /* JSONVariantWriter.cpp in Sources */,
 				7CBC891A139382050046CB82 /* DirtyRegionSolvers.cpp in Sources */,
 				7CBC891B139382050046CB82 /* DirtyRegionTracker.cpp in Sources */,
+				7C0A7CB613A3365E00AFC2BD /* GUIWindowDebugInfo.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8917,6 +8924,7 @@
 				1840B75413993DA0007C848B /* JSONVariantWriter.cpp in Sources */,
 				7CBC891C139382050046CB82 /* DirtyRegionSolvers.cpp in Sources */,
 				7CBC891D139382050046CB82 /* DirtyRegionTracker.cpp in Sources */,
+				7C0A7CB713A3365E00AFC2BD /* GUIWindowDebugInfo.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -540,6 +540,10 @@
 		7CAA20521079C8160096DE39 /* BaseRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CAA204F1079C8160096DE39 /* BaseRenderer.cpp */; };
 		7CAA25351085963B0096DE39 /* PasswordManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CAA25331085963B0096DE39 /* PasswordManager.cpp */; };
 		7CAA25361085963B0096DE39 /* PasswordManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CAA25331085963B0096DE39 /* PasswordManager.cpp */; };
+		7CBC891A139382050046CB82 /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC8916139382050046CB82 /* DirtyRegionSolvers.cpp */; };
+		7CBC891B139382050046CB82 /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC8918139382050046CB82 /* DirtyRegionTracker.cpp */; };
+		7CBC891C139382050046CB82 /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC8916139382050046CB82 /* DirtyRegionSolvers.cpp */; };
+		7CBC891D139382050046CB82 /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CBC8918139382050046CB82 /* DirtyRegionTracker.cpp */; };
 		7CBEBB8312912BA300431822 /* fstrcmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 7CBEBB8212912BA300431822 /* fstrcmp.c */; };
 		7CBEBB8412912BA400431822 /* fstrcmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 7CBEBB8212912BA300431822 /* fstrcmp.c */; };
 		7CCF7E721067643800992676 /* DirectoryNodeSets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCF7E701067643800992676 /* DirectoryNodeSets.cpp */; };
@@ -2417,6 +2421,11 @@
 		7CAA25341085963B0096DE39 /* PasswordManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PasswordManager.h; sourceTree = "<group>"; };
 		7CAA25371085971C0096DE39 /* MusicArtistInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MusicArtistInfo.h; sourceTree = "<group>"; };
 		7CAA25381085971C0096DE39 /* ScraperUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScraperUrl.h; sourceTree = "<group>"; };
+		7CBC8915139382050046CB82 /* DirtyRegion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegion.h; sourceTree = "<group>"; };
+		7CBC8916139382050046CB82 /* DirtyRegionSolvers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirtyRegionSolvers.cpp; sourceTree = "<group>"; };
+		7CBC8917139382050046CB82 /* DirtyRegionSolvers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionSolvers.h; sourceTree = "<group>"; };
+		7CBC8918139382050046CB82 /* DirtyRegionTracker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirtyRegionTracker.cpp; sourceTree = "<group>"; };
+		7CBC8919139382050046CB82 /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
 		7CBEBB8212912BA300431822 /* fstrcmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fstrcmp.c; sourceTree = "<group>"; };
 		7CCF7E701067643800992676 /* DirectoryNodeSets.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirectoryNodeSets.cpp; sourceTree = "<group>"; };
 		7CCF7E711067643800992676 /* DirectoryNodeSets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectoryNodeSets.h; sourceTree = "<group>"; };
@@ -3983,6 +3992,11 @@
 				18B7C6F81294222D009E7A26 /* D3DResource.h */,
 				18B7C6F91294222D009E7A26 /* DDSImage.h */,
 				18B7C6FA1294222D009E7A26 /* DirectXGraphics.h */,
+				7CBC8915139382050046CB82 /* DirtyRegion.h */,
+				7CBC8916139382050046CB82 /* DirtyRegionSolvers.cpp */,
+				7CBC8917139382050046CB82 /* DirtyRegionSolvers.h */,
+				7CBC8918139382050046CB82 /* DirtyRegionTracker.cpp */,
+				7CBC8919139382050046CB82 /* DirtyRegionTracker.h */,
 				18B7C6FB1294222D009E7A26 /* FrameBufferObject.h */,
 				18B7C6FC1294222D009E7A26 /* Geometry.h */,
 				18B7C6FD1294222D009E7A26 /* GraphicContext.h */,
@@ -8012,6 +8026,8 @@
 				18404D9E1396C13500863BBA /* Slingbox.cpp in Sources */,
 				1840B74D13993D8A007C848B /* JSONVariantParser.cpp in Sources */,
 				1840B75313993DA0007C848B /* JSONVariantWriter.cpp in Sources */,
+				7CBC891A139382050046CB82 /* DirtyRegionSolvers.cpp in Sources */,
+				7CBC891B139382050046CB82 /* DirtyRegionTracker.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8899,6 +8915,8 @@
 				18404E701396E05D00863BBA /* Slingbox.cpp in Sources */,
 				1840B74E13993D8A007C848B /* JSONVariantParser.cpp in Sources */,
 				1840B75413993DA0007C848B /* JSONVariantWriter.cpp in Sources */,
+				7CBC891C139382050046CB82 /* DirtyRegionSolvers.cpp in Sources */,
+				7CBC891D139382050046CB82 /* DirtyRegionTracker.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -688,6 +688,7 @@
     <ClCompile Include="..\..\xbmc\programs\Shortcut.cpp" />
     <ClCompile Include="..\..\xbmc\rendering\dx\GUIWindowTestPatternDX.cpp" />
     <ClCompile Include="..\..\xbmc\rendering\dx\RenderSystemDX.cpp" />
+    <ClCompile Include="..\..\xbmc\rendering\gles\RenderSystemGLES.cpp" />
     <ClCompile Include="..\..\xbmc\rendering\gl\GUIWindowTestPatternGL.cpp" />
     <ClCompile Include="..\..\xbmc\rendering\gl\RenderSystemGL.cpp" />
     <ClCompile Include="..\..\xbmc\rendering\RenderSystem.cpp" />
@@ -1522,6 +1523,7 @@
     <ClInclude Include="..\..\xbmc\programs\Shortcut.h" />
     <ClInclude Include="..\..\xbmc\rendering\dx\GUIWindowTestPatternDX.h" />
     <ClInclude Include="..\..\xbmc\rendering\dx\RenderSystemDX.h" />
+    <ClInclude Include="..\..\xbmc\rendering\gles\RenderSystemGLES.h" />
     <ClInclude Include="..\..\xbmc\rendering\gl\GUIWindowTestPatternGL.h" />
     <ClInclude Include="..\..\xbmc\rendering\gl\RenderSystemGL.h" />
     <ClInclude Include="..\..\xbmc\rendering\RenderSystem.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -351,6 +351,8 @@
     <ClCompile Include="..\..\xbmc\guilib\D3DResource.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\DDSImage.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\DirectXGraphics.cpp" />
+    <ClCompile Include="..\..\xbmc\guilib\DirtyRegionSolvers.cpp" />
+    <ClCompile Include="..\..\xbmc\guilib\DirtyRegionTracker.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\FrameBufferObject.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\GraphicContext.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\GUIAudioManager.cpp" />
@@ -1244,6 +1246,9 @@
     <ClInclude Include="..\..\xbmc\guilib\D3DResource.h" />
     <ClInclude Include="..\..\xbmc\guilib\DDSImage.h" />
     <ClInclude Include="..\..\xbmc\guilib\DirectXGraphics.h" />
+    <ClInclude Include="..\..\xbmc\guilib\DirtyRegion.h" />
+    <ClInclude Include="..\..\xbmc\guilib\DirtyRegionSolvers.h" />
+    <ClInclude Include="..\..\xbmc\guilib\DirtyRegionTracker.h" />
     <ClInclude Include="..\..\xbmc\guilib\FrameBufferObject.h" />
     <ClInclude Include="..\..\xbmc\guilib\Geometry.h" />
     <ClInclude Include="..\..\xbmc\guilib\GraphicContext.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1146,6 +1146,7 @@
     <ClCompile Include="..\..\xbmc\windowing\WinEventsSDL.cpp" />
     <ClCompile Include="..\..\xbmc\windowing\WinSystem.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIMediaWindow.cpp" />
+    <ClCompile Include="..\..\xbmc\windows\GUIWindowDebugInfo.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowFileManager.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowHome.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowLoginScreen.cpp" />
@@ -1982,6 +1983,7 @@
     <ClInclude Include="..\..\xbmc\windowing\WinSystem.h" />
     <ClInclude Include="..\..\xbmc\windowing\XBMC_events.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIMediaWindow.h" />
+    <ClInclude Include="..\..\xbmc\windows\GUIWindowDebugInfo.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowFileManager.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowHome.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowLoginScreen.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2460,7 +2460,9 @@
     <ClCompile Include="..\..\xbmc\guilib\DirtyRegionTracker.cpp">
       <Filter>guilib</Filter>
     </ClCompile>
-
+    <ClCompile Include="..\..\xbmc\rendering\gles\RenderSystemGLES.cpp">
+      <Filter>rendering\gl</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -4928,6 +4930,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\guilib\DirtyRegionSolvers.h">
       <Filter>guilib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\rendering\gles\RenderSystemGLES.h">
+      <Filter>rendering\gl</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2216,6 +2216,9 @@
     <ClCompile Include="..\..\xbmc\windows\GUIMediaWindow.cpp">
       <Filter>windows</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\windows\GUIWindowDebugInfo.cpp">
+      <Filter>windows</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\windows\GUIWindowFileManager.cpp">
       <Filter>windows</Filter>
     </ClCompile>
@@ -4673,6 +4676,9 @@
       <Filter>powermanagement</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\windows\GUIMediaWindow.h">
+      <Filter>windows</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\windows\GUIWindowDebugInfo.h">
       <Filter>windows</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\windows\GUIWindowFileManager.h">

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2454,6 +2454,13 @@
     <ClCompile Include="..\..\xbmc\utils\JSONVariantWriter.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\guilib\DirtyRegionSolvers.cpp">
+      <Filter>guilib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\guilib\DirtyRegionTracker.cpp">
+      <Filter>guilib</Filter>
+    </ClCompile>
+
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -4912,6 +4919,15 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\JSONVariantWriter.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\guilib\DirtyRegionTracker.h">
+      <Filter>guilib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\guilib\DirtyRegion.h">
+      <Filter>guilib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\guilib\DirtyRegionSolvers.h">
+      <Filter>guilib</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2789,6 +2789,14 @@ void CApplication::FrameMove()
   ProcessGamepad(frameTime);
   ProcessEventServer(frameTime);
 
+  // Process events and animate controls before rendering
+  unsigned int currentTime = CTimeUtils::GetFrameTime();
+  g_windowManager.Process(currentTime);
+  if (g_Mouse.IsActive())
+  {
+    CDirtyRegionList dirtyregions;
+    m_guiPointer.DoProcess(currentTime, dirtyregions);
+  }
   g_windowManager.FrameMove();
 }
 
@@ -4804,17 +4812,6 @@ void CApplication::Process()
     ProcessSlow();
   }
 
-  unsigned int currentTime = CTimeUtils::GetFrameTime();
-
-  // Process events and animate controls before rendering
-  g_windowManager.Process(currentTime);
-
-  // Render the mouse pointer
-  if (g_Mouse.IsActive())
-  {
-    CDirtyRegionList dirtyregions;
-    m_guiPointer.DoProcess(currentTime, dirtyregions);
-  }
 }
 
 // We get called every 500ms

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4804,8 +4804,14 @@ void CApplication::Process()
     ProcessSlow();
   }
 
+  unsigned int currentTime = CTimeUtils::GetFrameTime();
+
   // Process events and animate controls before rendering
-  g_windowManager.Process(CTimeUtils::GetFrameTime());
+  g_windowManager.Process(currentTime);
+
+  // Render the mouse pointer
+  if (g_Mouse.IsActive())
+    m_guiPointer.DoProcess(currentTime);
 }
 
 // We get called every 500ms

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4811,7 +4811,10 @@ void CApplication::Process()
 
   // Render the mouse pointer
   if (g_Mouse.IsActive())
-    m_guiPointer.DoProcess(currentTime);
+  {
+    CDirtyRegionList dirtyregions;
+    m_guiPointer.DoProcess(currentTime, dirtyregions);
+  }
 }
 
 // We get called every 500ms

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2075,8 +2075,6 @@ void CApplication::Render()
   else if (vsync_mode != VSYNC_DRIVER)
     g_Windowing.SetVSync(false);
 
-  g_windowManager.UpdateModelessVisibility();
-
   if(!g_Windowing.BeginRender())
     return;
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4803,6 +4803,9 @@ void CApplication::Process()
     m_slowTimer.Reset();
     ProcessSlow();
   }
+
+  // Process events and animate controls before rendering
+  g_windowManager.Process(CTimeUtils::GetFrameTime());
 }
 
 // We get called every 500ms

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2790,12 +2790,15 @@ void CApplication::FrameMove()
   ProcessEventServer(frameTime);
 
   // Process events and animate controls before rendering
-  unsigned int currentTime = CTimeUtils::GetFrameTime();
-  g_windowManager.Process(currentTime);
-  if (g_Mouse.IsActive())
+  if (!m_bStop)
   {
-    CDirtyRegionList dirtyregions;
-    m_guiPointer.DoProcess(currentTime, dirtyregions);
+    unsigned int currentTime = CTimeUtils::GetFrameTime();
+    g_windowManager.Process(currentTime);
+    if (g_Mouse.IsActive())
+    {
+      CDirtyRegionList dirtyregions;
+      m_guiPointer.DoProcess(currentTime, dirtyregions);
+    }
   }
   g_windowManager.FrameMove();
 }

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -39,7 +39,6 @@ namespace ADDON
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogVolumeBar.h"
 #include "dialogs/GUIDialogMuteBug.h"
-#include "windows/GUIWindowPointer.h"   // Mouse pointer
 
 #include "cores/IPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
@@ -223,7 +222,6 @@ public:
   CGUIDialogSeekBar m_guiDialogSeekBar;
   CGUIDialogKaiToast m_guiDialogKaiToast;
   CGUIDialogMuteBug m_guiDialogMuteBug;
-  CGUIWindowPointer m_guiPointer;
 
 #ifdef HAS_DVD_DRIVE
   MEDIA_DETECT::CAutorun m_Autorun;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -58,9 +58,6 @@ namespace ADDON
 #ifdef HAS_PERFORMANCE_SAMPLE
 #include "utils/PerformanceStats.h"
 #endif
-#ifdef _LINUX
-#include "linux/LinuxResourceCounter.h"
-#endif
 #include "windowing/XBMC_events.h"
 #include "threads/Thread.h"
 
@@ -74,7 +71,6 @@ class CKaraokeLyricsManager;
 class CApplicationMessenger;
 class DPMSSupport;
 class CSplash;
-class CGUITextLayout;
 
 class CBackgroundPlayer : public CThread
 {
@@ -158,7 +154,6 @@ public:
   bool OnKey(const CKey& key);
   bool OnAppCommand(const CAction &action);
   bool OnAction(const CAction &action);
-  void RenderMemoryStatus();
   void CheckShutdown();
   // Checks whether the screensaver and / or DPMS should become active.
   void CheckScreenSaverAndDPMS();
@@ -351,8 +346,6 @@ protected:
   bool m_bTestMode;
   bool m_bSystemScreenSaverEnable;
   
-  CGUITextLayout *m_debugLayout;
-
 #if defined(HAS_SDL) || defined(HAS_XBMC_MUTEX)
   int        m_frameCount;
   SDL_mutex* m_frameMutex;
@@ -392,9 +385,6 @@ protected:
 #endif
 #ifdef HAS_PERFORMANCE_SAMPLE
   CPerformanceStats m_perfStats;
-#endif
-#ifdef _LINUX
-  CLinuxResourceCounter m_resourceCounter;
 #endif
 
 #ifdef HAS_EVENT_SERVER

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -1015,7 +1015,7 @@ const TiXmlElement *CGUIDialogAddonSettings::GetFirstSetting() const
   return NULL;
 }
 
-void CGUIDialogAddonSettings::Render()
+void CGUIDialogAddonSettings::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // update status of current section button
   bool alphaFaded = false;
@@ -1035,8 +1035,8 @@ void CGUIDialogAddonSettings::Render()
       alphaFaded = true;
     }
   }
-  CGUIDialogBoxBase::Render();
-  if (alphaFaded && m_bRunning) // dialog may close during Render()
+  CGUIDialogBoxBase::DoProcess(currentTime, dirtyregions);
+  if (alphaFaded && m_bRunning) // dialog may close
   {
     control->SetFocus(false);
     if (control->GetControlType() == CGUIControl::GUICONTROL_BUTTON)

--- a/xbmc/addons/GUIDialogAddonSettings.h
+++ b/xbmc/addons/GUIDialogAddonSettings.h
@@ -35,7 +35,7 @@ public:
    \return true if settings were changed and the dialog confirmed, false otherwise.
    */
   static bool ShowAndGetInput(const ADDON::AddonPtr &addon, bool saveToDisk = true);
-  virtual void Render();
+  virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
 
 protected:
   virtual void OnInitWindow();

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -351,7 +351,7 @@ bool CDVDPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
       CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
       dialog->Show();
       while(!m_ready.WaitMSec(1))
-        g_windowManager.Process(false);
+        g_windowManager.ProcessRenderLoop(false);
       dialog->Close();
     }
 

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -97,7 +97,7 @@ void CGUIDialogProgress::Progress()
 {
   if (m_bRunning)
   {
-    g_windowManager.Process();
+    g_windowManager.ProcessRenderLoop();
   }
 }
 

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -167,7 +167,7 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, C
                   dialog->Close();
                   dialog = NULL;
                 }
-                g_windowManager.Process(false);
+                g_windowManager.ProcessRenderLoop(false);
               }
               else
               {
@@ -177,7 +177,7 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, C
                   if(dialog)
                     dialog->Show();
                 }
-                g_windowManager.Process(true);
+                g_windowManager.ProcessRenderLoop(true);
               }
             }
             if(dialog)

--- a/xbmc/guilib/DirtyRegion.h
+++ b/xbmc/guilib/DirtyRegion.h
@@ -1,0 +1,38 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "Geometry.h"
+#include <vector>
+
+class CDirtyRegion : public CRect
+{
+public:
+  CDirtyRegion(const CRect &rect) : CRect(rect) { m_age = 0; }
+  CDirtyRegion(float left, float top, float right, float bottom) : CRect(left, top, right, bottom) { m_age = 0; }
+  CDirtyRegion() : CRect() { m_age = 0; }
+
+  int UpdateAge() { return ++m_age; }
+private:
+  int m_age;
+};
+
+typedef std::vector<CDirtyRegion> CDirtyRegionList;

--- a/xbmc/guilib/DirtyRegionSolvers.cpp
+++ b/xbmc/guilib/DirtyRegionSolvers.cpp
@@ -1,0 +1,78 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "DirtyRegionSolvers.h"
+#include "GraphicContext.h"
+#include <stdio.h>
+
+void CUnionDirtyRegionSolver::Solve(const CDirtyRegionList &input, CDirtyRegionList &output)
+{
+  CDirtyRegion unifiedRegion;
+  for (unsigned int i = 0; i < input.size(); i++)
+    unifiedRegion.Union(input[i]);
+
+  if (!unifiedRegion.IsEmpty())
+    output.push_back(unifiedRegion);
+}
+
+void CFillViewportRegionSolver::Solve(const CDirtyRegionList &input, CDirtyRegionList &output)
+{
+  CDirtyRegion unifiedRegion(g_graphicsContext.GetViewWindow());
+  output.push_back(unifiedRegion);
+}
+
+CGreedyDirtyRegionSolver::CGreedyDirtyRegionSolver()
+{
+  m_costNewRegion = 10.0f;
+  m_costPerArea   = 0.01f;
+}
+
+void CGreedyDirtyRegionSolver::Solve(const CDirtyRegionList &input, CDirtyRegionList &output)
+{
+  for (unsigned int i = 0; i < input.size(); i++)
+  {
+    CDirtyRegion possibleUnionRegion;
+    int   possibleUnionNbr = -1;
+    float possibleUnionCost = 100000.0f;
+
+    CDirtyRegion currentRegion = input[i];
+    for (unsigned int j = 0; j < output.size(); j++)
+    {
+      CDirtyRegion temporaryUnion = output[j];
+      temporaryUnion.Union(currentRegion);
+      float temporaryCost = m_costPerArea * (temporaryUnion.Area() - output[j].Area());
+      if (temporaryCost < possibleUnionCost)
+      {
+        // TODO if the temporaryCost is 0 then we could skip checking the other regions since there exist no better solution
+        possibleUnionRegion = temporaryUnion;
+        possibleUnionNbr    = j;
+        possibleUnionCost   = temporaryCost;
+      }
+    }
+
+    float newRegionTotalCost = m_costPerArea * currentRegion.Area() + m_costNewRegion;
+
+    if (possibleUnionNbr >= 0 && possibleUnionCost < newRegionTotalCost)
+      output[possibleUnionNbr] = possibleUnionRegion;
+    else
+      output.push_back(currentRegion);
+  }
+}

--- a/xbmc/guilib/DirtyRegionSolvers.h
+++ b/xbmc/guilib/DirtyRegionSolvers.h
@@ -1,0 +1,45 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "IDirtyRegionSolver.h"
+
+class CUnionDirtyRegionSolver : public IDirtyRegionSolver
+{
+public:
+  virtual void Solve(const CDirtyRegionList &input, CDirtyRegionList &output);
+};
+
+class CFillViewportRegionSolver : public IDirtyRegionSolver
+{
+public:
+  virtual void Solve(const CDirtyRegionList &input, CDirtyRegionList &output);
+};
+
+class CGreedyDirtyRegionSolver : public IDirtyRegionSolver
+{
+public:
+  CGreedyDirtyRegionSolver();
+  virtual void Solve(const CDirtyRegionList &input, CDirtyRegionList &output);
+private:
+  float m_costNewRegion;
+  float m_costPerArea;
+};

--- a/xbmc/guilib/DirtyRegionTracker.cpp
+++ b/xbmc/guilib/DirtyRegionTracker.cpp
@@ -1,0 +1,91 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "DirtyRegionTracker.h"
+#include "settings/AdvancedSettings.h"
+#include "utils/log.h"
+#include <stdio.h>
+
+CDirtyRegionTracker::CDirtyRegionTracker(int buffering)
+{
+  m_buffering = buffering;
+  m_solver = NULL;
+}
+
+CDirtyRegionTracker::~CDirtyRegionTracker()
+{
+  delete m_solver;
+}
+
+void CDirtyRegionTracker::SelectAlgorithm()
+{
+  delete m_solver;
+
+  switch (g_advancedSettings.m_guiAlgorithmDirtyRegions)
+  {
+    case DIRTYREGION_SOLVER_UNION:
+      m_solver = new CUnionDirtyRegionSolver();
+      CLog::Log(LOGDEBUG, "guilib: Union as algorithm for solving rendering passes");
+      break;
+    case DIRTYREGION_SOLVER_COST_REDUCTION:
+      CLog::Log(LOGDEBUG, "guilib: Cost reduction as algorithm for solving rendering passes");
+      m_solver = new CGreedyDirtyRegionSolver();
+      break;
+    case DIRTYREGION_SOLVER_NONE:
+    default:
+      CLog::Log(LOGDEBUG, "guilib: No algorithm for solving rendering passes");
+      m_solver = new CFillViewportRegionSolver();
+      break;
+  }
+}
+
+void CDirtyRegionTracker::MarkDirtyRegion(const CDirtyRegion &region)
+{
+  if (!region.IsEmpty())
+    m_markedRegions.push_back(region);
+}
+
+const CDirtyRegionList &CDirtyRegionTracker::GetMarkedRegions() const
+{
+  return m_markedRegions;
+}
+
+CDirtyRegionList CDirtyRegionTracker::GetDirtyRegions()
+{
+  CDirtyRegionList output;
+
+  if (m_solver)
+    m_solver->Solve(m_markedRegions, output);
+
+  return output;
+}
+
+void CDirtyRegionTracker::CleanMarkedRegions()
+{
+  int i = m_markedRegions.size() - 1;
+  while (i >= 0)
+	{
+    if (m_markedRegions[i].UpdateAge() >= m_buffering)
+      m_markedRegions.erase(m_markedRegions.begin() + i);
+
+    i--;
+  }
+}

--- a/xbmc/guilib/DirtyRegionTracker.cpp
+++ b/xbmc/guilib/DirtyRegionTracker.cpp
@@ -80,10 +80,11 @@ CDirtyRegionList CDirtyRegionTracker::GetDirtyRegions()
 
 void CDirtyRegionTracker::CleanMarkedRegions()
 {
+  int buffering = g_advancedSettings.m_guiVisualizeDirtyRegions ? 20 : m_buffering;
   int i = m_markedRegions.size() - 1;
   while (i >= 0)
 	{
-    if (m_markedRegions[i].UpdateAge() >= m_buffering)
+    if (m_markedRegions[i].UpdateAge() >= buffering)
       m_markedRegions.erase(m_markedRegions.begin() + i);
 
     i--;

--- a/xbmc/guilib/DirtyRegionTracker.h
+++ b/xbmc/guilib/DirtyRegionTracker.h
@@ -1,0 +1,42 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "IDirtyRegionSolver.h"
+#include "DirtyRegionSolvers.h"
+
+class CDirtyRegionTracker
+{
+public:
+  CDirtyRegionTracker(int buffering = 2);
+  ~CDirtyRegionTracker();
+  void SelectAlgorithm();
+  void MarkDirtyRegion(const CDirtyRegion &region);
+
+  const CDirtyRegionList &GetMarkedRegions() const;
+  CDirtyRegionList GetDirtyRegions();
+  void CleanMarkedRegions();
+
+private:
+  CDirtyRegionList m_markedRegions;
+  int m_buffering;
+  IDirtyRegionSolver *m_solver;
+};

--- a/xbmc/guilib/DirtyRegionTracker.h
+++ b/xbmc/guilib/DirtyRegionTracker.h
@@ -23,10 +23,16 @@
 #include "IDirtyRegionSolver.h"
 #include "DirtyRegionSolvers.h"
 
+#ifdef _WIN32
+#define DEFAULT_BUFFERING 3
+#else
+#define DEFAULT_BUFFERING 2
+#endif
+
 class CDirtyRegionTracker
 {
 public:
-  CDirtyRegionTracker(int buffering = 2);
+  CDirtyRegionTracker(int buffering = DEFAULT_BUFFERING);
   ~CDirtyRegionTracker();
   void SelectAlgorithm();
   void MarkDirtyRegion(const CDirtyRegion &region);

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -812,6 +812,7 @@ void CGUIBaseContainer::UpdateLayout(bool updateAllItems)
   // and recalculate the layout
   CalculateLayout();
   SetPageControlRange();
+  MarkDirtyRegion();
 }
 
 void CGUIBaseContainer::SetPageControlRange()
@@ -865,8 +866,9 @@ void CGUIBaseContainer::UpdateVisibility(const CGUIListItem *item)
     for (unsigned int i = 0; i < m_staticItems.size(); ++i)
     {
       CGUIStaticItemPtr item = boost::static_pointer_cast<CGUIStaticItem>(m_staticItems[i]);
-      // m_idepth is used to store the visibility condition
-      if (!item->m_idepth || g_infoManager.GetBool(item->m_idepth, GetParentID()))
+      if (item->UpdateVisibility(GetParentID()))
+        MarkDirtyRegion();
+      if (item->IsVisible())
       {
         m_items.push_back(item);
         if (item.get() == lastItem)
@@ -988,7 +990,6 @@ void CGUIBaseContainer::Reset()
   m_wasReset = true;
   m_items.clear();
   m_lastItem = NULL;
-  MarkDirtyRegion();
 }
 
 void CGUIBaseContainer::LoadLayout(TiXmlElement *layout)

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1185,8 +1185,6 @@ void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter)
 
 void CGUIBaseContainer::SetCursor(int cursor)
 {
-  if (m_cursor != cursor)
-    MarkDirtyRegion();
   m_cursor = cursor;
 }
 

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -174,9 +174,9 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItem *item, 
       CGUIListItemLayout *layout = new CGUIListItemLayout(*m_layout);
       item->SetLayout(layout);
     }
-    if (item->GetFocusedLayout() && item->GetFocusedLayout()->IsAnimating(ANIM_TYPE_UNFOCUS))
+    if (item->GetFocusedLayout())
       item->GetFocusedLayout()->Process(item, m_parentID, currentTime, dirtyregions);
-    else if (item->GetLayout())
+    if (item->GetLayout())
       item->GetLayout()->Process(item, m_parentID, currentTime, dirtyregions);
   }
 

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -689,7 +689,7 @@ EVENT_RESULT CGUIBaseContainer::OnMouseEvent(const CPoint &point, const CMouseEv
     m_scrollOffset -= (m_orientation == HORIZONTAL) ? event.m_offsetX : event.m_offsetY;
     float size = (m_layout) ? m_layout->Size(m_orientation) : 10.0f;
     int offset = (int)MathUtils::round_int(m_scrollOffset / size);
-    m_offset = offset;
+    SetOffset(offset);
     ValidateOffset();
     return EVENT_RESULT_HANDLED;
   }
@@ -702,9 +702,9 @@ EVENT_RESULT CGUIBaseContainer::OnMouseEvent(const CPoint &point, const CMouseEv
     float offset = m_scrollOffset / size;
     int toOffset = (int)MathUtils::round_int(offset);
     if (toOffset < offset)
-      m_offset = toOffset+1;
+      SetOffset(toOffset+1);
     else
-      m_offset = toOffset-1;
+      SetOffset(toOffset-1);
     ScrollToOffset(toOffset);
     return EVENT_RESULT_HANDLED;
   }
@@ -954,7 +954,7 @@ void CGUIBaseContainer::ScrollToOffset(int offset)
     else
       m_scrollTimer.Stop();
   }
-  m_offset = offset;
+  SetOffset(offset);
 }
 
 void CGUIBaseContainer::SetContainerMoving(int direction)
@@ -965,6 +965,8 @@ void CGUIBaseContainer::SetContainerMoving(int direction)
 
 void CGUIBaseContainer::UpdateScrollOffset(unsigned int currentTime)
 {
+  if (m_scrollSpeed)
+    MarkDirtyRegion();
   m_scrollOffset += m_scrollSpeed * (currentTime - m_scrollLastTime);
   if ((m_scrollSpeed < 0 && m_scrollOffset < m_offset * m_layout->Size(m_orientation)) ||
       (m_scrollSpeed > 0 && m_scrollOffset > m_offset * m_layout->Size(m_orientation)))
@@ -986,6 +988,7 @@ void CGUIBaseContainer::Reset()
   m_wasReset = true;
   m_items.clear();
   m_lastItem = NULL;
+  MarkDirtyRegion();
 }
 
 void CGUIBaseContainer::LoadLayout(TiXmlElement *layout)
@@ -1204,6 +1207,20 @@ void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter)
     cacheBefore = m_cacheItems / 2;
     cacheAfter = m_cacheItems / 2;
   }
+}
+
+void CGUIBaseContainer::SetCursor(int cursor)
+{
+  if (m_cursor != cursor)
+    MarkDirtyRegion();
+  m_cursor = cursor;
+}
+
+void CGUIBaseContainer::SetOffset(int offset)
+{
+  if (m_offset != offset)
+    MarkDirtyRegion();
+  m_offset = offset;
 }
 
 bool CGUIBaseContainer::CanFocus() const

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -64,16 +64,16 @@ CGUIBaseContainer::~CGUIBaseContainer(void)
 {
 }
 
-void CGUIBaseContainer::DoProcess(unsigned int currentTime)
+void CGUIBaseContainer::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  CGUIControl::DoProcess(currentTime);
+  CGUIControl::DoProcess(currentTime, dirtyregions);
 
   if (m_pageChangeTimer.GetElapsedMilliseconds() > 200)
     m_pageChangeTimer.Stop();
   m_wasReset = false;
 }
 
-void CGUIBaseContainer::Process(unsigned int currentTime)
+void CGUIBaseContainer::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   ValidateOffset();
 
@@ -117,9 +117,9 @@ void CGUIBaseContainer::Process(unsigned int currentTime)
       CGUIListItemPtr item = m_items[itemNo];
       // render our item
       if (m_orientation == VERTICAL)
-        ProcessItem(origin.x, pos, item.get(), focused, currentTime);
+        ProcessItem(origin.x, pos, item.get(), focused, currentTime, dirtyregions);
       else
-        ProcessItem(pos, origin.y, item.get(), focused, currentTime);
+        ProcessItem(pos, origin.y, item.get(), focused, currentTime, dirtyregions);
     }
     // increment our position
     pos += focused ? m_focusedLayout->Size(m_orientation) : m_layout->Size(m_orientation);
@@ -128,10 +128,10 @@ void CGUIBaseContainer::Process(unsigned int currentTime)
 
   UpdatePageControl(offset);
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
-void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItem *item, bool focused, unsigned int currentTime)
+void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItem *item, bool focused, unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   if (!m_focusedLayout || !m_layout) return;
 
@@ -161,7 +161,7 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItem *item, 
           subItem = m_lastItem->GetFocusedLayout()->GetFocusedItem();
         item->GetFocusedLayout()->SetFocusedItem(subItem ? subItem : 1);
       }
-      item->GetFocusedLayout()->Process(item, m_parentID, currentTime);
+      item->GetFocusedLayout()->Process(item, m_parentID, currentTime, dirtyregions);
     }
     m_lastItem = item;
   }
@@ -175,9 +175,9 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItem *item, 
       item->SetLayout(layout);
     }
     if (item->GetFocusedLayout() && item->GetFocusedLayout()->IsAnimating(ANIM_TYPE_UNFOCUS))
-      item->GetFocusedLayout()->Process(item, m_parentID, currentTime);
+      item->GetFocusedLayout()->Process(item, m_parentID, currentTime, dirtyregions);
     else if (item->GetLayout())
-      item->GetLayout()->Process(item, m_parentID, currentTime);
+      item->GetLayout()->Process(item, m_parentID, currentTime, dirtyregions);
   }
 
   g_graphicsContext.RestoreOrigin();

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -263,38 +263,11 @@ void CGUIBaseContainer::RenderItem(float posX, float posY, CGUIListItem *item, b
 
   if (focused)
   {
-    if (!item->GetFocusedLayout())
-    {
-      CGUIListItemLayout *layout = new CGUIListItemLayout(*m_focusedLayout);
-      item->SetFocusedLayout(layout);
-    }
     if (item->GetFocusedLayout())
-    {
-      if (item != m_lastItem || !HasFocus())
-      {
-        item->GetFocusedLayout()->SetFocusedItem(0);
-      }
-      if (item != m_lastItem && HasFocus())
-      {
-        item->GetFocusedLayout()->ResetAnimation(ANIM_TYPE_UNFOCUS);
-        unsigned int subItem = 1;
-        if (m_lastItem && m_lastItem->GetFocusedLayout())
-          subItem = m_lastItem->GetFocusedLayout()->GetFocusedItem();
-        item->GetFocusedLayout()->SetFocusedItem(subItem ? subItem : 1);
-      }
       item->GetFocusedLayout()->Render(item, m_parentID);
-    }
-    m_lastItem = item;
   }
   else
   {
-    if (item->GetFocusedLayout())
-      item->GetFocusedLayout()->SetFocusedItem(0);  // focus is not set
-    if (!item->GetLayout())
-    {
-      CGUIListItemLayout *layout = new CGUIListItemLayout(*m_layout);
-      item->SetLayout(layout);
-    }
     if (item->GetFocusedLayout() && item->GetFocusedLayout()->IsAnimating(ANIM_TYPE_UNFOCUS))
       item->GetFocusedLayout()->Render(item, m_parentID);
     else if (item->GetLayout())

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -129,8 +129,6 @@ protected:
 
   CPoint m_renderOffset; ///< \brief render offset of the first item in the list \sa SetRenderOffset
     
-  int m_offset;
-  int m_cursor;
   float m_analogScrollCount;
   unsigned int m_lastHoldTime;
 
@@ -183,13 +181,18 @@ protected:
    this also marks the control as dirty (if needed)
    */
   virtual void SetCursor(int cursor);
+  inline int GetCursor() const { return m_cursor; };
 
   /*! \brief Set the container offset
    Should be used by all base classes rather than directly setting it, as
    this also marks the control as dirty (if needed)
    */
   void SetOffset(int offset);
+  inline int GetOffset() const { return m_offset; };
+
 private:
+  int m_cursor;
+  int m_offset;
   int m_cacheItems;
   float m_scrollSpeed;
   CStopWatch m_scrollTimer;

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -68,8 +68,8 @@ public:
   virtual void SaveStates(std::vector<CControlState> &states);
   virtual int GetSelectedItem() const;
 
-  virtual void DoProcess(unsigned int currentTime);
-  virtual void Process(unsigned int currentTime);
+  virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
 
   void LoadLayout(TiXmlElement *layout);
   void LoadContent(TiXmlElement *content);
@@ -100,7 +100,7 @@ protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   bool OnClick(int actionID);
 
-  virtual void ProcessItem(float posX, float posY, CGUIListItem *item, bool focused, unsigned int currentTime);
+  virtual void ProcessItem(float posX, float posY, CGUIListItem *item, bool focused, unsigned int currentTime, CDirtyRegionList &dirtyregions);
 
   virtual void Render();
   virtual void RenderItem(float posX, float posY, CGUIListItem *item, bool focused);

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -68,7 +68,9 @@ public:
   virtual void SaveStates(std::vector<CControlState> &states);
   virtual int GetSelectedItem() const;
 
-  virtual void DoRender(unsigned int currentTime);
+  virtual void DoProcess(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime);
+
   void LoadLayout(TiXmlElement *layout);
   void LoadContent(TiXmlElement *content);
 
@@ -97,6 +99,9 @@ public:
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   bool OnClick(int actionID);
+
+  virtual void ProcessItem(float posX, float posY, CGUIListItem *item, bool focused, unsigned int currentTime);
+
   virtual void Render();
   virtual void RenderItem(float posX, float posY, CGUIListItem *item, bool focused);
   virtual void Scroll(int amount);
@@ -138,8 +143,6 @@ protected:
 
   int m_pageControl;
 
-  unsigned int m_renderTime;
-
   std::vector<CGUIListItemLayout> m_layouts;
   std::vector<CGUIListItemLayout> m_focusedLayouts;
 
@@ -148,7 +151,7 @@ protected:
 
   void ScrollToOffset(int offset);
   void SetContainerMoving(int direction);
-  void UpdateScrollOffset();
+  void UpdateScrollOffset(unsigned int currentTime);
 
   unsigned int m_scrollLastTime;
   int          m_scrollTime;

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -177,6 +177,18 @@ protected:
   void OnJumpLetter(char letter);
   void OnJumpSMS(int letter);
   std::vector< std::pair<int, CStdString> > m_letterOffsets;
+
+  /*! \brief Set the cursor position
+   Should be used by all base classes rather than directly setting it, as
+   this also marks the control as dirty (if needed)
+   */
+  virtual void SetCursor(int cursor);
+
+  /*! \brief Set the container offset
+   Should be used by all base classes rather than directly setting it, as
+   this also marks the control as dirty (if needed)
+   */
+  void SetOffset(int offset);
 private:
   int m_cacheItems;
   float m_scrollSpeed;

--- a/xbmc/guilib/GUIBorderedImage.cpp
+++ b/xbmc/guilib/GUIBorderedImage.cpp
@@ -40,7 +40,7 @@ CGUIBorderedImage::~CGUIBorderedImage(void)
 {
 }
 
-void CGUIBorderedImage::Render()
+void CGUIBorderedImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   if (!m_borderImage.GetFileName().IsEmpty() && m_texture.ReadyToRender())
   {
@@ -50,9 +50,22 @@ void CGUIBorderedImage::Render()
     m_borderImage.SetWidth(rect.Width() + m_borderSize.x1 + m_borderSize.x2);
     m_borderImage.SetHeight(rect.Height() + m_borderSize.y1 + m_borderSize.y2);
     m_borderImage.SetDiffuseColor(m_diffuseColor);
-    m_borderImage.Render();
+    if (m_borderImage.Process(currentTime))
+      MarkDirtyRegion();
   }
+  CGUIImage::Process(currentTime, dirtyregions);
+}
+
+void CGUIBorderedImage::Render()
+{
+  if (!m_borderImage.GetFileName().IsEmpty() && m_texture.ReadyToRender())
+    m_borderImage.Render();
   CGUIImage::Render();
+}
+
+CRect CGUIBorderedImage::CalcRenderRegion() const
+{
+  return m_borderImage.GetRenderRect();
 }
 
 void CGUIBorderedImage::AllocResources()

--- a/xbmc/guilib/GUIBorderedImage.h
+++ b/xbmc/guilib/GUIBorderedImage.h
@@ -34,10 +34,13 @@ public:
   virtual ~CGUIBorderedImage(void);
   virtual CGUIBorderedImage *Clone() const { return new CGUIBorderedImage(*this); };
 
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);
   virtual void DynamicResourceAlloc(bool bOnOff);
+  
+  virtual CRect CalcRenderRegion() const;
 
 protected:
   CGUITexture m_borderImage;

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -218,12 +218,14 @@ void CGUIButtonControl::SetAlpha(unsigned char alpha)
   m_imgNoFocus.SetAlpha(alpha);
 }
 
-void CGUIButtonControl::UpdateColors()
+bool CGUIButtonControl::UpdateColors()
 {
-  m_label.UpdateColors();
-  CGUIControl::UpdateColors();
-  m_imgFocus.SetDiffuseColor(m_diffuseColor);
-  m_imgNoFocus.SetDiffuseColor(m_diffuseColor);
+  bool changed = m_label.UpdateColors();
+  changed |= CGUIControl::UpdateColors();
+  changed |= m_imgFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgNoFocus.SetDiffuseColor(m_diffuseColor);
+
+  return changed;
 }
 
 EVENT_RESULT CGUIButtonControl::OnMouseEvent(const CPoint &point, const CMouseEvent &event)

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -239,7 +239,7 @@ bool CGUIButtonControl::UpdateColors()
   return changed;
 }
 
-CRect CGUIButtonControl::GetRenderRegion()
+CRect CGUIButtonControl::GetRenderRegion() const
 {
   CRect buttonRect = CGUIControl::GetRenderRegion();
   CRect textRect = m_label.GetRenderRect();

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -44,7 +44,7 @@ CGUIButtonControl::~CGUIButtonControl(void)
 {
 }
 
-void CGUIButtonControl::Render()
+void CGUIButtonControl::Process(unsigned int currentTime)
 {
   if (m_bInvalidated)
   {
@@ -79,11 +79,24 @@ void CGUIButtonControl::Render()
     m_imgFocus.SetVisible(false);
     m_imgNoFocus.SetVisible(true);
   }
-  // render both so the visibility settings cause the frame counter to resetcorrectly
-  m_imgFocus.Render();
-  m_imgNoFocus.Render();
 
-  RenderText();
+  m_imgFocus.Process(currentTime);
+  m_imgNoFocus.Process(currentTime);
+
+  ProcessText(currentTime);
+  CGUIControl::Process(currentTime);
+}
+
+void CGUIButtonControl::Render()
+{
+  if (HasFocus())
+    m_imgFocus.Render();
+  else
+    m_imgNoFocus.Render();
+
+  m_label.Render();
+  m_label2.Render();
+
   CGUIControl::Render();
 }
 
@@ -96,7 +109,7 @@ CGUILabel::COLOR CGUIButtonControl::GetTextColor() const
   return CGUILabel::COLOR_TEXT;
 }
 
-void CGUIButtonControl::RenderText()
+void CGUIButtonControl::ProcessText(unsigned int currentTime)
 {
   m_label.SetMaxRect(m_posX, m_posY, m_width, m_height);
   m_label.SetText(m_info.GetLabel(m_parentID));
@@ -114,10 +127,8 @@ void CGUIButtonControl::RenderText()
     CGUILabel::CheckAndCorrectOverlap(m_label, m_label2);
 
     m_label2.SetColor(GetTextColor());
-    m_label2.Render();
   }
   m_label.SetColor(GetTextColor());
-  m_label.Render();
 }
 
 bool CGUIButtonControl::OnAction(const CAction &action)

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -111,24 +111,26 @@ CGUILabel::COLOR CGUIButtonControl::GetTextColor() const
 
 void CGUIButtonControl::ProcessText(unsigned int currentTime)
 {
-  m_label.SetMaxRect(m_posX, m_posY, m_width, m_height);
-  m_label.SetText(m_info.GetLabel(m_parentID));
-  m_label.SetScrolling(HasFocus());
+  bool changed = m_label.SetMaxRect(m_posX, m_posY, m_width, m_height);
+  changed |= m_label.SetText(m_info.GetLabel(m_parentID));
+  changed |= m_label.SetScrolling(HasFocus());
 
   // render the second label if it exists
   CStdString label2(m_info2.GetLabel(m_parentID));
   if (!label2.IsEmpty())
   {
-    m_label2.SetMaxRect(m_posX, m_posY, m_width, m_height);
-    m_label2.SetText(label2);
-    m_label2.SetAlign(XBFONT_RIGHT | (m_label.GetLabelInfo().align & XBFONT_CENTER_Y) | XBFONT_TRUNCATED);
-    m_label2.SetScrolling(HasFocus());
+    changed |= m_label2.SetMaxRect(m_posX, m_posY, m_width, m_height);
+    changed |= m_label2.SetText(label2);
+    changed |= m_label2.SetAlign(XBFONT_RIGHT | (m_label.GetLabelInfo().align & XBFONT_CENTER_Y) | XBFONT_TRUNCATED);
+    changed |= m_label2.SetScrolling(HasFocus());
 
-    CGUILabel::CheckAndCorrectOverlap(m_label, m_label2);
+    changed |= CGUILabel::CheckAndCorrectOverlap(m_label, m_label2);
 
-    m_label2.SetColor(GetTextColor());
+    changed |= m_label2.SetColor(GetTextColor());
   }
-  m_label.SetColor(GetTextColor());
+  changed |= m_label.SetColor(GetTextColor());
+  if (changed)
+    MarkDirtyRegion();
 }
 
 bool CGUIButtonControl::OnAction(const CAction &action)

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -57,10 +57,10 @@ void CGUIButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
 
   if (HasFocus())
   {
+    unsigned int alphaChannel = m_alpha;
     if (m_pulseOnSelect)
     {
       unsigned int alphaCounter = m_focusCounter + 2;
-      unsigned int alphaChannel;
       if ((alphaCounter % 128) >= 64)
         alphaChannel = alphaCounter % 64;
       else
@@ -68,8 +68,11 @@ void CGUIButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
 
       alphaChannel += 192;
       alphaChannel = (unsigned int)((float)m_alpha * (float)alphaChannel / 255.0f);
-      m_imgFocus.SetAlpha((unsigned char)alphaChannel);
+
+      if (m_imgFocus.SetAlpha((unsigned char)alphaChannel))
+        MarkDirtyRegion();
     }
+
     m_imgFocus.SetVisible(true);
     m_imgNoFocus.SetVisible(false);
     m_focusCounter++;
@@ -89,10 +92,8 @@ void CGUIButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
 
 void CGUIButtonControl::Render()
 {
-  if (HasFocus())
-    m_imgFocus.Render();
-  else
-    m_imgNoFocus.Render();
+  m_imgFocus.Render();
+  m_imgNoFocus.Render();
 
   m_label.Render();
   m_label2.Render();
@@ -224,9 +225,9 @@ void CGUIButtonControl::SetPosition(float posX, float posY)
 
 void CGUIButtonControl::SetAlpha(unsigned char alpha)
 {
+  if (m_alpha != alpha)
+    MarkDirtyRegion();
   m_alpha = alpha;
-  m_imgFocus.SetAlpha(alpha);
-  m_imgNoFocus.SetAlpha(alpha);
 }
 
 bool CGUIButtonControl::UpdateColors()

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -228,6 +228,14 @@ bool CGUIButtonControl::UpdateColors()
   return changed;
 }
 
+CRect CGUIButtonControl::GetRenderRegion()
+{
+  CRect buttonRect = CGUIControl::GetRenderRegion();
+  CRect textRect = m_label.GetRenderRect();
+  buttonRect.Union(textRect);
+  return buttonRect;
+}
+
 EVENT_RESULT CGUIButtonControl::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
 {
   if (event.m_id == ACTION_MOUSE_LEFT_CLICK)
@@ -317,4 +325,3 @@ void CGUIButtonControl::SetSelected(bool bSelected)
     SetInvalid();
   }
 }
-

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -231,8 +231,8 @@ void CGUIButtonControl::SetAlpha(unsigned char alpha)
 
 bool CGUIButtonControl::UpdateColors()
 {
-  bool changed = m_label.UpdateColors();
-  changed |= CGUIControl::UpdateColors();
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_label.UpdateColors();
   changed |= m_imgFocus.SetDiffuseColor(m_diffuseColor);
   changed |= m_imgNoFocus.SetDiffuseColor(m_diffuseColor);
 

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -44,7 +44,7 @@ CGUIButtonControl::~CGUIButtonControl(void)
 {
 }
 
-void CGUIButtonControl::Process(unsigned int currentTime)
+void CGUIButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   if (m_bInvalidated)
   {
@@ -84,7 +84,7 @@ void CGUIButtonControl::Process(unsigned int currentTime)
   m_imgNoFocus.Process(currentTime);
 
   ProcessText(currentTime);
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIButtonControl::Render()

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -68,10 +68,9 @@ void CGUIButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
 
       alphaChannel += 192;
       alphaChannel = (unsigned int)((float)m_alpha * (float)alphaChannel / 255.0f);
-
-      if (m_imgFocus.SetAlpha((unsigned char)alphaChannel))
-        MarkDirtyRegion();
     }
+    if (m_imgFocus.SetAlpha((unsigned char)alphaChannel))
+      MarkDirtyRegion();
 
     m_imgFocus.SetVisible(true);
     m_imgNoFocus.SetVisible(false);
@@ -209,11 +208,13 @@ void CGUIButtonControl::SetInvalid()
 void CGUIButtonControl::SetLabel(const string &label)
 { // NOTE: No fallback for buttons at this point
   m_info.SetLabel(label, "");
+  SetInvalid();
 }
 
 void CGUIButtonControl::SetLabel2(const string &label2)
 { // NOTE: No fallback for buttons at this point
   m_info2.SetLabel(label2, "");
+  SetInvalid();
 }
 
 void CGUIButtonControl::SetPosition(float posX, float posY)

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -240,9 +240,9 @@ bool CGUIButtonControl::UpdateColors()
   return changed;
 }
 
-CRect CGUIButtonControl::GetRenderRegion() const
+CRect CGUIButtonControl::CalcRenderRegion() const
 {
-  CRect buttonRect = CGUIControl::GetRenderRegion();
+  CRect buttonRect = CGUIControl::CalcRenderRegion();
   CRect textRect = m_label.GetRenderRect();
   buttonRect.Union(textRect);
   return buttonRect;

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -80,7 +80,7 @@ public:
 
   virtual bool UpdateColors();
 
-  virtual CRect GetRenderRegion() const;
+  virtual CRect CalcRenderRegion() const;
 
 protected:
   friend class CGUISpinControlEx;

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -48,6 +48,7 @@ public:
   virtual ~CGUIButtonControl(void);
   virtual CGUIButtonControl *Clone() const { return new CGUIButtonControl(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool OnAction(const CAction &action) ;
   virtual bool OnMessage(CGUIMessage& message);
@@ -86,7 +87,7 @@ protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   void OnFocus();
   void OnUnFocus();
-  virtual void RenderText();
+  virtual void ProcessText(unsigned int currentTime);
   CGUILabel::COLOR GetTextColor() const;
 
   CGUITexture m_imgFocus;

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -80,7 +80,7 @@ public:
 
   virtual bool UpdateColors();
 
-  virtual CRect GetRenderRegion();
+  virtual CRect GetRenderRegion() const;
 
 protected:
   friend class CGUISpinControlEx;

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -77,7 +77,7 @@ public:
   virtual void OnClick();
   bool HasClickActions() { return m_clickActions.size() > 0; };
 
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
 protected:
   friend class CGUISpinControlEx;
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -48,7 +48,7 @@ public:
   virtual ~CGUIButtonControl(void);
   virtual CGUIButtonControl *Clone() const { return new CGUIButtonControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action) ;
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -78,6 +78,9 @@ public:
   bool HasClickActions() { return m_clickActions.size() > 0; };
 
   virtual bool UpdateColors();
+
+  virtual CRect GetRenderRegion();
+
 protected:
   friend class CGUISpinControlEx;
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);

--- a/xbmc/guilib/GUIButtonScroller.cpp
+++ b/xbmc/guilib/GUIButtonScroller.cpp
@@ -677,8 +677,10 @@ void CGUIButtonScroller::DoDown()
 
 bool CGUIButtonScroller::UpdateColors()
 {
-  bool changed = m_label.UpdateColors();
-  return CGUIControl::UpdateColors() || changed;
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_label.UpdateColors();
+
+  return changed;
 }
 
 void CGUIButtonScroller::RenderItem(float &posX, float &posY, int &iOffset, bool bText)

--- a/xbmc/guilib/GUIButtonScroller.cpp
+++ b/xbmc/guilib/GUIButtonScroller.cpp
@@ -308,6 +308,14 @@ void CGUIButtonScroller::SetInvalid()
   m_imgNoFocus.SetInvalid();
 }
 
+void CGUIButtonScroller::Process(unsigned int currentTime)
+{
+  // TODO Proper processing which marks when its actually changed. Just mark always for now.
+  MarkDirtyRegion();
+
+  CGUIControl::Process(currentTime);
+}
+
 void CGUIButtonScroller::Render()
 {
   if (m_bInvalidated)

--- a/xbmc/guilib/GUIButtonScroller.cpp
+++ b/xbmc/guilib/GUIButtonScroller.cpp
@@ -308,12 +308,12 @@ void CGUIButtonScroller::SetInvalid()
   m_imgNoFocus.SetInvalid();
 }
 
-void CGUIButtonScroller::Process(unsigned int currentTime)
+void CGUIButtonScroller::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIButtonScroller::Render()

--- a/xbmc/guilib/GUIButtonScroller.cpp
+++ b/xbmc/guilib/GUIButtonScroller.cpp
@@ -667,10 +667,10 @@ void CGUIButtonScroller::DoDown()
   }
 }
 
-void CGUIButtonScroller::UpdateColors()
+bool CGUIButtonScroller::UpdateColors()
 {
-  m_label.UpdateColors();
-  CGUIControl::UpdateColors();
+  bool changed = m_label.UpdateColors();
+  return CGUIControl::UpdateColors() || changed;
 }
 
 void CGUIButtonScroller::RenderItem(float &posX, float &posY, int &iOffset, bool bText)

--- a/xbmc/guilib/GUIButtonScroller.h
+++ b/xbmc/guilib/GUIButtonScroller.h
@@ -66,6 +66,7 @@ public:
   virtual void OnRight();
   virtual void OnDown();
   virtual bool OnMouseOver(const CPoint &point);
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);

--- a/xbmc/guilib/GUIButtonScroller.h
+++ b/xbmc/guilib/GUIButtonScroller.h
@@ -82,7 +82,7 @@ public:
 
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   int GetNext(int iCurrent) const;
   int GetPrevious(int iCurrent);
   int GetButton(int iOffset);

--- a/xbmc/guilib/GUIButtonScroller.h
+++ b/xbmc/guilib/GUIButtonScroller.h
@@ -66,7 +66,7 @@ public:
   virtual void OnRight();
   virtual void OnDown();
   virtual bool OnMouseOver(const CPoint &point);
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);

--- a/xbmc/guilib/GUICheckMarkControl.cpp
+++ b/xbmc/guilib/GUICheckMarkControl.cpp
@@ -176,10 +176,12 @@ void CGUICheckMarkControl::PythonSetDisabledColor(color_t disabledColor)
   m_label.GetLabelInfo().disabledColor = disabledColor;
 }
 
-void CGUICheckMarkControl::UpdateColors()
+bool CGUICheckMarkControl::UpdateColors()
 {
-  m_label.UpdateColors();
-  CGUIControl::UpdateColors();
-  m_imgCheckMark.SetDiffuseColor(m_diffuseColor);
-  m_imgCheckMarkNoFocus.SetDiffuseColor(m_diffuseColor);
+  bool changed = m_label.UpdateColors();
+  changed |= CGUIControl::UpdateColors();
+  changed |= m_imgCheckMark.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgCheckMarkNoFocus.SetDiffuseColor(m_diffuseColor);
+
+  return changed;
 }

--- a/xbmc/guilib/GUICheckMarkControl.cpp
+++ b/xbmc/guilib/GUICheckMarkControl.cpp
@@ -43,9 +43,14 @@ CGUICheckMarkControl::~CGUICheckMarkControl(void)
 
 void CGUICheckMarkControl::Process(unsigned int currentTime)
 {
-  m_imgCheckMark.Process(currentTime);
-  m_imgCheckMarkNoFocus.Process(currentTime);
-  m_label.Process(currentTime);
+  bool changed = false;
+
+  changed |= m_imgCheckMark.Process(currentTime);
+  changed |= m_imgCheckMarkNoFocus.Process(currentTime);
+  changed |= m_label.Process(currentTime);
+
+  if (changed)
+    MarkDirtyRegion();
 
   CGUIControl::Process(currentTime);
 }

--- a/xbmc/guilib/GUICheckMarkControl.cpp
+++ b/xbmc/guilib/GUICheckMarkControl.cpp
@@ -41,7 +41,7 @@ CGUICheckMarkControl::CGUICheckMarkControl(int parentID, int controlID, float po
 CGUICheckMarkControl::~CGUICheckMarkControl(void)
 {}
 
-void CGUICheckMarkControl::Process(unsigned int currentTime)
+void CGUICheckMarkControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   bool changed = false;
 
@@ -52,7 +52,7 @@ void CGUICheckMarkControl::Process(unsigned int currentTime)
   if (changed)
     MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUICheckMarkControl::Render()

--- a/xbmc/guilib/GUICheckMarkControl.cpp
+++ b/xbmc/guilib/GUICheckMarkControl.cpp
@@ -41,6 +41,15 @@ CGUICheckMarkControl::CGUICheckMarkControl(int parentID, int controlID, float po
 CGUICheckMarkControl::~CGUICheckMarkControl(void)
 {}
 
+void CGUICheckMarkControl::Process(unsigned int currentTime)
+{
+  m_imgCheckMark.Process(currentTime);
+  m_imgCheckMarkNoFocus.Process(currentTime);
+  m_label.Process(currentTime);
+
+  CGUIControl::Process(currentTime);
+}
+
 void CGUICheckMarkControl::Render()
 {
   m_label.SetText(m_strLabel);

--- a/xbmc/guilib/GUICheckMarkControl.cpp
+++ b/xbmc/guilib/GUICheckMarkControl.cpp
@@ -174,7 +174,11 @@ EVENT_RESULT CGUICheckMarkControl::OnMouseEvent(const CPoint &point, const CMous
 
 void CGUICheckMarkControl::SetLabel(const string &label)
 {
-  m_strLabel = label;
+  if (m_strLabel != label)
+  {
+    m_strLabel = label;
+    SetInvalid();
+  }
 }
 
 void CGUICheckMarkControl::PythonSetLabel(const CStdString &strFont, const string &strText, color_t textColor)
@@ -183,6 +187,7 @@ void CGUICheckMarkControl::PythonSetLabel(const CStdString &strFont, const strin
   m_label.GetLabelInfo().textColor = textColor;
   m_label.GetLabelInfo().focusedColor = textColor;
   m_strLabel = strText;
+  SetInvalid();
 }
 
 void CGUICheckMarkControl::PythonSetDisabledColor(color_t disabledColor)

--- a/xbmc/guilib/GUICheckMarkControl.cpp
+++ b/xbmc/guilib/GUICheckMarkControl.cpp
@@ -192,8 +192,8 @@ void CGUICheckMarkControl::PythonSetDisabledColor(color_t disabledColor)
 
 bool CGUICheckMarkControl::UpdateColors()
 {
-  bool changed = m_label.UpdateColors();
-  changed |= CGUIControl::UpdateColors();
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_label.UpdateColors();
   changed |= m_imgCheckMark.SetDiffuseColor(m_diffuseColor);
   changed |= m_imgCheckMarkNoFocus.SetDiffuseColor(m_diffuseColor);
 

--- a/xbmc/guilib/GUICheckMarkControl.h
+++ b/xbmc/guilib/GUICheckMarkControl.h
@@ -44,6 +44,7 @@ public:
   virtual ~CGUICheckMarkControl(void);
   virtual CGUICheckMarkControl *Clone() const { return new CGUICheckMarkControl(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool OnAction(const CAction &action) ;
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUICheckMarkControl.h
+++ b/xbmc/guilib/GUICheckMarkControl.h
@@ -44,7 +44,7 @@ public:
   virtual ~CGUICheckMarkControl(void);
   virtual CGUICheckMarkControl *Clone() const { return new CGUICheckMarkControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action) ;
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUICheckMarkControl.h
+++ b/xbmc/guilib/GUICheckMarkControl.h
@@ -63,7 +63,7 @@ public:
 
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   CGUILabel::COLOR GetTextColor() const;
   
   CGUITexture m_imgCheckMark;

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -422,9 +422,11 @@ void CGUIControl::SetPosition(float posX, float posY)
   }
 }
 
-void CGUIControl::SetColorDiffuse(const CGUIInfoColor &color)
+bool CGUIControl::SetColorDiffuse(const CGUIInfoColor &color)
 {
+  bool changed = m_diffuseColor != color;
   m_diffuseColor = color;
+  return changed;
 }
 
 float CGUIControl::GetXPosition() const
@@ -613,9 +615,9 @@ void CGUIControl::UpdateVisibility(const CGUIListItem *item)
     UpdateInfo(item);
 }
 
-void CGUIControl::UpdateColors()
+bool CGUIControl::UpdateColors()
 {
-  m_diffuseColor.Update();
+  return m_diffuseColor.Update();
 }
 
 void CGUIControl::SetInitialVisibility()

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -139,6 +139,8 @@ void CGUIControl::DynamicResourceAlloc(bool bOnOff)
 // 3. reset the animation transform
 void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
+  CRect dirtyRegion = m_renderRegion;
+
   bool changed = m_bInvalidated;
 
   changed |= Animate(currentTime);
@@ -158,11 +160,8 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
 
   if (changed)
   {
-    CRect currentRenderRegion = g_graphicsContext.generateAABB(GetRenderRegion());
-    CRect dirtyRegion = currentRenderRegion;
-    dirtyRegion.Union(m_previousDirtyRegion);
+    dirtyRegion.Union(m_renderRegion);
     dirtyregions.push_back(dirtyRegion);
-    m_previousDirtyRegion = currentRenderRegion;
   }
 
   if (m_hasCamera)
@@ -175,6 +174,8 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
 
 void CGUIControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
+  // update our render region
+  m_renderRegion = g_graphicsContext.generateAABB(CalcRenderRegion());
 }
 
 // the main render routine.
@@ -502,7 +503,7 @@ void CGUIControl::MarkDirtyRegion()
   m_controlIsDirty = true;
 }
 
-CRect CGUIControl::GetRenderRegion() const
+CRect CGUIControl::CalcRenderRegion() const
 {
   CPoint tl(GetXPosition(), GetYPosition());
   CPoint br(tl.x + GetWidth(), tl.y + GetHeight());

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -132,13 +132,43 @@ void CGUIControl::DynamicResourceAlloc(bool bOnOff)
 
 }
 
-// the main render routine.
-// 1. animate and set the animation transform
-// 2. if visible, paint
+// the main processing routine.
+// 1. animate and set animation transform
+// 2. if visible, process
 // 3. reset the animation transform
-void CGUIControl::DoRender(unsigned int currentTime)
+void CGUIControl::DoProcess(unsigned int currentTime)
 {
   Animate(currentTime);
+
+  g_graphicsContext.AddTransform(m_transform);
+  if (m_hasCamera)
+    g_graphicsContext.SetCameraPosition(m_camera);
+
+//  GUIPROFILER_VISIBILITY_BEGIN(control);
+  UpdateVisibility();
+//  GUIPROFILER_VISIBILITY_END(control);
+
+  if (IsVisible())
+    Process(currentTime);
+
+  if (m_hasCamera)
+    g_graphicsContext.RestoreCameraPosition();
+  g_graphicsContext.RemoveTransform();
+
+  m_bInvalidated = false;
+}
+
+void CGUIControl::Process(unsigned int currentTime)
+{
+}
+
+// the main render routine.
+// 1. set the animation transform
+// 2. if visible, paint
+// 3. reset the animation transform
+void CGUIControl::DoRender()
+{
+  g_graphicsContext.AddTransform(m_transform);
   if (m_hasCamera)
     g_graphicsContext.SetCameraPosition(m_camera);
   if (IsVisible())
@@ -832,7 +862,6 @@ void CGUIControl::Animate(unsigned int currentTime)
       }
     }*/
   }
-  g_graphicsContext.AddTransform(m_transform);
 }
 
 bool CGUIControl::IsAnimating(ANIMATION_TYPE animType)

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -449,7 +449,11 @@ bool CGUIControl::IsDisabled() const
 
 void CGUIControl::SetEnabled(bool bEnable)
 {
-  m_enabled = bEnable;
+  if (bEnable != m_enabled)
+  {
+    m_enabled = bEnable;
+    SetInvalid();
+  }
 }
 
 void CGUIControl::SetEnableCondition(int condition)

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -864,7 +864,7 @@ void CGUIControl::UpdateStates(ANIMATION_TYPE type, ANIMATION_PROCESS currentPro
   }
 }
 
-void CGUIControl::Animate(unsigned int currentTime)
+bool CGUIControl::Animate(unsigned int currentTime)
 {
   // check visible state outside the loop, as it could change
   GUIVISIBLE visible = m_visible;
@@ -908,6 +908,8 @@ void CGUIControl::Animate(unsigned int currentTime)
 
     MarkDirtyRegion();
   }
+
+  return changed;
 }
 
 bool CGUIControl::IsAnimating(ANIMATION_TYPE animType)

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -137,7 +137,7 @@ void CGUIControl::DynamicResourceAlloc(bool bOnOff)
 // 1. animate and set animation transform
 // 2. if visible, process
 // 3. reset the animation transform
-void CGUIControl::DoProcess(unsigned int currentTime)
+void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   bool changed = m_bInvalidated;
 
@@ -152,7 +152,7 @@ void CGUIControl::DoProcess(unsigned int currentTime)
 //  GUIPROFILER_VISIBILITY_END(control);
 
   if (IsVisible())
-    Process(currentTime);
+    Process(currentTime, dirtyregions);
 
   changed |=  m_controlIsDirty;
 
@@ -172,7 +172,7 @@ void CGUIControl::DoProcess(unsigned int currentTime)
   m_controlIsDirty = false;
 }
 
-void CGUIControl::Process(unsigned int currentTime)
+void CGUIControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
 }
 

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -162,7 +162,7 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
   m_previousDirtyRegion = currentRenderRegion;
 
   if (changed)
-    SendFinalDirtyRegionToParent(dirtyRegion, this);
+    dirtyregions.push_back(dirtyRegion);
 
   if (m_hasCamera)
     g_graphicsContext.RestoreCameraPosition();
@@ -499,14 +499,6 @@ float CGUIControl::GetHeight() const
 void CGUIControl::MarkDirtyRegion()
 {
   m_controlIsDirty = true;
-}
-
-void CGUIControl::SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender)
-{
-  if (m_parentControl)
-    m_parentControl->SendFinalDirtyRegionToParent(dirtyRegion, sender);
-  else
-    g_windowManager.MarkDirtyRegion(dirtyRegion);
 }
 
 CRect CGUIControl::GetRenderRegion() const

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -156,13 +156,14 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
 
   changed |=  m_controlIsDirty;
 
-  CRect currentRenderRegion = g_graphicsContext.generateAABB(GetRenderRegion());
-  CRect dirtyRegion = currentRenderRegion;
-  dirtyRegion.Union(m_previousDirtyRegion);
-  m_previousDirtyRegion = currentRenderRegion;
-
   if (changed)
+  {
+    CRect currentRenderRegion = g_graphicsContext.generateAABB(GetRenderRegion());
+    CRect dirtyRegion = currentRenderRegion;
+    dirtyRegion.Union(m_previousDirtyRegion);
     dirtyregions.push_back(dirtyRegion);
+    m_previousDirtyRegion = currentRenderRegion;
+  }
 
   if (m_hasCamera)
     g_graphicsContext.RestoreCameraPosition();

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -528,7 +528,7 @@ void CGUIControl::FlushDirtyRegion(bool setMatrixBeforeFlush)
   m_markedLocalRegion = CRect();
 }
 
-CRect CGUIControl::GetRenderRegion()
+CRect CGUIControl::GetRenderRegion() const
 {
   CPoint tl(GetXPosition(), GetYPosition());
   CPoint br(tl.x + GetWidth(), tl.y + GetHeight());

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -143,7 +143,7 @@ void CGUIControl::DoProcess(unsigned int currentTime)
 
   changed |= Animate(currentTime);
 
-  g_graphicsContext.AddTransform(m_transform);
+  m_cachedTransform = g_graphicsContext.AddTransform(m_transform);
   if (m_hasCamera)
     g_graphicsContext.SetCameraPosition(m_camera);
 
@@ -182,7 +182,7 @@ void CGUIControl::Process(unsigned int currentTime)
 // 3. reset the animation transform
 void CGUIControl::DoRender()
 {
-  g_graphicsContext.AddTransform(m_transform);
+  g_graphicsContext.SetTransform(m_cachedTransform);
   if (m_hasCamera)
     g_graphicsContext.SetCameraPosition(m_camera);
   if (IsVisible())

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -636,13 +636,11 @@ void CGUIControl::UpdateVisibility(const CGUIListItem *item)
     { // automatic change of visibility - queue the in effect
   //    CLog::Log(LOGDEBUG, "Visibility changed to visible for control id %i", m_controlID);
       QueueAnimation(ANIM_TYPE_VISIBLE);
-      MarkDirtyRegion();
     }
     else if (bWasVisible && !m_visibleFromSkinCondition)
     { // automatic change of visibility - do the out effect
   //    CLog::Log(LOGDEBUG, "Visibility changed to hidden for control id %i", m_controlID);
       QueueAnimation(ANIM_TYPE_HIDDEN);
-      MarkDirtyRegion();
     }
   }
   // check for conditional animations
@@ -762,6 +760,7 @@ bool CGUIControl::CheckAnimation(ANIMATION_TYPE animType)
 
 void CGUIControl::QueueAnimation(ANIMATION_TYPE animType)
 {
+  MarkDirtyRegion();
   if (!CheckAnimation(animType))
     return;
   CAnimation *reverseAnim = GetAnimation((ANIMATION_TYPE)-animType, false);

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -420,6 +420,11 @@ bool CGUIControl::OnMessage(CGUIMessage& message)
     case GUI_MSG_DISABLED:
       SetEnabled(false);
       return true;
+
+    case GUI_MSG_WINDOW_RESIZE:
+      // invalidate controls to get them to recalculate sizing information
+      SetInvalid();
+      return true;
     }
   }
   return false;

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -149,10 +149,6 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
   if (m_hasCamera)
     g_graphicsContext.SetCameraPosition(m_camera);
 
-//  GUIPROFILER_VISIBILITY_BEGIN(control);
-  UpdateVisibility();
-//  GUIPROFILER_VISIBILITY_END(control);
-
   if (IsVisible())
     Process(currentTime, dirtyregions);
 

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -61,6 +61,7 @@ CGUIControl::CGUIControl()
   m_hasCamera = false;
   m_pushedUpdates = false;
   m_pulseOnSelect = false;
+  m_controlIsDirty = true;
 }
 
 CGUIControl::CGUIControl(int parentID, int controlID, float posX, float posY, float width, float height)
@@ -138,10 +139,9 @@ void CGUIControl::DynamicResourceAlloc(bool bOnOff)
 // 3. reset the animation transform
 void CGUIControl::DoProcess(unsigned int currentTime)
 {
-  if (m_bInvalidated)
-    MarkDirtyRegion();
+  bool changed = m_bInvalidated;
 
-  Animate(currentTime);
+  changed |= Animate(currentTime);
 
   g_graphicsContext.AddTransform(m_transform);
   if (m_hasCamera)
@@ -154,13 +154,22 @@ void CGUIControl::DoProcess(unsigned int currentTime)
   if (IsVisible())
     Process(currentTime);
 
-  FlushDirtyRegion(false);
+  changed |=  m_controlIsDirty;
+
+  CRect currentRenderRegion = g_graphicsContext.generateAABB(GetRenderRegion());
+  CRect dirtyRegion = currentRenderRegion;
+  dirtyRegion.Union(m_previousDirtyRegion);
+  m_previousDirtyRegion = currentRenderRegion;
+
+  if (changed)
+    SendFinalDirtyRegionToParent(dirtyRegion, this);
 
   if (m_hasCamera)
     g_graphicsContext.RestoreCameraPosition();
   g_graphicsContext.RemoveTransform();
 
   m_bInvalidated = false;
+  m_controlIsDirty = false;
 }
 
 void CGUIControl::Process(unsigned int currentTime)
@@ -489,7 +498,7 @@ float CGUIControl::GetHeight() const
 
 void CGUIControl::MarkDirtyRegion()
 {
-  m_markedLocalRegion.Union(GetRenderRegion());
+  m_controlIsDirty = true;
 }
 
 void CGUIControl::SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender)
@@ -498,34 +507,6 @@ void CGUIControl::SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const C
     m_parentControl->SendFinalDirtyRegionToParent(dirtyRegion, sender);
   else
     g_windowManager.MarkDirtyRegion(dirtyRegion);
-}
-
-void CGUIControl::FlushDirtyRegion(bool setMatrixBeforeFlush)
-{
-  if (!m_markedLocalRegion.IsEmpty())
-  {
-    if (setMatrixBeforeFlush)
-    {
-      g_graphicsContext.AddTransform(m_transform);
-      if (m_hasCamera)
-        g_graphicsContext.SetCameraPosition(m_camera);
-    }
-
-    CRect AABB = g_graphicsContext.generateAABB(m_markedLocalRegion);
-
-    if (setMatrixBeforeFlush)
-    {
-      if (m_hasCamera)
-        g_graphicsContext.RestoreCameraPosition();
-      g_graphicsContext.RemoveTransform();
-    }
-
-    // When we have transformed to screen cordinates we send it to
-    // the parent which may choose to ignore it or send it further down.
-    SendFinalDirtyRegionToParent(AABB, this);
-  }
-
-  m_markedLocalRegion = CRect();
 }
 
 CRect CGUIControl::GetRenderRegion() const
@@ -869,7 +850,7 @@ bool CGUIControl::Animate(unsigned int currentTime)
   // check visible state outside the loop, as it could change
   GUIVISIBLE visible = m_visible;
 
-  TransformMatrix newTransform;
+  m_transform.Reset();
   bool changed = false;
 
   CPoint center(m_posX + m_width * 0.5f, m_posY + m_height * 0.5f);
@@ -881,7 +862,7 @@ bool CGUIControl::Animate(unsigned int currentTime)
     UpdateStates(anim.GetType(), anim.GetProcess(), anim.GetState());
     // and render the animation effect
     changed |= (anim.GetProcess() != ANIM_PROCESS_NONE);
-    anim.RenderAnimation(newTransform, center);
+    anim.RenderAnimation(m_transform, center);
 
 /*    // debug stuff
     if (anim.currentProcess != ANIM_PROCESS_NONE)
@@ -897,16 +878,6 @@ bool CGUIControl::Animate(unsigned int currentTime)
           CLog::Log(LOGDEBUG, "Animating control %d with a %s fade effect %s. Amount is %2.1f. Visible=%s", m_controlID, anim.type == ANIM_TYPE_CONDITIONAL ? (anim.lastCondition ? "conditional_on" : "conditional_off") : (anim.type == ANIM_TYPE_VISIBLE ? "visible" : "hidden"), anim.currentProcess == ANIM_PROCESS_NORMAL ? "normal" : "reverse", anim.amount, IsVisible() ? "true" : "false");
       }
     }*/
-  }
-
-  if (changed)
-  {
-    MarkDirtyRegion();
-    FlushDirtyRegion(true);
-
-    m_transform = newTransform;
-
-    MarkDirtyRegion();
   }
 
   return changed;

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -153,7 +153,7 @@ public:
   virtual void SetPosition(float posX, float posY);
   virtual void SetHitRect(const CRect &rect);
   virtual void SetCamera(const CPoint &camera);
-  void SetColorDiffuse(const CGUIInfoColor &color);
+  bool SetColorDiffuse(const CGUIInfoColor &color);
   CPoint GetRenderPosition() const;
   virtual float GetXPosition() const;
   virtual float GetYPosition() const;
@@ -287,7 +287,7 @@ protected:
    */
   virtual bool CanFocusFromPoint(const CPoint &point) const;
 
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   virtual void Animate(unsigned int currentTime);
   virtual bool CheckAnimation(ANIMATION_TYPE animType);
   void UpdateStates(ANIMATION_TYPE type, ANIMATION_PROCESS currentProcess, ANIMATION_STATE currentState);

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -166,7 +166,7 @@ public:
   void MarkDirtyRegion();
   virtual void SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender);
   void FlushDirtyRegion(bool setMatrixBeforeFlush);
-  virtual CRect GetRenderRegion();
+  virtual CRect GetRenderRegion() const;
 
   virtual void SetNavigation(int up, int down, int left, int right);
   virtual void SetTabNavigation(int next, int prev);

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -291,7 +291,7 @@ protected:
   virtual bool CanFocusFromPoint(const CPoint &point) const;
 
   virtual bool UpdateColors();
-  virtual void Animate(unsigned int currentTime);
+  virtual bool Animate(unsigned int currentTime);
   virtual bool CheckAnimation(ANIMATION_TYPE animType);
   void UpdateStates(ANIMATION_TYPE type, ANIMATION_PROCESS currentProcess, ANIMATION_STATE currentState);
   bool SendWindowMessage(CGUIMessage &message);

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -165,7 +165,6 @@ public:
   virtual float GetHeight() const;
 
   void MarkDirtyRegion();
-  virtual void SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender);
   virtual CRect GetRenderRegion() const;
 
   virtual void SetNavigation(int up, int down, int left, int right);

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -75,8 +75,11 @@ public:
   virtual ~CGUIControl(void);
   virtual CGUIControl *Clone() const=0;
 
-  virtual void DoRender(unsigned int currentTime);
+  virtual void DoProcess(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime);
+  virtual void DoRender();
   virtual void Render();
+
   bool HasRendered() const { return m_hasRendered; };
 
   // OnAction() is called by our window when we are the focused control.

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -344,6 +344,7 @@ protected:
   CPoint m_camera;
   bool m_hasCamera;
   TransformMatrix m_transform;
+  TransformMatrix m_cachedTransform; // Contains the absolute transform the control
 
   bool  m_controlIsDirty;
   CRect m_previousDirtyRegion;

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -159,6 +159,12 @@ public:
   virtual float GetYPosition() const;
   virtual float GetWidth() const;
   virtual float GetHeight() const;
+
+  void MarkDirtyRegion();
+  virtual void SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender);
+  void FlushDirtyRegion();
+  virtual CRect GetRenderRegion();
+
   virtual void SetNavigation(int up, int down, int left, int right);
   virtual void SetTabNavigation(int next, int prev);
 
@@ -336,6 +342,8 @@ protected:
   CPoint m_camera;
   bool m_hasCamera;
   TransformMatrix m_transform;
+
+  CRect m_markedLocalRegion;
 };
 
 #endif

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -165,7 +165,6 @@ public:
 
   void MarkDirtyRegion();
   virtual void SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender);
-  void FlushDirtyRegion(bool setMatrixBeforeFlush);
   virtual CRect GetRenderRegion() const;
 
   virtual void SetNavigation(int up, int down, int left, int right);
@@ -346,7 +345,8 @@ protected:
   bool m_hasCamera;
   TransformMatrix m_transform;
 
-  CRect m_markedLocalRegion;
+  bool  m_controlIsDirty;
+  CRect m_previousDirtyRegion;
 };
 
 #endif

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -33,6 +33,7 @@
 #include "VisibleEffect.h"  // needed for the CAnimation members
 #include "GUIInfoTypes.h"   // needed for CGUIInfoColor to handle infolabel'ed colors
 #include "GUIActionDescriptor.h"
+#include "DirtyRegion.h"
 
 class CGUIListItem; // forward
 class CAction;
@@ -75,8 +76,8 @@ public:
   virtual ~CGUIControl(void);
   virtual CGUIControl *Clone() const=0;
 
-  virtual void DoProcess(unsigned int currentTime);
-  virtual void Process(unsigned int currentTime);
+  virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void DoRender();
   virtual void Render();
 

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -165,7 +165,14 @@ public:
   virtual float GetHeight() const;
 
   void MarkDirtyRegion();
-  virtual CRect GetRenderRegion() const;
+
+  /*! \brief return the render region in screen coordinates of this control
+   */
+  const CRect &GetRenderRegion() const { return m_renderRegion; };
+  /*! \brief calculate the render region in parentcontrol coordinates of this control
+   Called during process to update m_renderRegion
+   */
+  virtual CRect CalcRenderRegion() const;
 
   virtual void SetNavigation(int up, int down, int left, int right);
   virtual void SetTabNavigation(int next, int prev);
@@ -347,7 +354,7 @@ protected:
   TransformMatrix m_cachedTransform; // Contains the absolute transform the control
 
   bool  m_controlIsDirty;
-  CRect m_previousDirtyRegion;
+  CRect m_renderRegion;         // In screen coordinates
 };
 
 #endif

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -165,7 +165,7 @@ public:
 
   void MarkDirtyRegion();
   virtual void SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender);
-  void FlushDirtyRegion();
+  void FlushDirtyRegion(bool setMatrixBeforeFlush);
   virtual CRect GetRenderRegion();
 
   virtual void SetNavigation(int up, int down, int left, int right);

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -197,7 +197,7 @@ public:
   virtual void SetFocus(bool focus);
   virtual void SetWidth(float width);
   virtual void SetHeight(float height);
-  virtual void SetVisible(bool bVisible);
+  virtual void SetVisible(bool bVisible, bool setVisState = false);
   void SetVisibleCondition(int visible, const CGUIInfoBool &allowHiddenFocus);
   int GetVisibleCondition() const { return m_visibleCondition; };
   void SetEnableCondition(int condition);

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -647,3 +647,11 @@ void CGUIControlGroup::DumpTextureUse()
     (*it)->DumpTextureUse();
 }
 #endif
+
+void CGUIControlGroup::SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender)
+{
+  // If the controlgroup has been marked there is no point in allowing
+  // the children to mark since the parent should fully confine the children.
+  if (m_markedLocalRegion.IsEmpty() || sender == this)
+    CGUIControl::SendFinalDirtyRegionToParent(dirtyRegion, sender);
+}

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -94,7 +94,7 @@ void CGUIControlGroup::DynamicResourceAlloc(bool bOnOff)
   }
 }
 
-void CGUIControlGroup::Process(unsigned int currentTime)
+void CGUIControlGroup::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   CPoint pos(GetPosition());
   g_graphicsContext.SetOrigin(pos.x, pos.y);
@@ -102,11 +102,11 @@ void CGUIControlGroup::Process(unsigned int currentTime)
   for (iControls it = m_children.begin(); it != m_children.end(); ++it)
   {
     CGUIControl *control = *it;
-    control->DoProcess(currentTime);
+    control->DoProcess(currentTime, dirtyregions);
   }
 
   g_graphicsContext.RestoreOrigin();
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIControlGroup::Render()

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -655,6 +655,6 @@ void CGUIControlGroup::SendFinalDirtyRegionToParent(const CRect &dirtyRegion, co
 {
   // If the controlgroup has been marked there is no point in allowing
   // the children to mark since the parent should fully confine the children.
-  if (m_markedLocalRegion.IsEmpty() || sender == this)
+  if (!m_controlIsDirty || sender == this)
     CGUIControl::SendFinalDirtyRegionToParent(dirtyRegion, sender);
 }

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -650,11 +650,3 @@ void CGUIControlGroup::DumpTextureUse()
     (*it)->DumpTextureUse();
 }
 #endif
-
-void CGUIControlGroup::SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender)
-{
-  // If the controlgroup has been marked there is no point in allowing
-  // the children to mark since the parent should fully confine the children.
-  if (!m_controlIsDirty || sender == this)
-    CGUIControl::SendFinalDirtyRegionToParent(dirtyRegion, sender);
-}

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -104,8 +104,10 @@ void CGUIControlGroup::Process(unsigned int currentTime, CDirtyRegionList &dirty
   {
     CGUIControl *control = *it;
     control->UpdateVisibility();
+    unsigned int oldDirty = dirtyregions.size();
     control->DoProcess(currentTime, dirtyregions);
-    rect.Union(control->GetRenderRegion());
+    if (control->IsVisible() || (oldDirty != dirtyregions.size())) // visible or dirty (was visible?)
+      rect.Union(control->GetRenderRegion());
   }
 
   g_graphicsContext.RestoreOrigin();

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -232,6 +232,7 @@ bool CGUIControlGroup::OnMessage(CGUIMessage& message)
   case GUI_MSG_PAGE_CHANGE:
   case GUI_MSG_REFRESH_THUMBS:
   case GUI_MSG_REFRESH_LIST:
+  case GUI_MSG_WINDOW_RESIZE:
     { // send to all child controls (make sure the target is the control id)
       for (iControls it = m_children.begin(); it != m_children.end(); ++it)
       {
@@ -643,16 +644,6 @@ void CGUIControlGroup::GetContainers(vector<CGUIControl *> &containers) const
       containers.push_back(*it);
     else if ((*it)->IsGroup())
       ((CGUIControlGroup *)(*it))->GetContainers(containers);
-  }
-}
-
-void CGUIControlGroup::SetInvalid()
-{
-  if (!m_bInvalidated)
-  {
-    for (iControls it = m_children.begin(); it != m_children.end(); ++it)
-      (*it)->SetInvalid();
-    CGUIControl::SetInvalid();
   }
 }
 

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -99,14 +99,17 @@ void CGUIControlGroup::Process(unsigned int currentTime, CDirtyRegionList &dirty
   CPoint pos(GetPosition());
   g_graphicsContext.SetOrigin(pos.x, pos.y);
 
+  CRect rect;
   for (iControls it = m_children.begin(); it != m_children.end(); ++it)
   {
     CGUIControl *control = *it;
     control->DoProcess(currentTime, dirtyregions);
+    rect.Union(control->GetRenderRegion());
   }
 
   g_graphicsContext.RestoreOrigin();
   CGUIControl::Process(currentTime, dirtyregions);
+  m_renderRegion = rect;
 }
 
 void CGUIControlGroup::Render()

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -103,6 +103,7 @@ void CGUIControlGroup::Process(unsigned int currentTime, CDirtyRegionList &dirty
   for (iControls it = m_children.begin(); it != m_children.end(); ++it)
   {
     CGUIControl *control = *it;
+    control->UpdateVisibility();
     control->DoProcess(currentTime, dirtyregions);
     rect.Union(control->GetRenderRegion());
   }

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -505,6 +505,7 @@ void CGUIControlGroup::AddControl(CGUIControl *control, int position /* = -1*/)
   control->SetParentControl(this);
   control->SetPushUpdates(m_pushedUpdates);
   AddLookup(control);
+  SetInvalid();
 }
 
 void CGUIControlGroup::AddLookup(CGUIControl *control)
@@ -605,6 +606,7 @@ bool CGUIControlGroup::RemoveControl(const CGUIControl *control)
     {
       m_children.erase(it);
       RemoveLookup(child);
+      SetInvalid();
       return true;
     }
   }
@@ -627,6 +629,7 @@ void CGUIControlGroup::ClearAll()
   }
   m_children.clear();
   m_lookup.clear();
+  SetInvalid();
 }
 
 void CGUIControlGroup::GetContainers(vector<CGUIControl *> &containers) const
@@ -642,8 +645,12 @@ void CGUIControlGroup::GetContainers(vector<CGUIControl *> &containers) const
 
 void CGUIControlGroup::SetInvalid()
 {
-  for (iControls it = m_children.begin(); it != m_children.end(); ++it)
-    (*it)->SetInvalid();
+  if (!m_bInvalidated)
+  {
+    for (iControls it = m_children.begin(); it != m_children.end(); ++it)
+      (*it)->SetInvalid();
+    CGUIControl::SetInvalid();
+  }
 }
 
 #ifdef _DEBUG

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -65,7 +65,6 @@ public:
 
   virtual bool HasID(int id) const;
   virtual bool HasVisibleID(int id) const;
-  virtual void SetInvalid();
 
   int GetFocusedControlID() const;
   CGUIControl *GetFocusedControl() const;

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -41,7 +41,7 @@ public:
   virtual ~CGUIControlGroup(void);
   virtual CGUIControlGroup *Clone() const { return new CGUIControlGroup(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -88,7 +88,6 @@ public:
   virtual void DumpTextureUse();
 #endif
 protected:
-  virtual void SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender);
   /*!
    \brief Check whether a given control is valid
    Runs through controls and returns whether this control is valid.  Only functional

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -41,6 +41,7 @@ public:
   virtual ~CGUIControlGroup(void);
   virtual CGUIControlGroup *Clone() const { return new CGUIControlGroup(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual bool OnMessage(CGUIMessage& message);
@@ -56,7 +57,6 @@ public:
 
   virtual void SetInitialVisibility();
 
-  virtual void DoRender(unsigned int currentTime);
   virtual bool IsAnimating(ANIMATION_TYPE anim);
   virtual bool HasAnimation(ANIMATION_TYPE anim);
   virtual void QueueAnimation(ANIMATION_TYPE anim);
@@ -116,8 +116,5 @@ protected:
   bool m_defaultAlways;
   int m_focusedControl;
   bool m_renderFocusedLast;
-
-  // render time
-  unsigned int m_renderTime;
 };
 

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -88,6 +88,7 @@ public:
   virtual void DumpTextureUse();
 #endif
 protected:
+  virtual void SendFinalDirtyRegionToParent(const CRect &dirtyRegion, const CGUIControl *sender);
   /*!
    \brief Check whether a given control is valid
    Runs through controls and returns whether this control is valid.  Only functional

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -38,7 +38,6 @@ CGUIControlGroupList::CGUIControlGroupList(int parentID, int controlID, float po
   m_scrollSpeed = 0;
   m_scrollLastTime = 0;
   m_scrollTime = scrollTime ? scrollTime : 1;
-  m_renderTime = 0;
   m_useControlPositions = useControlPositions;
   ControlType = GUICONTROL_GROUPLIST;
 }
@@ -47,11 +46,11 @@ CGUIControlGroupList::~CGUIControlGroupList(void)
 {
 }
 
-void CGUIControlGroupList::Render()
+void CGUIControlGroupList::Process(unsigned int currentTime)
 {
   if (m_scrollSpeed != 0)
   {
-    m_offset += m_scrollSpeed * (m_renderTime - m_scrollLastTime);
+    m_offset += m_scrollSpeed * (currentTime - m_scrollLastTime);
     if ((m_scrollSpeed < 0 && m_offset < m_scrollOffset) ||
         (m_scrollSpeed > 0 && m_offset > m_scrollOffset))
     {
@@ -59,7 +58,7 @@ void CGUIControlGroupList::Render()
       m_scrollSpeed = 0;
     }
   }
-  m_scrollLastTime = m_renderTime;
+  m_scrollLastTime = currentTime;
 
   // first we update visibility of all our items, to ensure our size and
   // alignment computations are correct.
@@ -79,6 +78,28 @@ void CGUIControlGroupList::Render()
     CGUIMessage message2(GUI_MSG_ITEM_SELECT, GetParentID(), m_pageControl, (int)m_offset);
     SendWindowMessage(message2);
   }
+  // we run through the controls, rendering as we go
+  float pos = GetAlignOffset();
+  for (iControls it = m_children.begin(); it != m_children.end(); ++it)
+  {
+    // note we render all controls, even if they're offscreen, as then they'll be updated
+    // with respect to animations
+    CGUIControl *control = *it;
+    if (m_orientation == VERTICAL)
+      g_graphicsContext.SetOrigin(m_posX, m_posY + pos - m_offset);
+    else
+      g_graphicsContext.SetOrigin(m_posX + pos - m_offset, m_posY);
+    control->DoProcess(currentTime);
+
+    if (control->IsVisible())
+      pos += Size(control) + m_itemGap;
+    g_graphicsContext.RestoreOrigin();
+  }
+  CGUIControl::Process(currentTime);
+}
+
+void CGUIControlGroupList::Render()
+{
   // we run through the controls, rendering as we go
   bool render(g_graphicsContext.SetClipRegion(m_posX, m_posY, m_width, m_height));
   float pos = GetAlignOffset();
@@ -100,7 +121,7 @@ void CGUIControlGroupList::Render()
         g_graphicsContext.SetOrigin(m_posX, m_posY + pos - m_offset);
       else
         g_graphicsContext.SetOrigin(m_posX + pos - m_offset, m_posY);
-      control->DoRender(m_renderTime);
+      control->DoRender();
     }
     if (control->IsVisible())
       pos += Size(control) + m_itemGap;
@@ -112,7 +133,7 @@ void CGUIControlGroupList::Render()
       g_graphicsContext.SetOrigin(m_posX, m_posY + focusedPos - m_offset);
     else
       g_graphicsContext.SetOrigin(m_posX + focusedPos - m_offset, m_posY);
-    focusedControl->DoRender(m_renderTime);
+    focusedControl->DoRender();
   }
   if (render) g_graphicsContext.RestoreClipRegion();
   CGUIControl::Render();

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -46,7 +46,7 @@ CGUIControlGroupList::~CGUIControlGroupList(void)
 {
 }
 
-void CGUIControlGroupList::Process(unsigned int currentTime)
+void CGUIControlGroupList::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   if (m_scrollSpeed != 0)
   {
@@ -89,13 +89,13 @@ void CGUIControlGroupList::Process(unsigned int currentTime)
       g_graphicsContext.SetOrigin(m_posX, m_posY + pos - m_offset);
     else
       g_graphicsContext.SetOrigin(m_posX + pos - m_offset, m_posY);
-    control->DoProcess(currentTime);
+    control->DoProcess(currentTime, dirtyregions);
 
     if (control->IsVisible())
       pos += Size(control) + m_itemGap;
     g_graphicsContext.RestoreOrigin();
   }
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIControlGroupList::Render()

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -39,7 +39,7 @@ public:
   virtual ~CGUIControlGroupList(void);
   virtual CGUIControlGroupList *Clone() const { return new CGUIControlGroupList(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnMessage(CGUIMessage& message);
 

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -39,6 +39,7 @@ public:
   virtual ~CGUIControlGroupList(void);
   virtual CGUIControlGroupList *Clone() const { return new CGUIControlGroupList(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool OnMessage(CGUIMessage& message);
 

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -234,12 +234,6 @@ void CGUIDialog::Show()
   g_application.getApplicationMessenger().Show(this);
 }
 
-bool CGUIDialog::RenderAnimation(unsigned int time)
-{
-  CGUIWindow::RenderAnimation(time);
-  return m_bRunning;
-}
-
 void CGUIDialog::FrameMove()
 {
   if (m_autoClosing && m_showStartTime + m_showDuration < CTimeUtils::GetFrameTime() && !m_dialogClosing)
@@ -249,6 +243,9 @@ void CGUIDialog::FrameMove()
 
 void CGUIDialog::Render()
 {
+  if (!m_bRunning)
+    return;
+
   CGUIWindow::Render();
   // Check to see if we should close at this point
   // We check after the controls have finished rendering, as we may have to close due to

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -175,7 +175,7 @@ void CGUIDialog::DoModal_Internal(int iWindowID /*= WINDOW_INVALID */, const CSt
 
   while (m_bRunning && !g_application.m_bStop)
   {
-    g_windowManager.Process();
+    g_windowManager.ProcessRenderLoop();
   }
 }
 

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -43,6 +43,7 @@ public:
   virtual bool OnAction(const CAction &action);
   virtual bool OnMessage(CGUIMessage& message);
   virtual void FrameMove();
+  virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
 
   void DoModal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
@@ -61,6 +62,7 @@ public:
 protected:
   virtual void SetDefaults();
   virtual void OnWindowLoaded();
+  virtual void UpdateVisibility();
 
   friend class CApplicationMessenger;
   void DoModal_Internal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
@@ -68,6 +70,7 @@ protected:
   void Close_Internal(bool forceClose = false);
 
   bool m_bRunning;
+  bool m_wasRunning; ///< \brief true if we were running during the last DoProcess()
   bool m_bModal;
   bool m_dialogClosing;
   bool m_autoClosing;

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -59,7 +59,6 @@ public:
   void SetSound(bool OnOff) { m_enableSound = OnOff; };
 
 protected:
-  virtual bool RenderAnimation(unsigned int time);
   virtual void SetDefaults();
   virtual void OnWindowLoaded();
 

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -363,7 +363,7 @@ void CGUIEditControl::RecalcLabelPosition()
     m_textOffset = 0;
 }
 
-void CGUIEditControl::RenderText()
+void CGUIEditControl::ProcessText(unsigned int currentTime)
 {
   if (m_smsTimer.GetElapsedMilliseconds() > smsDelay)
     UpdateText();
@@ -375,6 +375,7 @@ void CGUIEditControl::RenderText()
     RecalcLabelPosition();
   }
 
+  bool changed = false;
 
   float posX = m_label.GetRenderRect().x1;
   float maxTextWidth = m_label.GetMaxWidth();
@@ -384,8 +385,8 @@ void CGUIEditControl::RenderText()
   if (leftTextWidth > 0)
   {
     // render the text on the left
-    m_label.SetColor(GetTextColor());
-    m_label.Render();
+    changed |= m_label.SetColor(GetTextColor());
+    changed |= m_label.Process(currentTime);
     
     posX += leftTextWidth + spaceWidth;
     maxTextWidth -= leftTextWidth + spaceWidth;
@@ -417,13 +418,20 @@ void CGUIEditControl::RenderText()
       text.Insert(m_cursorPos, col);
     }
 
-    m_label2.SetMaxRect(posX + m_textOffset, m_posY, maxTextWidth - m_textOffset, m_height);
-    m_label2.SetTextW(text);
-    m_label2.SetAlign(align);
-    m_label2.SetColor(GetTextColor());
-    m_label2.Render();
+    changed |= m_label2.SetMaxRect(posX + m_textOffset, m_posY, maxTextWidth - m_textOffset, m_height);
+    if (text != m_lastRenderedText)
+    {
+      m_label2.SetTextW(text);
+      m_lastRenderedText = text;
+      changed = true;
+    }
+    changed |= m_label2.SetAlign(align);
+    changed |= m_label2.SetColor(GetTextColor());
+    changed |= m_label2.Process(currentTime);
     g_graphicsContext.RestoreClipRegion();
   }
+  if (changed)
+    MarkDirtyRegion();
 }
 
 CStdStringW CGUIEditControl::GetDisplayedText() const

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -78,7 +78,7 @@ public:
   bool HasTextChangeActions() { return m_textChangeActions.size() > 0; };
 
 protected:
-  virtual void RenderText();
+  virtual void ProcessText(unsigned int currentTime);
   CStdStringW GetDisplayedText() const;
   void RecalcLabelPosition();
   void ValidateCursor();
@@ -115,5 +115,6 @@ protected:
 
   static const char*        smsLetters[10];
   static const unsigned int smsDelay;
+  CStdStringW m_lastRenderedText; ///< last rendered text
 };
 #endif

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -82,10 +82,12 @@ void CGUIFadeLabelControl::DoRender(unsigned int currentTime)
   CGUIControl::DoRender(currentTime);
 }
 
-void CGUIFadeLabelControl::UpdateColors()
+bool CGUIFadeLabelControl::UpdateColors()
 {
-  m_label.UpdateColors();
-  CGUIControl::UpdateColors();
+  bool changed = m_label.UpdateColors();
+  changed |= CGUIControl::UpdateColors();
+
+  return changed;
 }
 
 void CGUIFadeLabelControl::Render()

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -76,14 +76,14 @@ void CGUIFadeLabelControl::AddLabel(const string &label)
   m_infoLabels.push_back(CGUIInfoLabel(label));
 }
 
-void CGUIFadeLabelControl::Process(unsigned int currentTime)
+void CGUIFadeLabelControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
 
   m_renderTime = currentTime;
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 bool CGUIFadeLabelControl::UpdateColors()

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -88,8 +88,8 @@ void CGUIFadeLabelControl::Process(unsigned int currentTime)
 
 bool CGUIFadeLabelControl::UpdateColors()
 {
-  bool changed = m_label.UpdateColors();
-  changed |= CGUIControl::UpdateColors();
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_label.UpdateColors();
 
   return changed;
 }

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -78,7 +78,11 @@ void CGUIFadeLabelControl::AddLabel(const string &label)
 
 void CGUIFadeLabelControl::Process(unsigned int currentTime)
 {
+  // TODO Proper processing which marks when its actually changed. Just mark always for now.
+  MarkDirtyRegion();
+
   m_renderTime = currentTime;
+
   CGUIControl::Process(currentTime);
 }
 

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -76,10 +76,10 @@ void CGUIFadeLabelControl::AddLabel(const string &label)
   m_infoLabels.push_back(CGUIInfoLabel(label));
 }
 
-void CGUIFadeLabelControl::DoRender(unsigned int currentTime)
+void CGUIFadeLabelControl::Process(unsigned int currentTime)
 {
   m_renderTime = currentTime;
-  CGUIControl::DoRender(currentTime);
+  CGUIControl::Process(currentTime);
 }
 
 bool CGUIFadeLabelControl::UpdateColors()

--- a/xbmc/guilib/GUIFadeLabelControl.h
+++ b/xbmc/guilib/GUIFadeLabelControl.h
@@ -44,7 +44,7 @@ public:
   virtual ~CGUIFadeLabelControl(void);
   virtual CGUIFadeLabelControl *Clone() const { return new CGUIFadeLabelControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool CanFocus() const;
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUIFadeLabelControl.h
+++ b/xbmc/guilib/GUIFadeLabelControl.h
@@ -44,7 +44,7 @@ public:
   virtual ~CGUIFadeLabelControl(void);
   virtual CGUIFadeLabelControl *Clone() const { return new CGUIFadeLabelControl(*this); };
 
-  virtual void DoRender(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool CanFocus() const;
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUIFadeLabelControl.h
+++ b/xbmc/guilib/GUIFadeLabelControl.h
@@ -52,7 +52,7 @@ public:
   void SetInfo(const std::vector<CGUIInfoLabel> &vecInfo);
 
 protected:
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   virtual CStdString GetDescription() const;
   void AddLabel(const std::string &label);
 

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -30,7 +30,7 @@ CGUIFixedListContainer::CGUIFixedListContainer(int parentID, int controlID, floa
   m_type = VIEW_TYPE_LIST;
   m_fixedCursor = fixedPosition;
   m_cursorRange = std::max(0, cursorRange);
-  m_cursor = m_fixedCursor;
+  SetCursor(m_fixedCursor);
 }
 
 CGUIFixedListContainer::~CGUIFixedListContainer(void)
@@ -123,12 +123,12 @@ void CGUIFixedListContainer::Scroll(int amount)
   if (offset < -minCursor)
   {
     offset = -minCursor;
-    m_cursor = minCursor;
+    SetCursor(minCursor);
   }
   if (offset > (int)m_items.size() - maxCursor)
   {
     offset = m_items.size() - maxCursor;
-    m_cursor = maxCursor;
+    SetCursor(maxCursor);
   }
   ScrollToOffset(offset);
 }
@@ -145,17 +145,17 @@ void CGUIFixedListContainer::ValidateOffset()
   int minCursor, maxCursor;
   GetCursorRange(minCursor, maxCursor);
   // assure our cursor is between these limits
-  m_cursor = std::max(m_cursor, minCursor);
-  m_cursor = std::min(m_cursor, maxCursor);
+  SetCursor(std::max(m_cursor, minCursor));
+  SetCursor(std::min(m_cursor, maxCursor));
   // and finally ensure our offset is valid
   if (m_offset + maxCursor >= (int)m_items.size() || m_scrollOffset > ((int)m_items.size() - maxCursor - 1) * m_layout->Size(m_orientation))
   {
-    m_offset = m_items.size() - maxCursor - 1;
+    SetOffset(std::max(-minCursor, (int)m_items.size() - maxCursor - 1));
     m_scrollOffset = m_offset * m_layout->Size(m_orientation);
   }
   if (m_offset < -minCursor || m_scrollOffset < -minCursor * m_layout->Size(m_orientation))
   {
-    m_offset = -minCursor;
+    SetOffset(-minCursor);
     m_scrollOffset = m_offset * m_layout->Size(m_orientation);
   }
 }
@@ -235,7 +235,7 @@ bool CGUIFixedListContainer::SelectItemFromPoint(const CPoint &point)
     if (cursor < 0)
       return false;
     // calling SelectItem() here will focus the item and scroll, which isn't really what we're after
-    m_cursor = cursor;
+    SetCursor(cursor);
     return true;
   }
   return InsideLayout(m_focusedLayout, point);
@@ -262,7 +262,7 @@ void CGUIFixedListContainer::SelectItem(int item)
       cursor = m_fixedCursor;
     if (cursor != m_cursor)
       SetContainerMoving(cursor - m_cursor);
-    m_cursor = cursor;
+    SetCursor(cursor);
     ScrollToOffset(item - m_cursor);
   }
 }

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -119,7 +119,7 @@ void CGUIFixedListContainer::Scroll(int amount)
   // increase or decrease the offset within [-minCursor, m_items.size() - maxCursor]
   int minCursor, maxCursor;
   GetCursorRange(minCursor, maxCursor);
-  int offset = m_offset + amount;
+  int offset = GetOffset() + amount;
   if (offset < -minCursor)
   {
     offset = -minCursor;
@@ -145,18 +145,18 @@ void CGUIFixedListContainer::ValidateOffset()
   int minCursor, maxCursor;
   GetCursorRange(minCursor, maxCursor);
   // assure our cursor is between these limits
-  SetCursor(std::max(m_cursor, minCursor));
-  SetCursor(std::min(m_cursor, maxCursor));
+  SetCursor(std::max(GetCursor(), minCursor));
+  SetCursor(std::min(GetCursor(), maxCursor));
   // and finally ensure our offset is valid
-  if (m_offset + maxCursor >= (int)m_items.size() || m_scrollOffset > ((int)m_items.size() - maxCursor - 1) * m_layout->Size(m_orientation))
+  if (GetOffset() + maxCursor >= (int)m_items.size() || m_scrollOffset > ((int)m_items.size() - maxCursor - 1) * m_layout->Size(m_orientation))
   {
     SetOffset(std::max(-minCursor, (int)m_items.size() - maxCursor - 1));
-    m_scrollOffset = m_offset * m_layout->Size(m_orientation);
+    m_scrollOffset = GetOffset() * m_layout->Size(m_orientation);
   }
-  if (m_offset < -minCursor || m_scrollOffset < -minCursor * m_layout->Size(m_orientation))
+  if (GetOffset() < -minCursor || m_scrollOffset < -minCursor * m_layout->Size(m_orientation))
   {
     SetOffset(-minCursor);
-    m_scrollOffset = m_offset * m_layout->Size(m_orientation);
+    m_scrollOffset = GetOffset() * m_layout->Size(m_orientation);
   }
 }
 
@@ -175,7 +175,7 @@ int CGUIFixedListContainer::GetCursorFromPoint(const CPoint &point, CPoint *item
     pos -= minCursor * m_layout->Size(m_orientation);
     for (int row = minCursor; row <= maxCursor; row++)
     {
-      const CGUIListItemLayout *layout = (row == m_cursor) ? m_focusedLayout : m_layout;
+      const CGUIListItemLayout *layout = (row == GetCursor()) ? m_focusedLayout : m_layout;
       if (pos < layout->Size(m_orientation))
       {
         if (!InsideLayout(layout, point))
@@ -202,7 +202,7 @@ bool CGUIFixedListContainer::SelectItemFromPoint(const CPoint &point)
   float start = (minCursor + 0.2f) * sizeOfItem;
   float end = (maxCursor - 0.2f) * sizeOfItem + m_focusedLayout->Size(m_orientation);
   float pos = (m_orientation == VERTICAL) ? point.y : point.x;
-  if (pos < start && m_offset > -minCursor)
+  if (pos < start && GetOffset() > -minCursor)
   { // scroll backward
     if (!InsideLayout(m_layout, point))
       return false;
@@ -210,12 +210,12 @@ bool CGUIFixedListContainer::SelectItemFromPoint(const CPoint &point)
     m_analogScrollCount += amount * amount * mouse_scroll_speed;
     if (m_analogScrollCount > 1)
     {
-      ScrollToOffset(m_offset - 1);
+      ScrollToOffset(GetOffset() - 1);
       m_analogScrollCount = 0;
     }
     return true;
   }
-  else if (pos > end && m_offset + maxCursor < (int)m_items.size() - 1)
+  else if (pos > end && GetOffset() + maxCursor < (int)m_items.size() - 1)
   {
     if (!InsideLayout(m_layout, point))
       return false;
@@ -224,7 +224,7 @@ bool CGUIFixedListContainer::SelectItemFromPoint(const CPoint &point)
     m_analogScrollCount += amount * amount * mouse_scroll_speed;
     if (m_analogScrollCount > 1)
     {
-      ScrollToOffset(m_offset + 1);
+      ScrollToOffset(GetOffset() + 1);
       m_analogScrollCount = 0;
     }
     return true;
@@ -243,7 +243,7 @@ bool CGUIFixedListContainer::SelectItemFromPoint(const CPoint &point)
 
 void CGUIFixedListContainer::SelectItem(int item)
 {
-  // Check that m_offset is valid
+  // Check that GetOffset() is valid
   ValidateOffset();
   // only select an item if it's in a valid range
   if (item >= 0 && item < (int)m_items.size())
@@ -260,27 +260,27 @@ void CGUIFixedListContainer::SelectItem(int item)
       cursor = std::min(m_fixedCursor, minCursor + item);
     else
       cursor = m_fixedCursor;
-    if (cursor != m_cursor)
-      SetContainerMoving(cursor - m_cursor);
+    if (cursor != GetCursor())
+      SetContainerMoving(cursor - GetCursor());
     SetCursor(cursor);
-    ScrollToOffset(item - m_cursor);
+    ScrollToOffset(item - GetCursor());
   }
 }
 
 bool CGUIFixedListContainer::HasPreviousPage() const
 {
-  return (m_offset > 0);
+  return (GetOffset() > 0);
 }
 
 bool CGUIFixedListContainer::HasNextPage() const
 {
-  return (m_offset != (int)m_items.size() - m_itemsPerPage && (int)m_items.size() >= m_itemsPerPage);
+  return (GetOffset() != (int)m_items.size() - m_itemsPerPage && (int)m_items.size() >= m_itemsPerPage);
 }
 
 int CGUIFixedListContainer::GetCurrentPage() const
 {
-  int offset = CorrectOffset(m_offset, m_cursor);
-  if (offset + m_itemsPerPage - m_cursor >= (int)GetRows())  // last page
+  int offset = CorrectOffset(GetOffset(), GetCursor());
+  if (offset + m_itemsPerPage - GetCursor() >= (int)GetRows())  // last page
     return (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage;
   return offset / m_itemsPerPage + 1;
 }

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -164,14 +164,8 @@ void CGUIImage::Render()
 {
   if (!IsVisible()) return;
 
-  if (m_fadingTextures.size())  // have some fading images
-  {
-    for (vector<CFadingTexture *>::iterator itr = m_fadingTextures.begin(); itr != m_fadingTextures.end();)
-    {
-      (*itr)->m_texture->Render();
-      itr++;
-    }
-  }
+  for (vector<CFadingTexture *>::iterator itr = m_fadingTextures.begin(); itr != m_fadingTextures.end(); itr++)
+    (*itr)->m_texture->Render();
 
   m_texture.Render();
 

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -93,7 +93,7 @@ void CGUIImage::AllocateOnDemand()
     AllocResources();
 }
 
-void CGUIImage::Process(unsigned int currentTime)
+void CGUIImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // check whether our image failed to allocate, and if so drop back to the fallback image
   if (m_texture.FailedToAlloc() && !m_texture.GetFileName().Equals(m_info.GetFallback()))
@@ -165,7 +165,7 @@ void CGUIImage::Process(unsigned int currentTime)
   if (m_texture.Process(currentTime))
     MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIImage::Render()

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -282,6 +282,22 @@ float CGUIImage::GetTextureHeight() const
   return m_texture.GetTextureHeight();
 }
 
+CRect CGUIImage::CalcRenderRegion() const
+{
+  CRect region = m_texture.GetRenderRect();
+
+  if (m_fadingTextures.size())  // have some fading images
+  {
+    for (vector<CFadingTexture *>::const_iterator itr = m_fadingTextures.begin(); itr != m_fadingTextures.end();)
+    {
+      region.Union( (*itr)->m_texture->GetRenderRect() );
+      itr++;
+    }
+  }
+
+  return CGUIControl::CalcRenderRegion().Intersect(region);
+}
+
 const CStdString &CGUIImage::GetFileName() const
 {
   return m_texture.GetFileName();

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -131,8 +131,11 @@ void CGUIImage::Process(unsigned int currentTime)
         texture->m_fadeTime += frameTime;
         if (texture->m_fadeTime > m_crossFadeTime)
           texture->m_fadeTime = m_crossFadeTime;
-        texture->m_texture->SetAlpha(GetFadeLevel(texture->m_fadeTime));
-        texture->m_texture->SetDiffuseColor(m_diffuseColor);
+
+        if (texture->m_texture->SetAlpha(GetFadeLevel(texture->m_fadeTime)))
+          MarkDirtyRegion();
+        if (texture->m_texture->SetDiffuseColor(m_diffuseColor))
+          MarkDirtyRegion();
       }
     }
 
@@ -142,21 +145,25 @@ void CGUIImage::Process(unsigned int currentTime)
       if (m_currentFadeTime > m_crossFadeTime || frameTime == 0) // for if we allocate straight away on creation
         m_currentFadeTime = m_crossFadeTime;
     }
-    m_texture.SetAlpha(GetFadeLevel(m_currentFadeTime));
+    if (m_texture.SetAlpha(GetFadeLevel(m_currentFadeTime)))
+      MarkDirtyRegion();
   }
 
-  m_texture.SetDiffuseColor(m_diffuseColor);
+  if (m_texture.SetDiffuseColor(m_diffuseColor))
+    MarkDirtyRegion();
 
   if (m_fadingTextures.size())  // have some fading images
   { // anything other than the last old texture needs to be faded out as per usual
     for (vector<CFadingTexture *>::iterator itr = m_fadingTextures.begin(); itr != m_fadingTextures.end() - 1;)
     {
-      (*itr)->m_texture->Process(currentTime);
+      if ((*itr)->m_texture->Process(currentTime))
+        MarkDirtyRegion();
       itr++;
     }
   }
 
-  m_texture.Process(currentTime);
+  if (m_texture.Process(currentTime))
+    MarkDirtyRegion();
 
   CGUIControl::Process(currentTime);
 }
@@ -189,8 +196,12 @@ bool CGUIImage::ProcessFading(CGUIImage::CFadingTexture *texture, unsigned int f
   }
   // render this texture
   texture->m_fadeTime -= frameTime;
-  texture->m_texture->SetAlpha(GetFadeLevel(texture->m_fadeTime));
-  texture->m_texture->SetDiffuseColor(m_diffuseColor);
+
+  if (texture->m_texture->SetAlpha(GetFadeLevel(texture->m_fadeTime)))
+    MarkDirtyRegion();
+  if (texture->m_texture->SetDiffuseColor(m_diffuseColor))
+    MarkDirtyRegion();
+
   return true;
 }
 
@@ -302,6 +313,7 @@ void CGUIImage::SetFileName(const CStdString& strFileName, bool setConstant)
     if (m_texture.ReadyToRender() || m_texture.GetFileName().IsEmpty())
     { // save the current image
       m_fadingTextures.push_back(new CFadingTexture(m_texture, m_currentFadeTime));
+      MarkDirtyRegion();
     }
     m_currentFadeTime = 0;
   }
@@ -309,7 +321,8 @@ void CGUIImage::SetFileName(const CStdString& strFileName, bool setConstant)
   { // texture is changing - attempt to load it, and save the name in m_currentTexture.
     // we'll check whether it loaded or not in Render()
     m_currentTexture = strFileName;
-    m_texture.SetFileName(m_currentTexture);
+    if (m_texture.SetFileName(m_currentTexture))
+      MarkDirtyRegion();
   }
 }
 

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -173,8 +173,8 @@ void CGUIImage::Render()
   if (!IsVisible()) return;
 
   if (m_fadingTextures.size())  // have some fading images
-  { // anything other than the last old texture needs to be faded out as per usual
-    for (vector<CFadingTexture *>::iterator itr = m_fadingTextures.begin(); itr != m_fadingTextures.end() - 1;)
+  {
+    for (vector<CFadingTexture *>::iterator itr = m_fadingTextures.begin(); itr != m_fadingTextures.end();)
     {
       (*itr)->m_texture->Render();
       itr++;

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -114,7 +114,7 @@ void CGUIImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions
     { // anything other than the last old texture needs to be faded out as per usual
       for (vector<CFadingTexture *>::iterator i = m_fadingTextures.begin(); i != m_fadingTextures.end() - 1;)
       {
-        if (!ProcessFading(*i, frameTime))
+        if (!ProcessFading(*i, frameTime, currentTime))
           i = m_fadingTextures.erase(i);
         else
           i++;
@@ -122,7 +122,7 @@ void CGUIImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions
 
       if (m_texture.ReadyToRender() || m_texture.GetFileName().IsEmpty())
       { // fade out the last one as well
-        if (!ProcessFading(m_fadingTextures[m_fadingTextures.size() - 1], frameTime))
+        if (!ProcessFading(m_fadingTextures[m_fadingTextures.size() - 1], frameTime, currentTime))
           m_fadingTextures.erase(m_fadingTextures.end() - 1);
       }
       else
@@ -154,16 +154,6 @@ void CGUIImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions
   if (m_texture.SetDiffuseColor(m_diffuseColor))
     MarkDirtyRegion();
 
-  if (m_fadingTextures.size())  // have some fading images
-  { // anything other than the last old texture needs to be faded out as per usual
-    for (vector<CFadingTexture *>::iterator itr = m_fadingTextures.begin(); itr != m_fadingTextures.end() - 1;)
-    {
-      if ((*itr)->m_texture->Process(currentTime))
-        MarkDirtyRegion();
-      itr++;
-    }
-  }
-
   if (m_texture.Process(currentTime))
     MarkDirtyRegion();
 
@@ -188,7 +178,7 @@ void CGUIImage::Render()
   CGUIControl::Render();
 }
 
-bool CGUIImage::ProcessFading(CGUIImage::CFadingTexture *texture, unsigned int frameTime)
+bool CGUIImage::ProcessFading(CGUIImage::CFadingTexture *texture, unsigned int frameTime, unsigned int currentTime)
 {
   assert(texture);
   if (texture->m_fadeTime <= frameTime)
@@ -202,6 +192,8 @@ bool CGUIImage::ProcessFading(CGUIImage::CFadingTexture *texture, unsigned int f
   if (texture->m_texture->SetAlpha(GetFadeLevel(texture->m_fadeTime)))
     MarkDirtyRegion();
   if (texture->m_texture->SetDiffuseColor(m_diffuseColor))
+    MarkDirtyRegion();
+  if (texture->m_texture->Process(currentTime))
     MarkDirtyRegion();
 
   return true;

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -136,6 +136,8 @@ void CGUIImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions
           MarkDirtyRegion();
         if (texture->m_texture->SetDiffuseColor(m_diffuseColor))
           MarkDirtyRegion();
+        if (texture->m_texture->Process(currentTime))
+          MarkDirtyRegion();
       }
     }
 

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -93,6 +93,8 @@ public:
   float GetTextureWidth() const;
   float GetTextureHeight() const;
 
+  virtual CRect CalcRenderRegion() const;
+
 #ifdef _DEBUG
   virtual void DumpTextureUse();
 #endif

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -67,6 +67,7 @@ public:
   virtual ~CGUIImage(void);
   virtual CGUIImage *Clone() const { return new CGUIImage(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
   virtual bool OnAction(const CAction &action) ;
@@ -100,7 +101,7 @@ protected:
   virtual void FreeTextures(bool immediately = false);
   void FreeResourcesButNotAnims();
   unsigned char GetFadeLevel(unsigned int time) const;
-  bool RenderFading(CFadingTexture *texture, unsigned int frameTime);
+  bool ProcessFading(CFadingTexture *texture, unsigned int frameTime);
 
   bool m_bDynamicResourceAlloc;
 

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -103,7 +103,7 @@ protected:
   virtual void FreeTextures(bool immediately = false);
   void FreeResourcesButNotAnims();
   unsigned char GetFadeLevel(unsigned int time) const;
-  bool ProcessFading(CFadingTexture *texture, unsigned int frameTime);
+  bool ProcessFading(CFadingTexture *texture, unsigned int frameTime, unsigned int currentTime);
 
   bool m_bDynamicResourceAlloc;
 

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -67,7 +67,7 @@ public:
   virtual ~CGUIImage(void);
   virtual CGUIImage *Clone() const { return new CGUIImage(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
   virtual bool OnAction(const CAction &action) ;

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -82,17 +82,21 @@ const CGUIInfoColor &CGUIInfoColor::operator=(const CGUIInfoColor &color)
   return *this;
 }
 
-void CGUIInfoColor::Update()
+bool CGUIInfoColor::Update()
 {
   if (!m_info)
-    return; // no infolabel
+    return false; // no infolabel
 
   // Expand the infolabel, and then convert it to a color
   CStdString infoLabel(g_infoManager.GetLabel(m_info));
-  if (!infoLabel.IsEmpty())
-    m_color = g_colorManager.GetColor(infoLabel.c_str());
+  color_t color = !infoLabel.IsEmpty() ? g_colorManager.GetColor(infoLabel.c_str()) : 0;
+  if (m_color != color)
+  {
+    m_color = color;
+    return true;
+  }
   else
-    m_color = 0;
+    return false;
 }
 
 void CGUIInfoColor::Parse(const CStdString &label)

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -57,7 +57,7 @@ public:
   const CGUIInfoColor &operator=(color_t color);
   operator color_t() const { return m_color; };
 
-  void Update();
+  bool Update();
   void Parse(const CStdString &label);
 
 private:

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -39,16 +39,24 @@ CGUILabel::~CGUILabel(void)
 {
 }
 
-void CGUILabel::SetScrolling(bool scrolling)
+bool CGUILabel::SetScrolling(bool scrolling)
 {
+  bool changed = m_scrolling != scrolling;
+
   m_scrolling = scrolling;
   if (!m_scrolling)
     m_scrollInfo.Reset();
+
+  return changed;
 }
 
-void CGUILabel::SetColor(CGUILabel::COLOR color)
+bool CGUILabel::SetColor(CGUILabel::COLOR color)
 {
+  bool changed = m_color != color;
+
   m_color = color;
+
+  return changed;
 }
 
 color_t CGUILabel::GetColor() const
@@ -103,39 +111,51 @@ void CGUILabel::SetInvalid()
   m_invalid = true;
 }
 
-void CGUILabel::UpdateColors()
+bool CGUILabel::UpdateColors()
 {
-  m_label.UpdateColors();
+  return m_label.UpdateColors();
 }
 
-void CGUILabel::SetMaxRect(float x, float y, float w, float h)
+bool CGUILabel::SetMaxRect(float x, float y, float w, float h)
 {
+  CRect oldRect = m_maxRect;
+
   m_maxRect.SetRect(x, y, x + w, y + h);
   UpdateRenderRect();
+
+  return oldRect != m_maxRect;
 }
 
-void CGUILabel::SetAlign(uint32_t align)
+bool CGUILabel::SetAlign(uint32_t align)
 {
+  bool changed = m_label.align != align;
+
   m_label.align = align;
   UpdateRenderRect();
+
+  return changed;
 }
 
-void CGUILabel::SetText(const CStdString &label)
+bool CGUILabel::SetText(const CStdString &label)
 {
   if (m_textLayout.Update(label, m_maxRect.Width(), m_invalid))
   { // needed an update - reset scrolling and update our text layout
     m_scrollInfo.Reset();
     UpdateRenderRect();
     m_invalid = false;
+    return true;
   }
+  else
+    return false;
 }
 
-void CGUILabel::SetTextW(const CStdStringW &label)
+bool CGUILabel::SetTextW(const CStdStringW &label)
 {
   m_textLayout.SetText(label);
   m_scrollInfo.Reset();
   UpdateRenderRect();
   m_invalid = false;
+  return true;
 }
 
 void CGUILabel::UpdateRenderRect()

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -50,6 +50,11 @@ bool CGUILabel::SetScrolling(bool scrolling)
   return changed;
 }
 
+bool CGUILabel::IsScrolling()
+{
+  return m_scrolling;
+}
+
 bool CGUILabel::SetColor(CGUILabel::COLOR color)
 {
   bool changed = m_color != color;
@@ -73,6 +78,14 @@ color_t CGUILabel::GetColor() const
       break;
   }
   return m_label.textColor;
+}
+
+bool CGUILabel::Process(unsigned int currentTime)
+{
+  // TODO Add the correct processing
+
+  bool overFlows = (m_renderRect.Width() + 0.5f < m_textLayout.GetTextWidth()); // 0.5f to deal with floating point rounding issues
+  return (overFlows && m_scrolling);
 }
 
 void CGUILabel::Render()

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -50,11 +50,6 @@ bool CGUILabel::SetScrolling(bool scrolling)
   return changed;
 }
 
-bool CGUILabel::IsScrolling()
-{
-  return m_scrolling;
-}
-
 bool CGUILabel::SetColor(CGUILabel::COLOR color)
 {
   bool changed = m_color != color;

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -192,11 +192,11 @@ float CGUILabel::GetMaxWidth() const
   return m_maxRect.Width() - 2*m_label.offsetX;
 }
 
-void CGUILabel::CheckAndCorrectOverlap(CGUILabel &label1, CGUILabel &label2)
+bool CGUILabel::CheckAndCorrectOverlap(CGUILabel &label1, CGUILabel &label2)
 {
   CRect rect(label1.m_renderRect);
   if (rect.Intersect(label2.m_renderRect).IsEmpty())
-    return; // nothing to do (though it could potentially encroach on the min_space requirement)
+    return false; // nothing to do (though it could potentially encroach on the min_space requirement)
   
   static const float min_space = 10;
   // overlap vertically and horizontally - check alignment
@@ -214,5 +214,7 @@ void CGUILabel::CheckAndCorrectOverlap(CGUILabel &label1, CGUILabel &label2)
       chopPoint = left.m_renderRect.x2 + min_space;
     left.m_renderRect.x2 = chopPoint - min_space;
     right.m_renderRect.x1 = chopPoint + min_space;
+    return true;
   }
+  return false;
 }

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -95,6 +95,11 @@ public:
   CGUILabel(float posX, float posY, float width, float height, const CLabelInfo& labelInfo, OVER_FLOW overflow = OVER_FLOW_TRUNCATE);
   virtual ~CGUILabel(void);
 
+  /*! \brief Process the label
+   \return bool stating if process caused control to change
+   */
+  bool Process(unsigned int currentTime);
+
   /*! \brief Render the label on screen
    */
   void Render();
@@ -138,6 +143,9 @@ public:
    \param scrolling true if this label should scroll.
    */
   bool SetScrolling(bool scrolling);
+
+  
+  bool IsScrolling();
 
   /*! \brief Set this label invalid.  Forces an update of the control
    */

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -201,7 +201,7 @@ public:
    \param label1 First label to check
    \param label2 Second label to check
    */
-  static void CheckAndCorrectOverlap(CGUILabel &label1, CGUILabel &label2);
+  static bool CheckAndCorrectOverlap(CGUILabel &label1, CGUILabel &label2);
   
 protected:
   color_t GetColor() const;

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -144,9 +144,6 @@ public:
    */
   bool SetScrolling(bool scrolling);
 
-  
-  bool IsScrolling();
-
   /*! \brief Set this label invalid.  Forces an update of the control
    */
   void SetInvalid();

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -44,13 +44,17 @@ public:
     scrollSpeed = CScrollInfo::defaultSpeed;
     scrollSuffix = " | ";
   };
-  void UpdateColors()
+  bool UpdateColors()
   {
-    textColor.Update();
-    shadowColor.Update();
-    selectedColor.Update();
-    disabledColor.Update();
-    focusedColor.Update();
+    bool changed = false;
+
+    changed |= textColor.Update();
+    changed |= shadowColor.Update();
+    changed |= selectedColor.Update();
+    changed |= disabledColor.Update();
+    changed |= focusedColor.Update();
+
+    return changed;
   };
   
   CGUIInfoColor textColor;
@@ -99,29 +103,29 @@ public:
    Sets the maximal size and positioning that the label may render in.  Note that <textwidth> can override
    this, and <textoffsetx> and <textoffsety> may also allow the label to be moved outside this rectangle.
    */
-  void SetMaxRect(float x, float y, float w, float h);
+  bool SetMaxRect(float x, float y, float w, float h);
 
-  void SetAlign(uint32_t align);
+  bool SetAlign(uint32_t align);
   
   /*! \brief Set the text to be displayed in the label
    Updates the label control and recomputes final position and size
    \param text CStdString to set as this labels text
    \sa SetTextW
    */
-  void SetText(const CStdString &label);
+  bool SetText(const CStdString &label);
 
   /*! \brief Set the text to be displayed in the label
    Updates the label control and recomputes final position and size
    \param text CStdStringW to set as this labels text
    \sa SetText
    */
-  void SetTextW(const CStdStringW &label);
+  bool SetTextW(const CStdStringW &label);
   
   /*! \brief Set the color to use for the label
    Sets the color to be used for this label.  Takes effect at the next render
    \param color color to be used for the label
    */
-  void SetColor(COLOR color);
+  bool SetColor(COLOR color);
 
   /*! \brief Set the final layout of the current text
    Overrides the calculated layout of the current text, forcing a particular size and position
@@ -133,7 +137,7 @@ public:
   /*! \brief Set whether or not this label control should scroll
    \param scrolling true if this label should scroll.
    */
-  void SetScrolling(bool scrolling);
+  bool SetScrolling(bool scrolling);
 
   /*! \brief Set this label invalid.  Forces an update of the control
    */
@@ -141,7 +145,7 @@ public:
   
   /*! \brief Update this labels colors
    */
-  void UpdateColors();
+  bool UpdateColors();
   
   /*! \brief Returns the precalculated final layout of the current text
    \return CRect containing the extents of the current text

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -101,10 +101,17 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
   m_label.SetText(label);
 }
 
-void CGUILabelControl::Render()
+void CGUILabelControl::Process(unsigned int currentTime)
 {
   m_label.SetColor(IsDisabled() ? CGUILabel::COLOR_DISABLED : CGUILabel::COLOR_TEXT);
   m_label.SetMaxRect(m_posX, m_posY, m_width, m_height);
+  m_label.Process(currentTime);
+
+  CGUIControl::Process(currentTime);
+}
+
+void CGUILabelControl::Render()
+{
   m_label.Render();
   CGUIControl::Render();
 }

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -67,8 +67,8 @@ void CGUILabelControl::SetInfo(const CGUIInfoLabel &infoLabel)
 
 bool CGUILabelControl::UpdateColors()
 {
-  bool changed = m_label.UpdateColors();
-  changed |= CGUIControl::UpdateColors();
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_label.UpdateColors();
 
   return changed;
 }

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -140,6 +140,8 @@ void CGUILabelControl::SetLabel(const string &strLabel)
   m_infoLabel.SetLabel(strLabel, "");
   if (m_iCursorPos > (int)strLabel.size())
     m_iCursorPos = strLabel.size();
+
+  SetInvalid();
 }
 
 void CGUILabelControl::SetWidthControl(float minWidth, bool bScroll)

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -53,6 +53,7 @@ void CGUILabelControl::SetCursorPos(int iPos)
   CStdString label = m_infoLabel.GetLabel(m_parentID);
   if (iPos > (int)label.length()) iPos = label.length();
   if (iPos < 0) iPos = 0;
+
   m_iCursorPos = iPos;
 }
 
@@ -61,10 +62,12 @@ void CGUILabelControl::SetInfo(const CGUIInfoLabel &infoLabel)
   m_infoLabel = infoLabel;
 }
 
-void CGUILabelControl::UpdateColors()
+bool CGUILabelControl::UpdateColors()
 {
-  m_label.UpdateColors();
-  CGUIControl::UpdateColors();
+  bool changed = m_label.UpdateColors();
+  changed |= CGUIControl::UpdateColors();
+
+  return changed;
 }
 
 void CGUILabelControl::UpdateInfo(const CGUIListItem *item)

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -109,7 +109,7 @@ void CGUILabelControl::UpdateInfo(const CGUIListItem *item)
     MarkDirtyRegion();
 }
 
-void CGUILabelControl::Process(unsigned int currentTime)
+void CGUILabelControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   bool changed = false;
 
@@ -120,7 +120,7 @@ void CGUILabelControl::Process(unsigned int currentTime)
   if (changed)
     MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUILabelControl::Render()

--- a/xbmc/guilib/GUILabelControl.h
+++ b/xbmc/guilib/GUILabelControl.h
@@ -44,6 +44,7 @@ public:
   virtual ~CGUILabelControl(void);
   virtual CGUILabelControl *Clone() const { return new CGUILabelControl(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual void UpdateInfo(const CGUIListItem *item = NULL);
   virtual bool CanFocus() const;

--- a/xbmc/guilib/GUILabelControl.h
+++ b/xbmc/guilib/GUILabelControl.h
@@ -62,7 +62,7 @@ public:
   void SetHighlight(unsigned int start, unsigned int end);
 
 protected:
-  void UpdateColors();
+  bool UpdateColors();
   CStdString ShortenPath(const CStdString &path);
 
   CGUILabel m_label;

--- a/xbmc/guilib/GUILabelControl.h
+++ b/xbmc/guilib/GUILabelControl.h
@@ -44,7 +44,7 @@ public:
   virtual ~CGUILabelControl(void);
   virtual CGUILabelControl *Clone() const { return new CGUILabelControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual void UpdateInfo(const CGUIListItem *item = NULL);
   virtual bool CanFocus() const;

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -198,12 +198,12 @@ void CGUIListContainer::ValidateOffset()
   if (!m_layout) return;
   if (m_offset > (int)m_items.size() - m_itemsPerPage || m_scrollOffset > ((int)m_items.size() - m_itemsPerPage) * m_layout->Size(m_orientation))
   {
-    m_offset = m_items.size() - m_itemsPerPage;
+    SetOffset(std::max(0, (int)m_items.size() - m_itemsPerPage));
     m_scrollOffset = m_offset * m_layout->Size(m_orientation);
   }
   if (m_offset < 0 || m_scrollOffset < 0)
   {
-    m_offset = 0;
+    SetOffset(0);
     m_scrollOffset = 0;
   }
 }
@@ -214,7 +214,7 @@ void CGUIListContainer::SetCursor(int cursor)
   if (cursor < 0) cursor = 0;
   if (!m_wasReset)
     SetContainerMoving(cursor - m_cursor);
-  m_cursor = cursor;
+  CGUIBaseContainer::SetCursor(cursor);
 }
 
 void CGUIListContainer::SelectItem(int item)
@@ -274,8 +274,7 @@ bool CGUIListContainer::SelectItemFromPoint(const CPoint &point)
   if (row < 0)
     return false;
 
-  SetContainerMoving(row - m_cursor);
-  m_cursor = row;
+  SetCursor(row);
   CGUIListItemLayout *focusedLayout = GetFocusedLayout();
   if (focusedLayout)
     focusedLayout->SelectItemFromPoint(itemPoint);

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -41,7 +41,7 @@ bool CGUIListContainer::OnAction(const CAction &action)
   {
   case ACTION_PAGE_UP:
     {
-      if (m_offset == 0)
+      if (GetOffset() == 0)
       { // already on the first page, so move to the first item
         SetCursor(0);
       }
@@ -54,9 +54,9 @@ bool CGUIListContainer::OnAction(const CAction &action)
     break;
   case ACTION_PAGE_DOWN:
     {
-      if (m_offset == (int)m_items.size() - m_itemsPerPage || (int)m_items.size() < m_itemsPerPage)
+      if (GetOffset() == (int)m_items.size() - m_itemsPerPage || (int)m_items.size() < m_itemsPerPage)
       { // already at the last page, so move to the last item.
-        SetCursor(m_items.size() - m_offset - 1);
+        SetCursor(m_items.size() - GetOffset() - 1);
       }
       else
       { // scroll down to the next page
@@ -74,13 +74,13 @@ bool CGUIListContainer::OnAction(const CAction &action)
       {
         handled = true;
         m_analogScrollCount -= 0.4f;
-        if (m_offset > 0 && m_cursor <= m_itemsPerPage / 2)
+        if (GetOffset() > 0 && GetCursor() <= m_itemsPerPage / 2)
         {
           Scroll(-1);
         }
-        else if (m_cursor > 0)
+        else if (GetCursor() > 0)
         {
-          SetCursor(m_cursor - 1);
+          SetCursor(GetCursor() - 1);
         }
       }
       return handled;
@@ -94,13 +94,13 @@ bool CGUIListContainer::OnAction(const CAction &action)
       {
         handled = true;
         m_analogScrollCount -= 0.4f;
-        if (m_offset + m_itemsPerPage < (int)m_items.size() && m_cursor >= m_itemsPerPage / 2)
+        if (GetOffset() + m_itemsPerPage < (int)m_items.size() && GetCursor() >= m_itemsPerPage / 2)
         {
           Scroll(1);
         }
-        else if (m_cursor < m_itemsPerPage - 1 && m_offset + m_cursor < (int)m_items.size() - 1)
+        else if (GetCursor() < m_itemsPerPage - 1 && GetOffset() + GetCursor() < (int)m_items.size() - 1)
         {
-          SetCursor(m_cursor + 1);
+          SetCursor(GetCursor() + 1);
         }
       }
       return handled;
@@ -122,7 +122,7 @@ bool CGUIListContainer::OnMessage(CGUIMessage& message)
     {
       if (message.GetParam1()) // subfocus item is specified, so set the offset appropriately
       {
-        int item = std::min(m_offset + (int)message.GetParam1() - 1, (int)m_items.size() - 1);
+        int item = std::min(GetOffset() + (int)message.GetParam1() - 1, (int)m_items.size() - 1);
         SelectItem(item);
       }
     }
@@ -132,13 +132,13 @@ bool CGUIListContainer::OnMessage(CGUIMessage& message)
 
 bool CGUIListContainer::MoveUp(bool wrapAround)
 {
-  if (m_cursor > 0)
+  if (GetCursor() > 0)
   {
-    SetCursor(m_cursor - 1);
+    SetCursor(GetCursor() - 1);
   }
-  else if (m_cursor == 0 && m_offset)
+  else if (GetCursor() == 0 && GetOffset())
   {
-    ScrollToOffset(m_offset - 1);
+    ScrollToOffset(GetOffset() - 1);
   }
   else if (wrapAround)
   {
@@ -158,15 +158,15 @@ bool CGUIListContainer::MoveUp(bool wrapAround)
 
 bool CGUIListContainer::MoveDown(bool wrapAround)
 {
-  if (m_offset + m_cursor + 1 < (int)m_items.size())
+  if (GetOffset() + GetCursor() + 1 < (int)m_items.size())
   {
-    if (m_cursor + 1 < m_itemsPerPage)
+    if (GetCursor() + 1 < m_itemsPerPage)
     {
-      SetCursor(m_cursor + 1);
+      SetCursor(GetCursor() + 1);
     }
     else
     {
-      ScrollToOffset(m_offset + 1);
+      ScrollToOffset(GetOffset() + 1);
     }
   }
   else if(wrapAround)
@@ -184,7 +184,7 @@ bool CGUIListContainer::MoveDown(bool wrapAround)
 void CGUIListContainer::Scroll(int amount)
 {
   // increase or decrease the offset
-  int offset = m_offset + amount;
+  int offset = GetOffset() + amount;
   if (offset > (int)m_items.size() - m_itemsPerPage)
   {
     offset = m_items.size() - m_itemsPerPage;
@@ -194,14 +194,14 @@ void CGUIListContainer::Scroll(int amount)
 }
 
 void CGUIListContainer::ValidateOffset()
-{ // first thing is we check the range of m_offset
+{ // first thing is we check the range of our offset
   if (!m_layout) return;
-  if (m_offset > (int)m_items.size() - m_itemsPerPage || m_scrollOffset > ((int)m_items.size() - m_itemsPerPage) * m_layout->Size(m_orientation))
+  if (GetOffset() > (int)m_items.size() - m_itemsPerPage || m_scrollOffset > ((int)m_items.size() - m_itemsPerPage) * m_layout->Size(m_orientation))
   {
     SetOffset(std::max(0, (int)m_items.size() - m_itemsPerPage));
-    m_scrollOffset = m_offset * m_layout->Size(m_orientation);
+    m_scrollOffset = GetOffset() * m_layout->Size(m_orientation);
   }
-  if (m_offset < 0 || m_scrollOffset < 0)
+  if (GetOffset() < 0 || m_scrollOffset < 0)
   {
     SetOffset(0);
     m_scrollOffset = 0;
@@ -213,31 +213,31 @@ void CGUIListContainer::SetCursor(int cursor)
   if (cursor > m_itemsPerPage - 1) cursor = m_itemsPerPage - 1;
   if (cursor < 0) cursor = 0;
   if (!m_wasReset)
-    SetContainerMoving(cursor - m_cursor);
+    SetContainerMoving(cursor - GetCursor());
   CGUIBaseContainer::SetCursor(cursor);
 }
 
 void CGUIListContainer::SelectItem(int item)
 {
-  // Check that m_offset is valid
+  // Check that our offset is valid
   ValidateOffset();
   // only select an item if it's in a valid range
   if (item >= 0 && item < (int)m_items.size())
   {
     // Select the item requested
-    if (item >= m_offset && item < m_offset + m_itemsPerPage)
+    if (item >= GetOffset() && item < GetOffset() + m_itemsPerPage)
     { // the item is on the current page, so don't change it.
-      SetCursor(item - m_offset);
+      SetCursor(item - GetOffset());
     }
-    else if (item < m_offset)
+    else if (item < GetOffset())
     { // item is on a previous page - make it the first item on the page
       SetCursor(0);
       ScrollToOffset(item);
     }
-    else // (item >= m_offset+m_itemsPerPage)
+    else // (item >= GetOffset()+m_itemsPerPage)
     { // item is on a later page - make it the last item on the page
       SetCursor(m_itemsPerPage - 1);
-      ScrollToOffset(item - m_cursor);
+      ScrollToOffset(item - GetCursor());
     }
   }
 }
@@ -251,8 +251,8 @@ int CGUIListContainer::GetCursorFromPoint(const CPoint &point, CPoint *itemPoint
   float pos = (m_orientation == VERTICAL) ? point.y : point.x;
   while (row < m_itemsPerPage + 1)  // 1 more to ensure we get the (possible) half item at the end.
   {
-    const CGUIListItemLayout *layout = (row == m_cursor) ? m_focusedLayout : m_layout;
-    if (pos < layout->Size(m_orientation) && row + m_offset < (int)m_items.size())
+    const CGUIListItemLayout *layout = (row == GetCursor()) ? m_focusedLayout : m_layout;
+    if (pos < layout->Size(m_orientation) && row + GetOffset() < (int)m_items.size())
     { // found correct "row" -> check horizontal
       if (!InsideLayout(layout, point))
         return -1;
@@ -304,10 +304,10 @@ CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, fl
 
 bool CGUIListContainer::HasNextPage() const
 {
-  return (m_offset != (int)m_items.size() - m_itemsPerPage && (int)m_items.size() >= m_itemsPerPage);
+  return (GetOffset() != (int)m_items.size() - m_itemsPerPage && (int)m_items.size() >= m_itemsPerPage);
 }
 
 bool CGUIListContainer::HasPreviousPage() const
 {
-  return (m_offset > 0);
+  return (GetOffset() > 0);
 }

--- a/xbmc/guilib/GUIListGroup.cpp
+++ b/xbmc/guilib/GUIListGroup.cpp
@@ -113,6 +113,16 @@ void CGUIListGroup::UpdateInfo(const CGUIListItem *item)
   }
 }
 
+void CGUIListGroup::SetInvalid()
+{
+  if (!m_bInvalidated)
+  { // this can be triggered by an item change, so all children need invalidating rather than just the group
+    for (iControls it = m_children.begin(); it != m_children.end(); ++it)
+      (*it)->SetInvalid();
+    CGUIControlGroup::SetInvalid();
+  }
+}
+
 void CGUIListGroup::SetFocusedItem(unsigned int focus)
 {
   for (iControls it = m_children.begin(); it != m_children.end(); it++)

--- a/xbmc/guilib/GUIListGroup.cpp
+++ b/xbmc/guilib/GUIListGroup.cpp
@@ -61,9 +61,9 @@ void CGUIListGroup::AddControl(CGUIControl *control, int position /*= -1*/)
   CGUIControlGroup::AddControl(control, position);
 }
 
-void CGUIListGroup::Process(unsigned int currentTime)
+void CGUIListGroup::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  CGUIControlGroup::Process(currentTime);
+  CGUIControlGroup::Process(currentTime, dirtyregions);
   m_item = NULL;
 }
 

--- a/xbmc/guilib/GUIListGroup.cpp
+++ b/xbmc/guilib/GUIListGroup.cpp
@@ -61,20 +61,22 @@ void CGUIListGroup::AddControl(CGUIControl *control, int position /*= -1*/)
   CGUIControlGroup::AddControl(control, position);
 }
 
+void CGUIListGroup::Process(unsigned int currentTime)
+{
+  CGUIControlGroup::Process(currentTime);
+  m_item = NULL;
+}
+
 void CGUIListGroup::Render()
 {
   g_graphicsContext.SetOrigin(m_posX, m_posY);
   for (iControls it = m_children.begin(); it != m_children.end(); ++it)
   {
     CGUIControl *control = *it;
-    GUIPROFILER_VISIBILITY_BEGIN(control);
-    control->UpdateVisibility(m_item);
-    GUIPROFILER_VISIBILITY_END(control);
-    control->DoRender(m_renderTime);
+    control->DoRender();
   }
   CGUIControl::Render();
   g_graphicsContext.RestoreOrigin();
-  m_item = NULL;
 }
 
 void CGUIListGroup::ResetAnimation(ANIMATION_TYPE type)

--- a/xbmc/guilib/GUIListGroup.h
+++ b/xbmc/guilib/GUIListGroup.h
@@ -47,6 +47,7 @@ public:
   virtual void ResetAnimation(ANIMATION_TYPE type);
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
   virtual void UpdateInfo(const CGUIListItem *item);
+  virtual void SetInvalid();
 
   void SetFocusedItem(unsigned int subfocus);
   unsigned int GetFocusedItem() const;

--- a/xbmc/guilib/GUIListGroup.h
+++ b/xbmc/guilib/GUIListGroup.h
@@ -42,7 +42,7 @@ public:
 
   virtual void AddControl(CGUIControl *control, int position = -1);
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual void ResetAnimation(ANIMATION_TYPE type);
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);

--- a/xbmc/guilib/GUIListGroup.h
+++ b/xbmc/guilib/GUIListGroup.h
@@ -42,6 +42,7 @@ public:
 
   virtual void AddControl(CGUIControl *control, int position = -1);
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual void ResetAnimation(ANIMATION_TYPE type);
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -71,7 +71,7 @@ float CGUIListItemLayout::Size(ORIENTATION orientation) const
   return (orientation == HORIZONTAL) ? m_width : m_height;
 }
 
-void CGUIListItemLayout::Render(CGUIListItem *item, int parentID, unsigned int time)
+void CGUIListItemLayout::Process(CGUIListItem *item, int parentID, unsigned int currentTime)
 {
   if (m_invalidated)
   { // need to update our item
@@ -90,7 +90,12 @@ void CGUIListItemLayout::Render(CGUIListItem *item, int parentID, unsigned int t
   // update visibility, and render
   m_group.SetState(item->IsSelected() || m_isPlaying, m_focused);
   m_group.UpdateVisibility(item);
-  m_group.DoRender(time);
+  m_group.DoProcess(currentTime);
+}
+
+void CGUIListItemLayout::Render(CGUIListItem *item, int parentID)
+{
+  m_group.DoRender();
 }
 
 void CGUIListItemLayout::SetFocusedItem(unsigned int focus)

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -71,7 +71,7 @@ float CGUIListItemLayout::Size(ORIENTATION orientation) const
   return (orientation == HORIZONTAL) ? m_width : m_height;
 }
 
-void CGUIListItemLayout::Process(CGUIListItem *item, int parentID, unsigned int currentTime)
+void CGUIListItemLayout::Process(CGUIListItem *item, int parentID, unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   if (m_invalidated)
   { // need to update our item
@@ -90,7 +90,7 @@ void CGUIListItemLayout::Process(CGUIListItem *item, int parentID, unsigned int 
   // update visibility, and render
   m_group.SetState(item->IsSelected() || m_isPlaying, m_focused);
   m_group.UpdateVisibility(item);
-  m_group.DoProcess(currentTime);
+  m_group.DoProcess(currentTime, dirtyregions);
 }
 
 void CGUIListItemLayout::Render(CGUIListItem *item, int parentID)

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -35,7 +35,8 @@ public:
   CGUIListItemLayout(const CGUIListItemLayout &from);
   virtual ~CGUIListItemLayout();
   void LoadLayout(TiXmlElement *layout, bool focused);
-  void Render(CGUIListItem *item, int parentID, unsigned int time = 0);
+  void Process(CGUIListItem *item, int parentID, unsigned int currentTime);
+  void Render(CGUIListItem *item, int parentID);
   float Size(ORIENTATION orientation) const;
   unsigned int GetFocusedItem() const;
   void SetFocusedItem(unsigned int focus);

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -35,7 +35,7 @@ public:
   CGUIListItemLayout(const CGUIListItemLayout &from);
   virtual ~CGUIListItemLayout();
   void LoadLayout(TiXmlElement *layout, bool focused);
-  void Process(CGUIListItem *item, int parentID, unsigned int currentTime);
+  void Process(CGUIListItem *item, int parentID, unsigned int currentTime, CDirtyRegionList &dirtyregions);
   void Render(CGUIListItem *item, int parentID);
   float Size(ORIENTATION orientation) const;
   unsigned int GetFocusedItem() const;

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -73,12 +73,12 @@ bool CGUIListLabel::UpdateColors()
   return changed;
 }
 
-void CGUIListLabel::Process(unsigned int currentTime)
+void CGUIListLabel::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   if (m_label.Process(currentTime))
     MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIListLabel::Render()

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -60,7 +60,7 @@ void CGUIListLabel::SetFocus(bool focus)
     SetScrolling(false);
 }
 
-CRect CGUIListLabel::GetRenderRegion() const
+CRect CGUIListLabel::CalcRenderRegion() const
 {
   return m_label.GetRenderRect();
 }

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -60,6 +60,11 @@ void CGUIListLabel::SetFocus(bool focus)
     SetScrolling(false);
 }
 
+CRect CGUIListLabel::GetRenderRegion()
+{
+  return m_label.GetRenderRect();
+}
+
 bool CGUIListLabel::UpdateColors()
 {
   bool changed = m_label.UpdateColors();

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -60,7 +60,7 @@ void CGUIListLabel::SetFocus(bool focus)
     SetScrolling(false);
 }
 
-CRect CGUIListLabel::GetRenderRegion()
+CRect CGUIListLabel::GetRenderRegion() const
 {
   return m_label.GetRenderRect();
 }

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -75,7 +75,9 @@ bool CGUIListLabel::UpdateColors()
 
 void CGUIListLabel::Process(unsigned int currentTime)
 {
-  m_label.Process(currentTime);
+  if (m_label.Process(currentTime))
+    MarkDirtyRegion();
+
   CGUIControl::Process(currentTime);
 }
 

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -67,8 +67,8 @@ CRect CGUIListLabel::GetRenderRegion() const
 
 bool CGUIListLabel::UpdateColors()
 {
-  bool changed = m_label.UpdateColors();
-  changed |= CGUIControl::UpdateColors();
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_label.UpdateColors();
 
   return changed;
 }

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -60,10 +60,12 @@ void CGUIListLabel::SetFocus(bool focus)
     SetScrolling(false);
 }
 
-void CGUIListLabel::UpdateColors()
+bool CGUIListLabel::UpdateColors()
 {
-  m_label.UpdateColors();
-  CGUIControl::UpdateColors();
+  bool changed = m_label.UpdateColors();
+  changed |= CGUIControl::UpdateColors();
+
+  return changed;
 }
 
 void CGUIListLabel::Render()

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -73,6 +73,12 @@ bool CGUIListLabel::UpdateColors()
   return changed;
 }
 
+void CGUIListLabel::Process(unsigned int currentTime)
+{
+  m_label.Process(currentTime);
+  CGUIControl::Process(currentTime);
+}
+
 void CGUIListLabel::Render()
 {
   m_label.Render();

--- a/xbmc/guilib/GUIListLabel.h
+++ b/xbmc/guilib/GUIListLabel.h
@@ -57,7 +57,7 @@ public:
     CGUILabel::CheckAndCorrectOverlap(label1.m_label, label2.m_label);
   }
 
-  virtual CRect GetRenderRegion() const;
+  virtual CRect CalcRenderRegion() const;
 
 protected:
   virtual bool UpdateColors();

--- a/xbmc/guilib/GUIListLabel.h
+++ b/xbmc/guilib/GUIListLabel.h
@@ -57,7 +57,7 @@ public:
     CGUILabel::CheckAndCorrectOverlap(label1.m_label, label2.m_label);
   }
 
-  virtual CRect GetRenderRegion();
+  virtual CRect GetRenderRegion() const;
 
 protected:
   virtual bool UpdateColors();

--- a/xbmc/guilib/GUIListLabel.h
+++ b/xbmc/guilib/GUIListLabel.h
@@ -57,7 +57,7 @@ public:
   }
   
 protected:
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
 
   CGUILabel     m_label;
   CGUIInfoLabel m_info;

--- a/xbmc/guilib/GUIListLabel.h
+++ b/xbmc/guilib/GUIListLabel.h
@@ -41,6 +41,7 @@ public:
   virtual ~CGUIListLabel(void);
   virtual CGUIListLabel *Clone() const { return new CGUIListLabel(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool CanFocus() const { return false; };
   virtual void UpdateInfo(const CGUIListItem *item = NULL);

--- a/xbmc/guilib/GUIListLabel.h
+++ b/xbmc/guilib/GUIListLabel.h
@@ -55,7 +55,9 @@ public:
   {
     CGUILabel::CheckAndCorrectOverlap(label1.m_label, label2.m_label);
   }
-  
+
+  virtual CRect GetRenderRegion();
+
 protected:
   virtual bool UpdateColors();
 

--- a/xbmc/guilib/GUIListLabel.h
+++ b/xbmc/guilib/GUIListLabel.h
@@ -41,7 +41,7 @@ public:
   virtual ~CGUIListLabel(void);
   virtual CGUIListLabel *Clone() const { return new CGUIListLabel(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool CanFocus() const { return false; };
   virtual void UpdateInfo(const CGUIListItem *item = NULL);

--- a/xbmc/guilib/GUIMoverControl.cpp
+++ b/xbmc/guilib/GUIMoverControl.cpp
@@ -46,6 +46,14 @@ CGUIMoverControl::CGUIMoverControl(int parentID, int controlID, float posX, floa
 CGUIMoverControl::~CGUIMoverControl(void)
 {}
 
+void CGUIMoverControl::Process(unsigned int currentTime)
+{
+  // TODO Proper processing which marks when its actually changed. Just mark always for now.
+  MarkDirtyRegion();
+
+  CGUIControl::Process(currentTime);
+}
+
 void CGUIMoverControl::Render()
 {
   if (m_bInvalidated)

--- a/xbmc/guilib/GUIMoverControl.cpp
+++ b/xbmc/guilib/GUIMoverControl.cpp
@@ -46,12 +46,12 @@ CGUIMoverControl::CGUIMoverControl(int parentID, int controlID, float posX, floa
 CGUIMoverControl::~CGUIMoverControl(void)
 {}
 
-void CGUIMoverControl::Process(unsigned int currentTime)
+void CGUIMoverControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIMoverControl::Render()

--- a/xbmc/guilib/GUIMoverControl.cpp
+++ b/xbmc/guilib/GUIMoverControl.cpp
@@ -240,11 +240,13 @@ void CGUIMoverControl::SetAlpha(unsigned char alpha)
   m_imgNoFocus.SetAlpha(alpha);
 }
 
-void CGUIMoverControl::UpdateColors()
+bool CGUIMoverControl::UpdateColors()
 {
-  CGUIControl::UpdateColors();
-  m_imgFocus.SetDiffuseColor(m_diffuseColor);
-  m_imgNoFocus.SetDiffuseColor(m_diffuseColor);
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_imgFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgNoFocus.SetDiffuseColor(m_diffuseColor);
+
+  return changed;
 }
 
 void CGUIMoverControl::SetLimits(int iX1, int iY1, int iX2, int iY2)

--- a/xbmc/guilib/GUIMoverControl.cpp
+++ b/xbmc/guilib/GUIMoverControl.cpp
@@ -48,14 +48,6 @@ CGUIMoverControl::~CGUIMoverControl(void)
 
 void CGUIMoverControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  // TODO Proper processing which marks when its actually changed. Just mark always for now.
-  MarkDirtyRegion();
-
-  CGUIControl::Process(currentTime, dirtyregions);
-}
-
-void CGUIMoverControl::Render()
-{
   if (m_bInvalidated)
   {
     m_imgFocus.SetWidth(m_width);
@@ -74,17 +66,27 @@ void CGUIMoverControl::Render()
       alphaChannel = 63 - (alphaCounter % 64);
 
     alphaChannel += 192;
-    SetAlpha( (unsigned char)alphaChannel );
+    if (SetAlpha( (unsigned char)alphaChannel ))
+      MarkDirtyRegion();
     m_imgFocus.SetVisible(true);
     m_imgNoFocus.SetVisible(false);
     m_frameCounter++;
   }
   else
   {
-    SetAlpha(0xff);
+    if (SetAlpha(0xff))
+      MarkDirtyRegion();
     m_imgFocus.SetVisible(false);
     m_imgNoFocus.SetVisible(true);
   }
+  m_imgFocus.Process(currentTime);
+  m_imgNoFocus.Process(currentTime);
+
+  CGUIControl::Process(currentTime, dirtyregions);
+}
+
+void CGUIMoverControl::Render()
+{
   // render both so the visibility settings cause the frame counter to resetcorrectly
   m_imgFocus.Render();
   m_imgNoFocus.Render();
@@ -242,10 +244,10 @@ void CGUIMoverControl::SetPosition(float posX, float posY)
   m_imgNoFocus.SetPosition(posX, posY);
 }
 
-void CGUIMoverControl::SetAlpha(unsigned char alpha)
+bool CGUIMoverControl::SetAlpha(unsigned char alpha)
 {
-  m_imgFocus.SetAlpha(alpha);
-  m_imgNoFocus.SetAlpha(alpha);
+  return m_imgFocus.SetAlpha(alpha) | 
+         m_imgNoFocus.SetAlpha(alpha);
 }
 
 bool CGUIMoverControl::UpdateColors()

--- a/xbmc/guilib/GUIMoverControl.h
+++ b/xbmc/guilib/GUIMoverControl.h
@@ -80,7 +80,7 @@ public:
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool UpdateColors();
-  void SetAlpha(unsigned char alpha);
+  bool SetAlpha(unsigned char alpha);
   void UpdateSpeed(int nDirection);
   void Move(int iX, int iY);
   CGUITexture m_imgFocus;

--- a/xbmc/guilib/GUIMoverControl.h
+++ b/xbmc/guilib/GUIMoverControl.h
@@ -60,7 +60,7 @@ public:
   virtual ~CGUIMoverControl(void);
   virtual CGUIMoverControl *Clone() const { return new CGUIMoverControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void OnUp();

--- a/xbmc/guilib/GUIMoverControl.h
+++ b/xbmc/guilib/GUIMoverControl.h
@@ -78,7 +78,7 @@ public:
 
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   void SetAlpha(unsigned char alpha);
   void UpdateSpeed(int nDirection);
   void Move(int iX, int iY);

--- a/xbmc/guilib/GUIMoverControl.h
+++ b/xbmc/guilib/GUIMoverControl.h
@@ -60,6 +60,7 @@ public:
   virtual ~CGUIMoverControl(void);
   virtual CGUIMoverControl *Clone() const { return new CGUIMoverControl(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void OnUp();

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -106,7 +106,7 @@ void CGUIMultiImage::UpdateInfo(const CGUIListItem *item)
   }
 }
 
-void CGUIMultiImage::Process(unsigned int currentTime)
+void CGUIMultiImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // Set a viewport so that we don't render outside the defined area
   if (!m_files.empty() && g_graphicsContext.SetClipRegion(m_posX, m_posY, m_width, m_height))
@@ -135,12 +135,12 @@ void CGUIMultiImage::Process(unsigned int currentTime)
     if (m_image.SetColorDiffuse(m_diffuseColor))
       MarkDirtyRegion();
 
-    m_image.DoProcess(currentTime);
+    m_image.DoProcess(currentTime, dirtyregions);
 
     g_graphicsContext.RestoreClipRegion();
   }
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIMultiImage::Render()

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -126,10 +126,15 @@ void CGUIMultiImage::Process(unsigned int currentTime)
         // grab a new image
         m_currentImage = nextImage;
         m_image.SetFileName(m_files[m_currentImage]);
+        MarkDirtyRegion();
+
         m_imageTimer.StartZero();
       }
     }
-    m_image.SetColorDiffuse(m_diffuseColor);
+
+    if (m_image.SetColorDiffuse(m_diffuseColor))
+      MarkDirtyRegion();
+
     m_image.DoProcess(currentTime);
 
     g_graphicsContext.RestoreClipRegion();

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -106,7 +106,7 @@ void CGUIMultiImage::UpdateInfo(const CGUIListItem *item)
   }
 }
 
-void CGUIMultiImage::Render()
+void CGUIMultiImage::Process(unsigned int currentTime)
 {
   // Set a viewport so that we don't render outside the defined area
   if (!m_files.empty() && g_graphicsContext.SetClipRegion(m_posX, m_posY, m_width, m_height))
@@ -130,9 +130,24 @@ void CGUIMultiImage::Render()
       }
     }
     m_image.SetColorDiffuse(m_diffuseColor);
+    m_image.DoProcess(currentTime);
+
+    g_graphicsContext.RestoreClipRegion();
+  }
+
+  CGUIControl::Process(currentTime);
+}
+
+void CGUIMultiImage::Render()
+{
+  if (!m_files.empty())
+  {
+    // Set a viewport so that we don't render outside the defined area
+    g_graphicsContext.SetClipRegion(m_posX, m_posY, m_width, m_height);
     m_image.Render();
     g_graphicsContext.RestoreClipRegion();
   }
+
   CGUIControl::Render();
 }
 

--- a/xbmc/guilib/GUIMultiImage.h
+++ b/xbmc/guilib/GUIMultiImage.h
@@ -44,7 +44,7 @@ public:
   virtual ~CGUIMultiImage(void);
   virtual CGUIMultiImage *Clone() const { return new CGUIMultiImage(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
   virtual void UpdateInfo(const CGUIListItem *item = NULL);

--- a/xbmc/guilib/GUIMultiImage.h
+++ b/xbmc/guilib/GUIMultiImage.h
@@ -44,6 +44,7 @@ public:
   virtual ~CGUIMultiImage(void);
   virtual CGUIMultiImage *Clone() const { return new CGUIMultiImage(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
   virtual void UpdateInfo(const CGUIListItem *item = NULL);

--- a/xbmc/guilib/GUIMultiSelectText.cpp
+++ b/xbmc/guilib/GUIMultiSelectText.cpp
@@ -58,12 +58,6 @@ CGUIMultiSelectTextControl::~CGUIMultiSelectTextControl(void)
 {
 }
 
-void CGUIMultiSelectTextControl::DoRender(unsigned int currentTime)
-{
-  m_renderTime = currentTime;
-  CGUIControl::DoRender(currentTime);
-}
-
 bool CGUIMultiSelectTextControl::UpdateColors()
 {
   bool changed = m_label.UpdateColors();
@@ -72,8 +66,10 @@ bool CGUIMultiSelectTextControl::UpdateColors()
   return changed;
 }
 
-void CGUIMultiSelectTextControl::Render()
+void CGUIMultiSelectTextControl::Process(unsigned int currentTime)
 {
+  m_renderTime = currentTime;
+
   // check our selected item is in range
   unsigned int numSelectable = GetNumSelectable();
   if (!numSelectable)
@@ -96,6 +92,22 @@ void CGUIMultiSelectTextControl::Render()
   }
   m_scrollLastTime = m_renderTime;
 
+  g_graphicsContext.SetOrigin(-m_scrollOffset, 0);
+
+  // process the buttons
+  for (unsigned int i = 0; i < m_buttons.size(); i++)
+  {
+    m_buttons[i].SetFocus(HasFocus() && i == m_selectedItem);
+    m_buttons[i].DoProcess(currentTime);
+  }
+
+  g_graphicsContext.RestoreOrigin();
+
+  CGUIControl::Process(currentTime);
+}
+
+void CGUIMultiSelectTextControl::Render()
+{
   // clip and set our scrolling origin
   bool clip(m_width < m_totalWidth);
   if (clip)
@@ -107,10 +119,7 @@ void CGUIMultiSelectTextControl::Render()
 
   // render the buttons
   for (unsigned int i = 0; i < m_buttons.size(); i++)
-  {
-    m_buttons[i].SetFocus(HasFocus() && i == m_selectedItem);
-    m_buttons[i].DoRender(m_renderTime);
-  }
+    m_buttons[i].DoRender();
 
   // position the text - we center vertically if applicable, and use the offsets.
   // all x-alignment is ignored for now (see constructor)

--- a/xbmc/guilib/GUIMultiSelectText.cpp
+++ b/xbmc/guilib/GUIMultiSelectText.cpp
@@ -64,10 +64,12 @@ void CGUIMultiSelectTextControl::DoRender(unsigned int currentTime)
   CGUIControl::DoRender(currentTime);
 }
 
-void CGUIMultiSelectTextControl::UpdateColors()
+bool CGUIMultiSelectTextControl::UpdateColors()
 {
-  m_label.UpdateColors();
-  CGUIControl::UpdateColors();
+  bool changed = m_label.UpdateColors();
+  changed |= CGUIControl::UpdateColors();
+
+  return changed;
 }
 
 void CGUIMultiSelectTextControl::Render()

--- a/xbmc/guilib/GUIMultiSelectText.cpp
+++ b/xbmc/guilib/GUIMultiSelectText.cpp
@@ -66,7 +66,7 @@ bool CGUIMultiSelectTextControl::UpdateColors()
   return changed;
 }
 
-void CGUIMultiSelectTextControl::Process(unsigned int currentTime)
+void CGUIMultiSelectTextControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   m_renderTime = currentTime;
 
@@ -98,12 +98,12 @@ void CGUIMultiSelectTextControl::Process(unsigned int currentTime)
   for (unsigned int i = 0; i < m_buttons.size(); i++)
   {
     m_buttons[i].SetFocus(HasFocus() && i == m_selectedItem);
-    m_buttons[i].DoProcess(currentTime);
+    m_buttons[i].DoProcess(currentTime, dirtyregions);
   }
 
   g_graphicsContext.RestoreOrigin();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIMultiSelectTextControl::Render()

--- a/xbmc/guilib/GUIMultiSelectText.cpp
+++ b/xbmc/guilib/GUIMultiSelectText.cpp
@@ -60,8 +60,8 @@ CGUIMultiSelectTextControl::~CGUIMultiSelectTextControl(void)
 
 bool CGUIMultiSelectTextControl::UpdateColors()
 {
-  bool changed = m_label.UpdateColors();
-  changed |= CGUIControl::UpdateColors();
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_label.UpdateColors();
 
   return changed;
 }

--- a/xbmc/guilib/GUIMultiSelectText.h
+++ b/xbmc/guilib/GUIMultiSelectText.h
@@ -37,7 +37,7 @@ public:
   virtual ~CGUIMultiSelectTextControl(void);
   virtual CGUIMultiSelectTextControl *Clone() const { return new CGUIMultiSelectTextControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
 
   virtual bool OnAction(const CAction &action);

--- a/xbmc/guilib/GUIMultiSelectText.h
+++ b/xbmc/guilib/GUIMultiSelectText.h
@@ -37,7 +37,7 @@ public:
   virtual ~CGUIMultiSelectTextControl(void);
   virtual CGUIMultiSelectTextControl *Clone() const { return new CGUIMultiSelectTextControl(*this); };
 
-  virtual void DoRender(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
 
   virtual bool OnAction(const CAction &action);

--- a/xbmc/guilib/GUIMultiSelectText.h
+++ b/xbmc/guilib/GUIMultiSelectText.h
@@ -62,7 +62,7 @@ public:
   virtual void SetFocus(bool focus);
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   void AddString(const CStdString &text, bool selectable, const CStdString &clickAction = "");
   void PositionButtons();
   unsigned int GetNumSelectable() const;

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -388,12 +388,12 @@ void CGUIPanelContainer::ValidateOffset()
   if (!m_layout) return;
   if (m_offset > (int)GetRows() - m_itemsPerPage || m_scrollOffset > ((int)GetRows() - m_itemsPerPage) * m_layout->Size(m_orientation))
   {
-    m_offset = (int)GetRows() - m_itemsPerPage;
+    SetOffset(std::max(0, (int)GetRows() - m_itemsPerPage));
     m_scrollOffset = m_offset * m_layout->Size(m_orientation);
   }
   if (m_offset < 0 || m_scrollOffset < 0)
   {
-    m_offset = 0;
+    SetOffset(0);
     m_scrollOffset = 0;
   }
 }
@@ -405,7 +405,7 @@ void CGUIPanelContainer::SetCursor(int cursor)
   if (cursor < 0) cursor = 0;
   if (!m_wasReset)
     SetContainerMoving(cursor - m_cursor);
-  m_cursor = cursor;
+  CGUIBaseContainer::SetCursor(cursor);
 }
 
 void CGUIPanelContainer::CalculateLayout()

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -72,7 +72,7 @@ void CGUIPanelContainer::Process(unsigned int currentTime, CDirtyRegionList &dir
     if (current >= 0)
     {
       CGUIListItemPtr item = m_items[current];
-      bool focused = (current == m_offset * m_itemsPerRow + m_cursor) && m_bHasFocus;
+      bool focused = (current == GetOffset() * m_itemsPerRow + GetCursor()) && m_bHasFocus;
 
       if (m_orientation == VERTICAL)
         ProcessItem(origin.x + col * m_layout->Size(HORIZONTAL), pos, item.get(), focused, currentTime, dirtyregions);
@@ -127,7 +127,7 @@ void CGUIPanelContainer::Render()
     if (current >= 0)
     {
       CGUIListItemPtr item = m_items[current];
-      bool focused = (current == m_offset * m_itemsPerRow + m_cursor) && m_bHasFocus;
+      bool focused = (current == GetOffset() * m_itemsPerRow + GetCursor()) && m_bHasFocus;
       // render our item
       if (focused)
       {
@@ -173,7 +173,7 @@ bool CGUIPanelContainer::OnAction(const CAction &action)
   {
   case ACTION_PAGE_UP:
     {
-      if (m_offset == 0)
+      if (GetOffset() == 0)
       { // already on the first page, so move to the first item
         SetCursor(0);
       }
@@ -186,9 +186,9 @@ bool CGUIPanelContainer::OnAction(const CAction &action)
     break;
   case ACTION_PAGE_DOWN:
     {
-      if ((m_offset + m_itemsPerPage) * m_itemsPerRow >= (int)m_items.size() || (int)m_items.size() < m_itemsPerPage)
+      if ((GetOffset() + m_itemsPerPage) * m_itemsPerRow >= (int)m_items.size() || (int)m_items.size() < m_itemsPerPage)
       { // already at the last page, so move to the last item.
-        SetCursor(m_items.size() - m_offset * m_itemsPerRow - 1);
+        SetCursor(m_items.size() - GetOffset() * m_itemsPerRow - 1);
       }
       else
       { // scroll down to the next page
@@ -206,13 +206,13 @@ bool CGUIPanelContainer::OnAction(const CAction &action)
       {
         handled = true;
         m_analogScrollCount -= AnalogScrollSpeed();
-        if (m_offset > 0)// && m_cursor <= m_itemsPerPage * m_itemsPerRow / 2)
+        if (GetOffset() > 0)// && GetCursor() <= m_itemsPerPage * m_itemsPerRow / 2)
         {
           Scroll(-1);
         }
-        else if (m_cursor > 0)
+        else if (GetCursor() > 0)
         {
-          SetCursor(m_cursor - 1);
+          SetCursor(GetCursor() - 1);
         }
       }
       return handled;
@@ -226,13 +226,13 @@ bool CGUIPanelContainer::OnAction(const CAction &action)
       {
         handled = true;
         m_analogScrollCount -= AnalogScrollSpeed();
-        if ((m_offset + m_itemsPerPage) * m_itemsPerRow < (int)m_items.size())// && m_cursor >= m_itemsPerPage * m_itemsPerRow / 2)
+        if ((GetOffset() + m_itemsPerPage) * m_itemsPerRow < (int)m_items.size())// && GetCursor() >= m_itemsPerPage * m_itemsPerRow / 2)
         {
           Scroll(1);
         }
-        else if (m_cursor < m_itemsPerPage * m_itemsPerRow - 1 && m_offset * m_itemsPerRow + m_cursor < (int)m_items.size() - 1)
+        else if (GetCursor() < m_itemsPerPage * m_itemsPerRow - 1 && GetOffset() * m_itemsPerRow + GetCursor() < (int)m_items.size() - 1)
         {
-          SetCursor(m_cursor + 1);
+          SetCursor(GetCursor() + 1);
         }
       }
       return handled;
@@ -297,22 +297,22 @@ void CGUIPanelContainer::OnDown()
 
 bool CGUIPanelContainer::MoveDown(bool wrapAround)
 {
-  if (m_cursor + m_itemsPerRow < m_itemsPerPage * m_itemsPerRow && (m_offset + 1 + m_cursor / m_itemsPerRow) * m_itemsPerRow < (int)m_items.size())
+  if (GetCursor() + m_itemsPerRow < m_itemsPerPage * m_itemsPerRow && (GetOffset() + 1 + GetCursor() / m_itemsPerRow) * m_itemsPerRow < (int)m_items.size())
   { // move to last item if necessary
-    if ((m_offset + 1)*m_itemsPerRow + m_cursor >= (int)m_items.size())
-      SetCursor((int)m_items.size() - 1 - m_offset*m_itemsPerRow);
+    if ((GetOffset() + 1)*m_itemsPerRow + GetCursor() >= (int)m_items.size())
+      SetCursor((int)m_items.size() - 1 - GetOffset()*m_itemsPerRow);
     else
-      SetCursor(m_cursor + m_itemsPerRow);
+      SetCursor(GetCursor() + m_itemsPerRow);
   }
-  else if ((m_offset + 1 + m_cursor / m_itemsPerRow) * m_itemsPerRow < (int)m_items.size())
+  else if ((GetOffset() + 1 + GetCursor() / m_itemsPerRow) * m_itemsPerRow < (int)m_items.size())
   { // we scroll to the next row, and move to last item if necessary
-    if ((m_offset + 1)*m_itemsPerRow + m_cursor >= (int)m_items.size())
-      SetCursor((int)m_items.size() - 1 - (m_offset + 1)*m_itemsPerRow);
-    ScrollToOffset(m_offset + 1);
+    if ((GetOffset() + 1)*m_itemsPerRow + GetCursor() >= (int)m_items.size())
+      SetCursor((int)m_items.size() - 1 - (GetOffset() + 1)*m_itemsPerRow);
+    ScrollToOffset(GetOffset() + 1);
   }
   else if (wrapAround)
   { // move first item in list
-    SetCursor(m_cursor % m_itemsPerRow);
+    SetCursor(GetCursor() % m_itemsPerRow);
     ScrollToOffset(0);
     SetContainerMoving(1);
   }
@@ -323,16 +323,16 @@ bool CGUIPanelContainer::MoveDown(bool wrapAround)
 
 bool CGUIPanelContainer::MoveUp(bool wrapAround)
 {
-  if (m_cursor >= m_itemsPerRow)
-    SetCursor(m_cursor - m_itemsPerRow);
-  else if (m_offset > 0)
-    ScrollToOffset(m_offset - 1);
+  if (GetCursor() >= m_itemsPerRow)
+    SetCursor(GetCursor() - m_itemsPerRow);
+  else if (GetOffset() > 0)
+    ScrollToOffset(GetOffset() - 1);
   else if (wrapAround)
   { // move last item in list in this column
-    SetCursor((m_cursor % m_itemsPerRow) + (m_itemsPerPage - 1) * m_itemsPerRow);
+    SetCursor((GetCursor() % m_itemsPerRow) + (m_itemsPerPage - 1) * m_itemsPerRow);
     int offset = max((int)GetRows() - m_itemsPerPage, 0);
     // should check here whether cursor is actually allowed here, and reduce accordingly
-    if (offset * m_itemsPerRow + m_cursor >= (int)m_items.size())
+    if (offset * m_itemsPerRow + GetCursor() >= (int)m_items.size())
       SetCursor((int)m_items.size() - offset * m_itemsPerRow - 1);
     ScrollToOffset(offset);
     SetContainerMoving(-1);
@@ -344,14 +344,14 @@ bool CGUIPanelContainer::MoveUp(bool wrapAround)
 
 bool CGUIPanelContainer::MoveLeft(bool wrapAround)
 {
-  int col = m_cursor % m_itemsPerRow;
+  int col = GetCursor() % m_itemsPerRow;
   if (col > 0)
-    SetCursor(m_cursor - 1);
+    SetCursor(GetCursor() - 1);
   else if (wrapAround)
   { // wrap around
-    SetCursor(m_cursor + m_itemsPerRow - 1);
-    if (m_offset * m_itemsPerRow + m_cursor >= (int)m_items.size())
-      SetCursor((int)m_items.size() - m_offset * m_itemsPerRow);
+    SetCursor(GetCursor() + m_itemsPerRow - 1);
+    if (GetOffset() * m_itemsPerRow + GetCursor() >= (int)m_items.size())
+      SetCursor((int)m_items.size() - GetOffset() * m_itemsPerRow);
   }
   else
     return false;
@@ -360,11 +360,11 @@ bool CGUIPanelContainer::MoveLeft(bool wrapAround)
 
 bool CGUIPanelContainer::MoveRight(bool wrapAround)
 {
-  int col = m_cursor % m_itemsPerRow;
-  if (col + 1 < m_itemsPerRow && m_offset * m_itemsPerRow + m_cursor + 1 < (int)m_items.size())
-    SetCursor(m_cursor + 1);
+  int col = GetCursor() % m_itemsPerRow;
+  if (col + 1 < m_itemsPerRow && GetOffset() * m_itemsPerRow + GetCursor() + 1 < (int)m_items.size())
+    SetCursor(GetCursor() + 1);
   else if (wrapAround) // move first item in row
-    SetCursor(m_cursor - col);
+    SetCursor(GetCursor() - col);
   else
     return false;
   return true;
@@ -374,7 +374,7 @@ bool CGUIPanelContainer::MoveRight(bool wrapAround)
 void CGUIPanelContainer::Scroll(int amount)
 {
   // increase or decrease the offset
-  int offset = m_offset + amount;
+  int offset = GetOffset() + amount;
   if (offset > ((int)GetRows() - m_itemsPerPage) * m_itemsPerRow)
   {
     offset = ((int)GetRows() - m_itemsPerPage) * m_itemsPerRow;
@@ -384,14 +384,14 @@ void CGUIPanelContainer::Scroll(int amount)
 }
 
 void CGUIPanelContainer::ValidateOffset()
-{ // first thing is we check the range of m_offset
+{ // first thing is we check the range of our offset
   if (!m_layout) return;
-  if (m_offset > (int)GetRows() - m_itemsPerPage || m_scrollOffset > ((int)GetRows() - m_itemsPerPage) * m_layout->Size(m_orientation))
+  if (GetOffset() > (int)GetRows() - m_itemsPerPage || m_scrollOffset > ((int)GetRows() - m_itemsPerPage) * m_layout->Size(m_orientation))
   {
     SetOffset(std::max(0, (int)GetRows() - m_itemsPerPage));
-    m_scrollOffset = m_offset * m_layout->Size(m_orientation);
+    m_scrollOffset = GetOffset() * m_layout->Size(m_orientation);
   }
-  if (m_offset < 0 || m_scrollOffset < 0)
+  if (GetOffset() < 0 || m_scrollOffset < 0)
   {
     SetOffset(0);
     m_scrollOffset = 0;
@@ -404,7 +404,7 @@ void CGUIPanelContainer::SetCursor(int cursor)
   if (cursor > (m_itemsPerPage + 1)*m_itemsPerRow - 1) cursor = (m_itemsPerPage + 1)*m_itemsPerRow - 1;
   if (cursor < 0) cursor = 0;
   if (!m_wasReset)
-    SetContainerMoving(cursor - m_cursor);
+    SetContainerMoving(cursor - GetCursor());
   CGUIBaseContainer::SetCursor(cursor);
 }
 
@@ -428,7 +428,7 @@ void CGUIPanelContainer::CalculateLayout()
   if (m_itemsPerPage < 1) m_itemsPerPage = 1;
 
   // ensure that the scroll offset is a multiple of our size
-  m_scrollOffset = m_offset * m_layout->Size(m_orientation);
+  m_scrollOffset = GetOffset() * m_layout->Size(m_orientation);
 }
 
 unsigned int CGUIPanelContainer::GetRows() const
@@ -462,7 +462,7 @@ int CGUIPanelContainer::GetCursorFromPoint(const CPoint &point, CPoint *itemPoin
     for (int x = 0; x < m_itemsPerRow; x++)
     {
       int item = x + y * m_itemsPerRow;
-      if (posX < sizeX && posY < sizeY && item + m_offset < (int)m_items.size())
+      if (posX < sizeX && posY < sizeY && item + GetOffset() < (int)m_items.size())
       { // found
         return item;
       }
@@ -484,8 +484,8 @@ bool CGUIPanelContainer::SelectItemFromPoint(const CPoint &point)
 
 bool CGUIPanelContainer::GetCondition(int condition, int data) const
 { // probably only works vertically atm...
-  int row = m_cursor / m_itemsPerRow;
-  int col = m_cursor % m_itemsPerRow;
+  int row = GetCursor() / m_itemsPerRow;
+  int col = GetCursor() % m_itemsPerRow;
   if (m_orientation == HORIZONTAL)
     swap(row, col);
   switch (condition)
@@ -501,36 +501,36 @@ bool CGUIPanelContainer::GetCondition(int condition, int data) const
 
 void CGUIPanelContainer::SelectItem(int item)
 {
-  // Check that m_offset is valid
+  // Check that our offset is valid
   ValidateOffset();
   // only select an item if it's in a valid range
   if (item >= 0 && item < (int)m_items.size())
   {
     // Select the item requested
-    if (item >= m_offset * m_itemsPerRow && item < (m_offset + m_itemsPerPage) * m_itemsPerRow)
+    if (item >= GetOffset() * m_itemsPerRow && item < (GetOffset() + m_itemsPerPage) * m_itemsPerRow)
     { // the item is on the current page, so don't change it.
-      SetCursor(item - m_offset * m_itemsPerRow);
+      SetCursor(item - GetOffset() * m_itemsPerRow);
     }
-    else if (item < m_offset * m_itemsPerRow)
+    else if (item < GetOffset() * m_itemsPerRow)
     { // item is on a previous page - make it the first item on the page
       SetCursor(item % m_itemsPerRow);
-      ScrollToOffset((item - m_cursor) / m_itemsPerRow);
+      ScrollToOffset((item - GetCursor()) / m_itemsPerRow);
     }
-    else // (item >= m_offset+m_itemsPerPage)
+    else // (item >= GetOffset()+m_itemsPerPage)
     { // item is on a later page - make it the last row on the page
       SetCursor(item % m_itemsPerRow + m_itemsPerRow * (m_itemsPerPage - 1));
-      ScrollToOffset((item - m_cursor) / m_itemsPerRow);
+      ScrollToOffset((item - GetCursor()) / m_itemsPerRow);
     }
   }
 }
 
 bool CGUIPanelContainer::HasPreviousPage() const
 {
-  return (m_offset > 0);
+  return (GetOffset() > 0);
 }
 
 bool CGUIPanelContainer::HasNextPage() const
 {
-  return (m_offset != (int)GetRows() - m_itemsPerPage && (int)GetRows() > m_itemsPerPage);
+  return (GetOffset() != (int)GetRows() - m_itemsPerPage && (int)GetRows() > m_itemsPerPage);
 }
 

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -38,7 +38,7 @@ CGUIPanelContainer::~CGUIPanelContainer(void)
 {
 }
 
-void CGUIPanelContainer::Render()
+void CGUIPanelContainer::Process(unsigned int currentTime)
 {
   ValidateOffset();
 
@@ -47,7 +47,58 @@ void CGUIPanelContainer::Render()
 
   if (!m_layout || !m_focusedLayout) return;
 
-  UpdateScrollOffset();
+  UpdateScrollOffset(currentTime);
+
+  int offset = (int)(m_scrollOffset / m_layout->Size(m_orientation));
+
+  int cacheBefore, cacheAfter;
+  GetCacheOffsets(cacheBefore, cacheAfter);
+
+  // Free memory not used on screen at the moment, do this first so there's more memory for the new items.
+  FreeMemory(CorrectOffset(offset - cacheBefore, 0), CorrectOffset(offset + cacheAfter + m_itemsPerPage + 1, 0));
+
+  CPoint origin = CPoint(m_posX, m_posY) + m_renderOffset;
+  float pos = (m_orientation == VERTICAL) ? origin.y : origin.x;
+  float end = (m_orientation == VERTICAL) ? m_posY + m_height : m_posX + m_width;
+  pos += (offset - cacheBefore) * m_layout->Size(m_orientation) - m_scrollOffset;
+  end += cacheAfter * m_layout->Size(m_orientation);
+
+  int current = (offset - cacheBefore) * m_itemsPerRow;
+  int col = 0;
+  while (pos < end && m_items.size())
+  {
+    if (current >= (int)m_items.size())
+      break;
+    if (current >= 0)
+    {
+      CGUIListItemPtr item = m_items[current];
+      bool focused = (current == m_offset * m_itemsPerRow + m_cursor) && m_bHasFocus;
+
+      if (m_orientation == VERTICAL)
+        ProcessItem(origin.x + col * m_layout->Size(HORIZONTAL), pos, item.get(), focused, currentTime);
+      else
+        ProcessItem(pos, origin.y + col * m_layout->Size(VERTICAL), item.get(), focused, currentTime);
+    }
+    // increment our position
+    if (col < m_itemsPerRow - 1)
+      col++;
+    else
+    {
+      pos += m_layout->Size(m_orientation);
+      col = 0;
+    }
+    current++;
+  }
+
+  UpdatePageControl(offset);
+
+  CGUIControl::Process(currentTime);
+}
+
+
+void CGUIPanelContainer::Render()
+{
+  if (!m_layout || !m_focusedLayout) return;
 
   int offset = (int)(m_scrollOffset / m_layout->Size(m_orientation));
 
@@ -112,8 +163,6 @@ void CGUIPanelContainer::Render()
   }
 
   g_graphicsContext.RestoreClipRegion();
-
-  UpdatePageControl(offset);
 
   CGUIControl::Render();
 }

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -38,7 +38,7 @@ CGUIPanelContainer::~CGUIPanelContainer(void)
 {
 }
 
-void CGUIPanelContainer::Process(unsigned int currentTime)
+void CGUIPanelContainer::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   ValidateOffset();
 
@@ -75,9 +75,9 @@ void CGUIPanelContainer::Process(unsigned int currentTime)
       bool focused = (current == m_offset * m_itemsPerRow + m_cursor) && m_bHasFocus;
 
       if (m_orientation == VERTICAL)
-        ProcessItem(origin.x + col * m_layout->Size(HORIZONTAL), pos, item.get(), focused, currentTime);
+        ProcessItem(origin.x + col * m_layout->Size(HORIZONTAL), pos, item.get(), focused, currentTime, dirtyregions);
       else
-        ProcessItem(pos, origin.y + col * m_layout->Size(VERTICAL), item.get(), focused, currentTime);
+        ProcessItem(pos, origin.y + col * m_layout->Size(VERTICAL), item.get(), focused, currentTime, dirtyregions);
     }
     // increment our position
     if (col < m_itemsPerRow - 1)
@@ -92,7 +92,7 @@ void CGUIPanelContainer::Process(unsigned int currentTime)
 
   UpdatePageControl(offset);
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 

--- a/xbmc/guilib/GUIPanelContainer.h
+++ b/xbmc/guilib/GUIPanelContainer.h
@@ -39,7 +39,7 @@ public:
   virtual ~CGUIPanelContainer(void);
   virtual CGUIPanelContainer *Clone() const { return new CGUIPanelContainer(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUIPanelContainer.h
+++ b/xbmc/guilib/GUIPanelContainer.h
@@ -39,6 +39,7 @@ public:
   virtual ~CGUIPanelContainer(void);
   virtual CGUIPanelContainer *Clone() const { return new CGUIPanelContainer(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUIProgressControl.cpp
+++ b/xbmc/guilib/GUIProgressControl.cpp
@@ -54,12 +54,12 @@ void CGUIProgressControl::SetPosition(float posX, float posY)
   m_guiBackground.SetPosition(posX, posY);
 }
 
-void CGUIProgressControl::Process(unsigned int currentTime)
+void CGUIProgressControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIProgressControl::Render()

--- a/xbmc/guilib/GUIProgressControl.cpp
+++ b/xbmc/guilib/GUIProgressControl.cpp
@@ -54,6 +54,14 @@ void CGUIProgressControl::SetPosition(float posX, float posY)
   m_guiBackground.SetPosition(posX, posY);
 }
 
+void CGUIProgressControl::Process(unsigned int currentTime)
+{
+  // TODO Proper processing which marks when its actually changed. Just mark always for now.
+  MarkDirtyRegion();
+
+  CGUIControl::Process(currentTime);
+}
+
 void CGUIProgressControl::Render()
 {
   if (!IsDisabled())

--- a/xbmc/guilib/GUIProgressControl.cpp
+++ b/xbmc/guilib/GUIProgressControl.cpp
@@ -56,29 +56,24 @@ void CGUIProgressControl::SetPosition(float posX, float posY)
 
 void CGUIProgressControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  // TODO Proper processing which marks when its actually changed. Just mark always for now.
-  MarkDirtyRegion();
+  bool changed = false;
 
-  CGUIControl::Process(currentTime, dirtyregions);
-}
-
-void CGUIProgressControl::Render()
-{
   if (!IsDisabled())
   {
+    float percent = m_fPercent;
     if (m_iInfoCode)
       m_fPercent = (float)g_infoManager.GetInt(m_iInfoCode);
     if (m_fPercent < 0.0f) m_fPercent = 0.0f;
     if (m_fPercent > 100.0f) m_fPercent = 100.0f;
+    changed |= (percent != m_fPercent);
 
     if (m_width == 0)
       m_width = m_guiBackground.GetTextureWidth();
     if (m_height == 0)
       m_height = m_guiBackground.GetTextureHeight();
 
-    m_guiBackground.SetHeight(m_height);
-    m_guiBackground.SetWidth(m_width);
-    m_guiBackground.Render();
+    changed |= m_guiBackground.SetHeight(m_height);
+    changed |= m_guiBackground.SetWidth(m_width);
 
     float fScaleX, fScaleY;
     fScaleY = m_guiBackground.GetTextureHeight() ? m_height / m_guiBackground.GetTextureHeight() : 1.0f;
@@ -90,31 +85,26 @@ void CGUIProgressControl::Render()
     if (m_guiLeft.GetFileName().IsEmpty() && m_guiRight.GetFileName().IsEmpty())
     { // rendering without left and right image - fill the mid image completely
       float width = m_fPercent * m_width * 0.01f;
-      if (m_fPercent && width > 1)
+      float offset = fabs(fScaleY * 0.5f * (m_guiMid.GetTextureHeight() - m_guiBackground.GetTextureHeight()));
+      if (offset > 0)  //  Center texture to the background if necessary
+        changed |= m_guiMid.SetPosition(posX, posY + offset);
+      else
+        changed |= m_guiMid.SetPosition(posX, posY);
+      changed |= m_guiMid.SetHeight(fScaleY * m_guiMid.GetTextureHeight());
+      if (m_bReveal)
       {
-        float offset = fabs(fScaleY * 0.5f * (m_guiMid.GetTextureHeight() - m_guiBackground.GetTextureHeight()));
-        if (offset > 0)  //  Center texture to the background if necessary
-          m_guiMid.SetPosition(posX, posY + offset);
-        else
-          m_guiMid.SetPosition(posX, posY);
-        m_guiMid.SetHeight(fScaleY * m_guiMid.GetTextureHeight());
-        if (m_bReveal)
-        {
-          m_guiMid.SetWidth(m_width);
-          g_graphicsContext.SetClipRegion(posX, posY+offset, width, fScaleY * m_guiMid.GetTextureHeight());
-          m_guiMid.Render();
-          g_graphicsContext.RestoreClipRegion();
-        }
-        else
-        {
-          m_guiMid.SetWidth(width);
-          m_guiMid.Render();
-        }
+        changed |= m_guiMid.SetWidth(m_width);
+        float x = posX, y = posY + offset, w = width, h = fScaleY * m_guiMid.GetTextureHeight();
+        m_guiMidClipRect = CRect(x, y, x + w, y + h);
+      }
+      else
+      {
+        changed |= m_guiMid.SetWidth(width);
+        m_guiMidClipRect = CRect();
       }
     }
     else
     {
-
       float fWidth = m_fPercent;
       float fFullWidth = m_guiBackground.GetTextureWidth() - m_guiLeft.GetTextureWidth() - m_guiRight.GetTextureWidth();
       fWidth /= 100.0f;
@@ -122,55 +112,100 @@ void CGUIProgressControl::Render()
 
       float offset = fabs(fScaleY * 0.5f * (m_guiLeft.GetTextureHeight() - m_guiBackground.GetTextureHeight()));
       if (offset > 0)  //  Center texture to the background if necessary
-        m_guiLeft.SetPosition(posX, posY + offset);
+        changed |= m_guiLeft.SetPosition(posX, posY + offset);
       else
-        m_guiLeft.SetPosition(posX, posY);
-      m_guiLeft.SetHeight(fScaleY * m_guiLeft.GetTextureHeight());
-      m_guiLeft.SetWidth(fScaleX * m_guiLeft.GetTextureWidth());
-      m_guiLeft.Render();
+        changed |= m_guiLeft.SetPosition(posX, posY);
+      changed |= m_guiLeft.SetHeight(fScaleY * m_guiLeft.GetTextureHeight());
+      changed |= m_guiLeft.SetWidth(fScaleX * m_guiLeft.GetTextureWidth());
 
       posX += fScaleX * m_guiLeft.GetTextureWidth();
-      if (m_fPercent && (int)(fScaleX * fWidth) > 1)
+      offset = fabs(fScaleY * 0.5f * (m_guiMid.GetTextureHeight() - m_guiBackground.GetTextureHeight()));
+      if (offset > 0)  //  Center texture to the background if necessary
+        changed |= m_guiMid.SetPosition(posX, posY + offset);
+      else
+        changed |= m_guiMid.SetPosition(posX, posY);
+      changed |= m_guiMid.SetHeight(fScaleY * m_guiMid.GetTextureHeight());
+      if (m_bReveal)
       {
-        float offset = fabs(fScaleY * 0.5f * (m_guiMid.GetTextureHeight() - m_guiBackground.GetTextureHeight()));
-        if (offset > 0)  //  Center texture to the background if necessary
-          m_guiMid.SetPosition(posX, posY + offset);
-        else
-          m_guiMid.SetPosition(posX, posY);
-        m_guiMid.SetHeight(fScaleY * m_guiMid.GetTextureHeight());
-        if (m_bReveal)
-        {
-          m_guiMid.SetWidth(fScaleX * fFullWidth);
-          g_graphicsContext.SetClipRegion(posX, posY+offset, fScaleX * fWidth, fScaleY * m_guiMid.GetTextureHeight());
-          m_guiMid.Render();
-          g_graphicsContext.RestoreClipRegion();
-        }
-        else
-        {
-          m_guiMid.SetWidth(fScaleX * fWidth);
-          m_guiMid.Render();
-        }
-        posX += fWidth * fScaleX;
+        changed |= m_guiMid.SetWidth(fScaleX * fFullWidth);
+        float x = posX, y = posY + offset, w =  fScaleX * fWidth, h = fScaleY * m_guiMid.GetTextureHeight();
+        m_guiMidClipRect = CRect(x, y, x + w, y + h);
       }
+      else
+      {
+        changed |= m_guiMid.SetWidth(fScaleX * fWidth);
+        m_guiMidClipRect = CRect();
+      }
+
+      posX += fWidth * fScaleX;
 
       offset = fabs(fScaleY * 0.5f * (m_guiRight.GetTextureHeight() - m_guiBackground.GetTextureHeight()));
       if (offset > 0)  //  Center texture to the background if necessary
-        m_guiRight.SetPosition(posX, posY + offset);
+        changed |= m_guiRight.SetPosition(posX, posY + offset);
       else
-        m_guiRight.SetPosition(posX, posY);
-      m_guiRight.SetHeight(fScaleY * m_guiRight.GetTextureHeight());
-      m_guiRight.SetWidth(fScaleX * m_guiRight.GetTextureWidth());
-      m_guiRight.Render();
+        changed |= m_guiRight.SetPosition(posX, posY);
+      changed |= m_guiRight.SetHeight(fScaleY * m_guiRight.GetTextureHeight());
+      changed |= m_guiRight.SetWidth(fScaleX * m_guiRight.GetTextureWidth());
     }
     float offset = fabs(fScaleY * 0.5f * (m_guiOverlay.GetTextureHeight() - m_guiBackground.GetTextureHeight()));
     if (offset > 0)  //  Center texture to the background if necessary
-      m_guiOverlay.SetPosition(m_guiBackground.GetXPosition(), m_guiBackground.GetYPosition() + offset);
+      changed |= m_guiOverlay.SetPosition(m_guiBackground.GetXPosition(), m_guiBackground.GetYPosition() + offset);
     else
-      m_guiOverlay.SetPosition(m_guiBackground.GetXPosition(), m_guiBackground.GetYPosition());
-    m_guiOverlay.SetHeight(fScaleY * m_guiOverlay.GetTextureHeight());
-    m_guiOverlay.SetWidth(fScaleX * m_guiOverlay.GetTextureWidth());
+      changed |= m_guiOverlay.SetPosition(m_guiBackground.GetXPosition(), m_guiBackground.GetYPosition());
+    changed |= m_guiOverlay.SetHeight(fScaleY * m_guiOverlay.GetTextureHeight());
+    changed |= m_guiOverlay.SetWidth(fScaleX * m_guiOverlay.GetTextureWidth());
+  }
+
+  changed |= m_guiBackground.Process(currentTime);
+  changed |= m_guiMid.Process(currentTime);
+  changed |= m_guiLeft.Process(currentTime);
+  changed |= m_guiRight.Process(currentTime);
+  changed |= m_guiOverlay.Process(currentTime);
+
+  if (changed)
+    MarkDirtyRegion();
+
+  CGUIControl::Process(currentTime, dirtyregions);
+}
+
+void CGUIProgressControl::Render()
+{
+  if (!IsDisabled())
+  {
+    m_guiBackground.Render();
+
+    if (m_guiLeft.GetFileName().IsEmpty() && m_guiRight.GetFileName().IsEmpty())
+    {
+      if (m_bReveal && !m_guiMidClipRect.IsEmpty())
+      {
+        bool restore = g_graphicsContext.SetClipRegion(m_guiMidClipRect.x1, m_guiMidClipRect.y1, m_guiMidClipRect.Width(), m_guiMidClipRect.Height());
+        m_guiMid.Render();
+        if (restore)
+          g_graphicsContext.RestoreClipRegion();
+      }
+      else if (m_guiMid.GetWidth() > 0)
+        m_guiMid.Render();
+    }
+    else
+    {
+      m_guiLeft.Render();
+
+      if (m_bReveal && !m_guiMidClipRect.IsEmpty())
+      {
+        bool restore = g_graphicsContext.SetClipRegion(m_guiMidClipRect.x1, m_guiMidClipRect.y1, m_guiMidClipRect.Width(), m_guiMidClipRect.Height());
+        m_guiMid.Render();
+        if (restore)
+          g_graphicsContext.RestoreClipRegion();
+      }
+      else if (m_guiMid.GetWidth() > 0)
+        m_guiMid.Render();
+
+      m_guiRight.Render();
+    }
+
     m_guiOverlay.Render();
   }
+
   CGUIControl::Render();
 }
 
@@ -188,6 +223,8 @@ bool CGUIProgressControl::OnMessage(CGUIMessage& message)
 
 void CGUIProgressControl::SetPercentage(float fPercent)
 {
+  if (m_fPercent != fPercent)
+    SetInvalid();
   m_fPercent = fPercent;
 }
 

--- a/xbmc/guilib/GUIProgressControl.cpp
+++ b/xbmc/guilib/GUIProgressControl.cpp
@@ -238,14 +238,16 @@ void CGUIProgressControl::SetInfo(int iInfo)
   m_iInfoCode = iInfo;
 }
 
-void CGUIProgressControl::UpdateColors()
+bool CGUIProgressControl::UpdateColors()
 {
-  CGUIControl::UpdateColors();
-  m_guiBackground.SetDiffuseColor(m_diffuseColor);
-  m_guiRight.SetDiffuseColor(m_diffuseColor);
-  m_guiLeft.SetDiffuseColor(m_diffuseColor);
-  m_guiMid.SetDiffuseColor(m_diffuseColor);
-  m_guiOverlay.SetDiffuseColor(m_diffuseColor);
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_guiBackground.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiRight.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiLeft.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiMid.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiOverlay.SetDiffuseColor(m_diffuseColor);
+
+  return changed;
 }
 
 CStdString CGUIProgressControl::GetDescription() const

--- a/xbmc/guilib/GUIProgressControl.h
+++ b/xbmc/guilib/GUIProgressControl.h
@@ -70,6 +70,8 @@ protected:
   CGUITexture m_guiMid;
   CGUITexture m_guiRight;
   CGUITexture m_guiOverlay;
+  CRect m_guiMidClipRect;
+
   int m_iInfoCode;
   float m_fPercent;
   bool m_bReveal;

--- a/xbmc/guilib/GUIProgressControl.h
+++ b/xbmc/guilib/GUIProgressControl.h
@@ -48,7 +48,7 @@ public:
   virtual ~CGUIProgressControl(void);
   virtual CGUIProgressControl *Clone() const { return new CGUIProgressControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool CanFocus() const;
   virtual void AllocResources();

--- a/xbmc/guilib/GUIProgressControl.h
+++ b/xbmc/guilib/GUIProgressControl.h
@@ -48,6 +48,7 @@ public:
   virtual ~CGUIProgressControl(void);
   virtual CGUIProgressControl *Clone() const { return new CGUIProgressControl(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool CanFocus() const;
   virtual void AllocResources();

--- a/xbmc/guilib/GUIProgressControl.h
+++ b/xbmc/guilib/GUIProgressControl.h
@@ -63,7 +63,7 @@ public:
   float GetPercentage() const;
   CStdString GetDescription() const;
 protected:
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   CGUITexture m_guiBackground;
   CGUITexture m_guiLeft;
   CGUITexture m_guiMid;

--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -80,10 +80,10 @@ void CGUIRSSControl::SetIntervals(const vector<int>& vecIntervals)
 
 bool CGUIRSSControl::UpdateColors()
 {
-  bool changed = m_label.UpdateColors();
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_label.UpdateColors();
   changed |= m_headlineColor.Update();
   changed |= m_channelColor.Update();
-  changed |= CGUIControl::UpdateColors();
 
   return changed;
 }

--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -88,6 +88,14 @@ bool CGUIRSSControl::UpdateColors()
   return changed;
 }
 
+void CGUIRSSControl::Process(unsigned int currentTime)
+{
+  // TODO Proper processing which marks when its actually changed. Just mark always for now.
+  MarkDirtyRegion();
+
+  CGUIControl::Process(currentTime);
+}
+
 void CGUIRSSControl::Render()
 {
   // only render the control if they are enabled

--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -88,12 +88,12 @@ bool CGUIRSSControl::UpdateColors()
   return changed;
 }
 
-void CGUIRSSControl::Process(unsigned int currentTime)
+void CGUIRSSControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIRSSControl::Render()

--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -78,12 +78,14 @@ void CGUIRSSControl::SetIntervals(const vector<int>& vecIntervals)
   m_vecIntervals = vecIntervals;
 }
 
-void CGUIRSSControl::UpdateColors()
+bool CGUIRSSControl::UpdateColors()
 {
-  m_label.UpdateColors();
-  m_headlineColor.Update();
-  m_channelColor.Update();
-  CGUIControl::UpdateColors();
+  bool changed = m_label.UpdateColors();
+  changed |= m_headlineColor.Update();
+  changed |= m_channelColor.Update();
+  changed |= CGUIControl::UpdateColors();
+
+  return changed;
 }
 
 void CGUIRSSControl::Render()

--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -142,6 +142,13 @@ void CGUIRSSControl::Render()
   CGUIControl::Render();
 }
 
+CRect CGUIRSSControl::CalcRenderRegion() const
+{
+  if (m_label.font)
+    return CRect(m_posX, m_posY, m_posX + m_width, m_posY + m_label.font->GetTextHeight(1));
+  return CGUIControl::CalcRenderRegion();
+}
+
 void CGUIRSSControl::OnFeedUpdate(const vecText &feed)
 {
   CSingleLock lock(m_criticalSection);

--- a/xbmc/guilib/GUIRSSControl.h
+++ b/xbmc/guilib/GUIRSSControl.h
@@ -64,6 +64,7 @@ public:
   virtual void OnFeedUpdate(const vecText &feed);
   virtual void OnFeedRelease();
   virtual bool CanFocus() const { return false; };
+  virtual CRect CalcRenderRegion() const;
 
   void SetIntervals(const std::vector<int>& vecIntervals);
   void SetUrls(const std::vector<std::string>& vecUrl, bool rtl);

--- a/xbmc/guilib/GUIRSSControl.h
+++ b/xbmc/guilib/GUIRSSControl.h
@@ -59,6 +59,7 @@ public:
   virtual ~CGUIRSSControl(void);
   virtual CGUIRSSControl *Clone() const { return new CGUIRSSControl(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual void OnFeedUpdate(const vecText &feed);
   virtual void OnFeedRelease();

--- a/xbmc/guilib/GUIRSSControl.h
+++ b/xbmc/guilib/GUIRSSControl.h
@@ -59,7 +59,7 @@ public:
   virtual ~CGUIRSSControl(void);
   virtual CGUIRSSControl *Clone() const { return new CGUIRSSControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual void OnFeedUpdate(const vecText &feed);
   virtual void OnFeedRelease();

--- a/xbmc/guilib/GUIRSSControl.h
+++ b/xbmc/guilib/GUIRSSControl.h
@@ -68,7 +68,7 @@ public:
   void SetUrls(const std::vector<std::string>& vecUrl, bool rtl);
 
 protected:
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
 
   CCriticalSection m_criticalSection;
 

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -150,10 +150,12 @@ CStdString CGUIRadioButtonControl::GetDescription() const
   return strLabel;
 }
 
-void CGUIRadioButtonControl::UpdateColors()
+bool CGUIRadioButtonControl::UpdateColors()
 {
-  CGUIButtonControl::UpdateColors();
-  m_imgRadioOn.SetDiffuseColor(m_diffuseColor);
-  m_imgRadioOff.SetDiffuseColor(m_diffuseColor);
+  bool changed = CGUIButtonControl::UpdateColors();
+  changed |= m_imgRadioOn.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgRadioOff.SetDiffuseColor(m_diffuseColor);
+
+  return changed;
 }
 

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -63,6 +63,7 @@ bool CGUIRadioButtonControl::OnAction(const CAction &action)
   if (action.GetID() == ACTION_SELECT_ITEM)
   {
     m_bSelected = !m_bSelected;
+    MarkDirtyRegion();
   }
   return CGUIButtonControl::OnAction(action);
 }

--- a/xbmc/guilib/GUIRadioButtonControl.h
+++ b/xbmc/guilib/GUIRadioButtonControl.h
@@ -60,7 +60,7 @@ public:
   void SetToggleSelect(int toggleSelect) { m_toggleSelect = toggleSelect; };
   bool IsSelected() const { return m_bSelected; };
 protected:
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   CGUITexture m_imgRadioOn;
   CGUITexture m_imgRadioOff;
   float m_radioPosX;

--- a/xbmc/guilib/GUIRenderingControl.cpp
+++ b/xbmc/guilib/GUIRenderingControl.cpp
@@ -79,14 +79,14 @@ void CGUIRenderingControl::UpdateVisibility(const CGUIListItem *item)
     FreeResources();
 }
 
-void CGUIRenderingControl::Process(unsigned int currentTime)
+void CGUIRenderingControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Add processing to the addon so it could mark when actually changing
   CSingleLock lock(m_rendering);
   if (m_addon)
     MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIRenderingControl::Render()

--- a/xbmc/guilib/GUIRenderingControl.cpp
+++ b/xbmc/guilib/GUIRenderingControl.cpp
@@ -79,6 +79,16 @@ void CGUIRenderingControl::UpdateVisibility(const CGUIListItem *item)
     FreeResources();
 }
 
+void CGUIRenderingControl::Process(unsigned int currentTime)
+{
+  // TODO Add processing to the addon so it could mark when actually changing
+  CSingleLock lock(m_rendering);
+  if (m_addon)
+    MarkDirtyRegion();
+
+  CGUIControl::Process(currentTime);
+}
+
 void CGUIRenderingControl::Render()
 {
   CSingleLock lock(m_rendering);

--- a/xbmc/guilib/GUIRenderingControl.h
+++ b/xbmc/guilib/GUIRenderingControl.h
@@ -30,6 +30,7 @@ public:
   CGUIRenderingControl(const CGUIRenderingControl &from);
   virtual CGUIRenderingControl *Clone() const { return new CGUIRenderingControl(*this); }; //TODO check for naughties
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
   virtual void FreeResources(bool immediately = false);

--- a/xbmc/guilib/GUIRenderingControl.h
+++ b/xbmc/guilib/GUIRenderingControl.h
@@ -30,7 +30,7 @@ public:
   CGUIRenderingControl(const CGUIRenderingControl &from);
   virtual CGUIRenderingControl *Clone() const { return new CGUIRenderingControl(*this); }; //TODO check for naughties
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
   virtual void FreeResources(bool immediately = false);

--- a/xbmc/guilib/GUIResizeControl.cpp
+++ b/xbmc/guilib/GUIResizeControl.cpp
@@ -45,6 +45,14 @@ CGUIResizeControl::CGUIResizeControl(int parentID, int controlID, float posX, fl
 CGUIResizeControl::~CGUIResizeControl(void)
 {}
 
+void CGUIResizeControl::Process(unsigned int currentTime)
+{
+  // TODO Proper processing which marks when its actually changed. Just mark always for now.
+  MarkDirtyRegion();
+
+  CGUIControl::Process(currentTime);
+}
+
 void CGUIResizeControl::Render()
 {
   if (m_bInvalidated)

--- a/xbmc/guilib/GUIResizeControl.cpp
+++ b/xbmc/guilib/GUIResizeControl.cpp
@@ -221,11 +221,13 @@ void CGUIResizeControl::SetAlpha(unsigned char alpha)
   m_imgNoFocus.SetAlpha(alpha);
 }
 
-void CGUIResizeControl::UpdateColors()
+bool CGUIResizeControl::UpdateColors()
 {
-  CGUIControl::UpdateColors();
-  m_imgFocus.SetDiffuseColor(m_diffuseColor);
-  m_imgNoFocus.SetDiffuseColor(m_diffuseColor);
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_imgFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgNoFocus.SetDiffuseColor(m_diffuseColor);
+
+  return changed;
 }
 
 void CGUIResizeControl::SetLimits(float x1, float y1, float x2, float y2)

--- a/xbmc/guilib/GUIResizeControl.cpp
+++ b/xbmc/guilib/GUIResizeControl.cpp
@@ -45,12 +45,12 @@ CGUIResizeControl::CGUIResizeControl(int parentID, int controlID, float posX, fl
 CGUIResizeControl::~CGUIResizeControl(void)
 {}
 
-void CGUIResizeControl::Process(unsigned int currentTime)
+void CGUIResizeControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIResizeControl::Render()

--- a/xbmc/guilib/GUIResizeControl.h
+++ b/xbmc/guilib/GUIResizeControl.h
@@ -69,7 +69,7 @@ public:
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool UpdateColors();
-  void SetAlpha(unsigned char alpha);
+  bool SetAlpha(unsigned char alpha);
   void UpdateSpeed(int nDirection);
   void Resize(float x, float y);
   CGUITexture m_imgFocus;

--- a/xbmc/guilib/GUIResizeControl.h
+++ b/xbmc/guilib/GUIResizeControl.h
@@ -67,7 +67,7 @@ public:
 
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   void SetAlpha(unsigned char alpha);
   void UpdateSpeed(int nDirection);
   void Resize(float x, float y);

--- a/xbmc/guilib/GUIResizeControl.h
+++ b/xbmc/guilib/GUIResizeControl.h
@@ -52,6 +52,7 @@ public:
   virtual ~CGUIResizeControl(void);
   virtual CGUIResizeControl *Clone() const { return new CGUIResizeControl(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void OnUp();

--- a/xbmc/guilib/GUIResizeControl.h
+++ b/xbmc/guilib/GUIResizeControl.h
@@ -52,7 +52,7 @@ public:
   virtual ~CGUIResizeControl(void);
   virtual CGUIResizeControl *Clone() const { return new CGUIResizeControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void OnUp();

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -312,14 +312,16 @@ CStdString CGUIScrollBar::GetDescription() const
   return description;
 }
 
-void CGUIScrollBar::UpdateColors()
+bool CGUIScrollBar::UpdateColors()
 {
-  CGUIControl::UpdateColors();
-  m_guiBackground.SetDiffuseColor(m_diffuseColor);
-  m_guiBarNoFocus.SetDiffuseColor(m_diffuseColor);
-  m_guiBarFocus.SetDiffuseColor(m_diffuseColor);
-  m_guiNibNoFocus.SetDiffuseColor(m_diffuseColor);
-  m_guiNibFocus.SetDiffuseColor(m_diffuseColor);
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_guiBackground.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiBarNoFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiBarFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiNibNoFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiNibFocus.SetDiffuseColor(m_diffuseColor);
+
+  return changed;
 }
 
 bool CGUIScrollBar::IsVisible() const

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -46,7 +46,7 @@ CGUIScrollBar::~CGUIScrollBar(void)
 {
 }
 
-void CGUIScrollBar::Process(unsigned int currentTime)
+void CGUIScrollBar::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   bool changed = false;
 
@@ -62,7 +62,7 @@ void CGUIScrollBar::Process(unsigned int currentTime)
   if (changed)
     MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIScrollBar::Render()

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -46,12 +46,22 @@ CGUIScrollBar::~CGUIScrollBar(void)
 {
 }
 
-
-void CGUIScrollBar::Render()
+void CGUIScrollBar::Process(unsigned int currentTime)
 {
   if (m_bInvalidated)
     UpdateBarSize();
 
+  m_guiBackground.Process(currentTime);
+  m_guiBarNoFocus.Process(currentTime);
+  m_guiBarFocus.Process(currentTime);
+  m_guiNibNoFocus.Process(currentTime);
+  m_guiNibFocus.Process(currentTime);
+
+  CGUIControl::Process(currentTime);
+}
+
+void CGUIScrollBar::Render()
+{
   m_guiBackground.Render();
   if (m_bHasFocus)
   {

--- a/xbmc/guilib/GUIScrollBarControl.h
+++ b/xbmc/guilib/GUIScrollBarControl.h
@@ -66,7 +66,7 @@ protected:
   virtual bool HitTest(const CPoint &point) const;
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool UpdateColors();
-  void UpdateBarSize();
+  bool UpdateBarSize();
   bool Move(int iNumSteps);
   virtual void SetFromPosition(const CPoint &point);
 

--- a/xbmc/guilib/GUIScrollBarControl.h
+++ b/xbmc/guilib/GUIScrollBarControl.h
@@ -64,7 +64,7 @@ public:
 protected:
   virtual bool HitTest(const CPoint &point) const;
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   void UpdateBarSize();
   bool Move(int iNumSteps);
   virtual void SetFromPosition(const CPoint &point);

--- a/xbmc/guilib/GUIScrollBarControl.h
+++ b/xbmc/guilib/GUIScrollBarControl.h
@@ -49,6 +49,7 @@ public:
   virtual ~CGUIScrollBar(void);
   virtual CGUIScrollBar *Clone() const { return new CGUIScrollBar(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void AllocResources();

--- a/xbmc/guilib/GUIScrollBarControl.h
+++ b/xbmc/guilib/GUIScrollBarControl.h
@@ -49,7 +49,7 @@ public:
   virtual ~CGUIScrollBar(void);
   virtual CGUIScrollBar *Clone() const { return new CGUIScrollBar(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void AllocResources();

--- a/xbmc/guilib/GUISelectButtonControl.cpp
+++ b/xbmc/guilib/GUISelectButtonControl.cpp
@@ -399,13 +399,15 @@ void CGUISelectButtonControl::SetPosition(float posX, float posY)
   m_imgBackground.SetPosition(posX + backOffX, posY + backOffY);
 }
 
-void CGUISelectButtonControl::UpdateColors()
+bool CGUISelectButtonControl::UpdateColors()
 {
-  CGUIButtonControl::UpdateColors();
-  m_imgLeft.SetDiffuseColor(m_diffuseColor);
-  m_imgLeftFocus.SetDiffuseColor(m_diffuseColor);
-  m_imgRight.SetDiffuseColor(m_diffuseColor);
-  m_imgRightFocus.SetDiffuseColor(m_diffuseColor);
-  m_imgBackground.SetDiffuseColor(m_diffuseColor);
+  bool changed = CGUIButtonControl::UpdateColors();
+  changed |= m_imgLeft.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgLeftFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgRight.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgRightFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgBackground.SetDiffuseColor(m_diffuseColor);
+
+  return changed;
 }
 

--- a/xbmc/guilib/GUISelectButtonControl.h
+++ b/xbmc/guilib/GUISelectButtonControl.h
@@ -114,7 +114,7 @@ public:
 
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   bool m_bShowSelect;
   CGUITexture m_imgBackground;
   CGUITexture m_imgLeft;

--- a/xbmc/guilib/GUISelectButtonControl.h
+++ b/xbmc/guilib/GUISelectButtonControl.h
@@ -99,6 +99,7 @@ public:
   virtual ~CGUISelectButtonControl(void);
   virtual CGUISelectButtonControl *Clone() const { return new CGUISelectButtonControl(*this); };
 
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action) ;
   virtual void OnLeft();

--- a/xbmc/guilib/GUISettingsSliderControl.cpp
+++ b/xbmc/guilib/GUISettingsSliderControl.cpp
@@ -118,6 +118,8 @@ CStdString CGUISettingsSliderControl::GetDescription() const
 
 bool CGUISettingsSliderControl::UpdateColors()
 {
-  bool changed = m_buttonControl.UpdateColors();
-  return changed || CGUISliderControl::UpdateColors();
+  bool changed = CGUISliderControl::UpdateColors();
+  changed |= m_buttonControl.UpdateColors();
+
+  return changed;
 }

--- a/xbmc/guilib/GUISettingsSliderControl.cpp
+++ b/xbmc/guilib/GUISettingsSliderControl.cpp
@@ -116,8 +116,8 @@ CStdString CGUISettingsSliderControl::GetDescription() const
   return m_buttonControl.GetDescription() + " " + CGUISliderControl::GetDescription();
 }
 
-void CGUISettingsSliderControl::UpdateColors()
+bool CGUISettingsSliderControl::UpdateColors()
 {
-  m_buttonControl.UpdateColors();
-  CGUISliderControl::UpdateColors();
+  bool changed = m_buttonControl.UpdateColors();
+  return changed || CGUISliderControl::UpdateColors();
 }

--- a/xbmc/guilib/GUISettingsSliderControl.cpp
+++ b/xbmc/guilib/GUISettingsSliderControl.cpp
@@ -34,6 +34,11 @@ CGUISettingsSliderControl::~CGUISettingsSliderControl(void)
 {
 }
 
+void CGUISettingsSliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
+{
+  m_buttonControl.Process(currentTime, dirtyregions);
+  CGUISliderControl::Process(currentTime, dirtyregions);
+}
 
 void CGUISettingsSliderControl::Render()
 {

--- a/xbmc/guilib/GUISettingsSliderControl.h
+++ b/xbmc/guilib/GUISettingsSliderControl.h
@@ -48,6 +48,7 @@ public:
   virtual ~CGUISettingsSliderControl(void);
   virtual CGUISettingsSliderControl *Clone() const { return new CGUISettingsSliderControl(*this); };
 
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void AllocResources();

--- a/xbmc/guilib/GUISettingsSliderControl.h
+++ b/xbmc/guilib/GUISettingsSliderControl.h
@@ -68,7 +68,7 @@ public:
   virtual bool HitTest(const CPoint &point) const { return m_buttonControl.HitTest(point); };
 
 protected:
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   
 private:
   CGUIButtonControl m_buttonControl;

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -60,7 +60,9 @@ void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
-
+  m_guiBackground.Process(currentTime);
+  m_guiMidFocus.Process(currentTime);
+  m_guiMid.Process(currentTime);
   CGUIControl::Process(currentTime, dirtyregions);
 }
 

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -380,12 +380,14 @@ CStdString CGUISliderControl::GetDescription() const
   return description;
 }
 
-void CGUISliderControl::UpdateColors()
+bool CGUISliderControl::UpdateColors()
 {
-  CGUIControl::UpdateColors();
-  m_guiBackground.SetDiffuseColor(m_diffuseColor);
-  m_guiMid.SetDiffuseColor(m_diffuseColor);
-  m_guiMidFocus.SetDiffuseColor(m_diffuseColor);
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_guiBackground.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiMid.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiMidFocus.SetDiffuseColor(m_diffuseColor);
+
+  return changed;
 }
 
 float CGUISliderControl::GetProportion() const

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -56,12 +56,12 @@ CGUISliderControl::~CGUISliderControl(void)
 {
 }
 
-void CGUISliderControl::Process(unsigned int currentTime)
+void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUISliderControl::Render()

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -56,6 +56,14 @@ CGUISliderControl::~CGUISliderControl(void)
 {
 }
 
+void CGUISliderControl::Process(unsigned int currentTime)
+{
+  // TODO Proper processing which marks when its actually changed. Just mark always for now.
+  MarkDirtyRegion();
+
+  CGUIControl::Process(currentTime);
+}
+
 void CGUISliderControl::Render()
 {
   m_guiBackground.SetPosition( m_posX, m_posY );

--- a/xbmc/guilib/GUISliderControl.h
+++ b/xbmc/guilib/GUISliderControl.h
@@ -56,6 +56,7 @@ public:
   virtual ~CGUISliderControl(void);
   virtual CGUISliderControl *Clone() const { return new CGUISliderControl(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void AllocResources();

--- a/xbmc/guilib/GUISliderControl.h
+++ b/xbmc/guilib/GUISliderControl.h
@@ -81,7 +81,7 @@ public:
 protected:
   virtual bool HitTest(const CPoint &point) const;
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   virtual void Move(int iNumSteps);
   virtual void SetFromPosition(const CPoint &point);
   /*! \brief Get the current position of the slider as a proportion

--- a/xbmc/guilib/GUISliderControl.h
+++ b/xbmc/guilib/GUISliderControl.h
@@ -56,7 +56,7 @@ public:
   virtual ~CGUISliderControl(void);
   virtual CGUISliderControl *Clone() const { return new CGUISliderControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void AllocResources();

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -921,8 +921,8 @@ void CGUISpinControl::ChangePage(int amount)
 
 bool CGUISpinControl::UpdateColors()
 {
-  bool changed = m_label.UpdateColors();
-  changed |= CGUIControl::UpdateColors();
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_label.UpdateColors();
   changed |= m_imgspinDownFocus.SetDiffuseColor(m_diffuseColor);
   changed |= m_imgspinDown.SetDiffuseColor(m_diffuseColor);
   changed |= m_imgspinUp.SetDiffuseColor(m_diffuseColor);

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -347,12 +347,12 @@ void CGUISpinControl::SetInvalid()
   m_imgspinDownFocus.SetInvalid();
 }
 
-void CGUISpinControl::Process(unsigned int currentTime)
+void CGUISpinControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUISpinControl::Render()

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -911,14 +911,16 @@ void CGUISpinControl::ChangePage(int amount)
   SendWindowMessage(message);
 }
 
-void CGUISpinControl::UpdateColors()
+bool CGUISpinControl::UpdateColors()
 {
-  m_label.UpdateColors();
-  CGUIControl::UpdateColors();
-  m_imgspinDownFocus.SetDiffuseColor(m_diffuseColor);
-  m_imgspinDown.SetDiffuseColor(m_diffuseColor);
-  m_imgspinUp.SetDiffuseColor(m_diffuseColor);
-  m_imgspinUpFocus.SetDiffuseColor(m_diffuseColor);
+  bool changed = m_label.UpdateColors();
+  changed |= CGUIControl::UpdateColors();
+  changed |= m_imgspinDownFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgspinDown.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgspinUp.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgspinUpFocus.SetDiffuseColor(m_diffuseColor);
+
+  return changed;
 }
 
 bool CGUISpinControl::IsVisible() const

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -347,6 +347,14 @@ void CGUISpinControl::SetInvalid()
   m_imgspinDownFocus.SetInvalid();
 }
 
+void CGUISpinControl::Process(unsigned int currentTime)
+{
+  // TODO Proper processing which marks when its actually changed. Just mark always for now.
+  MarkDirtyRegion();
+
+  CGUIControl::Process(currentTime);
+}
+
 void CGUISpinControl::Render()
 {
   if (!HasFocus())

--- a/xbmc/guilib/GUISpinControl.h
+++ b/xbmc/guilib/GUISpinControl.h
@@ -49,6 +49,7 @@ public:
   virtual ~CGUISpinControl(void);
   virtual CGUISpinControl *Clone() const { return new CGUISpinControl(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void OnLeft();

--- a/xbmc/guilib/GUISpinControl.h
+++ b/xbmc/guilib/GUISpinControl.h
@@ -89,7 +89,7 @@ public:
 
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   /*! \brief Render the spinner text
    \param posX position of the left edge of the text
    \param width width of the text

--- a/xbmc/guilib/GUISpinControl.h
+++ b/xbmc/guilib/GUISpinControl.h
@@ -49,7 +49,7 @@ public:
   virtual ~CGUISpinControl(void);
   virtual CGUISpinControl *Clone() const { return new CGUISpinControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void OnLeft();

--- a/xbmc/guilib/GUISpinControlEx.cpp
+++ b/xbmc/guilib/GUISpinControlEx.cpp
@@ -101,12 +101,6 @@ void CGUISpinControlEx::SetHeight(float height)
   SetPosition(m_buttonControl.GetXPosition(), m_buttonControl.GetYPosition());
 }
 
-void CGUISpinControlEx::SetVisible(bool bVisible)
-{
-  m_buttonControl.SetVisible(bVisible);
-  CGUISpinControl::SetVisible(bVisible);
-}
-
 bool CGUISpinControlEx::UpdateColors()
 {
   bool changed = CGUISpinControl::UpdateColors();

--- a/xbmc/guilib/GUISpinControlEx.cpp
+++ b/xbmc/guilib/GUISpinControlEx.cpp
@@ -62,16 +62,22 @@ void CGUISpinControlEx::SetInvalid()
   m_buttonControl.SetInvalid();
 }
 
-void CGUISpinControlEx::Render()
+void CGUISpinControlEx::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // make sure the button has focus if it should have...
   m_buttonControl.SetFocus(HasFocus());
   m_buttonControl.SetPulseOnSelect(m_pulseOnSelect);
   m_buttonControl.SetEnabled(m_enabled);
-  m_buttonControl.Render();
   if (m_bInvalidated)
     SetPosition(GetXPosition(), GetYPosition());
 
+  m_buttonControl.Process(currentTime, dirtyregions);
+  CGUISpinControl::Process(currentTime, dirtyregions);
+}
+
+void CGUISpinControlEx::Render()
+{
+  m_buttonControl.Render();
   CGUISpinControl::Render();
 }
 

--- a/xbmc/guilib/GUISpinControlEx.cpp
+++ b/xbmc/guilib/GUISpinControlEx.cpp
@@ -101,11 +101,13 @@ void CGUISpinControlEx::SetVisible(bool bVisible)
   CGUISpinControl::SetVisible(bVisible);
 }
 
-void CGUISpinControlEx::UpdateColors()
+bool CGUISpinControlEx::UpdateColors()
 {
-  CGUISpinControl::UpdateColors();
-  m_buttonControl.SetColorDiffuse(m_diffuseColor);
-  m_buttonControl.UpdateColors();
+  bool changed = CGUISpinControl::UpdateColors();
+  changed |= m_buttonControl.SetColorDiffuse(m_diffuseColor);
+  changed |= m_buttonControl.UpdateColors();
+
+  return changed;
 }
 
 void CGUISpinControlEx::SetEnabled(bool bEnable)

--- a/xbmc/guilib/GUISpinControlEx.h
+++ b/xbmc/guilib/GUISpinControlEx.h
@@ -66,7 +66,7 @@ public:
   void SetItemInvalid(bool invalid);
 protected:
   virtual void RenderText(float posX, float width);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   CGUIButtonControl m_buttonControl;
   float m_spinPosX;
 };

--- a/xbmc/guilib/GUISpinControlEx.h
+++ b/xbmc/guilib/GUISpinControlEx.h
@@ -43,6 +43,7 @@ public:
   virtual ~CGUISpinControlEx(void);
   virtual CGUISpinControlEx *Clone() const { return new CGUISpinControlEx(*this); };
 
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual void SetPosition(float posX, float posY);
   virtual float GetWidth() const { return m_buttonControl.GetWidth();};

--- a/xbmc/guilib/GUISpinControlEx.h
+++ b/xbmc/guilib/GUISpinControlEx.h
@@ -56,7 +56,6 @@ public:
   virtual void SetInvalid();
   const CStdString GetCurrentLabel() const;
   void SetText(const std::string & aLabel) {m_buttonControl.SetLabel(aLabel);};
-  virtual void SetVisible(bool bVisible);
   virtual void SetEnabled(bool bEnable);
   virtual float GetXPosition() const { return m_buttonControl.GetXPosition();};
   virtual float GetYPosition() const { return m_buttonControl.GetYPosition();};

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -22,11 +22,15 @@
 #include "GUIStaticItem.h"
 #include "utils/XMLUtils.h"
 #include "GUIControlFactory.h"
+#include "GUIInfoManager.h"
 
 using namespace std;
 
 CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileItem()
 {
+  m_visCondition = 0;
+  m_visState = false;
+
   assert(item);
 
   // check whether we're using the more verbose method...
@@ -62,7 +66,7 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
     if (!thumb.IsConstant())  m_info.push_back(make_pair(thumb, "thumb"));
     if (!icon.IsConstant())   m_info.push_back(make_pair(icon, "icon"));
     m_iprogramCount = id ? atoi(id) : 0;
-    m_idepth = visibleCondition;
+    m_visCondition = visibleCondition;
     // add any properties
     const TiXmlElement *property = item->FirstChildElement("property");
     while (property)
@@ -92,7 +96,6 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
     SetThumbnailImage(CGUIInfoLabel::GetLabel(thumb, parentID, true));
     SetIconImage(CGUIInfoLabel::GetLabel(icon, parentID, true));
     m_iprogramCount = id ? atoi(id) : 0;
-    m_idepth = 0;  // no visibility condition
   }
 }
     
@@ -115,4 +118,24 @@ void CGUIStaticItem::UpdateProperties(int contextWindow)
     else
       SetProperty(name, value);
   }
+}
+
+bool CGUIStaticItem::UpdateVisibility(int contextWindow)
+{
+  if (!m_visCondition)
+    return false;
+  bool state = g_infoManager.GetBool(m_visCondition, contextWindow);
+  if (state != m_visState)
+  {
+    m_visState = state;
+    return true;
+  }
+  return false;
+}
+
+bool CGUIStaticItem::IsVisible() const
+{
+  if (m_visCondition)
+    return m_visState;
+  return true;
 }

--- a/xbmc/guilib/GUIStaticItem.h
+++ b/xbmc/guilib/GUIStaticItem.h
@@ -67,9 +67,21 @@ public:
    \param contextWindow window context to use for any info labels
    */
   void UpdateProperties(int contextWindow);
+
+  /*! \brief update visibility of this item
+   \param contextWindow window context to use for any info labels
+   \return true if visible state has changed, false otherwise
+   */
+  bool UpdateVisibility(int contextWindow);
+
+  /*! \brief whether this item is visible or not
+   */
+  bool IsVisible() const;
 private:
   typedef std::vector< std::pair<CGUIInfoLabel, CStdString> > InfoVector;
   InfoVector m_info;
+  int  m_visCondition;
+  bool m_visState;
 };
 
 typedef boost::shared_ptr<CGUIStaticItem> CGUIStaticItemPtr;

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -81,33 +81,6 @@ CGUITextBox::~CGUITextBox(void)
   m_autoScrollRepeatAnim = NULL;
 }
 
-void CGUITextBox::DoRender(unsigned int currentTime)
-{
-  m_renderTime = currentTime;
-
-  // render the repeat anim as appropriate
-  if (m_autoScrollRepeatAnim)
-  {
-    m_autoScrollRepeatAnim->Animate(m_renderTime, true);
-    TransformMatrix matrix;
-    m_autoScrollRepeatAnim->RenderAnimation(matrix);
-    g_graphicsContext.AddTransform(matrix);
-  }
-
-  CGUIControl::DoRender(currentTime);
-  // if not visible, we reset the autoscroll timer and positioning
-  if (!IsVisible() && m_autoScrollTime)
-  {
-    ResetAutoScrolling();
-    m_lastRenderTime = 0;
-    m_offset = 0;
-    m_scrollOffset = 0;
-    m_scrollSpeed = 0;
-  }
-  if (m_autoScrollRepeatAnim)
-    g_graphicsContext.RemoveTransform();
-}
-
 bool CGUITextBox::UpdateColors()
 {
   bool changed = m_label.UpdateColors();
@@ -129,6 +102,50 @@ void CGUITextBox::UpdateInfo(const CGUIListItem *item)
   m_itemsPerPage = (unsigned int)(m_height / m_itemHeight);
 
   UpdatePageControl();
+}
+
+void CGUITextBox::DoProcess(unsigned int currentTime)
+{
+  m_renderTime = currentTime;
+
+  // render the repeat anim as appropriate
+  if (m_autoScrollRepeatAnim)
+  {
+    m_autoScrollRepeatAnim->Animate(m_renderTime, true);
+    m_autoScrollRepeatAnim->RenderAnimation(m_textMatrix);
+    g_graphicsContext.AddTransform(m_textMatrix);
+  }
+
+  CGUIControl::DoProcess(currentTime);
+
+  // if not visible, we reset the autoscroll timer and positioning
+  if (!IsVisible() && m_autoScrollTime)
+  {
+    ResetAutoScrolling();
+    m_lastRenderTime = 0;
+    m_offset = 0;
+    m_scrollOffset = 0;
+    m_scrollSpeed = 0;
+  }
+  if (m_autoScrollRepeatAnim)
+    g_graphicsContext.RemoveTransform();
+}
+
+void CGUITextBox::Process(unsigned int currentTime)
+{
+  CGUIControl::Process(currentTime);
+}
+
+void CGUITextBox::DoRender()
+{
+  // render the repeat anim as appropriate
+  if (m_autoScrollRepeatAnim)
+    g_graphicsContext.AddTransform(m_textMatrix);
+
+  CGUIControl::DoRender();
+
+  if (m_autoScrollRepeatAnim)
+    g_graphicsContext.RemoveTransform();
 }
 
 void CGUITextBox::Render()

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -83,8 +83,10 @@ CGUITextBox::~CGUITextBox(void)
 
 bool CGUITextBox::UpdateColors()
 {
-  bool changed = m_label.UpdateColors();
-  return CGUIControl::UpdateColors() || changed;
+  bool changed = CGUIControl::UpdateColors();
+  changed |= m_label.UpdateColors();
+
+  return changed;
 }
 
 void CGUITextBox::UpdateInfo(const CGUIListItem *item)

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -108,10 +108,10 @@ void CGUITextBox::DoRender(unsigned int currentTime)
     g_graphicsContext.RemoveTransform();
 }
 
-void CGUITextBox::UpdateColors()
+bool CGUITextBox::UpdateColors()
 {
-  m_label.UpdateColors();
-  CGUIControl::UpdateColors();
+  bool changed = m_label.UpdateColors();
+  return CGUIControl::UpdateColors() || changed;
 }
 
 void CGUITextBox::UpdateInfo(const CGUIListItem *item)

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -133,6 +133,9 @@ void CGUITextBox::DoProcess(unsigned int currentTime)
 
 void CGUITextBox::Process(unsigned int currentTime)
 {
+  // TODO Proper processing which marks when its actually changed. Just mark always for now.
+  MarkDirtyRegion();
+
   CGUIControl::Process(currentTime);
 }
 

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -115,7 +115,7 @@ void CGUITextBox::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
   {
     m_autoScrollRepeatAnim->Animate(m_renderTime, true);
     m_autoScrollRepeatAnim->RenderAnimation(m_textMatrix);
-    g_graphicsContext.AddTransform(m_textMatrix);
+    m_cachedTextMatrix = g_graphicsContext.AddTransform(m_textMatrix);
   }
 
   CGUIControl::DoProcess(currentTime, dirtyregions);
@@ -145,7 +145,7 @@ void CGUITextBox::DoRender()
 {
   // render the repeat anim as appropriate
   if (m_autoScrollRepeatAnim)
-    g_graphicsContext.AddTransform(m_textMatrix);
+    g_graphicsContext.SetTransform(m_cachedTextMatrix);
 
   CGUIControl::DoRender();
 

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -106,7 +106,7 @@ void CGUITextBox::UpdateInfo(const CGUIListItem *item)
   UpdatePageControl();
 }
 
-void CGUITextBox::DoProcess(unsigned int currentTime)
+void CGUITextBox::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   m_renderTime = currentTime;
 
@@ -118,7 +118,7 @@ void CGUITextBox::DoProcess(unsigned int currentTime)
     g_graphicsContext.AddTransform(m_textMatrix);
   }
 
-  CGUIControl::DoProcess(currentTime);
+  CGUIControl::DoProcess(currentTime, dirtyregions);
 
   // if not visible, we reset the autoscroll timer and positioning
   if (!IsVisible() && m_autoScrollTime)
@@ -133,12 +133,12 @@ void CGUITextBox::DoProcess(unsigned int currentTime)
     g_graphicsContext.RemoveTransform();
 }
 
-void CGUITextBox::Process(unsigned int currentTime)
+void CGUITextBox::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUITextBox::DoRender()

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -49,8 +49,8 @@ public:
   virtual ~CGUITextBox(void);
   virtual CGUITextBox *Clone() const { return new CGUITextBox(*this); };
 
-  virtual void DoProcess(unsigned int currentTime);
-  virtual void Process(unsigned int currentTime);
+  virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void DoRender();
   virtual void Render();
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -87,6 +87,7 @@ protected:
   CLabelInfo m_label;
 
   TransformMatrix m_textMatrix;
+  TransformMatrix m_cachedTextMatrix;
 
   // autoscrolling
   int          m_autoScrollCondition;

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -65,7 +65,7 @@ public:
 
 protected:
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   virtual void UpdateInfo(const CGUIListItem *item = NULL);
   void UpdatePageControl();
   void ScrollToOffset(int offset, bool autoScroll = false);

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -49,7 +49,9 @@ public:
   virtual ~CGUITextBox(void);
   virtual CGUITextBox *Clone() const { return new CGUITextBox(*this); };
 
-  virtual void DoRender(unsigned int currentTime);
+  virtual void DoProcess(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime);
+  virtual void DoRender();
   virtual void Render();
   virtual bool OnMessage(CGUIMessage& message);
 
@@ -83,6 +85,8 @@ protected:
   unsigned int m_lastRenderTime;
 
   CLabelInfo m_label;
+
+  TransformMatrix m_textMatrix;
 
   // autoscrolling
   int          m_autoScrollCondition;

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -126,12 +126,16 @@ CGUITextureBase::~CGUITextureBase(void)
 {
 }
 
-void CGUITextureBase::AllocateOnDemand()
+bool CGUITextureBase::AllocateOnDemand()
 {
   if (m_visible)
   { // visible, so make sure we're allocated
+    ALLOCATE_TYPE old = m_isAllocated;
     if (!IsAllocated() || (m_isAllocated == LARGE && !m_texture.size()))
+    {
       AllocResources();
+      return old != m_isAllocated;
+    }
   }
   else
   { // hidden, so deallocate as applicable
@@ -142,21 +146,29 @@ void CGUITextureBase::AllocateOnDemand()
     m_currentFrame = 0;
     m_frameCounter = 0;
   }
+
+  return false;
+}
+
+bool CGUITextureBase::Process(unsigned int currentTime)
+{
+  bool changed = false;
+  // check if we need to allocate our resources
+  changed |= AllocateOnDemand();
+
+  if (m_texture.size() > 1)
+    changed |= UpdateAnimFrame();
+
+  if (m_invalid)
+    changed |= CalculateSize();
+
+  return changed;
 }
 
 void CGUITextureBase::Render()
 {
-  // check if we need to allocate our resources
-  AllocateOnDemand();
-
   if (!m_visible || !m_texture.size())
     return;
-
-  if (m_texture.size() > 1)
-    UpdateAnimFrame();
-
-  if (m_invalid)
-    CalculateSize();
 
   // see if we need to clip the image
   if (m_vertex.Width() > m_width || m_vertex.Height() > m_height)
@@ -344,10 +356,10 @@ void CGUITextureBase::AllocResources()
   Allocate();
 }
 
-void CGUITextureBase::CalculateSize()
+bool CGUITextureBase::CalculateSize()
 {
   if (m_currentFrame >= m_texture.size())
-    return;
+    return false;
 
   m_texCoordsScaleU = 1.0f / m_texture.m_texWidth;
   m_texCoordsScaleV = 1.0f / m_texture.m_texHeight;
@@ -400,6 +412,7 @@ void CGUITextureBase::CalculateSize()
     else
       newPosY = m_posY + (m_height - newHeight) * 0.5f;
   }
+  
   m_vertex.SetRect(newPosX, newPosY, newPosX + newWidth, newPosY + newHeight);
 
   // scale the diffuse coords as well
@@ -433,7 +446,9 @@ void CGUITextureBase::CalculateSize()
       m_diffuseOffset = CPoint((m_vertex.x1 - m_posX) / m_vertex.Width() * m_diffuseScaleU, (m_vertex.y1 - m_posY) / m_vertex.Height() * m_diffuseScaleV);
     }
   }
+
   m_invalid = false;
+  return true;
 }
 
 void CGUITextureBase::FreeResources(bool immediately /* = false */)
@@ -470,8 +485,10 @@ void CGUITextureBase::SetInvalid()
   m_invalid = true;
 }
 
-void CGUITextureBase::UpdateAnimFrame()
+bool CGUITextureBase::UpdateAnimFrame()
 {
+  bool changed = false;
+
   m_frameCounter++;
   unsigned int delay = m_texture.m_delays[m_currentFrame];
   if (!delay) delay = 100;
@@ -486,34 +503,45 @@ void CGUITextureBase::UpdateAnimFrame()
         {
           m_currentLoop++;
           m_currentFrame = 0;
+          changed = true;
         }
       }
       else
       {
         // 0 == loop forever
         m_currentFrame = 0;
+        changed = true;
       }
     }
     else
     {
       m_currentFrame++;
+      changed = true;
     }
   }
+
+  return changed;
 }
 
-void CGUITextureBase::SetVisible(bool visible)
+bool CGUITextureBase::SetVisible(bool visible)
 {
+  bool changed = m_visible != visible;
   m_visible = visible;
+  return changed;
 }
 
-void CGUITextureBase::SetAlpha(unsigned char alpha)
+bool CGUITextureBase::SetAlpha(unsigned char alpha)
 {
+  bool changed = m_alpha != alpha;
   m_alpha = alpha;
+  return changed;
 }
 
-void CGUITextureBase::SetDiffuseColor(color_t color)
+bool CGUITextureBase::SetDiffuseColor(color_t color)
 {
+  bool changed = m_diffuseColor != color;
   m_diffuseColor = color;
+  return changed;
 }
 
 bool CGUITextureBase::ReadyToRender() const
@@ -558,7 +586,7 @@ void CGUITextureBase::OrientateTexture(CRect &rect, float width, float height, i
   }
 }
 
-void CGUITextureBase::SetWidth(float width)
+bool CGUITextureBase::SetWidth(float width)
 {
   if (width < m_info.border.x1 + m_info.border.x2)
     width = m_info.border.x1 + m_info.border.x2;
@@ -566,10 +594,13 @@ void CGUITextureBase::SetWidth(float width)
   {
     m_width = width;
     m_invalid = true;
+    return true;
   }
+  else
+    return false;
 }
 
-void CGUITextureBase::SetHeight(float height)
+bool CGUITextureBase::SetHeight(float height)
 {
   if (height < m_info.border.y1 + m_info.border.y2)
     height = m_info.border.y1 + m_info.border.y2;
@@ -577,36 +608,46 @@ void CGUITextureBase::SetHeight(float height)
   {
     m_height = height;
     m_invalid = true;
+    return true;
   }
+  else
+    return false;
 }
 
-void CGUITextureBase::SetPosition(float posX, float posY)
+bool CGUITextureBase::SetPosition(float posX, float posY)
 {
   if (m_posX != posX || m_posY != posY)
   {
     m_posX = posX;
     m_posY = posY;
     m_invalid = true;
+    return true;
   }
+  else
+    return false;
 }
 
-void CGUITextureBase::SetAspectRatio(const CAspectRatio &aspect)
+bool CGUITextureBase::SetAspectRatio(const CAspectRatio &aspect)
 {
   if (m_aspect != aspect)
   {
     m_aspect = aspect;
     m_invalid = true;
+    return true;
   }
+  else
+    return false;
 }
 
-void CGUITextureBase::SetFileName(const CStdString& filename)
+bool CGUITextureBase::SetFileName(const CStdString& filename)
 {
-  if (m_info.filename.Equals(filename)) return;
+  if (m_info.filename.Equals(filename)) return false;
   // Don't completely free resources here - we may be just changing
   // filenames mid-animation
   FreeResources();
   m_info.filename = filename;
   // Don't allocate resources here as this is done at render time
+  return true;
 }
 
 int CGUITextureBase::GetOrientation() const

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -88,6 +88,7 @@ public:
   CGUITextureBase(const CGUITextureBase &left);
   virtual ~CGUITextureBase(void);
 
+  bool Process(unsigned int currentTime);
   void Render();
 
   void DynamicResourceAlloc(bool bOnOff);
@@ -95,14 +96,14 @@ public:
   void FreeResources(bool immediately = false);
   void SetInvalid();
 
-  void SetVisible(bool visible);
-  void SetAlpha(unsigned char alpha);
-  void SetDiffuseColor(color_t color);
-  void SetPosition(float x, float y);
-  void SetWidth(float width);
-  void SetHeight(float height);
-  void SetFileName(const CStdString &filename);
-  void SetAspectRatio(const CAspectRatio &aspect);
+  bool SetVisible(bool visible);
+  bool SetAlpha(unsigned char alpha);
+  bool SetDiffuseColor(color_t color);
+  bool SetPosition(float x, float y);
+  bool SetWidth(float width);
+  bool SetHeight(float height);
+  bool SetFileName(const CStdString &filename);
+  bool SetAspectRatio(const CAspectRatio &aspect);
 
   const CStdString& GetFileName() const { return m_info.filename; };
   float GetTextureWidth() const { return m_frameWidth; };
@@ -120,10 +121,10 @@ public:
   bool FailedToAlloc() const { return m_isAllocated == NORMAL_FAILED || m_isAllocated == LARGE_FAILED; };
   bool ReadyToRender() const;
 protected:
-  void CalculateSize();
+  bool CalculateSize();
   void LoadDiffuseImage();
-  void AllocateOnDemand();
-  void UpdateAnimFrame();
+  bool AllocateOnDemand();
+  bool UpdateAnimFrame();
   void Render(float left, float top, float bottom, float right, float u1, float v1, float u2, float v2, float u3, float v3);
   void OrientateTexture(CRect &rect, float width, float height, int orientation);
 

--- a/xbmc/guilib/GUIToggleButtonControl.cpp
+++ b/xbmc/guilib/GUIToggleButtonControl.cpp
@@ -39,11 +39,17 @@ CGUIToggleButtonControl::~CGUIToggleButtonControl(void)
 {
 }
 
-void CGUIToggleButtonControl::Render()
+void CGUIToggleButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // ask our infoManager whether we are selected or not...
+  bool selected = m_bSelected;
   if (m_toggleSelect)
-    m_bSelected = g_infoManager.GetBool(m_toggleSelect, m_parentID);
+    selected = g_infoManager.GetBool(m_toggleSelect, m_parentID);
+  if (selected != m_bSelected)
+  {
+    MarkDirtyRegion();
+    m_bSelected = selected;
+  }
 
   if (m_bSelected)
   {
@@ -52,6 +58,15 @@ void CGUIToggleButtonControl::Render()
     m_selectButton.SetVisible(IsVisible());
     m_selectButton.SetEnabled(!IsDisabled());
     m_selectButton.SetPulseOnSelect(m_pulseOnSelect);
+    m_selectButton.Process(currentTime, dirtyregions);
+  }
+  CGUIButtonControl::Process(currentTime, dirtyregions);
+}
+
+void CGUIToggleButtonControl::Render()
+{
+  if (m_bSelected)
+  {
     m_selectButton.Render();
     CGUIControl::Render();
   }

--- a/xbmc/guilib/GUIToggleButtonControl.cpp
+++ b/xbmc/guilib/GUIToggleButtonControl.cpp
@@ -112,11 +112,13 @@ void CGUIToggleButtonControl::SetHeight(float height)
   m_selectButton.SetHeight(height);
 }
 
-void CGUIToggleButtonControl::UpdateColors()
+bool CGUIToggleButtonControl::UpdateColors()
 {
-  CGUIButtonControl::UpdateColors();
-  m_selectButton.SetColorDiffuse(m_diffuseColor);
-  m_selectButton.UpdateColors();
+  bool changed = CGUIButtonControl::UpdateColors();
+  changed |= m_selectButton.SetColorDiffuse(m_diffuseColor);
+  changed |= m_selectButton.UpdateColors();
+
+  return changed;
 }
 
 void CGUIToggleButtonControl::SetLabel(const string &strLabel)

--- a/xbmc/guilib/GUIToggleButtonControl.h
+++ b/xbmc/guilib/GUIToggleButtonControl.h
@@ -58,7 +58,7 @@ public:
   void SetAltClickActions(const std::vector<CGUIActionDescriptor> &clickActions);
 
 protected:
-  virtual void UpdateColors();
+  virtual bool UpdateColors();
   virtual void OnClick();
   CGUIButtonControl m_selectButton;
   int m_toggleSelect;

--- a/xbmc/guilib/GUIToggleButtonControl.h
+++ b/xbmc/guilib/GUIToggleButtonControl.h
@@ -42,6 +42,7 @@ public:
   virtual ~CGUIToggleButtonControl(void);
   virtual CGUIToggleButtonControl *Clone() const { return new CGUIToggleButtonControl(*this); };
 
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual void AllocResources();

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -38,12 +38,12 @@ CGUIVideoControl::CGUIVideoControl(int parentID, int controlID, float posX, floa
 CGUIVideoControl::~CGUIVideoControl(void)
 {}
 
-void CGUIVideoControl::Process(unsigned int currentTime)
+void CGUIVideoControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // TODO Proper processing which marks when its actually changed. Just mark always for now.
   MarkDirtyRegion();
 
-  CGUIControl::Process(currentTime);
+  CGUIControl::Process(currentTime, dirtyregions);
 }
 
 void CGUIVideoControl::Render()

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -38,6 +38,13 @@ CGUIVideoControl::CGUIVideoControl(int parentID, int controlID, float posX, floa
 CGUIVideoControl::~CGUIVideoControl(void)
 {}
 
+void CGUIVideoControl::Process(unsigned int currentTime)
+{
+  // TODO Proper processing which marks when its actually changed. Just mark always for now.
+  MarkDirtyRegion();
+
+  CGUIControl::Process(currentTime);
+}
 
 void CGUIVideoControl::Render()
 {

--- a/xbmc/guilib/GUIVideoControl.h
+++ b/xbmc/guilib/GUIVideoControl.h
@@ -43,6 +43,7 @@ public:
   virtual ~CGUIVideoControl(void);
   virtual CGUIVideoControl *Clone() const { return new CGUIVideoControl(*this); };
 
+  virtual void Process(unsigned int currentTime);
   virtual void Render();
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool CanFocus() const;

--- a/xbmc/guilib/GUIVideoControl.h
+++ b/xbmc/guilib/GUIVideoControl.h
@@ -43,7 +43,7 @@ public:
   virtual ~CGUIVideoControl(void);
   virtual CGUIVideoControl *Clone() const { return new CGUIVideoControl(*this); };
 
-  virtual void Process(unsigned int currentTime);
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool CanFocus() const;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -671,12 +671,15 @@ bool CGUIWindow::IsAnimating(ANIMATION_TYPE animType)
   return CGUIControlGroup::IsAnimating(animType);
 }
 
-void CGUIWindow::Animate(unsigned int currentTime)
+bool CGUIWindow::Animate(unsigned int currentTime)
 {
   if (m_animationsEnabled)
-    CGUIControlGroup::Animate(currentTime);
+    return CGUIControlGroup::Animate(currentTime);
   else
+  {
     m_transform.Reset();
+    return false;
+  }
 }
 
 void CGUIWindow::DisableAnimations()

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -287,11 +287,11 @@ void CGUIWindow::CenterWindow()
   m_posY = (m_coordsRes.iHeight - GetHeight()) / 2;
 }
 
-void CGUIWindow::DoProcess(unsigned int currentTime)
+void CGUIWindow::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   g_graphicsContext.SetRenderingResolution(m_coordsRes, m_needsScaling);
   g_graphicsContext.ResetWindowTransform();
-  CGUIControlGroup::DoProcess(currentTime);
+  CGUIControlGroup::DoProcess(currentTime, dirtyregions);
 }
 
 void CGUIWindow::Render()

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -429,7 +429,7 @@ void CGUIWindow::OnDeinitWindow(int nextWindowID)
       QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
       while (IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
       {
-        g_windowManager.Process(true);
+        g_windowManager.ProcessRenderLoop(true);
       }
     }
   }

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -287,6 +287,13 @@ void CGUIWindow::CenterWindow()
   m_posY = (m_coordsRes.iHeight - GetHeight()) / 2;
 }
 
+void CGUIWindow::DoProcess(unsigned int currentTime)
+{
+  g_graphicsContext.SetRenderingResolution(m_coordsRes, m_needsScaling);
+  g_graphicsContext.ResetWindowTransform();
+  CGUIControlGroup::DoProcess(currentTime);
+}
+
 void CGUIWindow::Render()
 {
   // If we're rendering from a different thread, then we should wait for the main
@@ -297,14 +304,7 @@ void CGUIWindow::Render()
 
   g_graphicsContext.SetRenderingResolution(m_coordsRes, m_needsScaling);
 
-  m_renderTime = CTimeUtils::GetFrameTime();
-  // render our window animation - returns false if it needs to stop rendering
-  if (!RenderAnimation(m_renderTime))
-    return;
-
-  if (m_hasCamera)
-    g_graphicsContext.SetCameraPosition(m_camera);
-
+  g_graphicsContext.ResetWindowTransform();
   CGUIControlGroup::Render();
 
   if (CGUIControlProfiler::IsRunning()) CGUIControlProfiler::Instance().EndFrame();
@@ -671,14 +671,12 @@ bool CGUIWindow::IsAnimating(ANIMATION_TYPE animType)
   return CGUIControlGroup::IsAnimating(animType);
 }
 
-bool CGUIWindow::RenderAnimation(unsigned int time)
+void CGUIWindow::Animate(unsigned int currentTime)
 {
-  g_graphicsContext.ResetWindowTransform();
   if (m_animationsEnabled)
-    CGUIControlGroup::Animate(time);
+    CGUIControlGroup::Animate(currentTime);
   else
     m_transform.Reset();
-  return true;
 }
 
 void CGUIWindow::DisableAnimations()

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -429,6 +429,10 @@ void CGUIWindow::OnDeinitWindow(int nextWindowID)
       QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
       while (IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
       {
+        // TODO This shouldn't be handled like this
+        // The processing should be done from WindowManager and deinit
+        // should probably be called from there.
+        g_windowManager.Process(CTimeUtils::GetFrameTime());
         g_windowManager.ProcessRenderLoop(true);
       }
     }

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -554,7 +554,8 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
       {
         if (message.GetParam1() == GUI_MSG_PAGE_CHANGE ||
             message.GetParam1() == GUI_MSG_REFRESH_THUMBS ||
-            message.GetParam1() == GUI_MSG_REFRESH_LIST)
+            message.GetParam1() == GUI_MSG_REFRESH_LIST ||
+            message.GetParam1() == GUI_MSG_WINDOW_RESIZE)
         { // alter the message accordingly, and send to all controls
           for (iControls it = m_children.begin(); it != m_children.end(); ++it)
           {
@@ -562,12 +563,6 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
             CGUIMessage msg(message.GetParam1(), message.GetControlId(), control->GetID(), message.GetParam2());
             control->OnMessage(msg);
           }
-        }
-        if (message.GetParam1() == GUI_MSG_WINDOW_RESIZE)
-        {
-          // invalidate controls to get them to recalculate sizing information
-          SetInvalid();
-          return true;
         }
       }
     }

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -220,7 +220,7 @@ protected:
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);
   EVENT_RESULT OnMouseAction(const CAction &action);
-  virtual void Animate(unsigned int currentTime);
+  virtual bool Animate(unsigned int currentTime);
   virtual bool CheckAnimation(ANIMATION_TYPE animType);
 
   CAnimation *GetAnimation(ANIMATION_TYPE animType, bool checkConditions = true);

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -85,6 +85,8 @@ public:
   bool Load(const CStdString& strFileName, bool bContainsPath = false);
 
   void CenterWindow();
+
+  virtual void DoProcess(unsigned int currentTime);
   
   /*! \brief Main render function, called every frame.
    Window classes should override this only if they need to alter how something is rendered.
@@ -218,7 +220,7 @@ protected:
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);
   EVENT_RESULT OnMouseAction(const CAction &action);
-  virtual bool RenderAnimation(unsigned int time);
+  virtual void Animate(unsigned int currentTime);
   virtual bool CheckAnimation(ANIMATION_TYPE animType);
 
   CAnimation *GetAnimation(ANIMATION_TYPE animType, bool checkConditions = true);

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -86,7 +86,7 @@ public:
 
   void CenterWindow();
 
-  virtual void DoProcess(unsigned int currentTime);
+  virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   
   /*! \brief Main render function, called every frame.
    Window classes should override this only if they need to alter how something is rendered.

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -48,6 +48,8 @@ CGUIWindowManager::~CGUIWindowManager(void)
 void CGUIWindowManager::Initialize()
 {
   LoadNotOnDemandWindows();
+  m_tracker.SelectAlgorithm();
+
   m_initialized = true;
 }
 
@@ -491,6 +493,7 @@ void CGUIWindowManager::Render()
 {
   assert(g_application.IsCurrentThread());
   CSingleLock lock(g_graphicsContext);
+
   CGUIWindow* pWindow = GetWindow(GetActiveWindow());
   if (pWindow)
   {
@@ -534,6 +537,11 @@ void CGUIWindowManager::FrameMove()
   vector<CGUIWindow *> dialogs = m_activeDialogs;
   for (iDialog it = dialogs.begin(); it != dialogs.end(); ++it)
     (*it)->FrameMove();
+}
+
+void CGUIWindowManager::MarkDirtyRegion(CRect region)
+{
+  m_tracker.MarkDirtyRegion(CDirtyRegion(region));
 }
 
 CGUIWindow* CGUIWindowManager::GetWindow(int id) const

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -541,24 +541,21 @@ void CGUIWindowManager::Render()
   assert(g_application.IsCurrentThread());
   CSingleLock lock(g_graphicsContext);
 
-  CDirtyRegionList markedRegions  = m_tracker.GetMarkedRegions(); 
-  CDirtyRegionList dirtyRegions   = m_tracker.GetDirtyRegions();
+  CDirtyRegionList dirtyRegions = m_tracker.GetDirtyRegions();
 
   // If we visualize the regions we will always render the entire viewport
   if (g_advancedSettings.m_guiVisualizeDirtyRegions || g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_NONE)
     RenderPass();
   else
   {
-    for (unsigned int i = 0; i < dirtyRegions.size(); i++)
+    for (CDirtyRegionList::const_iterator i = dirtyRegions.begin(); i != dirtyRegions.end(); i++)
     {
-      CDirtyRegion currentRegion = dirtyRegions[i];
-      if (currentRegion.IsEmpty())
-          continue;
-
+      if (i->IsEmpty())
+        continue;
       GLint oldRegion[8];
       glGetIntegerv(GL_SCISSOR_BOX, oldRegion);
 
-      glScissor(currentRegion.x1, g_graphicsContext.GetHeight() - currentRegion.y2, currentRegion.Width(), currentRegion.Height());
+      glScissor(i->x1, g_graphicsContext.GetHeight() - i->y2, i->Width(), i->Height());
       glEnable(GL_SCISSOR_TEST);
 
       RenderPass();
@@ -571,10 +568,11 @@ void CGUIWindowManager::Render()
   if (g_advancedSettings.m_guiVisualizeDirtyRegions)
   {
     g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), false);
-    for (unsigned int i = 0; i <markedRegions.size(); i++)
-      CGUITexture::DrawQuad(markedRegions[i], 0x4cff0000);
-    for (unsigned int i = 0; i <dirtyRegions.size(); i++)
-      CGUITexture::DrawQuad(dirtyRegions[i], 0x4c00ff00);
+    const CDirtyRegionList &markedRegions  = m_tracker.GetMarkedRegions(); 
+    for (CDirtyRegionList::const_iterator i = markedRegions.begin(); i != markedRegions.end(); i++)
+      CGUITexture::DrawQuad(*i, 0x4cff0000);
+    for (CDirtyRegionList::const_iterator i = dirtyRegions.begin(); i != dirtyRegions.end(); i++)
+      CGUITexture::DrawQuad(*i, 0x4c00ff00);
   }
 
   m_tracker.CleanMarkedRegions();

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -575,7 +575,7 @@ void CGUIWindowManager::UpdateModelessVisibility()
   }
 }
 
-void CGUIWindowManager::Process(bool renderOnly /*= false*/)
+void CGUIWindowManager::ProcessRenderLoop(bool renderOnly /*= false*/)
 {
   if (g_application.IsCurrentThread() && m_pCallback)
   {

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -32,6 +32,7 @@
 #include "settings/AdvancedSettings.h"
 #include "addons/Skin.h"
 #include "GUITexture.h"
+#include "windowing/WindowingFactory.h"
 
 using namespace std;
 
@@ -552,17 +553,11 @@ void CGUIWindowManager::Render()
     {
       if (i->IsEmpty())
         continue;
-      GLint oldRegion[8];
-      glGetIntegerv(GL_SCISSOR_BOX, oldRegion);
 
-      glScissor(i->x1, g_graphicsContext.GetHeight() - i->y2, i->Width(), i->Height());
-      glEnable(GL_SCISSOR_TEST);
-
+      g_Windowing.SetScissors(*i);
       RenderPass();
-
-      // Reset scissorbox
-      glScissor(oldRegion[0], oldRegion[1], oldRegion[2], oldRegion[3]);
     }
+    g_Windowing.ResetScissors();
   }
 
   if (g_advancedSettings.m_guiVisualizeDirtyRegions)

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -570,7 +570,7 @@ void CGUIWindowManager::Render()
     g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), false);
     const CDirtyRegionList &markedRegions  = m_tracker.GetMarkedRegions(); 
     for (CDirtyRegionList::const_iterator i = markedRegions.begin(); i != markedRegions.end(); i++)
-      CGUITexture::DrawQuad(*i, 0x4cff0000);
+      CGUITexture::DrawQuad(*i, 0x0fff0000);
     for (CDirtyRegionList::const_iterator i = dirtyRegions.begin(); i != dirtyRegions.end(); i++)
       CGUITexture::DrawQuad(*i, 0x4c00ff00);
   }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -31,6 +31,7 @@
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "addons/Skin.h"
+#include "GUITexture.h"
 
 using namespace std;
 
@@ -510,20 +511,6 @@ void CGUIWindowManager::Process(unsigned int currentTime)
   }
 }
 
-#ifdef HAS_GL
-// TODO Need to draw this in the RenderSystems instead
-void DrawColoredQuad(const CRect & rect, float a, float r, float g, float b)
-{
-  glColor4f(r, g, b, a);
-  glBegin(GL_QUADS);
-    glVertex3f(rect.x1, rect.y1, 0.0f);	// Bottom Left Of The Texture and Quad
-    glVertex3f(rect.x2, rect.y1, 0.0f);	// Bottom Right Of The Texture and Quad
-    glVertex3f(rect.x2, rect.y2, 0.0f);	// Top Right Of The Texture and Quad
-    glVertex3f(rect.x1, rect.y2, 0.0f);	// Top Left Of The Texture and Quad
-  glEnd();
-}
-#endif
-
 void CGUIWindowManager::RenderPass()
 {
   CGUIWindow* pWindow = GetWindow(GetActiveWindow());
@@ -578,32 +565,11 @@ void CGUIWindowManager::Render()
 
   if (g_advancedSettings.m_guiVisualizeDirtyRegions)
   {
-#ifdef HAS_GL
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-
-    glOrtho(0.0f, g_graphicsContext.GetWidth(), g_graphicsContext.GetHeight(), 0.0f, -1.0f, 1.0f);
-
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE);
-    glEnable(GL_BLEND);          // Turn Blending On
-    glDisable(GL_DEPTH_TEST);
-    glDisable(GL_TEXTURE_2D);
-
+    g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), false);
     for (unsigned int i = 0; i <markedRegions.size(); i++)
-    {
-      CRect rect = markedRegions[i];
-      DrawColoredQuad(rect, 0.3f, 1.0f, 0.0f, 0.0f);
-    }
-
+      CGUITexture::DrawQuad(markedRegions[i], 0x4cff0000);
     for (unsigned int i = 0; i <dirtyRegions.size(); i++)
-    {
-      CRect rect = dirtyRegions[i];
-      DrawColoredQuad(rect, 0.3f, 0.0f, 1.0f, 0.0f);
-    }
-#endif
+      CGUITexture::DrawQuad(dirtyRegions[i], 0x4c00ff00);
   }
 
   m_tracker.CleanMarkedRegions();

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -489,6 +489,26 @@ bool RenderOrderSortFunction(CGUIWindow *first, CGUIWindow *second)
   return first->GetRenderOrder() < second->GetRenderOrder();
 }
 
+void CGUIWindowManager::Process(unsigned int currentTime)
+{
+  assert(g_application.IsCurrentThread());
+  CSingleLock lock(g_graphicsContext);
+
+  CGUIWindow* pWindow = GetWindow(GetActiveWindow());
+  if (pWindow)
+    pWindow->DoProcess(currentTime);
+
+  // we process the dialogs based on their render order.
+  vector<CGUIWindow *> renderList = m_activeDialogs;
+  // stable_sort(renderList.begin(), renderList.end(), RenderOrderSortFunction);
+
+  for (iDialog it = renderList.begin(); it != renderList.end(); ++it)
+  {
+    if ((*it)->IsDialogRunning())
+      (*it)->DoProcess(currentTime);
+  }
+}
+
 void CGUIWindowManager::Render()
 {
   assert(g_application.IsCurrentThread());

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -503,14 +503,12 @@ void CGUIWindowManager::Process(unsigned int currentTime)
   if (pWindow)
     pWindow->DoProcess(currentTime, dirtyregions);
 
-  // we process the dialogs based on their render order.
-  vector<CGUIWindow *> renderList = m_activeDialogs;
-  // stable_sort(renderList.begin(), renderList.end(), RenderOrderSortFunction);
-
-  for (iDialog it = renderList.begin(); it != renderList.end(); ++it)
+  // process all dialogs - visibility may change etc.
+  for (WindowMap::iterator it = m_mapWindows.begin(); it != m_mapWindows.end(); it++)
   {
-    if ((*it)->IsDialogRunning())
-      (*it)->DoProcess(currentTime, dirtyregions);
+    CGUIWindow *pWindow = (*it).second;
+    if (pWindow && pWindow->IsDialog())
+      pWindow->DoProcess(currentTime, dirtyregions);
   }
 
   for (CDirtyRegionList::iterator itr = dirtyregions.begin(); itr != dirtyregions.end(); itr++)
@@ -617,23 +615,6 @@ CGUIWindow* CGUIWindowManager::GetWindow(int id) const
   if (it != m_mapWindows.end())
     return (*it).second;
   return NULL;
-}
-
-// Shows and hides modeless dialogs as necessary.
-void CGUIWindowManager::UpdateModelessVisibility()
-{
-  CSingleLock lock(g_graphicsContext);
-  for (WindowMap::iterator it = m_mapWindows.begin(); it != m_mapWindows.end(); it++)
-  {
-    CGUIWindow *pWindow = (*it).second;
-    if (pWindow && pWindow->IsDialog() && pWindow->GetVisibleCondition())
-    {
-      if (g_infoManager.GetBool(pWindow->GetVisibleCondition(), GetActiveWindow()))
-        ((CGUIDialog *)pWindow)->Show();
-      else
-        ((CGUIDialog *)pWindow)->Close();
-    }
-  }
 }
 
 void CGUIWindowManager::ProcessRenderLoop(bool renderOnly /*= false*/)

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -511,6 +511,9 @@ void CGUIWindowManager::Process(unsigned int currentTime)
     if ((*it)->IsDialogRunning())
       (*it)->DoProcess(currentTime, dirtyregions);
   }
+
+  for (CDirtyRegionList::iterator itr = dirtyregions.begin(); itr != dirtyregions.end(); itr++)
+    m_tracker.MarkDirtyRegion(*itr);
 }
 
 void CGUIWindowManager::RenderPass()
@@ -602,11 +605,6 @@ void CGUIWindowManager::FrameMove()
   vector<CGUIWindow *> dialogs = m_activeDialogs;
   for (iDialog it = dialogs.begin(); it != dialogs.end(); ++it)
     (*it)->FrameMove();
-}
-
-void CGUIWindowManager::MarkDirtyRegion(CRect region)
-{
-  m_tracker.MarkDirtyRegion(CDirtyRegion(region));
 }
 
 CGUIWindow* CGUIWindowManager::GetWindow(int id) const

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -496,9 +496,11 @@ void CGUIWindowManager::Process(unsigned int currentTime)
   assert(g_application.IsCurrentThread());
   CSingleLock lock(g_graphicsContext);
 
+  CDirtyRegionList dirtyregions;
+
   CGUIWindow* pWindow = GetWindow(GetActiveWindow());
   if (pWindow)
-    pWindow->DoProcess(currentTime);
+    pWindow->DoProcess(currentTime, dirtyregions);
 
   // we process the dialogs based on their render order.
   vector<CGUIWindow *> renderList = m_activeDialogs;
@@ -507,7 +509,7 @@ void CGUIWindowManager::Process(unsigned int currentTime)
   for (iDialog it = renderList.begin(); it != renderList.end(); ++it)
   {
     if ((*it)->IsDialogRunning())
-      (*it)->DoProcess(currentTime);
+      (*it)->DoProcess(currentTime, dirtyregions);
   }
 }
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -517,6 +517,11 @@ void CGUIWindowManager::Process(unsigned int currentTime)
     m_tracker.MarkDirtyRegion(*itr);
 }
 
+void CGUIWindowManager::MarkDirty(const CDirtyRegion &rect)
+{
+  m_tracker.MarkDirtyRegion(rect);
+}
+
 void CGUIWindowManager::RenderPass()
 {
   CGUIWindow* pWindow = GetWindow(GetActiveWindow());

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -84,11 +84,6 @@ public:
    */
   void FrameMove();
 
-  /*! \brief Method used to mark selected region as dirty so next pass of rendering
-   contains said region.
-   */
-  void MarkDirtyRegion(CRect region);
-
   /*! \brief Return whether the window manager is initialized.
    The window manager is initialized on skin load - if the skin isn't yet loaded,
    no windows should be able to be initialized.

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -128,6 +128,8 @@ public:
   void DumpTextureUse();
 #endif
 private:
+  void RenderPass();
+
   void LoadNotOnDemandWindows();
   void UnloadNotOnDemandWindows();
   void HideOverlay(CGUIWindow::OVERLAY_STATE state);

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -115,7 +115,6 @@ public:
   int GetFocusedWindow() const;
   bool HasModalDialog() const;
   bool HasDialogOnScreen() const;
-  void UpdateModelessVisibility();
   bool IsWindowActive(int id, bool ignoreClosing = true) const;
   bool IsWindowVisible(int id) const;
   bool IsWindowTopMost(int id) const;

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -72,6 +72,12 @@ public:
    */
   void Process(unsigned int currentTime);
 
+  /*! \brief Mark a region of the screen as dirty - used by the mouse and dim/black screensavers currently
+      Ideally this would be removed and a technique for marking the screen as dirty implemented for ssavers
+      in addition to moving the mouse rendering into the manager.
+   */
+  void MarkDirty(const CDirtyRegion &rect);
+
   /*! \brief Rendering of the current window and any dialogs
    Render is called every frame to draw the current window and any dialogs.
    It should only be called from the application thread.
@@ -157,7 +163,6 @@ private:
   bool m_initialized;
 
   CDirtyRegionTracker m_tracker;
-  std::vector<CRect> m_DirtyRegion;
 };
 
 /*!

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -32,6 +32,7 @@
 #include "GUIWindow.h"
 #include "IWindowManagerCallback.h"
 #include "IMsgTargetCallback.h"
+#include "DirtyRegionTracker.h"
 
 class CGUIDialog;
 
@@ -78,6 +79,11 @@ public:
    on screen. It should only be called from the application thread.
    */
   void FrameMove();
+
+  /*! \brief Method used to mark selected region as dirty so next pass of rendering
+   contains said region.
+   */
+  void MarkDirtyRegion(CRect region);
 
   /*! \brief Return whether the window manager is initialized.
    The window manager is initialized on skin load - if the skin isn't yet loaded,
@@ -148,6 +154,9 @@ private:
   bool m_bShowOverlay;
   int  m_iNested;
   bool m_initialized;
+
+  CDirtyRegionTracker m_tracker;
+  std::vector<CRect> m_DirtyRegion;
 };
 
 /*!

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -93,7 +93,7 @@ public:
   bool Initialized() const { return m_initialized; };
 
   CGUIWindow* GetWindow(int id) const;
-  void Process(bool renderOnly = false);
+  void ProcessRenderLoop(bool renderOnly = false);
   void SetCallback(IWindowManagerCallback& callback);
   void DeInitialize();
 

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -68,6 +68,10 @@ public:
   // currently focused window(s).  Returns true only if the message is handled.
   bool OnAction(const CAction &action);
 
+  /*! \brief Process active controls allowing them to animate before rendering.
+   */
+  void Process(unsigned int currentTime);
+
   /*! \brief Rendering of the current window and any dialogs
    Render is called every frame to draw the current window and any dialogs.
    It should only be called from the application thread.

--- a/xbmc/guilib/GUIWrappingListContainer.cpp
+++ b/xbmc/guilib/GUIWrappingListContainer.cpp
@@ -41,7 +41,7 @@ void CGUIWrappingListContainer::UpdatePageControl(int offset)
 {
   if (m_pageControl)
   { // tell our pagecontrol (scrollbar or whatever) to update (offset it by our cursor position)
-    CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), m_pageControl, CorrectOffset(offset, m_cursor));
+    CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), m_pageControl, CorrectOffset(offset, GetCursor()));
     SendWindowMessage(msg);
   }
 }
@@ -95,7 +95,7 @@ bool CGUIWrappingListContainer::OnMessage(CGUIMessage& message)
     {
       if (message.GetSenderId() == m_pageControl && IsVisible())
       { // offset by our cursor position
-        message.SetParam1(message.GetParam1() - m_cursor);
+        message.SetParam1(message.GetParam1() - GetCursor());
       }
     }
   }
@@ -117,7 +117,7 @@ bool CGUIWrappingListContainer::MoveDown(bool wrapAround)
 // scrolls the said amount
 void CGUIWrappingListContainer::Scroll(int amount)
 {
-  ScrollToOffset(m_offset + amount);
+  ScrollToOffset(GetOffset() + amount);
 }
 
 void CGUIWrappingListContainer::ValidateOffset()
@@ -159,7 +159,7 @@ int CGUIWrappingListContainer::GetSelectedItem() const
   if (m_items.size() > m_extraItems)
   {
     int numItems = (int)(m_items.size() - m_extraItems);
-    int correctOffset = (m_offset + m_cursor) % numItems;
+    int correctOffset = (GetOffset() + GetCursor()) % numItems;
     if (correctOffset < 0) correctOffset += numItems;
     return correctOffset;
   }
@@ -175,7 +175,7 @@ bool CGUIWrappingListContainer::SelectItemFromPoint(const CPoint &point)
   const float mouse_max_amount = 1.0f;   // max speed: 1 item per frame
   float sizeOfItem = m_layout->Size(m_orientation);
   // see if the point is either side of our focused item
-  float start = m_cursor * sizeOfItem;
+  float start = GetCursor() * sizeOfItem;
   float end = start + m_focusedLayout->Size(m_orientation);
   float pos = (m_orientation == VERTICAL) ? point.y : point.x;
   if (pos < start - 0.5f * sizeOfItem)
@@ -211,7 +211,7 @@ bool CGUIWrappingListContainer::SelectItemFromPoint(const CPoint &point)
 void CGUIWrappingListContainer::SelectItem(int item)
 {
   if (item >= 0 && item < (int)m_items.size())
-    ScrollToOffset(item - m_cursor);
+    ScrollToOffset(item - GetCursor());
 }
 
 void CGUIWrappingListContainer::ResetExtraItems()
@@ -230,8 +230,8 @@ void CGUIWrappingListContainer::Reset()
 
 int CGUIWrappingListContainer::GetCurrentPage() const
 {
-  int offset = CorrectOffset(m_offset, m_cursor);
-  if (offset + m_itemsPerPage - m_cursor >= (int)GetRows())  // last page
+  int offset = CorrectOffset(GetOffset(), GetCursor());
+  if (offset + m_itemsPerPage - GetCursor() >= (int)GetRows())  // last page
     return (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage;
   return offset / m_itemsPerPage + 1;
 }

--- a/xbmc/guilib/GUIWrappingListContainer.cpp
+++ b/xbmc/guilib/GUIWrappingListContainer.cpp
@@ -27,7 +27,7 @@
 CGUIWrappingListContainer::CGUIWrappingListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, int scrollTime, int preloadItems, int fixedPosition)
     : CGUIBaseContainer(parentID, controlID, posX, posY, width, height, orientation, scrollTime, preloadItems)
 {
-  m_cursor = fixedPosition;
+  SetCursor(fixedPosition);
   ControlType = GUICONTAINER_WRAPLIST;
   m_type = VIEW_TYPE_LIST;
   m_extraItems = 0;

--- a/xbmc/guilib/Geometry.h
+++ b/xbmc/guilib/Geometry.h
@@ -27,7 +27,7 @@
 #else
 #define XBMC_FORCE_INLINE
 #endif
-
+#include <algorithm>
 
 class CPoint
 {
@@ -126,11 +126,11 @@ public:
       *this = rect;
     else if (!rect.IsEmpty())
     {
-      x1 = x1 < rect.x1 ? x1 : rect.x1;
-      y1 = y1 < rect.y1 ? y1 : rect.y1;
+      x1 = std::min(x1,rect.x1);
+      y1 = std::min(y1,rect.y1);
 
-      x2 = x2 > rect.x2 ? x2 : rect.x2;
-      y2 = y2 > rect.y2 ? y2 : rect.y2;
+      x2 = std::max(x2,rect.x2);
+      y2 = std::max(y2,rect.y2);
     }
 
     return *this;

--- a/xbmc/guilib/Geometry.h
+++ b/xbmc/guilib/Geometry.h
@@ -151,6 +151,11 @@ public:
     return y2 - y1;
   };
 
+  inline float Area() const XBMC_FORCE_INLINE
+  {
+    return Width() * Height();
+  };
+
   bool operator !=(const CRect &rect) const
   {
     if (x1 != rect.x1) return true;

--- a/xbmc/guilib/Geometry.h
+++ b/xbmc/guilib/Geometry.h
@@ -120,6 +120,22 @@ public:
     return *this;
   };
 
+  const CRect &Union(const CRect &rect)
+  {
+    if (IsEmpty())
+      *this = rect;
+    else if (!rect.IsEmpty())
+    {
+      x1 = x1 < rect.x1 ? x1 : rect.x1;
+      y1 = y1 < rect.y1 ? y1 : rect.y1;
+
+      x2 = x2 > rect.x2 ? x2 : rect.x2;
+      y2 = y2 > rect.y2 ? y2 : rect.y2;
+    }
+
+    return *this;
+  };
+
   inline bool IsEmpty() const XBMC_FORCE_INLINE
   {
     return (x2 - x1) * (y2 - y1) == 0;

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -671,15 +671,31 @@ void CGraphicContext::RestoreCameraPosition()
 
 CRect CGraphicContext::generateAABB(const CRect &rect) const
 {
-  CRect newRect = rect;
+// ------------------------
+// |(x1, y1)      (x2, y2)|
+// |                      |
+// |(x3, y3)      (x4, y4)|
+// ------------------------
+
+  float x1 = rect.x1, x2 = rect.x2, x3 = rect.x1, x4 = rect.x2;
+  float y1 = rect.y1, y2 = rect.y1, y3 = rect.y2, y4 = rect.y2;
 
   float z = 0.0f;
-  ScaleFinalCoords(newRect.x1, newRect.y1, z);
+  ScaleFinalCoords(x1, y1, z);
 
   z = 0.0f;
-  ScaleFinalCoords(newRect.x2, newRect.y2, z);
+  ScaleFinalCoords(x2, y2, z);
 
-  return newRect;
+  z = 0.0f;
+  ScaleFinalCoords(x3, y3, z);
+
+  z = 0.0f;
+  ScaleFinalCoords(x4, y4, z);
+
+  return CRect( min(min(min(x1, x2), x3), x4),
+                min(min(min(y1, y2), y3), y4),
+                max(max(max(x1, x2), x3), x4),
+                max(max(max(y1, y2), y3), y4));
 }
 
 // NOTE: This routine is currently called (twice) every time there is a <camera>

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -669,6 +669,19 @@ void CGraphicContext::RestoreCameraPosition()
   UpdateCameraPosition(m_cameras.top());
 }
 
+CRect CGraphicContext::generateAABB(const CRect &rect) const
+{
+  CRect newRect = rect;
+
+  float z = 0.0f;
+  ScaleFinalCoords(newRect.x1, newRect.y1, z);
+
+  z = 0.0f;
+  ScaleFinalCoords(newRect.x2, newRect.y2, z);
+
+  return newRect;
+}
+
 // NOTE: This routine is currently called (twice) every time there is a <camera>
 //       tag in the skin.  It actually only has to be called before we render
 //       something, so another option is to just save the camera coordinates

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -190,6 +190,8 @@ public:
       UpdateFinalTransform(TransformMatrix());
   }
 
+  CRect generateAABB(const CRect &rect) const;
+
 protected:
   std::stack<CRect> m_viewStack;
 

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -178,6 +178,12 @@ public:
     UpdateFinalTransform(m_groupTransform.top());
     return absoluteMatrix;
   }
+  inline void SetTransform(const TransformMatrix &matrix)
+  {
+    ASSERT(m_groupTransform.size());
+    m_groupTransform.push(matrix);
+    UpdateFinalTransform(m_groupTransform.top());
+  }
   inline void RemoveTransform()
   {
     ASSERT(m_groupTransform.size() > 1);

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -180,6 +180,8 @@ public:
   }
   inline void SetTransform(const TransformMatrix &matrix)
   {
+    // TODO: We only need to add it to the group transform as other transforms may be added on top of this one later on
+    //       Once all transforms are cached then this can be removed and UpdateFinalTransform can be called directly
     ASSERT(m_groupTransform.size());
     m_groupTransform.push(matrix);
     UpdateFinalTransform(m_groupTransform.top());

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -170,14 +170,13 @@ public:
       m_groupTransform.pop();
     m_groupTransform.push(m_guiTransform);
   }
-  inline void AddTransform(const TransformMatrix &matrix)
+  inline TransformMatrix AddTransform(const TransformMatrix &matrix)
   {
     ASSERT(m_groupTransform.size());
-    if (m_groupTransform.size())
-      m_groupTransform.push(m_groupTransform.top() * matrix);
-    else
-      m_groupTransform.push(matrix);
+    TransformMatrix absoluteMatrix = m_groupTransform.size() ? m_groupTransform.top() * matrix : matrix;
+    m_groupTransform.push(absoluteMatrix);
     UpdateFinalTransform(m_groupTransform.top());
+    return absoluteMatrix;
   }
   inline void RemoveTransform()
   {

--- a/xbmc/guilib/IDirtyRegionSolver.h
+++ b/xbmc/guilib/IDirtyRegionSolver.h
@@ -1,0 +1,36 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "DirtyRegion.h"
+
+#define DIRTYREGION_SOLVER_NONE 0
+#define DIRTYREGION_SOLVER_UNION 1
+#define DIRTYREGION_SOLVER_COST_REDUCTION 2
+
+class IDirtyRegionSolver
+{
+public:
+  virtual ~IDirtyRegionSolver() { }
+
+  // Takes a number of dirty regions which will become a number of needed rendering passes.
+  virtual void Solve(const CDirtyRegionList &input, CDirtyRegionList &output) = 0;
+};

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -333,6 +333,7 @@
 
 #define WINDOW_ADDON_BROWSER              10040
 
+#define WINDOW_DIALOG_POINTER             10099
 #define WINDOW_DIALOG_YES_NO              10100
 #define WINDOW_DIALOG_PROGRESS            10101
 #define WINDOW_DIALOG_KEYBOARD            10103

--- a/xbmc/guilib/Makefile.in
+++ b/xbmc/guilib/Makefile.in
@@ -2,6 +2,8 @@ SRCS=AnimatedGif.cpp \
      AudioContext.cpp \
      DDSImage.cpp \
      DirectXGraphics.cpp \
+     DirtyRegionSolvers.cpp \
+     DirtyRegionTracker.cpp \
      FrameBufferObject.cpp \
      GraphicContext.cpp \
      GUIAudioManager.cpp \
@@ -73,8 +75,6 @@ SRCS=AnimatedGif.cpp \
      VisibleEffect.cpp \
      XBTF.cpp \
      XBTFReader.cpp \
-     DirtyRegionTracker.cpp \
-     DirtyRegionSolvers.cpp \
 
 ifeq (@USE_OPENGL@,1)
 SRCS+=TextureGL.cpp \

--- a/xbmc/guilib/Makefile.in
+++ b/xbmc/guilib/Makefile.in
@@ -73,6 +73,8 @@ SRCS=AnimatedGif.cpp \
      VisibleEffect.cpp \
      XBTF.cpp \
      XBTFReader.cpp \
+     DirtyRegionTracker.cpp \
+     DirtyRegionSolvers.cpp \
 
 ifeq (@USE_OPENGL@,1)
 SRCS+=TextureGL.cpp \

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -77,6 +77,9 @@ public:
   virtual void SetViewPort(CRect& viewPort) = 0;
   virtual void GetViewPort(CRect& viewPort) = 0;
 
+  virtual void SetScissors(const CRect &rect) = 0;
+  virtual void ResetScissors() = 0;
+
   virtual void CaptureStateBlock() = 0;
   virtual void ApplyStateBlock() = 0;
 

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -924,7 +924,7 @@ void CRenderSystemDX::SetScissors(const CRect& rect)
   scissor.left = MathUtils::round_int(rect.x1);
   scissor.top = MathUtils::round_int(rect.y1);
   scissor.right = MathUtils::round_int(rect.x2);
-  scissor.bottom = MathUtils::rount_int(rect.y2);
+  scissor.bottom = MathUtils::round_int(rect.y2);
   m_pD3DDevice->SetRenderState(D3DRS_SCISSORTESTENABLE, TRUE);
   m_pD3DDevice->SetScissorRect(&scissor);
 }

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -26,6 +26,7 @@
 #include "RenderSystemDX.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
+#include "utils/MathUtils.h"
 #include "guilib/GUIWindowManager.h"
 #include "threads/SingleLock.h"
 #include "guilib/D3DResource.h"
@@ -912,6 +913,34 @@ void CRenderSystemDX::SetViewPort(CRect& viewPort)
   newviewport.Width  = (DWORD)(viewPort.x2 - viewPort.x1);
   newviewport.Height = (DWORD)(viewPort.y2 - viewPort.y1);
   m_pD3DDevice->SetViewport(&newviewport);
+}
+
+void CRenderSystemDX::SetScissors(const CRect& rect)
+{
+  if (!m_bRenderCreated)
+    return;
+
+  RECT scissor;
+  scissor.left = MathUtils::round_int(rect.x1);
+  scissor.top = MathUtils::round_int(rect.y1);
+  scissor.right = MathUtils::round_int(rect.x2);
+  scissor.bottom = MathUtils::rount_int(rect.y2);
+  m_pD3DDevice->SetRenderState(D3DRS_SCISSORTESTENABLE, TRUE);
+  m_pD3DDevice->SetScissorRect(&scissor);
+}
+
+void CRenderSystemDX::ResetScissors()
+{
+  if (!m_bRenderCreated)
+    return;
+
+  RECT scissor;
+  scissor.left = 0;
+  scissor.top = 0;
+  scissor.right = m_nBackBufferWidth;
+  scissor.bottom = m_nBackBufferHeight;
+  m_pD3DDevice->SetScissorRect(&scissor);
+  m_pD3DDevice->SetRenderState(D3DRS_SCISSORTESTENABLE, FALSE);
 }
 
 void CRenderSystemDX::Register(ID3DResource *resource)

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -61,6 +61,9 @@ public:
   virtual void SetViewPort(CRect& viewPort);
   virtual void GetViewPort(CRect& viewPort);
 
+  virtual void SetScissors(const CRect &rect);
+  virtual void ResetScissors();
+
   virtual void CaptureStateBlock();
   virtual void ApplyStateBlock();
 

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -542,6 +542,22 @@ void CRenderSystemGL::SetViewPort(CRect& viewPort)
   glViewport((GLint) viewPort.x1, (GLint) (m_height - viewPort.y1 - viewPort.Height()), (GLsizei) viewPort.Width(), (GLsizei) viewPort.Height());
 }
 
+void CRenderSystemGL::SetScissors(const CRect &rect)
+{
+  if (!m_bRenderCreated)
+    return;
+  GLint x1 = MathUtils::round_int(rect.x1);
+  GLint y1 = MathUtils::round_int(rect.y1);
+  GLint x2 = MathUtils::round_int(rect.x2);
+  GLint y2 = MathUtils::round_int(rect.y2);
+  glScissor(x1, m_height - y2, x2-x1, y2-y1);
+}
+
+void CRenderSystemGL::ResetScissors()
+{
+  SetScissors(CRect(0, 0, (float)m_width, (float)m_height));
+}
+
 void CRenderSystemGL::GetGLSLVersion(int& major, int& minor)
 {
   major = m_glslMajor;

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -525,7 +525,7 @@ void CRenderSystemGL::GetViewPort(CRect& viewPort)
     return;
 
   GLint glvp[4];
-  glGetIntegerv(GL_SCISSOR_BOX, glvp);
+  glGetIntegerv(GL_VIEWPORT, glvp);
 
   viewPort.x1 = glvp[0];
   viewPort.y1 = m_height - glvp[1] - glvp[3];

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -47,6 +47,9 @@ public:
   virtual void SetViewPort(CRect& viewPort);
   virtual void GetViewPort(CRect& viewPort);
 
+  virtual void SetScissors(const CRect &rect);
+  virtual void ResetScissors();
+
   virtual void CaptureStateBlock();
   virtual void ApplyStateBlock();
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -32,6 +32,7 @@
 #include "utils/GLUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/SystemInfo.h"
+#include "utils/MathUtils.h"
 
 static const char* ShaderNames[SM_ESHADERCOUNT] =
     {"guishader_frag_default.glsl",
@@ -491,6 +492,22 @@ void CRenderSystemGLES::SetViewPort(CRect& viewPort)
 
   glScissor((GLint) viewPort.x1, (GLint) (m_height - viewPort.y1 - viewPort.Height()), (GLsizei) viewPort.Width(), (GLsizei) viewPort.Height());
   glViewport((GLint) viewPort.x1, (GLint) (m_height - viewPort.y1 - viewPort.Height()), (GLsizei) viewPort.Width(), (GLsizei) viewPort.Height());
+}
+
+void CRenderSystemGLES::SetScissors(const CRect &rect)
+{
+  if (!m_bRenderCreated)
+    return;
+  GLint x1 = MathUtils::round_int(rect.x1);
+  GLint y1 = MathUtils::round_int(rect.y1);
+  GLint x2 = MathUtils::round_int(rect.x2);
+  GLint y2 = MathUtils::round_int(rect.y2);
+  glScissor(x1, m_height - y2, x2-x1, y2-y1);
+}
+
+void CRenderSystemGLES::ResetScissors()
+{
+  SetScissors(CRect(0, 0, (float)m_width, (float)m_height));
 }
 
 void CRenderSystemGLES::InitialiseGUIShader()

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -476,7 +476,7 @@ void CRenderSystemGLES::GetViewPort(CRect& viewPort)
     return;
   
   GLint glvp[4];
-  glGetIntegerv(GL_SCISSOR_BOX, glvp);
+  glGetIntegerv(GL_VIEWPORT, glvp);
   
   viewPort.x1 = glvp[0];
   viewPort.y1 = m_height - glvp[1] - glvp[3];

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -61,6 +61,9 @@ public:
   virtual void SetViewPort(CRect& viewPort);
   virtual void GetViewPort(CRect& viewPort);
 
+  virtual void SetScissors(const CRect& rect);
+  virtual void ResetScissors();
+
   virtual void CaptureStateBlock();
   virtual void ApplyStateBlock();
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -278,6 +278,8 @@ void CAdvancedSettings::Initialize()
   m_jsonTcpPort = 9090;
 
   m_enableMultimediaKeys = false;
+  m_guiVisualizeDirtyRegions = false;
+  m_guiAlgorithmDirtyRegions = 0;
 }
 
 bool CAdvancedSettings::Load()
@@ -880,6 +882,13 @@ bool CAdvancedSettings::Load()
   if (pElement)
   {
     XMLUtils::GetBoolean(pRootElement, "enablemultimediakeys", m_enableMultimediaKeys);
+  }
+  
+  pElement = pRootElement->FirstChildElement("gui");
+  if (pElement)
+  {
+    XMLUtils::GetBoolean(pElement, "visualizedirtyregions", m_guiVisualizeDirtyRegions);
+    XMLUtils::GetInt(pElement, "algorithmdirtyregions",     m_guiAlgorithmDirtyRegions);
   }
 
   // load in the GUISettings overrides:

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -284,6 +284,9 @@ class CAdvancedSettings
     DatabaseSettings m_databaseMusic; // advanced music database setup
     DatabaseSettings m_databaseVideo; // advanced video database setup
 
+    bool m_guiVisualizeDirtyRegions;
+    int  m_guiAlgorithmDirtyRegions;
+
     unsigned int m_cacheMemBufferSize;
 
     bool m_jsonOutputCompact;

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -2013,7 +2013,7 @@ void CGUIWindowSettingsCategory::FrameMove()
   CGUIWindow::FrameMove();
 }
 
-void CGUIWindowSettingsCategory::Render()
+void CGUIWindowSettingsCategory::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   // update alpha status of current button
   bool bAlphaFaded = false;
@@ -2033,7 +2033,7 @@ void CGUIWindowSettingsCategory::Render()
       bAlphaFaded = true;
     }
   }
-  CGUIWindow::Render();
+  CGUIWindow::DoProcess(currentTime, dirtyregions);
   if (bAlphaFaded)
   {
     control->SetFocus(false);
@@ -2042,6 +2042,11 @@ void CGUIWindowSettingsCategory::Render()
     else
       ((CGUIButtonControl *)control)->SetSelected(false);
   }
+}
+
+void CGUIWindowSettingsCategory::Render()
+{
+  CGUIWindow::Render();
   // render the error message if necessary
   if (m_strErrorMessage.size())
   {

--- a/xbmc/settings/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/GUIWindowSettingsCategory.h
@@ -36,6 +36,7 @@ public:
   virtual bool OnAction(const CAction &action);
   virtual void FrameMove();
   virtual void Render();
+  virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual int GetID() const { return CGUIWindow::GetID() + m_iScreen; };
 
 protected:

--- a/xbmc/settings/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/GUIWindowSettingsScreenCalibration.cpp
@@ -375,30 +375,34 @@ void CGUIWindowSettingsScreenCalibration::FrameMove()
   CGUIWindow::FrameMove();
 }
 
+void CGUIWindowSettingsScreenCalibration::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
+{
+  MarkDirtyRegion();
+
+  for (int i = CONTROL_TOP_LEFT; i <= CONTROL_PIXEL_RATIO; i++)
+    SET_CONTROL_HIDDEN(i);
+
+  m_needsScaling = true;
+  CGUIWindow::DoProcess(currentTime, dirtyregions);
+  m_needsScaling = false;
+
+  g_graphicsContext.SetRenderingResolution(m_Res[m_iCurRes], false);
+  g_graphicsContext.ResetWindowTransform();
+
+  // process the movers etc.
+  for (int i = CONTROL_TOP_LEFT; i <= CONTROL_PIXEL_RATIO; i++)
+  {
+    SET_CONTROL_VISIBLE(i);
+    CGUIControl *control = (CGUIControl *)GetControl(i);
+    if (control)
+      control->DoProcess(currentTime, dirtyregions);
+  }
+}
+
 void CGUIWindowSettingsScreenCalibration::Render()
 {
-  SET_CONTROL_HIDDEN(CONTROL_TOP_LEFT);
-  SET_CONTROL_HIDDEN(CONTROL_BOTTOM_RIGHT);
-  SET_CONTROL_HIDDEN(CONTROL_SUBTITLES);
-  SET_CONTROL_HIDDEN(CONTROL_PIXEL_RATIO);
-
   // we set that we need scaling here to render so that anything else on screen scales correctly
   m_needsScaling = true;
   CGUIWindow::Render();
   m_needsScaling = false;
-  g_graphicsContext.SetRenderingResolution(m_coordsRes, false);
-
-  SET_CONTROL_VISIBLE(CONTROL_TOP_LEFT);
-  SET_CONTROL_VISIBLE(CONTROL_BOTTOM_RIGHT);
-  SET_CONTROL_VISIBLE(CONTROL_SUBTITLES);
-  SET_CONTROL_VISIBLE(CONTROL_PIXEL_RATIO);
-
-  // render the movers etc.
-  for (int i = CONTROL_TOP_LEFT; i <= CONTROL_PIXEL_RATIO; i++)
-  {
-    CGUIControl *control = (CGUIControl *)GetControl(i);
-    if (control)
-      control->Render();
-  }
-
 }

--- a/xbmc/settings/GUIWindowSettingsScreenCalibration.h
+++ b/xbmc/settings/GUIWindowSettingsScreenCalibration.h
@@ -30,6 +30,7 @@ public:
   virtual ~CGUIWindowSettingsScreenCalibration(void);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
+  virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void FrameMove();
   virtual void Render();
   virtual void AllocResources(bool forceLoad = false);

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -52,7 +52,9 @@
 #include "input/ButtonTranslator.h"
 
 #include <stdio.h>
-
+#ifdef __APPLE__
+#include "linux/LinuxResourceCounter.h"
+#endif
 
 #define BLUE_BAR                          0
 #define LABEL_ROW1                       10
@@ -838,6 +840,15 @@ void CGUIWindowFullScreen::FrameMove()
     SET_CONTROL_HIDDEN(LABEL_ROW3);
     SET_CONTROL_HIDDEN(BLUE_BAR);
   }
+}
+
+void CGUIWindowFullScreen::Process(unsigned int currentTime, CDirtyRegionList &dirtyregion)
+{
+  // TODO: This isn't quite optimal - ideally we'd only be dirtying up the actual video render rect
+  //       which is probably the job of the renderer as it can more easily track resizing etc.
+  MarkDirtyRegion();
+  CGUIWindow::Process(currentTime, dirtyregion);
+  m_renderRegion.SetRect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
 }
 
 void CGUIWindowFullScreen::Render()

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -38,6 +38,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
   virtual void FrameMove();
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregion);
   virtual void Render();
   virtual void OnWindowLoaded();
   void ChangetheTimeCode(int remote);

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -1,0 +1,162 @@
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "GUIWindowDebugInfo.h"
+#include "input/MouseStat.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
+#include "addons/Skin.h"
+#include "utils/CPUInfo.h"
+#include "utils/log.h"
+#include "input/ButtonTranslator.h"
+#include "guilib/GUIControlFactory.h"
+#include "guilib/GUIFontManager.h"
+#include "guilib/GUITextLayout.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/GUIControlProfiler.h"
+#include "GUIInfoManager.h"
+
+CGUIWindowDebugInfo::CGUIWindowDebugInfo(void)
+    : CGUIDialog(98, "")
+{
+  m_loadOnDemand = false;
+  m_needsScaling = false;
+  m_layout = NULL;
+  m_renderOrder = INT_MAX - 1;
+}
+
+CGUIWindowDebugInfo::~CGUIWindowDebugInfo(void)
+{
+}
+
+void CGUIWindowDebugInfo::UpdateVisibility()
+{
+  if (LOG_LEVEL_DEBUG_FREEMEM <= g_advancedSettings.m_logLevel || g_SkinInfo->IsDebugging())
+    Show();
+  else
+    Close();
+}
+
+bool CGUIWindowDebugInfo::OnMessage(CGUIMessage &message)
+{
+  if (message.GetMessage() == GUI_MSG_WINDOW_DEINIT)
+  {
+    delete m_layout;
+    m_layout = NULL;
+  }
+  return CGUIDialog::OnMessage(message);
+}
+
+void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
+{
+  g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), false);
+
+  g_cpuInfo.getUsedPercentage(); // must call it to recalculate pct values
+
+  static int yShift = 20;
+  static int xShift = 40;
+  static unsigned int lastShift = time(NULL);
+  time_t now = time(NULL);
+  if (now - lastShift > 10)
+  {
+    yShift *= -1;
+    if (now % 5 == 0)
+      xShift *= -1;
+    lastShift = now;
+    MarkDirtyRegion();
+  }
+
+  if (!m_layout)
+  {
+    CGUIFont *font13 = g_fontManager.GetDefaultFont();
+    CGUIFont *font13border = g_fontManager.GetDefaultFont(true);
+    if (font13)
+      m_layout = new CGUITextLayout(font13, true, 0, font13border);
+  }
+  if (!m_layout)
+    return;
+
+  CStdString info;
+  if (LOG_LEVEL_DEBUG_FREEMEM <= g_advancedSettings.m_logLevel)
+  {
+    MEMORYSTATUS stat;
+    GlobalMemoryStatus(&stat);
+    CStdString profiling = CGUIControlProfiler::IsRunning() ? " (profiling)" : "";
+    CStdString strCores = g_cpuInfo.GetCoresUsageString();
+#if !defined(_LINUX)
+    info.Format("LOG: %sxbmc.log\nMEM: %d/%d KB - FPS: %2.1f fps\nCPU: %s%s", g_settings.m_logFolder.c_str(),
+                stat.dwAvailPhys/1024, stat.dwTotalPhys/1024, g_infoManager.GetFPS(), strCores.c_str(), profiling.c_str());
+#else
+    double dCPU = m_resourceCounter.GetCPUUsage();
+    info.Format("LOG: %sxbmc.log\nMEM: %"PRIu64"/%"PRIu64" KB - FPS: %2.1f fps\nCPU: %s (CPU-XBMC %4.2f%%%s)", g_settings.m_logFolder.c_str(),
+                stat.dwAvailPhys/1024, stat.dwTotalPhys/1024, g_infoManager.GetFPS(), strCores.c_str(), dCPU, profiling.c_str());
+#endif
+  }
+
+  // render the skin debug info
+  if (g_SkinInfo->IsDebugging())
+  {
+    if (!info.IsEmpty())
+      info += "\n";
+    CGUIWindow *window = g_windowManager.GetWindow(g_windowManager.GetFocusedWindow());
+    CGUIWindow *pointer = g_windowManager.GetWindow(WINDOW_DIALOG_POINTER);
+    CPoint point;
+    if (pointer)
+      point = CPoint(pointer->GetXPosition(), pointer->GetYPosition());
+    if (window)
+    {
+      CStdString windowName = CButtonTranslator::TranslateWindow(window->GetID());
+      if (!windowName.IsEmpty())
+        windowName += " (" + window->GetProperty("xmlfile") + ")";
+      else
+        windowName = window->GetProperty("xmlfile");
+      info += "Window: " + windowName + "  ";
+      // transform the mouse coordinates to this window's coordinates
+      g_graphicsContext.SetScalingResolution(window->GetCoordsRes(), true);
+      point.x *= g_graphicsContext.GetGUIScaleX();
+      point.y *= g_graphicsContext.GetGUIScaleY();
+      g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), false);
+    }
+    info.AppendFormat("Mouse: (%d,%d)  ", (int)point.x, (int)point.y);
+    if (window)
+    {
+      CGUIControl *control = window->GetFocusedControl();
+      if (control)
+        info.AppendFormat("Focused: %i (%s)", control->GetID(), CGUIControlFactory::TranslateControlType(control->GetControlType()).c_str());
+    }
+  }
+
+  float w, h;
+  if (m_layout->Update(info))
+    MarkDirtyRegion();
+  m_layout->GetTextExtent(w, h);
+
+  float x = xShift + 0.04f * g_graphicsContext.GetWidth();
+  float y = yShift + 0.04f * g_graphicsContext.GetHeight();
+  m_renderRegion.SetRect(x, y, x+w, y+h);
+}
+
+void CGUIWindowDebugInfo::Render()
+{
+  g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), false);
+  if (m_layout)
+    m_layout->RenderOutline(m_renderRegion.x1, m_renderRegion.y1, 0xffffffff, 0xff000000, 0, 0);
+}

--- a/xbmc/windows/GUIWindowDebugInfo.h
+++ b/xbmc/windows/GUIWindowDebugInfo.h
@@ -1,0 +1,47 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "guilib/GUIDialog.h"
+#ifdef _LINUX
+#include "linux/LinuxResourceCounter.h"
+#endif
+
+class CGUITextLayout;
+
+class CGUIWindowDebugInfo :
+      public CGUIDialog
+{
+public:
+  CGUIWindowDebugInfo();
+  virtual ~CGUIWindowDebugInfo();
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
+  virtual void Render();
+  virtual bool OnMessage(CGUIMessage &message);
+protected:
+  virtual void UpdateVisibility();
+private:
+  CGUITextLayout *m_layout;
+#ifdef _LINUX
+  CLinuxResourceCounter m_resourceCounter;
+#endif
+};

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -21,7 +21,7 @@
 
 #include "GUIWindowPointer.h"
 #include "input/MouseStat.h"
-
+#include <climits>
 #define ID_POINTER 10
 
 CGUIWindowPointer::CGUIWindowPointer(void)
@@ -31,6 +31,7 @@ CGUIWindowPointer::CGUIWindowPointer(void)
   m_loadOnDemand = false;
   m_needsScaling = false;
   m_active = false;
+  m_renderOrder = INT_MAX;
 }
 
 CGUIWindowPointer::~CGUIWindowPointer(void)
@@ -71,6 +72,7 @@ void CGUIWindowPointer::OnWindowLoaded()
   CGUIWindow::OnWindowLoaded();
   DynamicResourceAlloc(false);
   m_pointer = 0;
+  m_renderOrder = INT_MAX;
 }
 
 void CGUIWindowPointer::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -25,11 +25,12 @@
 #define ID_POINTER 10
 
 CGUIWindowPointer::CGUIWindowPointer(void)
-    : CGUIWindow(105, "Pointer.xml")
+    : CGUIDialog(WINDOW_DIALOG_POINTER, "Pointer.xml")
 {
   m_pointer = 0;
   m_loadOnDemand = false;
   m_needsScaling = false;
+  m_active = false;
 }
 
 CGUIWindowPointer::~CGUIWindowPointer(void)
@@ -52,6 +53,14 @@ void CGUIWindowPointer::SetPointer(int pointer)
   }
 }
 
+void CGUIWindowPointer::UpdateVisibility()
+{
+  if (g_Mouse.IsActive())
+    Show();
+  else
+    Close();
+}
+
 void CGUIWindowPointer::OnWindowLoaded()
 { // set all our pointer images invisible
   for (iControls i = m_children.begin();i != m_children.end(); ++i)
@@ -64,9 +73,15 @@ void CGUIWindowPointer::OnWindowLoaded()
   m_pointer = 0;
 }
 
-void CGUIWindowPointer::Render()
+void CGUIWindowPointer::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
+  bool active = g_Mouse.IsActive();
+  if (active != m_active)
+  {
+    MarkDirtyRegion();
+    m_active = active;
+  }
+  SetPosition((float)g_Mouse.GetX(), (float)g_Mouse.GetY());
   SetPointer(g_Mouse.GetState());
-  CGUIWindow::Render();
+  return CGUIWindow::Process(currentTime, dirtyregions);
 }
-

--- a/xbmc/windows/GUIWindowPointer.h
+++ b/xbmc/windows/GUIWindowPointer.h
@@ -21,18 +21,20 @@
  *
  */
 
-#include "guilib/GUIWindow.h"
+#include "guilib/GUIDialog.h"
 
 class CGUIWindowPointer :
-      public CGUIWindow
+      public CGUIDialog
 {
 public:
   CGUIWindowPointer(void);
   virtual ~CGUIWindowPointer(void);
-  virtual void Render();
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
 protected:
   void SetPointer(int pointer);
   virtual void OnWindowLoaded();
+  virtual void UpdateVisibility();
 private:
   int m_pointer;
+  bool m_active;
 };

--- a/xbmc/windows/Makefile
+++ b/xbmc/windows/Makefile
@@ -1,4 +1,5 @@
 SRCS=GUIMediaWindow.cpp \
+     GUIWindowDebugInfo.cpp \
      GUIWindowFileManager.cpp \
      GUIWindowHome.cpp \
      GUIWindowLoginScreen.cpp \


### PR DESCRIPTION
This pull req pulls in work that topfs2 did in GSOC last year, updated for latest master.

The basic idea is to introduce a Process() routine in CGUIControl et. al. that does most of the heavy lifting, so that Render() is light.  Then, we mark whether a control is dirty or not and accumulate up the total region to render so that we can Scissor() that off and only render the small region.

This gives significant savings in both CPU and GPU on all platforms - primarily as the GPU doesn't need to render such a large area.

In the future the plan is to prevent it swapping buffers when we don't need to, and also use the masking to save running through the Render() loop.  It is also first steps towards event-based rendering, where the Process() loop will be run only as required, saving significant CPU.

There's still a few controls to tidy up (that are currently marked always dirty) but we feel it will only really get the last niggles worked through if it gets the wider testing that comes from being in master.
