### PR TITLE
Adding USB device detection support for Windows and Multiple keymap support for keyboards

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -818,6 +818,7 @@
     <ClCompile Include="..\..\xbmc\win32\strverscmp.cpp" />
     <ClCompile Include="..\..\xbmc\win32\Win32DelayedDllLoad.cpp" />
     <ClCompile Include="..\..\xbmc\win32\win32env.cpp" />
+    <ClCompile Include="..\..\xbmc\win32\WIN32USBScan.cpp" />
     <ClCompile Include="..\..\xbmc\win32\WIN32Util.cpp" />
     <ClCompile Include="..\..\xbmc\win32\WINDirectSound.cpp" />
     <ClCompile Include="..\..\xbmc\win32\WindowHelper.cpp" />
@@ -1644,6 +1645,7 @@
     <ClInclude Include="..\..\xbmc\ViewState.h" />
     <ClInclude Include="..\..\xbmc\win32\pch.h" />
     <ClInclude Include="..\..\xbmc\win32\PlatformDefs.h" />
+    <ClInclude Include="..\..\xbmc\win32\WIN32USBScan.h" />
     <ClInclude Include="..\..\xbmc\XBDateTime.h" />
     <CustomBuild Include="..\..\xbmc\win32\PlatformInclude.h">
       <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">update_git_rev.bat</Command>

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -437,6 +437,7 @@
     <ClCompile Include="..\..\xbmc\input\ButtonTranslator.cpp" />
     <ClCompile Include="..\..\xbmc\input\KeyboardLayoutConfiguration.cpp" />
     <ClCompile Include="..\..\xbmc\input\KeyboardStat.cpp" />
+    <ClCompile Include="..\..\xbmc\input\KeymapLoader.cpp" />
     <ClCompile Include="..\..\xbmc\input\MouseStat.cpp" />
     <ClCompile Include="..\..\xbmc\input\SDLJoystick.cpp" />
     <ClCompile Include="..\..\xbmc\input\windows\IRServerSuite.cpp" />
@@ -1341,6 +1342,7 @@
     <ClInclude Include="..\..\xbmc\input\ButtonTranslator.h" />
     <ClInclude Include="..\..\xbmc\input\KeyboardLayoutConfiguration.h" />
     <ClInclude Include="..\..\xbmc\input\KeyboardStat.h" />
+    <ClInclude Include="..\..\xbmc\input\KeymapLoader.h" />
     <ClInclude Include="..\..\xbmc\input\MouseStat.h" />
     <ClInclude Include="..\..\xbmc\input\SDLJoystick.h" />
     <ClInclude Include="..\..\xbmc\input\windows\IRServerSuite.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1823,6 +1823,9 @@
     <ClCompile Include="..\..\xbmc\win32\WIN32USBScan.cpp">
       <Filter>win32</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\input\KeymapLoader.cpp">
+      <Filter>input</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\storage\AutorunMediaJob.cpp">
       <Filter>storage</Filter>
     </ClCompile>
@@ -4293,6 +4296,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\win32\WIN32USBScan.h">
       <Filter>win32</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\input\KeymapLoader.h">
+      <Filter>input</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\storage\AutorunMediaJob.h">
       <Filter>storage</Filter>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1820,6 +1820,9 @@
     <ClCompile Include="..\..\xbmc\settings\VideoSettings.cpp">
       <Filter>settings</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\win32\WIN32USBScan.cpp">
+      <Filter>win32</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\storage\AutorunMediaJob.cpp">
       <Filter>storage</Filter>
     </ClCompile>
@@ -4287,6 +4290,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\settings\VideoSettings.h">
       <Filter>settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\win32\WIN32USBScan.h">
+      <Filter>win32</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\storage\AutorunMediaJob.h">
       <Filter>storage</Filter>

--- a/system/deviceidmappings.xml
+++ b/system/deviceidmappings.xml
@@ -1,0 +1,3 @@
+<devicemappings>
+	<device id="HID#VID_1915&PID_003B&MI_00#7&314e95d&0&0000#" keymap="Motorola Nyxboard Hybrid" />
+</devicemappings>

--- a/system/keymaps/keyboard.nyxboard.xml
+++ b/system/keymaps/keyboard.nyxboard.xml
@@ -1,0 +1,564 @@
+<keymap>
+  <global>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <p>Play</p>
+      <q>Queue</q>
+      <f>FastForward</f>
+      <r>Rewind</r>
+      <left>Right</left>
+      <right>Left</right>
+      <up>Up</up>
+      <down>Down</down>
+      <left mod="ctrl">analogseekback</left>
+      <right mod="ctrl">analogseekforward</right>
+      <pageup>PageUp</pageup>
+      <pagedown>PageDown</pagedown>
+      <return>Select</return>
+      <enter>Select</enter>
+      <backspace>ParentDir</backspace>
+      <m>ActivateWindow(PlayerControls)</m>
+      <s>ActivateWindow(shutdownmenu)</s>
+      <escape>PreviousMenu</escape>
+      <i>Info</i>
+      <menu>ContextMenu</menu>
+      <c>ContextMenu</c>
+      <space>Pause</space>
+      <x>Stop</x>
+      <period>SkipNext</period>
+      <comma>SkipPrevious</comma>
+      <tab>FullScreen</tab>
+      <printscreen>Screenshot</printscreen>
+      <s mod="ctrl">Screenshot</s>
+      <minus>VolumeDown</minus>
+      <plus>VolumeUp</plus>
+      <zero>Number0</zero>
+      <one>Number1</one>
+      <two>Number2</two>
+      <three>Number3</three>
+      <four>Number4</four>
+      <five>Number5</five>
+      <six>Number6</six>
+      <seven>Number7</seven>
+      <eight>Number8</eight>
+      <nine>Number9</nine>
+      <numpadminus>VolumeDown</numpadminus>
+      <numpadplus>VolumeUp</numpadplus>
+      <numpadzero>Number0</numpadzero>
+      <numpadone>Number1</numpadone>
+      <numpadtwo>Number2</numpadtwo>
+      <numpadthree>Number3</numpadthree>
+      <numpadfour>Number4</numpadfour>
+      <numpadfive>Number5</numpadfive>
+      <numpadsix>Number6</numpadsix>
+      <numpadseven>Number7</numpadseven>
+      <numpadeight>Number8</numpadeight>
+      <numpadnine>Number9</numpadnine>
+      <backslash>ToggleFullScreen</backslash>
+      <home>FirstPage</home>
+      <end>LastPage</end>
+      <!-- Multimedia keyboard keys -->
+      <browser_back>ParentDir</browser_back>
+      <browser_forward/>
+      <browser_refresh/>
+      <browser_stop/>
+      <browser_search/>
+      <browser_favorites>ActivateWindow(Favourites)</browser_favorites>
+      <browser_home>XBMC.ActivateWindow(Home)</browser_home>
+      <volume_mute>Mute</volume_mute>
+      <volume_down>VolumeDown</volume_down>
+      <volume_up>VolumeUp</volume_up>
+      <next_track>SkipNext</next_track>
+      <prev_track>SkipPrevious</prev_track>
+      <stop>Stop</stop>
+      <play_pause>Pause</play_pause>
+      <launch_mail></launch_mail>
+      <launch_media_select>XBMC.ActivateWindow(MyMusic)</launch_media_select>
+      <launch_app1_pc_icon>ActivateWindow(MyPrograms)</launch_app1_pc_icon>
+      <launch_app2_pc_icon>ActivateWindow(MyPrograms)</launch_app2_pc_icon>
+      <launch_file_browser/>
+      <launch_media_center/>
+      <!-- ****************************************************** -->
+      <!-- MS Media Center keyboard shortcuts sent by MCE remotes -->
+      <!-- See http://msdn.microsoft.com/en-us/library/bb189249.aspx -->
+      <p mod="ctrl,shift">Play</p>        <!-- Play -->
+      <s mod="ctrl,shift">Stop</s>        <!-- Stop -->
+      <p mod="ctrl">Pause</p>             <!-- Pause -->
+      <f mod="ctrl,shift">FastForward</f> <!-- Fwd -->
+      <b mod="ctrl,shift">Rewind</b>      <!-- Rew -->
+      <f mod="ctrl">SkipNext</f>          <!-- Skip -->
+      <b mod="ctrl">SkipPrevious</b>      <!-- Replay -->
+      <d mod="ctrl">Info</d>              <!-- MCE Details -->
+      <f10>VolumeUp</f10>                 <!-- MCE Vol up -->
+      <f9>VolumeDown</f9>                 <!-- MCE Vol down -->
+      <f8>Mute</f8>                       <!-- MCE mute -->
+      <g mod="ctrl">OSD</g>               <!-- MCE Guide -->
+      <m mod="ctrl">ActivateWindow(music)</m>    <!-- MCE My music -->
+      <i mod="ctrl">ActivateWindow(pictures)</i> <!-- MCE My pictures -->
+      <e mod="ctrl">ActivateWindow(video)</e>    <!-- MCE videos -->
+      <!-- MCE keypresses without an obvious use in XBMC -->
+      <o mod="ctrl">Notification(MCEKeypress, Recorded TV, 3)</o>
+      <t mod="ctrl">Notification(MCEKeypress, Live TV, 3)</t>
+      <t mod="ctrl,shift">Notification(MCEKeypress, My TV, 3)</t>
+      <a mod="ctrl">Notification(MCEKeypress, Radio, 3)</a>
+      <m mod="ctrl,shift">Notification(MCEKeypress, DVD menu, 3)</m>
+      <u mod="ctrl">Notification(MCEKeypress, DVD subtitle, 3)</u>
+      <a mod="ctrl,shift">Notification(MCEKeypress, DVD audio, 3)</a>
+    </keyboard>
+  </global>
+  <LoginScreen>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <end>XBMC.ShutDown()</end>
+    </keyboard>
+  </LoginScreen>
+  <Home>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <i>info</i>
+      <end>XBMC.ShutDown()</end>
+    </keyboard>
+  </Home>
+  <VirtualKeyboard>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Backspace</backspace>
+    </keyboard>
+  </VirtualKeyboard>
+  <MyFiles>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <space>Highlight</space>
+      <delete>Delete</delete>
+      <m>Move</m>
+      <r>Rename</r>
+    </keyboard>
+  </MyFiles>
+  <MyMusicPlaylist>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <space>Playlist</space>      <!-- Close playlist -->
+      <delete>Delete</delete>
+      <u>MoveItemUp</u>
+      <d>MoveItemDown</d>
+      <backspace>Playlist</backspace>      <!-- Close playlist -->
+    </keyboard>
+  </MyMusicPlaylist>
+  <MyMusicPlaylistEditor>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <u>MoveItemUp</u>
+      <d>MoveItemDown</d>
+      <delete>Delete</delete>
+    </keyboard>
+  </MyMusicPlaylistEditor>
+  <MyMusicFiles>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <space>Playlist</space>
+      <q>Queue</q>
+      <delete>Delete</delete>
+    </keyboard>
+  </MyMusicFiles>
+  <MyMusicLibrary>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <space>Playlist</space>
+      <q>Queue</q>
+    </keyboard>
+  </MyMusicLibrary>
+  <FullscreenVideo>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <f>FastForward</f>
+      <r>Rewind</r>
+      <period>StepForward</period>
+      <comma>StepBack</comma>
+      <backspace>Fullscreen</backspace>
+      <quote>SmallStepBack</quote>
+      <opensquarebracket>BigStepForward</opensquarebracket>
+      <closesquarebracket>BigStepBack</closesquarebracket>
+      <return>OSD</return>
+      <enter>OSD</enter>
+      <m>OSD</m>
+      <i>Info</i>
+      <o>CodecInfo</o>
+      <z>AspectRatio</z>
+      <t>ShowSubtitles</t>
+      <l>NextSubtitle</l>
+      <left>StepBack</left>
+      <right>StepForward</right>
+      <up>BigStepForward</up>
+      <down>BigStepBack</down>
+      <a>AudioDelay</a>
+      <escape>Fullscreen</escape>
+      <v>XBMC.ActivateWindow(Teletext)</v>
+    </keyboard>
+  </FullscreenVideo>
+  <VideoTimeSeek>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <return>Select</return>
+      <enter>Select</enter>
+    </keyboard>
+  </VideoTimeSeek>
+  <FullscreenInfo>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <f>FastForward</f>
+      <r>Rewind</r>
+      <period>StepForward</period>
+      <backspace>Close</backspace>
+      <o>CodecInfo</o>
+      <i>Close</i>
+      <d mod="ctrl">Close</d>
+      <m>OSD</m>
+    </keyboard>
+  </FullscreenInfo>
+  <PlayerControls>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <escape>Close</escape>
+      <m>close</m>
+    </keyboard>
+  </PlayerControls>
+  <Visualisation>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <f>FastForward</f>
+      <r>Rewind</r>
+      <period>SkipNext</period>
+      <comma>SkipPrevious</comma>
+      <return>ActivateWindow(MusicOSD)</return>
+      <enter>ActivateWindow(MusicOSD)</enter>
+      <m>ActivateWindow(MusicOSD)</m>
+      <i>Info</i>
+      <p>ActivateWindow(VisualisationPresetList)</p>
+      <v>ActivateWindow(VisualisationSettings)</v>
+      <n>ActivateWindow(MusicPlaylist)</n>
+      <left>SkipPrevious</left>
+      <right>SkipNext</right>
+      <up>IncreaseRating</up>
+      <down>DecreaseRating</down>      <!--<back>NextPreset</back>!-->
+      <o>CodecInfo</o>
+      <l>LockPreset</l>
+      <escape>FullScreen</escape>
+    </keyboard>
+  </Visualisation>
+  <MusicOSD>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <escape>Close</escape>
+      <f>FastForward</f>
+      <r>Rewind</r>
+      <period>SkipNext</period>
+      <comma>SkipPrevious</comma>
+      <m>Close</m>
+      <i>Info</i>
+      <o>CodecInfo</o>
+      <p>ActivateWindow(VisualisationPresetList)</p>
+      <v>ActivateWindow(VisualisationSettings)</v>
+      <n>ActivateWindow(MusicPlaylist)</n>
+    </keyboard>
+  </MusicOSD>
+  <VisualisationSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <escape>Close</escape>
+      <f>FastForward</f>
+      <r>Rewind</r>
+      <period>SkipNext</period>
+      <comma>SkipPrevious</comma>
+      <m>Close</m>
+      <i>Info</i>
+      <o>CodecInfo</o>
+      <p>ActivateWindow(VisualisationPresetList)</p>
+      <v>Close</v>
+      <n>ActivateWindow(MusicPlaylist)</n>
+    </keyboard>
+  </VisualisationSettings>
+  <VisualisationPresetList>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <escape>Close</escape>
+      <f>FastForward</f>
+      <r>Rewind</r>
+      <period>SkipNext</period>
+      <comma>SkipPrevious</comma>
+      <m>Close</m>
+      <i>Info</i>
+      <o>CodecInfo</o>
+      <p>Close</p>
+      <v>Close</v>
+      <n>ActivateWindow(MusicPlaylist)</n>
+    </keyboard>
+  </VisualisationPresetList>
+  <SlideShow>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <zero>ZoomNormal</zero>
+      <one>ZoomLevel1</one>
+      <two>ZoomLevel2</two>
+      <three>ZoomLevel3</three>
+      <four>ZoomLevel4</four>
+      <five>ZoomLevel5</five>
+      <six>ZoomLevel6</six>
+      <seven>ZoomLevel7</seven>
+      <eight>ZoomLevel8</eight>
+      <nine>ZoomLevel9</nine>
+      <i>Info</i>
+      <o>CodecInfo</o>
+      <period>NextPicture</period>
+      <comma>PreviousPicture</comma>
+      <plus>ZoomIn</plus>
+      <minus>ZoomOut</minus>
+      <r>Rotate</r>
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </SlideShow>
+  <ScreenCalibration>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <return>NextCalibration</return>
+      <enter>NextCalibration</enter>
+      <d>ResetCalibration</d>
+      <r>NextResolution</r>
+    </keyboard>
+  </ScreenCalibration>
+  <GUICalibration>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <return>NextCalibration</return>
+      <enter>NextCalibration</enter>
+      <d>ResetCalibration</d>
+    </keyboard>
+  </GUICalibration>
+  <SelectDialog>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+      <escape>Close</escape>
+    </keyboard>
+  </SelectDialog>
+  <VideoOSD>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+      <escape>Close</escape>
+      <m>Close</m>
+      <g mod="ctrl">close</g> <!-- MCE Guide button -->
+      <i>Info</i>
+      <o>CodecInfo</o>
+    </keyboard>
+  </VideoOSD>
+  <VideoMenu>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <opensquarebracket>BigStepForward</opensquarebracket>
+      <closesquarebracket>BigStepBack</closesquarebracket>
+      <m>OSD</m>
+      <i>Info</i>
+      <o>CodecInfo</o>
+      <z>AspectRatio</z>
+      <t>ShowSubtitles</t>
+      <l>NextSubtitle</l>
+      <a>AudioDelay</a>
+      <escape>Fullscreen</escape>
+      <return>Select</return>
+      <enter>Select</enter>      <!-- backspace>Fullscreen</backspace -->
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </VideoMenu>
+  <OSDVideoSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+      <escape>Close</escape>
+      <i>Info</i>
+      <o>CodecInfo</o>
+    </keyboard>
+  </OSDVideoSettings>
+  <OSDAudioSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+      <escape>Close</escape>
+      <i>Info</i>
+      <o>CodecInfo</o>
+    </keyboard>
+  </OSDAudioSettings>
+  <VideoBookmarks>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+      <escape>Close</escape>
+      <delete>Delete</delete>
+    </keyboard>
+  </VideoBookmarks>
+  <MyVideoLibrary>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <delete>Delete</delete>
+      <space>Playlist</space>
+      <w>ToggleWatched</w>
+    </keyboard>
+  </MyVideoLibrary>
+  <MyVideoFiles>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <space>Playlist</space>
+      <q>Queue</q>
+      <w>ToggleWatched</w>
+    </keyboard>
+  </MyVideoFiles>
+  <MyVideoPlaylist>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Playlist</backspace>      <!-- Close playlist -->
+      <space>Playlist</space>      <!-- Close playlist -->
+      <delete>Delete</delete>
+      <u>MoveItemUp</u>
+      <d>MoveItemDown</d>
+    </keyboard>
+  </MyVideoPlaylist>
+  <MyPictures>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <delete>Delete</delete>
+    </keyboard>
+  </MyPictures>
+  <ContextMenu>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <c>Close</c>
+      <menu>Close</menu>
+      <backspace>Close</backspace>
+    </keyboard>
+  </ContextMenu>
+  <FileStackingDialog>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+    </keyboard>
+  </FileStackingDialog>
+  <Scripts>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <i>info</i>
+    </keyboard>
+  </Scripts>
+  <Weather>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+      <key id='65446'>PreviousMenu</key>
+    </keyboard>
+  </Weather>
+  <Settings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </Settings>
+  <MyPicturesSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </MyPicturesSettings>
+  <MyProgramsSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </MyProgramsSettings>
+  <MyWeatherSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </MyWeatherSettings>
+  <MyMusicSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </MyMusicSettings>
+  <SystemSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </SystemSettings>
+  <MyVideosSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </MyVideosSettings>
+  <NetworkSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </NetworkSettings>
+  <AppearanceSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </AppearanceSettings>
+  <Profiles>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </Profiles>
+  <systeminfo>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </systeminfo>
+  <shutdownmenu>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+      <s>Close</s>  
+    </keyboard>
+  </shutdownmenu>
+  <submenu>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </submenu>
+  <MusicInformation>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+      <i>Close</i>
+      <d mod="ctrl">Close</d>
+      <key id='65446'>Close</key>
+    </keyboard>
+  </MusicInformation>
+  <MovieInformation>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+      <i>Close</i>
+      <key id='65446'>Close</key>
+    </keyboard>
+  </MovieInformation>
+  <AddonInformation>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+    </keyboard>
+  </AddonInformation>
+  <AddonSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+    </keyboard>
+  </AddonSettings>
+  <TextViewer>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+    </keyboard>
+  </TextViewer>
+  <LockSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <escape>Close</escape>
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </LockSettings>
+  <ProfileSettings>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <escape>Close</escape>
+      <backspace>PreviousMenu</backspace>
+    </keyboard>
+  </ProfileSettings>
+  <PictureInfo>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <period>NextPicture</period>
+      <comma>PreviousPicture</comma>
+      <i>Close</i>
+      <d mod="ctrl">Close</d>
+      <o>Close</o>
+      <backspace>Close</backspace>
+      <space>Pause</space>
+    </keyboard>
+  </PictureInfo>
+  <Teletext>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+      <escape>Close</escape>
+      <v>Close</v>
+    </keyboard>
+  </Teletext>
+  <Favourites>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+    </keyboard>
+  </Favourites>
+  <NumericInput>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <backspace>Close</backspace>
+    </keyboard>
+  </NumericInput>
+  <FileBrowser>
+    <keyboard name="Motorola Nyxboard Hybrid">
+      <space>Highlight</space>
+    </keyboard>
+  </FileBrowser>
+</keymap>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -234,6 +234,7 @@
 #ifdef _WIN32
 #include <shlobj.h>
 #include "win32util.h"
+#include "win32/WIN32USBScan.h"
 #endif
 #ifdef HAS_XRANDR
 #include "windowing/X11/XRandR.h"
@@ -464,6 +465,8 @@ bool CApplication::Create()
   /* install win32 exception translator, win32 exceptions
    * can now be caught using c++ try catch */
   win32_exception::install_handler();
+
+  CWIN32USBScan();
 #endif
 
   // only the InitDirectories* for the current platform should return true

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -466,7 +466,6 @@ bool CApplication::Create()
    * can now be caught using c++ try catch */
   win32_exception::install_handler();
 
-  CWIN32USBScan();
 #endif
 
   // only the InitDirectories* for the current platform should return true
@@ -600,6 +599,10 @@ bool CApplication::Create()
   }
 
   g_powerManager.Initialize();
+
+#ifdef _WIN32
+  CWIN32USBScan();
+#endif
 
   CLog::Log(LOGNOTICE, "load settings...");
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -360,7 +360,7 @@ CButtonTranslator::~CButtonTranslator()
 
 bool CButtonTranslator::Load()
 {
-  translatorMap.clear();
+  deviceMappings.clear();
 
   //directories to search for keymaps
   //they're applied in this order,
@@ -785,8 +785,14 @@ CAction CButtonTranslator::GetAction(int window, const CKey &key, bool fallback)
 int CButtonTranslator::GetActionCode(int window, const CKey &key, CStdString &strAction)
 {
   uint32_t code = key.GetButtonCode();
-  map<int, buttonMap>::iterator it = translatorMap.find(window);
-  if (it == translatorMap.end())
+
+  map<CStdString, std::map<int, buttonMap>>::iterator activeMapIt = deviceMappings.find(g_settings.m_activeKeyboardMapping);
+  if (activeMapIt == deviceMappings.end())
+    return 0;
+
+  std::map<int, buttonMap> deviceMap = (*activeMapIt).second;
+  map<int, buttonMap>::iterator it = deviceMap.find(window);
+  if (it == deviceMap.end())
     return 0;
   buttonMap::iterator it2 = (*it).second.find(code);
   int action = 0;
@@ -844,13 +850,7 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
 {
   if (!pWindow || windowID == WINDOW_INVALID) 
     return;
-  buttonMap map;
-  std::map<int, buttonMap>::iterator it = translatorMap.find(windowID);
-  if (it != translatorMap.end())
-  {
-    map = it->second;
-    translatorMap.erase(it);
-  }
+
   TiXmlNode* pDevice;
 
   const char* types[] = {"gamepad", "remote", "universalremote", "keyboard", "mouse", "appcommand", NULL};
@@ -860,7 +860,30 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
     if (HasDeviceType(pWindow, type))
     {
       pDevice = pWindow->FirstChild(type);
+      TiXmlElement *pDeviceElement = pDevice->ToElement();
+      CStdString deviceName;
+      //check if exists, if not use "default"
+      deviceName = pDeviceElement->Attribute("name");
+      if (deviceName.empty())
+        deviceName = "default";
+
+      std::map<CStdString, std::map<int, buttonMap>>::iterator deviceMapIt = deviceMappings.find(deviceName);
+      if (deviceMapIt == deviceMappings.end())
+      {
+        //First time encountering this device, lets initialise the buttonMap for it.
+        deviceMapIt = deviceMappings.insert(pair<CStdString, std::map<int, buttonMap>>(deviceName, std::map<int, buttonMap>())).first;
+      }
+      
+      std::map<int, buttonMap>::iterator windowIt = deviceMapIt->second.find(windowID);
+      if (windowIt == deviceMapIt->second.end())
+      {
+        //add it now
+        windowIt = deviceMapIt->second.insert(pair<int, buttonMap>(windowID, buttonMap())).first;
+      }
+      buttonMap& windowMap = windowIt->second;
+
       TiXmlElement *pButton = pDevice->FirstChildElement();
+
       while (pButton)
       {
         uint32_t buttonCode=0;
@@ -878,11 +901,12 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
             buttonCode = TranslateAppCommand(pButton->Value());
 
         if (buttonCode && pButton->FirstChild())
-          MapAction(buttonCode, pButton->FirstChild()->Value(), map);
+          MapAction(buttonCode, pButton->FirstChild()->Value(), windowMap);
         pButton = pButton->NextSiblingElement();
       }
     }
   }
+
 #if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
   if ((pDevice = pWindow->FirstChild("joystick")) != NULL)
   {
@@ -894,9 +918,6 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
     }
   }
 #endif
-  // add our map to our table
-  if (map.size() > 0)
-    translatorMap.insert(pair<int, buttonMap>( windowID, map));
 }
 
 bool CButtonTranslator::TranslateActionString(const char *szAction, int &action)
@@ -1191,7 +1212,7 @@ uint32_t CButtonTranslator::TranslateMouseCommand(const char *szButton)
 
 void CButtonTranslator::Clear()
 {
-  translatorMap.clear();
+  deviceMappings.clear();
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
   lircRemotesMap.clear();
 #endif

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -782,15 +782,19 @@ CAction CButtonTranslator::GetAction(int window, const CKey &key, bool fallback)
   return action;
 }
 
+std::map<CStdString, std::map<int, CButtonTranslator::buttonMap>>::iterator CButtonTranslator::GetActiveButtonMap()
+{
+  std::map<CStdString, std::map<int, buttonMap>>::iterator activeMapIt = deviceMappings.find(g_settings.m_activeKeyboardMapping);
+  if (activeMapIt == deviceMappings.end())
+    return deviceMappings.find("default");
+  return activeMapIt;
+}
+
 int CButtonTranslator::GetActionCode(int window, const CKey &key, CStdString &strAction)
 {
   uint32_t code = key.GetButtonCode();
 
-  map<CStdString, std::map<int, buttonMap>>::iterator activeMapIt = deviceMappings.find(g_settings.m_activeKeyboardMapping);
-  if (activeMapIt == deviceMappings.end())
-    return 0;
-
-  std::map<int, buttonMap> deviceMap = (*activeMapIt).second;
+  std::map<int, buttonMap> deviceMap = (*GetActiveButtonMap()).second;
   map<int, buttonMap>::iterator it = deviceMap.find(window);
   if (it == deviceMap.end())
     return 0;

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -98,6 +98,7 @@ private:
   typedef std::multimap<uint32_t, CButtonAction> buttonMap; // our button map to fill in
   
   std::map<CStdString, std::map<int, buttonMap>> deviceMappings;
+  std::map<CStdString, std::map<int, buttonMap>>::iterator CButtonTranslator::GetActiveButtonMap();
   int GetActionCode(int window, const CKey &key, CStdString &strAction);
 
   static uint32_t TranslateGamepadString(const char *szButton);

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -96,7 +96,8 @@ public:
 
 private:
   typedef std::multimap<uint32_t, CButtonAction> buttonMap; // our button map to fill in
-  std::map<int, buttonMap> translatorMap;       // mapping of windows to button maps
+  
+  std::map<CStdString, std::map<int, buttonMap>> deviceMappings;
   int GetActionCode(int window, const CKey &key, CStdString &strAction);
 
   static uint32_t TranslateGamepadString(const char *szButton);

--- a/xbmc/input/KeymapLoader.cpp
+++ b/xbmc/input/KeymapLoader.cpp
@@ -1,0 +1,90 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "KeymapLoader.h"
+#include "filesystem/File.h"
+#include "settings/Settings.h"
+#include "utils/log.h"
+#include "utils/XMLUtils.h"
+
+using namespace std;
+using namespace XFILE;
+
+CKeymapLoader::CKeymapLoader()
+{
+  if (!parsedMappings)
+  {
+    ParseDeviceMappings();
+  }
+}
+
+void CKeymapLoader::DeviceAdded(CStdString deviceId)
+{
+  CStdString keymapName;
+  if (FindMappedDevice(deviceId, keymapName))
+  {
+    CLog::Log(LOGDEBUG, "Switching Active Keymapping to: %s", keymapName.c_str());
+    g_settings.m_activeKeyboardMapping = keymapName;
+  }
+}
+
+void CKeymapLoader::DeviceRemoved(CStdString deviceId)
+{
+  CStdString keymapName;
+  if (FindMappedDevice(deviceId, keymapName))
+  {
+    CLog::Log(LOGDEBUG, "Switching Active Keymapping to: default");
+    g_settings.m_activeKeyboardMapping = "default";
+  }
+}
+
+void CKeymapLoader::ParseDeviceMappings()
+{
+  parsedMappings = true;
+  CStdString file("special://xbmc/system/deviceidmappings.xml");
+  TiXmlDocument deviceXML;
+  if (!CFile::Exists(file) || !deviceXML.LoadFile(file))
+    return;
+
+  TiXmlElement *pRootElement = deviceXML.RootElement();
+  if (!pRootElement || strcmpi(pRootElement->Value(), "devicemappings") != 0)
+    return;
+  
+  TiXmlElement *pDevice = pRootElement->FirstChildElement("device");
+  while (pDevice)
+  {
+    CStdString deviceId(pDevice->Attribute("id"));
+    CStdString keymap(pDevice->Attribute("keymap"));
+    if (!deviceId.empty() && !keymap.empty())
+      deviceMappings.insert(pair<CStdString, CStdString>(deviceId.ToUpper(), keymap));
+    pDevice = pDevice->NextSiblingElement("device");
+  }
+}
+
+bool CKeymapLoader::FindMappedDevice(CStdString deviceId, CStdString& keymapName)
+{
+  std::map<CStdString, CStdString>::iterator deviceIdIt = deviceMappings.find(deviceId.ToUpper());
+  if (deviceIdIt == deviceMappings.end())
+    return false;
+
+  keymapName = deviceIdIt->second;
+  return true;
+}

--- a/xbmc/input/KeymapLoader.h
+++ b/xbmc/input/KeymapLoader.h
@@ -1,0 +1,34 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+static std::map<CStdString, CStdString> deviceMappings;
+static bool parsedMappings;
+
+class CKeymapLoader
+{
+  public:
+    CKeymapLoader();
+    void DeviceRemoved(CStdString deviceID);
+    void DeviceAdded(CStdString deviceID);
+  private:
+    void ParseDeviceMappings();
+    bool FindMappedDevice(CStdString deviceId, CStdString& keymapName);
+};

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -137,6 +137,8 @@ void CSettings::Initialize()
   m_usingLoginScreen = false;
   m_lastUsedProfile = 0;
   m_currentProfile = 0;
+
+  m_activeKeyboardMapping = "default";
 }
 
 CSettings::~CSettings(void)

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -157,6 +157,8 @@ public:
 
   CStdString m_logFolder;
 
+  CStdString m_activeKeyboardMapping;
+
   bool m_bMyMusicSongInfoInVis;
   bool m_bMyMusicSongThumbInVis;
 

--- a/xbmc/win32/WIN32USBScan.cpp
+++ b/xbmc/win32/WIN32USBScan.cpp
@@ -1,17 +1,77 @@
 #include <setupapi.h>
 #include "WIN32USBScan.h"
+#include "input/KeymapLoader.h"
 
 static GUID USB_HID_GUID = { 0x4D1E55B2, 0xF16F, 0x11CF, { 0x88, 0xCB, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30 } };
 
 CWIN32USBScan::CWIN32USBScan()
 {
-  HDEVINFO hDevInfo;
-  SP_DEVINFO_DATA DeviceInfoData;
+  HDEVINFO hDevHandle;
+  SP_DEVICE_INTERFACE_DATA deviceInterfaceData;
+  DWORD required = 0;
+  deviceInterfaceData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
 
-  hDevInfo = SetupDiGetClassDevs(&USB_HID_GUID, 0, 0, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
-  DeviceInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
-  for (DWORD i = 0; SetupDiEnumDeviceInfo(hDevInfo, i, &DeviceInfoData); i++)
-  {
+  int nBufferSize = 0;
+      
+  SP_DEVINFO_DATA devInfoData;
+  devInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
 
-  }
+  DWORD MemberIndex = 0;
+  BOOL  Result;
+
+  hDevHandle = SetupDiGetClassDevs(&USB_HID_GUID, 0, 0, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+
+  if (hDevHandle == INVALID_HANDLE_VALUE)
+    return;
+
+  bool bStart = false;
+  TCHAR *buffer = NULL;
+  PSP_DEVICE_INTERFACE_DETAIL_DATA devicedetailData;
+	do
+	{
+		Result = SetupDiEnumDeviceInfo(hDevHandle, MemberIndex, &devInfoData);
+
+		if (Result)
+			Result = SetupDiEnumDeviceInterfaces(hDevHandle, 0, &USB_HID_GUID, MemberIndex, &deviceInterfaceData);
+           
+    if(!Result)
+    {
+      SetupDiDestroyDeviceInfoList(hDevHandle);
+      delete []buffer;
+      buffer = NULL;
+      return;
+    }
+
+    MemberIndex++;
+    BOOL detailResult = false;
+      
+    if(!bStart)
+    {
+      // As per MSDN, Get the required buffer size. Call SetupDiGetDeviceInterfaceDetail with a 
+      // NULL DeviceInterfaceDetailData pointer, a DeviceInterfaceDetailDataSize of zero, 
+      // and a valid RequiredSize variable. In response to such a call, this function returns 
+      // the required buffer size at RequiredSize and fails with GetLastError returning 
+      // ERROR_INSUFFICIENT_BUFFER. 
+      // Allocate an appropriately sized buffer and call the function again to get the interface details. 
+
+      SetupDiGetDeviceInterfaceDetail(hDevHandle, &deviceInterfaceData, NULL, 0, &required, NULL);
+
+      buffer = new TCHAR[required];
+      devicedetailData = (PSP_DEVICE_INTERFACE_DETAIL_DATA) buffer;
+      devicedetailData->cbSize = sizeof(SP_INTERFACE_DEVICE_DETAIL_DATA);
+      nBufferSize = required;
+      bStart = true;
+    }
+
+    detailResult = SetupDiGetDeviceInterfaceDetail(hDevHandle, &deviceInterfaceData, devicedetailData, nBufferSize , &required, NULL);
+
+    CStdString dbcc_name(devicedetailData->DevicePath);
+    dbcc_name = dbcc_name.Mid(dbcc_name.find_last_of('\\')+1, dbcc_name.find_last_of('#') - dbcc_name.find_last_of('\\'));
+
+    CKeymapLoader().DeviceAdded(dbcc_name);
+
+    if(!detailResult)
+        continue;
+
+  } while(Result);
 }

--- a/xbmc/win32/WIN32USBScan.cpp
+++ b/xbmc/win32/WIN32USBScan.cpp
@@ -1,12 +1,14 @@
 #include <setupapi.h>
 #include "WIN32USBScan.h"
 
+static GUID USB_HID_GUID = { 0x4D1E55B2, 0xF16F, 0x11CF, { 0x88, 0xCB, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30 } };
+
 CWIN32USBScan::CWIN32USBScan()
 {
   HDEVINFO hDevInfo;
   SP_DEVINFO_DATA DeviceInfoData;
 
-  hDevInfo = SetupDiGetClassDevs(NULL, 0, 0, DIGCF_PRESENT | DIGCF_ALLCLASSES);
+  hDevInfo = SetupDiGetClassDevs(&USB_HID_GUID, 0, 0, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
   DeviceInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
   for (DWORD i = 0; SetupDiEnumDeviceInfo(hDevInfo, i, &DeviceInfoData); i++)
   {

--- a/xbmc/win32/WIN32USBScan.cpp
+++ b/xbmc/win32/WIN32USBScan.cpp
@@ -1,0 +1,15 @@
+#include <setupapi.h>
+#include "WIN32USBScan.h"
+
+CWIN32USBScan::CWIN32USBScan()
+{
+  HDEVINFO hDevInfo;
+  SP_DEVINFO_DATA DeviceInfoData;
+
+  hDevInfo = SetupDiGetClassDevs(NULL, 0, 0, DIGCF_PRESENT | DIGCF_ALLCLASSES);
+  DeviceInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
+  for (DWORD i = 0; SetupDiEnumDeviceInfo(hDevInfo, i, &DeviceInfoData); i++)
+  {
+
+  }
+}

--- a/xbmc/win32/WIN32USBScan.h
+++ b/xbmc/win32/WIN32USBScan.h
@@ -1,0 +1,5 @@
+class CWIN32USBScan
+{
+  public:
+    CWIN32USBScan();
+};

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -27,6 +27,7 @@
 #include "Application.h"
 #include "input/XBMC_vkeys.h"
 #include "input/MouseStat.h"
+#include "input/KeymapLoader.h"
 #include "storage/MediaManager.h"
 #include "windowing/WindowingFactory.h"
 #include <dbt.h>
@@ -36,6 +37,7 @@
 #include "guilib/GUIControl.h"       // for EVENT_RESULT
 #include "powermanagement/windows/Win32PowerSyscall.h"
 #include "Shlobj.h"
+#include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 
 #ifdef _WIN32
@@ -649,13 +651,15 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       break;
     case WM_DEVICECHANGE:
       PDEV_BROADCAST_DEVICEINTERFACE b = (PDEV_BROADCAST_DEVICEINTERFACE) lParam;
+      CStdString dbcc_name(b->dbcc_name);
+      dbcc_name = dbcc_name.Mid(dbcc_name.find_last_of('\\')+1, dbcc_name.find_last_of('#') - dbcc_name.find_last_of('\\'));
       switch (wParam)
       {
         case DBT_DEVICEARRIVAL:
-          CLog::Log(LOGDEBUG, "HID Device Arrived");
+          CKeymapLoader().DeviceAdded(dbcc_name);
           break;
         case DBT_DEVICEREMOVECOMPLETE:
-          CLog::Log(LOGDEBUG, "HID Device Removed");
+          CKeymapLoader().DeviceRemoved(dbcc_name);
           break;
         case DBT_DEVNODES_CHANGED:
           //CLog::Log(LOGDEBUG, "HID Device Changed");

--- a/xbmc/windowing/windows/WinEventsWin32.h
+++ b/xbmc/windowing/windows/WinEventsWin32.h
@@ -32,6 +32,7 @@ public:
   static bool MessagePump();
   static LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 private:
+  static void RegisterDeviceInterfaceToHwnd(GUID InterfaceClassGuid, HWND hWnd, HDEVNOTIFY *hDeviceNotify);
   static void WindowFromScreenCoords(HWND hWnd, POINT *point);
   static void OnGestureNotify(HWND hWnd, LPARAM lParam);
   static void OnGesture(HWND hWnd, LPARAM lParam);


### PR DESCRIPTION
Device list is enumerated when application starts, any USB Hid devices are sent to the Keymaploader, here it checks a list of known device ids and will load the respective keymap.

Easily extendable for mac and linux
