### PR TITLE
Libarchive archive handling

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -699,6 +699,7 @@ XB_FIND_SONAME([VORBISFILE],  [vorbisfile])
 XB_FIND_SONAME([MODPLUG],     [modplug])
 XB_FIND_SONAME([ASS],         [ass])
 XB_FIND_SONAME([MPEG2],       [mpeg2])
+XB_FIND_SONAME([ARCHIVE],     [archive])
 
 # WebServer
 if test "$use_webserver" = "yes"; then

--- a/configure.in
+++ b/configure.in
@@ -597,6 +597,7 @@ AC_CHECK_LIB([crypto],      [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([mysqlclient], [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([ssh],         [sftp_tell64],, AC_MSG_RESULT([Could not find suitable version of libssh]))
 AC_CHECK_LIB([smbclient],   [main],, AC_MSG_ERROR($missing_library))
+AC_CHECK_LIB([archive],     [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([bluetooth],   [hci_devid],, AC_MSG_RESULT([Could not find suitable version of libbluetooth]))
 AC_CHECK_LIB([yajl],        [main],, AC_MSG_ERROR($missing_library))
 PKG_CHECK_MODULES([FONTCONFIG], [fontconfig],

--- a/configure.in
+++ b/configure.in
@@ -305,6 +305,12 @@ AC_ARG_WITH([lirc-device],
   [lirc_device=/dev/lircd])
 AC_DEFINE_UNQUOTED([LIRC_DEVICE], ["$lirc_device"], [Default LIRC device])
 
+AC_ARG_ENABLE([libarchive],
+  [AS_HELP_STRING([--enable-libarchive],
+  [enable libarchive support (default is auto)])],
+  [use_libarchive=$enableval],
+  [use_libarchive=auto])
+
 ### External libraries options
 AC_ARG_ENABLE([external-libraries],
   [AS_HELP_STRING([--enable-external-libraries],
@@ -597,7 +603,6 @@ AC_CHECK_LIB([crypto],      [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([mysqlclient], [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([ssh],         [sftp_tell64],, AC_MSG_RESULT([Could not find suitable version of libssh]))
 AC_CHECK_LIB([smbclient],   [main],, AC_MSG_ERROR($missing_library))
-AC_CHECK_LIB([archive],     [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([bluetooth],   [hci_devid],, AC_MSG_RESULT([Could not find suitable version of libbluetooth]))
 AC_CHECK_LIB([yajl],        [main],, AC_MSG_ERROR($missing_library))
 PKG_CHECK_MODULES([FONTCONFIG], [fontconfig],
@@ -651,6 +656,24 @@ AS_CASE([x$use_libbluray],
   ]
 )
 
+# check for libarchive
+AS_CASE([x$use_libarchive],
+  [xyes],[
+    AC_CHECK_LIB([archive], [main],, AC_MSG_ERROR($missing_library))
+  ],
+  [xauto],[
+    AC_CHECK_LIB([archive], [main], [use_libarchive="yes"], [use_libarchive="no"])
+  ])
+
+if [[ "$use_libarchive" = "yes" ]]; then
+  XB_FIND_SONAME([ARCHIVE], [archive])
+  AC_DEFINE([HAVE_LIBARCHIVE], 1, [System has libarchive library])
+  AC_SUBST([HAVE_LIBARCHIVE], 1)
+else
+  AC_SUBST([HAVE_LIBARCHIVE], 0)
+  AC_MSG_NOTICE(libarchive use disabled)
+fi
+
 # platform dependent libraries
 if test "$host_vendor" = "apple" ; then
   AC_CHECK_LIB([iconv],     [main],, AC_MSG_ERROR($missing_library))
@@ -699,7 +722,6 @@ XB_FIND_SONAME([VORBISFILE],  [vorbisfile])
 XB_FIND_SONAME([MODPLUG],     [modplug])
 XB_FIND_SONAME([ASS],         [ass])
 XB_FIND_SONAME([MPEG2],       [mpeg2])
-XB_FIND_SONAME([ARCHIVE],     [archive])
 
 # WebServer
 if test "$use_webserver" = "yes"; then

--- a/lib/DllLibArchive.h
+++ b/lib/DllLibArchive.h
@@ -24,6 +24,9 @@
 #if (defined HAVE_CONFIG_H) && (!defined WIN32)
   #include "config.h"
 #endif
+
+#ifdef HAVE_LIBARCHIVE
+
 #include "DynamicDll.h"
 #include "utils/log.h"
 
@@ -122,3 +125,5 @@ class DllLibArchive : public DllDynamic, DllLibArchiveInterface
     RESOLVE_METHOD(archive_entry_stat)
   END_METHOD_RESOLVE()
 };
+
+#endif // HAVE_LIBARCHIVE

--- a/lib/DllLibArchive.h
+++ b/lib/DllLibArchive.h
@@ -1,0 +1,124 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2009 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
+#include "DynamicDll.h"
+#include "utils/log.h"
+
+#include <archive.h>
+#include <archive_entry.h>
+
+class DllLibArchiveInterface
+{
+public:
+  virtual ~DllLibArchiveInterface() {}
+  virtual struct archive  *archive_read_new()=0;
+  virtual int    archive_read_support_format_all(struct archive *)=0;
+  virtual int    archive_read_support_compression_all(struct archive *)=0;
+  virtual struct archive  *archive_write_disk_new()=0;
+  virtual int    archive_write_disk_set_options(struct archive *, int)=0;
+  virtual int  archive_write_disk_set_standard_lookup(struct archive *)=0;
+  virtual int    archive_read_open2(struct archive *, void *_client_data,
+            archive_open_callback *, archive_read_callback *,
+            archive_skip_callback *, archive_close_callback *)=0;
+  virtual const char  *archive_error_string(struct archive *)=0;
+  virtual int    archive_read_next_header(struct archive *,
+            struct archive_entry **)=0;
+  virtual const char  *archive_entry_pathname(struct archive_entry *)=0;
+  virtual void  archive_entry_set_pathname(struct archive_entry *, const char *)=0;
+  virtual int    archive_write_header(struct archive *,
+            struct archive_entry *)=0;
+  virtual __LA_INT64_T   archive_entry_size(struct archive_entry *)=0;
+  virtual int    archive_read_data_block(struct archive *a,
+            const void **buff, size_t *size, off_t *offset)=0;
+#if ARCHIVE_VERSION_NUMBER < 3000000
+  virtual __LA_SSIZE_T   archive_write_data_block(struct archive *,
+            const void *, size_t, off_t)=0;
+#else
+  virtual __LA_SSIZE_T   archive_write_data_block(struct archive *,
+            const void *, size_t, __LA_INT64_T)=0;
+#endif
+  virtual int    archive_write_finish_entry(struct archive *)=0;
+  virtual int    archive_read_close(struct archive *)=0;
+  virtual int    archive_write_close(struct archive *)=0;
+  virtual const struct stat *archive_entry_stat(struct archive_entry *)=0;
+};
+
+class DllLibArchive : public DllDynamic, DllLibArchiveInterface
+{
+  DECLARE_DLL_WRAPPER(DllLibArchive, DLL_PATH_LIBARCHIVE)
+  DEFINE_METHOD0(struct archive  *, archive_read_new)
+  DEFINE_METHOD1(int, archive_read_support_format_all, (struct archive *p1))
+  DEFINE_METHOD1(int, archive_read_support_compression_all, (struct archive *p1))
+  DEFINE_METHOD0(struct archive  *, archive_write_disk_new)
+  DEFINE_METHOD2(int, archive_write_disk_set_options, (struct archive *p1, int p2))
+  DEFINE_METHOD1(int, archive_write_disk_set_standard_lookup, (struct archive *p1))
+  DEFINE_METHOD6(int, archive_read_open2, (struct archive *p1, void *p2,
+                 archive_open_callback *p3, archive_read_callback *p4,
+                 archive_skip_callback *p5, archive_close_callback *p6))
+  DEFINE_METHOD1(const char  *, archive_error_string, (struct archive *p1))
+  DEFINE_METHOD2(int, archive_read_next_header, (struct archive *p1,
+                 struct archive_entry **p2))
+  DEFINE_METHOD1(const char  *, archive_entry_pathname, (struct archive_entry *p1))
+  DEFINE_METHOD2(void, archive_entry_set_pathname, (struct archive_entry *p1, const char *p2))
+  DEFINE_METHOD2(int, archive_write_header, (struct archive *p1,
+                 struct archive_entry *p2))
+  DEFINE_METHOD1(__LA_INT64_T, archive_entry_size, (struct archive_entry *p1))
+  DEFINE_METHOD4(int, archive_read_data_block, (struct archive *p1,
+                 const void **p2, size_t *p3, off_t *p4))
+#if ARCHIVE_VERSION_NUMBER < 3000000
+  DEFINE_METHOD4(__LA_SSIZE_T, archive_write_data_block, (struct archive *p1,
+                 const void *p2, size_t p3, off_t p4))
+#else
+  DEFINE_METHOD4(__LA_SSIZE_T, archive_write_data_block, (struct archive *p1,
+                 const void *p2, size_t p3, __LA_INT64_T p4))
+#endif
+  DEFINE_METHOD1(int, archive_write_finish_entry, (struct archive *p1))
+  DEFINE_METHOD1(int, archive_read_close, (struct archive *p1))
+  DEFINE_METHOD1(int, archive_write_close, (struct archive *p1))
+  DEFINE_METHOD1(const struct stat *, archive_entry_stat, (struct archive_entry *p1))
+
+  BEGIN_METHOD_RESOLVE()
+    RESOLVE_METHOD(archive_read_new)
+    RESOLVE_METHOD(archive_read_support_format_all)
+    RESOLVE_METHOD(archive_read_support_compression_all)
+    RESOLVE_METHOD(archive_write_disk_new)
+    RESOLVE_METHOD(archive_write_disk_set_options)
+    RESOLVE_METHOD(archive_write_disk_set_standard_lookup)
+    RESOLVE_METHOD(archive_read_open2)
+    RESOLVE_METHOD(archive_error_string)
+    RESOLVE_METHOD(archive_read_next_header)
+    RESOLVE_METHOD(archive_entry_pathname)
+    RESOLVE_METHOD(archive_entry_set_pathname)
+    RESOLVE_METHOD(archive_write_header)
+    RESOLVE_METHOD(archive_entry_size)
+    RESOLVE_METHOD(archive_read_data_block)
+    RESOLVE_METHOD(archive_write_data_block)
+    RESOLVE_METHOD(archive_write_finish_entry)
+    RESOLVE_METHOD(archive_read_close)
+    RESOLVE_METHOD(archive_write_close)
+    RESOLVE_METHOD(archive_entry_stat)
+  END_METHOD_RESOLVE()
+};

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -340,11 +340,13 @@ case TMSG_POWERDOWN:
         pSlideShow->Reset();
         if (g_windowManager.GetActiveWindow() != WINDOW_SLIDESHOW)
           g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
-        if (URIUtils::IsZIP(pMsg->strParam) || URIUtils::IsRAR(pMsg->strParam)) // actually a cbz/cbr
+        if (URIUtils::IsArchive(pMsg->strParam) || URIUtils::IsZIP(pMsg->strParam) || URIUtils::IsRAR(pMsg->strParam)) // actually a cbz/cbr
         {
           CFileItemList items;
           CStdString strPath;
-          if (URIUtils::IsZIP(pMsg->strParam))
+          if (URIUtils::IsArchive(pMsg->strParam))
+            URIUtils::CreateArchivePath(strPath, "archive", pMsg->strParam.c_str(), "");
+          else if (URIUtils::IsZIP(pMsg->strParam))
             URIUtils::CreateArchivePath(strPath, "zip", pMsg->strParam.c_str(), "");
           else
             URIUtils::CreateArchivePath(strPath, "rar", pMsg->strParam.c_str(), "");

--- a/xbmc/DllPaths_generated.h.in
+++ b/xbmc/DllPaths_generated.h.in
@@ -36,6 +36,7 @@
 
 #define DLL_PATH_LIBRTMP       "@RTMP_SONAME@"
 #define DLL_PATH_LIBNFS        "@NFS_SONAME@"
+#define DLL_PATH_LIBARCHIVE    "@ARCHIVE_SONAME@"
 
 #ifndef DLL_PATH_LIBCURL
 #define DLL_PATH_LIBCURL       "@CURL_SONAME@"

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -19,6 +19,9 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
@@ -698,7 +701,11 @@ bool CFileItem::IsBDFile() const
 
 bool CFileItem::IsArchive() const
 {
+#ifdef HAVE_LIBARCHIVE
   return URIUtils::IsArchive(m_strPath);
+#else
+  return false;
+#endif
 }
 
 bool CFileItem::IsRAR() const
@@ -713,7 +720,11 @@ bool CFileItem::IsZIP() const
 
 bool CFileItem::IsCBArchive() const
 {
+#ifdef HAVE_LIBARCHIVE
   return URIUtils::GetExtension(m_strPath).Equals(".cbt", false);
+#else
+  return false;
+#endif
 }
 
 bool CFileItem::IsCBZ() const

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -608,6 +608,7 @@ bool CFileItem::IsFileFolder() const
   return (
     IsSmartPlayList() ||
    (IsPlayList() && g_advancedSettings.m_playlistAsFolders) ||
+    IsArchive() ||
     IsZIP() ||
     IsRAR() ||
     IsRSS() ||
@@ -695,6 +696,11 @@ bool CFileItem::IsBDFile() const
   return (strFileName.Equals("index.bdmv"));
 }
 
+bool CFileItem::IsArchive() const
+{
+  return URIUtils::IsArchive(m_strPath);
+}
+
 bool CFileItem::IsRAR() const
 {
   return URIUtils::IsRAR(m_strPath);
@@ -703,6 +709,11 @@ bool CFileItem::IsRAR() const
 bool CFileItem::IsZIP() const
 {
   return URIUtils::IsZIP(m_strPath);
+}
+
+bool CFileItem::IsCBArchive() const
+{
+  return URIUtils::GetExtension(m_strPath).Equals(".cbt", false);
 }
 
 bool CFileItem::IsCBZ() const
@@ -942,7 +953,7 @@ void CFileItem::FillInDefaultIcon()
   {
     if (URIUtils::IsInRAR(m_strPath))
       SetOverlayImage(CGUIListItem::ICON_OVERLAY_RAR);
-    else if (URIUtils::IsInZIP(m_strPath))
+    else if (URIUtils::IsInZIP(m_strPath) || URIUtils::IsInArchive(m_strPath))
       SetOverlayImage(CGUIListItem::ICON_OVERLAY_ZIP);
   }
 }
@@ -1999,6 +2010,7 @@ void CFileItemList::Stack()
       // 1. rars and zips may be on slow sources? is this supposed to be allowed?
       if( !item->IsRemote()
         || item->IsSmb()
+        || URIUtils::IsInArchive(item->m_strPath)
         || URIUtils::IsInRAR(item->m_strPath)
         || URIUtils::IsInZIP(item->m_strPath)
         )

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -106,8 +106,10 @@ public:
   bool IsOpticalMediaFile() const;
   bool IsDVDFile(bool bVobs = true, bool bIfos = true) const;
   bool IsBDFile() const;
+  bool IsArchive() const;
   bool IsRAR() const;
   bool IsZIP() const;
+  bool IsCBArchive() const;
   bool IsCBZ() const;
   bool IsCBR() const;
   bool IsISO9660() const;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3974,7 +3974,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info) const
       return path;
     }
   case LISTITEM_PICTURE_PATH:
-    if (item->IsPicture() && (!item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR()))
+    if (item->IsPicture() && !(item->IsArchive() || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR()))
       return item->m_strPath;
     break;
   case LISTITEM_PICTURE_DATETIME:

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -48,7 +48,7 @@ CImageLoader::~CImageLoader()
 bool CImageLoader::DoWork()
 {
   CFileItem file(m_path, false);
-  if (file.IsPicture() && !(file.IsZIP() || file.IsRAR() || file.IsCBR() || file.IsCBZ())) // ignore non-pictures
+  if (file.IsPicture() && !(file.IsArchive() || file.IsZIP() || file.IsRAR() || file.IsCBR() || file.IsCBZ())) // ignore non-pictures
   { // check for filename only (i.e. lookup in skin/media/)
     CStdString loadPath = g_TextureManager.GetTexturePath(m_path);
 

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -312,7 +312,10 @@ void CURL::Parse(const CStdString& strURL1)
   SetFileName(m_strFileName);
 
   /* decode urlencoding on this stuff */
-  if( m_strProtocol.Equals("rar") || m_strProtocol.Equals("zip") || m_strProtocol.Equals("musicsearch"))
+  if( m_strProtocol.Equals("archive")
+    || m_strProtocol.Equals("rar")
+    || m_strProtocol.Equals("zip")
+    || m_strProtocol.Equals("musicsearch"))
   {
     Decode(m_strHostName);
     // Validate it as it is likely to contain a filename
@@ -466,7 +469,7 @@ const CStdString& CURL::GetProtocolOptions() const
 const CStdString CURL::GetFileNameWithoutPath() const
 {
   // *.zip and *.rar store the actual zip/rar path in the hostname of the url
-  if ((m_strProtocol == "rar" || m_strProtocol == "zip") && m_strFileName.IsEmpty())
+  if ((m_strProtocol == "archive" || m_strProtocol == "rar" || m_strProtocol == "zip") && m_strFileName.IsEmpty())
     return URIUtils::GetFileName(m_strHostName);
 
   // otherwise, we've already got the filepath, so just grab the filename portion
@@ -554,7 +557,9 @@ CStdString CURL::GetWithoutUserDetails() const
 
   if (m_strHostName != "")
   {
-    if (m_strProtocol.Equals("rar") || m_strProtocol.Equals("zip"))
+    if (m_strProtocol.Equals("archive")
+      || m_strProtocol.Equals("rar")
+      || m_strProtocol.Equals("zip"))
       strURL += CURL(m_strHostName).GetWithoutUserDetails();
     else
       strURL += m_strHostName;
@@ -616,7 +621,10 @@ CStdString CURL::GetWithoutFilename() const
 
   if (m_strHostName != "")
   {
-    if( m_strProtocol.Equals("rar") || m_strProtocol.Equals("zip") || m_strProtocol.Equals("musicsearch"))
+    if( m_strProtocol.Equals("archive")
+      || m_strProtocol.Equals("rar")
+      || m_strProtocol.Equals("zip")
+      || m_strProtocol.Equals("musicsearch"))
       strURL += URLEncodeInline(m_strHostName);
     else
       strURL += m_strHostName;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2469,7 +2469,11 @@ int CUtil::ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStd
     else if (URIUtils::GetExtension(strPathInArchive).Equals(".zip"))
       URIUtils::CreateArchivePath(strEmbeddedArchive, "zip", strArchivePath, strPathInArchive);
     else
+#ifdef HAVE_LIBARCHIVE
       URIUtils::CreateArchivePath(strEmbeddedArchive, "archive", strArchivePath, strPathInArchive);
+#else
+      continue;
+#endif
     ScanArchiveForSubtitles(strEmbeddedArchive,strMovieFileNameNoExt,vecSubtitles);
    }
    // done checking if this is an embedded archive

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -144,7 +144,7 @@ void CExternalPlayer::Process()
     // Unwind archive names
     CURL url(m_launchFilename);
     CStdString protocol = url.GetProtocol();
-    if (protocol == "zip" || protocol == "rar"/* || protocol == "iso9660" ??*/)
+    if (protocol == "archive" || protocol == "zip" || protocol == "rar"/* || protocol == "iso9660" ??*/)
     {
       mainFile = url.GetHostName();
       archiveContent = url.GetFileName();

--- a/xbmc/filesystem/ArchiveDirectory.cpp
+++ b/xbmc/filesystem/ArchiveDirectory.cpp
@@ -19,6 +19,12 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
+
+#ifdef HAVE_LIBARCHIVE
+
 #include "ArchiveDirectory.h"
 #include "utils/log.h"
 #include "utils/CharsetConverter.h"
@@ -146,3 +152,5 @@ namespace XFILE
     return false;
   }
 }
+
+#endif // HAVE_LIBARCHIVE

--- a/xbmc/filesystem/ArchiveDirectory.cpp
+++ b/xbmc/filesystem/ArchiveDirectory.cpp
@@ -1,0 +1,148 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "ArchiveDirectory.h"
+#include "utils/log.h"
+#include "utils/CharsetConverter.h"
+#include "utils/URIUtils.h"
+#include "Util.h"
+#include "URL.h"
+#include "ArchiveManager.h"
+#include "FileItem.h"
+
+#include <deque>
+#include <sys/stat.h>
+
+using namespace std;
+namespace XFILE
+{
+  CArchiveDirectory::CArchiveDirectory(){}
+
+  CArchiveDirectory::~CArchiveDirectory(){}
+
+  bool CArchiveDirectory::GetDirectory(const CStdString& strPathOrig, CFileItemList& items)
+  {
+    CStdString strPath;
+
+    /* if this isn't a proper archive path, assume it's the path to a archive file */
+    if( !strPathOrig.Left(10).Equals("archive://") )
+      URIUtils::CreateArchivePath(strPath, "archive", strPathOrig, "");
+    else
+      strPath = strPathOrig;
+
+    CURL url(strPath);
+
+    CStdString strArchive = url.GetHostName();
+    CStdString strOptions = url.GetOptions();
+    CStdString strPathInArchive = url.GetFileName();
+
+    url.SetOptions(""); // delete options to have a clean path to add stuff too
+    url.SetFileName(""); // delete filename too as our names later will contain it
+
+    CStdString strSlashPath = url.Get();
+
+    CStdString strBuffer;
+
+    deque<CArchiveEntry> entries;
+    // turn on fast lookups
+    bool bWasFast(items.GetFastLookup());
+    items.SetFastLookup(true);
+    if (!g_archiveManager.GetArchiveList(strPath,entries))
+      return false;
+
+    vector<CStdString> baseTokens;
+    if (!strPathInArchive.IsEmpty())
+      CUtil::Tokenize(strPathInArchive,baseTokens,"/");
+
+    for (deque<CArchiveEntry>::iterator it = entries.begin(); it != entries.end(); ++it)
+    {
+      CStdString strEntryName;
+      it->get_file(strEntryName);
+      strEntryName.Replace('\\','/');
+      if (strEntryName == strPathInArchive) // skip the listed dir
+        continue;
+
+      vector<CStdString> pathTokens;
+      CUtil::Tokenize(strEntryName,pathTokens,"/");
+      if (pathTokens.size() < baseTokens.size()+1)
+        continue;
+
+      bool bAdd=true;
+      strEntryName = "";
+      for ( unsigned int i=0;i<baseTokens.size();++i )
+      {
+        if (pathTokens[i] != baseTokens[i])
+        {
+          bAdd = false;
+          break;
+        }
+        strEntryName += pathTokens[i] + "/";
+      }
+      if (!bAdd)
+        continue;
+
+      strEntryName += pathTokens[baseTokens.size()];
+      char c=strEntryName.c_str()[strEntryName.size()];
+      if (c == '/' || c == '\\')
+        strEntryName += '/';
+      bool bIsFolder = false;
+      const struct stat *file_stat = it->get_file_stat();
+      if (!S_ISDIR(file_stat->st_mode)) // this is a file
+      {
+        strBuffer = strSlashPath + strEntryName + strOptions;
+      }
+      else
+      { // this is new folder. add if not already added
+        bIsFolder = true;
+        strBuffer = strSlashPath + strEntryName + strOptions;
+        if (items.Contains(strBuffer)) // already added
+          continue;
+      }
+
+      CFileItemPtr pFileItem(new CFileItem);
+
+      if (g_charsetConverter.isValidUtf8(pathTokens[baseTokens.size()]))
+        g_charsetConverter.utf8ToStringCharset(pathTokens[baseTokens.size()]);
+
+      pFileItem->SetLabel(pathTokens[baseTokens.size()]);
+      if (bIsFolder)
+        pFileItem->m_dwSize = 0;
+      else
+        pFileItem->m_dwSize = file_stat->st_size;
+      pFileItem->m_strPath = strBuffer;
+      pFileItem->m_bIsFolder = bIsFolder;
+      if (bIsFolder)
+        URIUtils::AddSlashAtEnd(pFileItem->m_strPath);
+      items.Add(pFileItem);
+    }
+    items.SetFastLookup(bWasFast);
+    return true;
+  }
+
+  bool CArchiveDirectory::ContainsFiles(const CStdString& strPath)
+  {
+    deque<CArchiveEntry> items;
+    g_archiveManager.GetArchiveList(strPath,items);
+    if (!items.empty())
+      return true;
+    return false;
+  }
+}

--- a/xbmc/filesystem/ArchiveDirectory.h
+++ b/xbmc/filesystem/ArchiveDirectory.h
@@ -1,0 +1,41 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#ifndef ARCHIVEDIRECTORY_H_
+#define ARCHIVEDIRECTORY_H_
+
+#include "IFileDirectory.h"
+#include "ArchiveManager.h"
+
+namespace XFILE
+{
+  class CArchiveDirectory : public IFileDirectory
+  {
+  public:
+    CArchiveDirectory();
+    ~CArchiveDirectory();
+    virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
+    virtual bool ContainsFiles(const CStdString& strPath);
+    virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ALWAYS; };
+  };
+}
+
+#endif

--- a/xbmc/filesystem/ArchiveDirectory.h
+++ b/xbmc/filesystem/ArchiveDirectory.h
@@ -22,6 +22,12 @@
 #ifndef ARCHIVEDIRECTORY_H_
 #define ARCHIVEDIRECTORY_H_
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
+
+#ifdef HAVE_LIBARCHIVE
+
 #include "IFileDirectory.h"
 #include "ArchiveManager.h"
 
@@ -37,5 +43,7 @@ namespace XFILE
     virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ALWAYS; };
   };
 }
+
+#endif // HAVE_LIBARCHIVE
 
 #endif

--- a/xbmc/filesystem/ArchiveManager.cpp
+++ b/xbmc/filesystem/ArchiveManager.cpp
@@ -28,6 +28,7 @@
 #include "SpecialProtocol.h"
 #include "Util.h"
 #include "XFileUtils.h"
+#include "threads/SingleLock.h"
 
 #include <sys/stat.h>
 
@@ -314,6 +315,7 @@ bool CArchiveManager::libarchive_extract(const CStdString &strArchive,
 bool CArchiveManager::libarchive_list(const CStdString &strPath,
                                       deque<CArchiveEntry> &items)
 {
+  CSingleLock lock(m_CritSection);
   map<CStdString,deque<CArchiveEntry> >::iterator it = m_archiveMap.find(strPath);
   if (it != m_archiveMap.end())
   {

--- a/xbmc/filesystem/ArchiveManager.cpp
+++ b/xbmc/filesystem/ArchiveManager.cpp
@@ -1,0 +1,352 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "system.h"
+#include "ArchiveManager.h"
+#include "filesystem/File.h"
+#include "utils/log.h"
+#include "URL.h"
+#include "utils/URIUtils.h"
+#include "SpecialProtocol.h"
+#include "Util.h"
+#include "XFileUtils.h"
+
+#include <archive.h>
+#include <archive_entry.h>
+#include <sys/stat.h>
+
+#define LIBARCHIVE_BLOCK_SIZE 10240
+
+using namespace XFILE;
+using namespace std;
+
+struct mydata
+{
+  CFile *file;
+  void *buffer;
+};
+
+static int  file_close(struct archive *, void *);
+static ssize_t  file_read(struct archive *, void *, const void **buff);
+static int64_t  file_skip(struct archive *, void *, int64_t request);
+
+static ssize_t file_read(struct archive *a, void *client_data, const void **buff)
+{
+  struct mydata *data = (struct mydata*)client_data;
+  CFile *file = data->file;
+  *buff = data->buffer;
+  return file->Read(data->buffer, LIBARCHIVE_BLOCK_SIZE);
+}
+
+static int64_t
+file_skip(struct archive *a, void *client_data, int64_t request)
+{
+  struct mydata *data = (struct mydata*)client_data;
+  CFile *file = data->file;
+  int64_t result = file->Seek(request, SEEK_CUR);
+  if (result >= 0)
+    return result;
+
+  /* Let libarchive recover with read+discard. */
+  if (errno == ESPIPE)
+    return 0;
+  archive_set_error(a, errno, "Error seeking");
+  return -1;
+}
+
+static int
+file_close(struct archive *a, void *client_data)
+{
+  struct mydata *data = (struct mydata*)client_data;
+  CFile *file = data->file;
+  free(data->buffer);
+  file->Close();
+  return ARCHIVE_OK;
+}
+
+CArchiveManager g_archiveManager;
+
+CArchiveEntry::CArchiveEntry()
+{
+  m_file.clear();
+  m_file_stat = NULL;
+  m_cache_path.clear();
+}
+CArchiveEntry::~CArchiveEntry()
+{
+  CStdString strCachedDir;
+  if (m_cache_path.length() > 0)
+  {
+    CFile::Delete(m_cache_path);
+    URIUtils::GetDirectory(m_cache_path, strCachedDir);
+    RemoveDirectory(strCachedDir.c_str());
+  }
+}
+void CArchiveEntry::get_file(CStdString &file)
+{
+  file = m_file;
+}
+void CArchiveEntry::set_file(const CStdString &file)
+{
+  m_file = file;
+}
+struct stat *CArchiveEntry::get_file_stat()
+{
+  return m_file_stat;
+}
+void CArchiveEntry::set_file_stat(const struct stat *file_stat)
+{
+  m_file_stat = (struct stat*)file_stat;
+}
+void CArchiveEntry::get_cache_path(CStdString &cache_path)
+{
+  cache_path = m_cache_path;
+}
+void CArchiveEntry::set_cache_path(const CStdString &cache_path)
+{
+  m_cache_path = cache_path;
+}
+
+CArchiveManager::CArchiveManager()
+{
+  m_archiveMap.clear();
+}
+
+CArchiveManager::~CArchiveManager()
+{
+  m_archiveMap.clear();
+}
+
+bool CArchiveManager::GetArchiveList(const CStdString &strPath,
+                                     deque<CArchiveEntry> &items)
+{
+  CURL url(strPath);
+  CStdString strFile = url.GetHostName();
+  return libarchive_list(strFile, items);
+}
+
+bool CArchiveManager::GetArchiveEntry(const CStdString &strPath,
+                                      CArchiveEntry &item)
+{
+  CURL url(strPath);
+
+  CStdString strFile = url.GetHostName();
+
+  map<CStdString,deque<CArchiveEntry> >::iterator it = m_archiveMap.find(strFile);
+  deque<CArchiveEntry> items;
+  if (it == m_archiveMap.end()) // we need to list the archive
+  {
+    GetArchiveList(strPath, items);
+  }
+  else
+  {
+    items = it->second;
+  }
+
+  CStdString strFileName = url.GetFileName();
+  for (deque<CArchiveEntry>::iterator it2=items.begin();it2 != items.end();++it2)
+  {
+    CStdString s;
+    it2->get_file(s);
+    if (s == strFileName)
+    {
+      item = *it2;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool CArchiveManager::ExtractArchive(const CStdString &strArchive,
+                                     const CStdString &strPath,
+                                     const CStdString &strPathInArchive)
+{
+  return libarchive_extract(strArchive, strPath, strPathInArchive);
+}
+
+bool CArchiveManager::CacheArchivedPath(const CStdString &strArchive,
+                                        CArchiveEntry &item)
+{
+  CStdString strCachedPath, strPathInArchive, strDir(_P("special://temp/"));
+  item.get_file(strPathInArchive);
+  URIUtils::AddFileToFolder(strDir + "archivefolder%04d",
+                            URIUtils::GetFileName(strPathInArchive),
+                            strCachedPath);
+  strCachedPath = CUtil::GetNextPathname(strCachedPath, 9999);
+  if (strCachedPath.IsEmpty())
+  {
+    CLog::Log(LOGWARNING, "%s: Could not cache file %s from archive %s.",
+              __FUNCTION__, strPathInArchive.c_str(), strArchive.c_str());
+    return false;
+  }
+  strCachedPath = CUtil::MakeLegalPath(strCachedPath);
+  CStdString strCachedDir;
+  URIUtils::GetDirectory(strCachedPath, strCachedDir);
+  if (!libarchive_extract(strArchive, strCachedDir, strPathInArchive))
+    return false;
+  item.set_cache_path(strCachedPath.c_str());
+  return true;
+}
+
+bool CArchiveManager::libarchive_extract(const CStdString &strArchive,
+                                         const CStdString &strPath,
+                                         const CStdString &strPathInArchive)
+{
+  struct archive *a;
+  struct archive *ext;
+  struct archive_entry *entry;
+  int r;
+  const void *buff;
+  size_t size;
+  off_t offset;
+
+  int flags = ARCHIVE_EXTRACT_PERM | ARCHIVE_EXTRACT_TIME;
+
+  a = archive_read_new();
+  archive_read_support_format_all(a);
+  archive_read_support_compression_all(a);
+  ext = archive_write_disk_new();
+  archive_write_disk_set_options(ext, flags);
+  archive_write_disk_set_standard_lookup(ext);
+
+  CFile file;
+  if (!file.Open(strArchive))
+  {
+    CLog::Log(LOGERROR,"%s: Unable to open file '%s'.", __FUNCTION__,
+              strPath.c_str());
+    return false;
+  }
+  struct mydata data;
+  data.file = &file;
+  data.buffer = calloc(1, LIBARCHIVE_BLOCK_SIZE);
+  r = archive_read_open2(a, &data, NULL, file_read, file_skip, file_close);
+  if (r != ARCHIVE_OK)
+  {
+    CLog::Log(LOGERROR,"%s", archive_error_string(a));
+    return false;
+  }
+  while (1)
+  {
+    r = archive_read_next_header(a, &entry);
+    if (r == ARCHIVE_EOF)
+      break;
+
+    /* Extract single file specified by strPathInArchive if defined */
+    if (strPathInArchive.length() > 0 &&
+      strPathInArchive.compare(archive_entry_pathname(entry)) != 0)
+      continue;
+
+    /* Extract to path if strPath specified, otherwise extract to current
+     * directory.
+     */
+    if (strPath.length() > 0 && strPath.compare(".") != 0)
+    {
+      CStdString destpath(strPath);
+      URIUtils::AddSlashAtEnd(destpath);
+      destpath.append(archive_entry_pathname(entry));
+      archive_entry_set_pathname(entry, destpath);
+    }
+    if (r != ARCHIVE_OK)
+      CLog::Log(LOGERROR,"%s", archive_error_string(a));
+    if (r < ARCHIVE_WARN)
+      return false;
+    r = archive_write_header(ext, entry);
+    if (r != ARCHIVE_OK)
+      CLog::Log(LOGERROR,"%s", archive_error_string(ext));
+    else if (archive_entry_size(entry) > 0) {
+      while (1) {
+        r = archive_read_data_block(a, &buff, &size, &offset);
+        if (r == ARCHIVE_EOF)
+          break;
+        r = archive_write_data_block(ext, buff, size, offset);
+        if (r != ARCHIVE_OK) {
+          CLog::Log(LOGERROR,"%s", archive_error_string(ext));
+          break;
+        }
+      }
+      if (r < ARCHIVE_WARN)
+        return false;
+    }
+    r = archive_write_finish_entry(ext);
+    if (r != ARCHIVE_OK)
+      CLog::Log(LOGERROR,"%s", archive_error_string(ext));
+    if (r < ARCHIVE_WARN)
+      return false;
+    if (strPathInArchive.length() > 0)
+      break;
+  }
+
+  archive_read_close(a);
+  archive_write_close(ext);
+  return true;
+}
+
+bool CArchiveManager::libarchive_list(const CStdString &strPath,
+                                      deque<CArchiveEntry> &items)
+{
+  map<CStdString,deque<CArchiveEntry> >::iterator it = m_archiveMap.find(strPath);
+  if (it != m_archiveMap.end())
+  {
+    items = (*it).second;
+    return true;
+  }
+
+  struct archive *a;
+  struct archive_entry *entry;
+  int r;
+
+  a = archive_read_new();
+  archive_read_support_compression_all(a);
+  archive_read_support_format_all(a);
+
+  CFile file;
+  if (!file.Open(strPath))
+  {
+    CLog::Log(LOGERROR,"%s: Unable to open file '%s'.", __FUNCTION__,
+              strPath.c_str());
+    return false;
+  }
+  struct mydata data;
+  data.file = &file;
+  data.buffer = calloc(1, LIBARCHIVE_BLOCK_SIZE);
+  r = archive_read_open2(a, &data, NULL, file_read, file_skip, file_close);
+  if (r != ARCHIVE_OK)
+  {
+    CLog::Log(LOGERROR,"%s", archive_error_string(a));
+    return false;
+  }
+  while (archive_read_next_header(a, &entry) == ARCHIVE_OK) {
+    CArchiveEntry e;
+    CStdString file(archive_entry_pathname(entry));
+    e.set_file(file);
+    e.set_file_stat(archive_entry_stat(entry));
+    items.push_back(e);
+  }
+  r = archive_read_close(a);
+  if (r != ARCHIVE_OK)
+  {
+    CLog::Log(LOGERROR,"Error closing archive file '%s'",
+              strPath.c_str());
+    return false;
+  }
+  m_archiveMap.insert(pair<CStdString,deque<CArchiveEntry> >(strPath, items));
+  return true;
+}

--- a/xbmc/filesystem/ArchiveManager.cpp
+++ b/xbmc/filesystem/ArchiveManager.cpp
@@ -19,6 +19,12 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
+
+#ifdef HAVE_LIBARCHIVE
+
 #include "system.h"
 #include "ArchiveManager.h"
 #include "filesystem/File.h"
@@ -369,3 +375,5 @@ bool CArchiveManager::libarchive_list(const CStdString &strPath,
   m_archiveMap.insert(pair<CStdString,deque<CArchiveEntry> >(strPath, items));
   return true;
 }
+
+#endif // HAVE_LIBARCHIVE

--- a/xbmc/filesystem/ArchiveManager.h
+++ b/xbmc/filesystem/ArchiveManager.h
@@ -22,6 +22,12 @@
 #ifndef ARCHIVE_MANAGER_H_
 #define ARCHIVE_MANAGER_H_
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
+
+#ifdef HAVE_LIBARCHIVE
+
 #include "utils/StdString.h"
 #include "DllLibArchive.h"
 #include "threads/CriticalSection.h"
@@ -72,5 +78,7 @@ private:
 };
 
 extern CArchiveManager g_archiveManager;
+
+#endif // HAVE_LIBARCHIVE
 
 #endif

--- a/xbmc/filesystem/ArchiveManager.h
+++ b/xbmc/filesystem/ArchiveManager.h
@@ -1,0 +1,71 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#ifndef ARCHIVE_MANAGER_H_
+#define ARCHIVE_MANAGER_H_
+
+#include  "utils/StdString.h"
+
+#include <deque>
+#include <map>
+
+class CArchiveEntry
+{
+public:
+  CArchiveEntry();
+  ~CArchiveEntry();
+  void get_file(CStdString &file);
+  void set_file(const CStdString &file);
+  struct stat *get_file_stat();
+  void set_file_stat(const struct stat *file_stat);
+  void get_cache_path(CStdString &cache_path);
+  void set_cache_path(const CStdString &cache_path);
+private:
+  CStdString m_file;
+  struct stat *m_file_stat;
+  CStdString m_cache_path;
+};
+
+class CArchiveManager
+{
+public:
+  CArchiveManager();
+  ~CArchiveManager();
+
+  bool GetArchiveList(const CStdString &strPath,
+                      std::deque<CArchiveEntry> &items);
+  bool GetArchiveEntry(const CStdString &strPath, CArchiveEntry &item);
+  bool ExtractArchive(const CStdString &strArchive, const CStdString &strPath,
+                      const CStdString &strPathInArchive);
+  bool CacheArchivedPath(const CStdString &strArchive,
+                         CArchiveEntry &item);
+private:
+  std::map<CStdString,std::deque<CArchiveEntry> > m_archiveMap;
+  bool libarchive_extract(const CStdString &strArchive,
+                          const CStdString &strPath,
+                          const CStdString &strPathInArchive);
+  bool libarchive_list(const CStdString &strPath,
+                       std::deque<CArchiveEntry> &items);
+};
+
+extern CArchiveManager g_archiveManager;
+
+#endif

--- a/xbmc/filesystem/ArchiveManager.h
+++ b/xbmc/filesystem/ArchiveManager.h
@@ -23,6 +23,7 @@
 #define ARCHIVE_MANAGER_H_
 
 #include  "utils/StdString.h"
+#include "DllLibArchive.h"
 
 #include <deque>
 #include <map>
@@ -59,6 +60,8 @@ public:
                          CArchiveEntry &item);
 private:
   std::map<CStdString,std::deque<CArchiveEntry> > m_archiveMap;
+  DllLibArchive m_dllLibArchive;
+  bool Load();
   bool libarchive_extract(const CStdString &strArchive,
                           const CStdString &strPath,
                           const CStdString &strPathInArchive);

--- a/xbmc/filesystem/ArchiveManager.h
+++ b/xbmc/filesystem/ArchiveManager.h
@@ -22,7 +22,7 @@
 #ifndef ARCHIVE_MANAGER_H_
 #define ARCHIVE_MANAGER_H_
 
-#include  "utils/StdString.h"
+#include "utils/StdString.h"
 #include "DllLibArchive.h"
 
 #include <deque>

--- a/xbmc/filesystem/ArchiveManager.h
+++ b/xbmc/filesystem/ArchiveManager.h
@@ -24,6 +24,7 @@
 
 #include "utils/StdString.h"
 #include "DllLibArchive.h"
+#include "threads/CriticalSection.h"
 
 #include <deque>
 #include <map>
@@ -61,6 +62,7 @@ public:
 private:
   std::map<CStdString,std::deque<CArchiveEntry> > m_archiveMap;
   DllLibArchive m_dllLibArchive;
+  CCriticalSection m_CritSection;
   bool Load();
   bool libarchive_extract(const CStdString &strArchive,
                           const CStdString &strPath,

--- a/xbmc/filesystem/FactoryDirectory.cpp
+++ b/xbmc/filesystem/FactoryDirectory.cpp
@@ -76,6 +76,7 @@
 #ifdef HAS_FILESYSTEM_HTSP
 #include "HTSPDirectory.h"
 #endif
+#include "ArchiveDirectory.h"
 #include "ZipDirectory.h"
 #ifdef HAS_FILESYSTEM_RAR
 #include "RarDirectory.h"
@@ -125,6 +126,7 @@ IDirectory* CFactoryDirectory::Create(const CStdString& strPath)
 #endif
   if (strProtocol == "udf") return new CUDFDirectory();
   if (strProtocol == "plugin") return new CPluginDirectory();
+  if (strProtocol == "archive") return new CArchiveDirectory();
   if (strProtocol == "zip") return new CZipDirectory();
 #ifdef HAS_FILESYSTEM_RAR
   if (strProtocol == "rar") return new CRarDirectory();

--- a/xbmc/filesystem/FactoryDirectory.cpp
+++ b/xbmc/filesystem/FactoryDirectory.cpp
@@ -126,7 +126,9 @@ IDirectory* CFactoryDirectory::Create(const CStdString& strPath)
 #endif
   if (strProtocol == "udf") return new CUDFDirectory();
   if (strProtocol == "plugin") return new CPluginDirectory();
+#ifdef HAVE_LIBARCHIVE
   if (strProtocol == "archive") return new CArchiveDirectory();
+#endif
   if (strProtocol == "zip") return new CZipDirectory();
 #ifdef HAS_FILESYSTEM_RAR
   if (strProtocol == "rar") return new CRarDirectory();

--- a/xbmc/filesystem/FactoryFileDirectory.cpp
+++ b/xbmc/filesystem/FactoryFileDirectory.cpp
@@ -113,6 +113,7 @@ IFileDirectory* CFactoryFileDirectory::Create(const CStdString& strPath, CFileIt
     return new CRSSDirectory();
 
 #endif
+#ifdef HAVE_LIBARCHIVE
   if (strExtension.Equals(".tar")
     || strExtension.Equals(".gz")
     || strExtension.Equals(".bz")
@@ -137,6 +138,7 @@ IFileDirectory* CFactoryFileDirectory::Create(const CStdString& strPath, CFileIt
     }
     return NULL;
   }
+#endif
   if (strExtension.Equals(".zip"))
   {
     CStdString strUrl;

--- a/xbmc/filesystem/FileArchive.cpp
+++ b/xbmc/filesystem/FileArchive.cpp
@@ -1,0 +1,126 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "FileArchive.h"
+#include "URL.h"
+#include "utils/URIUtils.h"
+
+#include <deque>
+#include <sys/stat.h>
+
+using namespace XFILE;
+using namespace std;
+
+CFileArchive::CFileArchive()
+{
+  m_bCached = false;
+}
+
+CFileArchive::~CFileArchive()
+{
+  Close();
+}
+
+bool CFileArchive::Open(const CURL&url)
+{
+  CStdString strOpts = url.GetOptions();
+  CURL url2(url);
+  url2.SetOptions("");
+  CStdString strPath = url2.Get();
+  if (!g_archiveManager.GetArchiveEntry(strPath,m_archiveItem))
+    return false;
+
+  CStdString cache_path;
+  m_archiveItem.get_cache_path(cache_path);
+
+  if (cache_path.length() <= 0)
+  {
+    CStdString file;
+    m_archiveItem.get_file(file);
+    if (!g_archiveManager.CacheArchivedPath(url2.GetHostName(),m_archiveItem))
+      return false;
+    m_archiveItem.get_cache_path(cache_path);
+  }
+
+  return mFile.Open(cache_path);
+}
+
+int64_t CFileArchive::GetLength()
+{
+  return m_archiveItem.get_file_stat()->st_size;
+}
+
+int64_t CFileArchive::GetPosition()
+{
+  return mFile.GetPosition();
+}
+
+int64_t CFileArchive::Seek(int64_t iFilePosition, int iWhence)
+{
+  return mFile.Seek(iFilePosition,iWhence);
+}
+
+bool CFileArchive::Exists(const CURL& url)
+{
+  CArchiveEntry item;
+  if (g_archiveManager.GetArchiveEntry(url.Get(),item))
+    return true;
+  return false;
+}
+
+int CFileArchive::Stat(struct __stat64 *buffer)
+{
+  /* libarchive doesn't support stat64 yet */
+  const struct stat *s = m_archiveItem.get_file_stat();
+  if (!s)
+    return -1;
+  buffer->st_dev = s->st_dev;
+  buffer->st_ino = s->st_ino;
+  buffer->st_mode = s->st_mode;
+  buffer->st_nlink = s->st_nlink;
+  buffer->st_uid = s->st_uid;
+  buffer->st_gid = s->st_gid;
+  buffer->st_rdev = s->st_rdev;
+  buffer->st_size = s->st_size;
+  buffer->st_atime = s->st_atime;
+  buffer->st_mtime = s->st_mtime;
+  buffer->st_ctime = s->st_ctime;
+  buffer->st_blksize = s->st_blksize;
+  buffer->st_blocks = s->st_blocks;
+  return 0;
+}
+
+int CFileArchive::Stat(const CURL& url, struct __stat64* buffer)
+{
+  if (!g_archiveManager.GetArchiveEntry(url.Get(),m_archiveItem))
+    return -1;
+  return Stat(buffer);
+}
+
+unsigned int CFileArchive::Read(void* lpBuf, int64_t uiBufSize)
+{
+  return mFile.Read(lpBuf,uiBufSize);
+}
+
+void CFileArchive::Close()
+{
+  mFile.Close();
+}

--- a/xbmc/filesystem/FileArchive.cpp
+++ b/xbmc/filesystem/FileArchive.cpp
@@ -19,6 +19,12 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
+
+#ifdef HAVE_LIBARCHIVE
+
 #include "FileArchive.h"
 #include "URL.h"
 #include "utils/URIUtils.h"
@@ -124,3 +130,5 @@ void CFileArchive::Close()
 {
   mFile.Close();
 }
+
+#endif // HAVE_LIBARCHIVE

--- a/xbmc/filesystem/FileArchive.h
+++ b/xbmc/filesystem/FileArchive.h
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#ifndef FILE_ARCHIVE_H_
+#define FILE_ARCHIVE_H_
+
+#include "IFile.h"
+#include "utils/log.h"
+#include "File.h"
+#include "ArchiveManager.h"
+
+namespace XFILE
+{
+  class CFileArchive : public IFile
+  {
+  public:
+    CFileArchive();
+    virtual ~CFileArchive();
+
+    virtual int64_t GetPosition();
+    virtual int64_t GetLength();
+    virtual bool Open(const CURL& url);
+    virtual bool Exists(const CURL& url);
+    virtual int Stat(struct __stat64* buffer);
+    virtual int Stat(const CURL& url, struct __stat64* buffer);
+    virtual unsigned int Read(void* lpBuf, int64_t uiBufSize);
+    virtual int64_t Seek(int64_t iFilePosition, int iWhence = SEEK_SET);
+    virtual void Close();
+  private:
+    CFile mFile;
+    bool m_bCached;
+    CArchiveEntry m_archiveItem;
+  };
+}
+
+#endif

--- a/xbmc/filesystem/FileArchive.h
+++ b/xbmc/filesystem/FileArchive.h
@@ -22,6 +22,12 @@
 #ifndef FILE_ARCHIVE_H_
 #define FILE_ARCHIVE_H_
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
+
+#ifdef HAVE_LIBARCHIVE
+
 #include "IFile.h"
 #include "utils/log.h"
 #include "File.h"
@@ -50,5 +56,7 @@ namespace XFILE
     CArchiveEntry m_archiveItem;
   };
 }
+
+#endif
 
 #endif

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -96,8 +96,10 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   CStdString strProtocol = url.GetProtocol();
   strProtocol.MakeLower();
 
-  if (strProtocol == "archive") return new CFileArchive();
-  else if (strProtocol == "zip") return new CFileZip();
+  if (strProtocol == "zip") return new CFileZip();
+#ifdef HAVE_LIBARCHIVE
+  else if (strProtocol == "archive") return new CFileArchive();
+#endif
 #ifdef HAS_FILESYSTEM_RAR
   else if (strProtocol == "rar") return new CFileRar();
 #endif

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -55,6 +55,7 @@
 #ifdef HAS_FILESYSTEM_VTP
 #include "VTPFile.h"
 #endif
+#include "FileArchive.h"
 #include "FileZip.h"
 #ifdef HAS_FILESYSTEM_RAR
 #include "FileRar.h"
@@ -95,7 +96,8 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   CStdString strProtocol = url.GetProtocol();
   strProtocol.MakeLower();
 
-  if (strProtocol == "zip") return new CFileZip();
+  if (strProtocol == "archive") return new CFileArchive();
+  else if (strProtocol == "zip") return new CFileZip();
 #ifdef HAS_FILESYSTEM_RAR
   else if (strProtocol == "rar") return new CFileRar();
 #endif

--- a/xbmc/filesystem/Makefile.in
+++ b/xbmc/filesystem/Makefile.in
@@ -35,6 +35,7 @@ SRCS=AddonsDirectory.cpp \
      FileSpecialProtocol.cpp \
      FileTuxBox.cpp \
      FileUDF.cpp \
+     FileArchive.cpp \
      FileZip.cpp \
      FTPDirectory.cpp \
      FTPParse.cpp \
@@ -84,6 +85,8 @@ SRCS=AddonsDirectory.cpp \
      VTPFile.cpp \
      VTPSession.cpp \
      ZeroconfDirectory.cpp \
+     ArchiveDirectory.cpp \
+     ArchiveManager.cpp \
      ZipDirectory.cpp \
      ZipManager.cpp \
 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -54,6 +54,7 @@
 #include "Util.h"
 
 #include "filesystem/PluginDirectory.h"
+#include "filesystem/ArchiveManager.h"
 #ifdef HAS_FILESYSTEM_RAR
 #include "filesystem/RarManager.h"
 #endif
@@ -415,7 +416,9 @@ int CBuiltins::Execute(const CStdString& execString)
 
     URIUtils::AddSlashAtEnd(strDestDirect);
 
-    if (URIUtils::IsZIP(params[0]))
+    if (URIUtils::IsArchive(params[0]))
+      g_archiveManager.ExtractArchive(params[0],strDestDirect,"");
+    else if (URIUtils::IsZIP(params[0]))
       g_ZipManager.ExtractArchive(params[0],strDestDirect);
 #ifdef HAS_FILESYSTEM_RAR
     else if (URIUtils::IsRAR(params[0]))

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -416,10 +416,12 @@ int CBuiltins::Execute(const CStdString& execString)
 
     URIUtils::AddSlashAtEnd(strDestDirect);
 
-    if (URIUtils::IsArchive(params[0]))
-      g_archiveManager.ExtractArchive(params[0],strDestDirect,"");
-    else if (URIUtils::IsZIP(params[0]))
+    if (URIUtils::IsZIP(params[0]))
       g_ZipManager.ExtractArchive(params[0],strDestDirect);
+#ifdef HAVE_LIBARCHIVE
+    else if (URIUtils::IsArchive(params[0]))
+      g_archiveManager.ExtractArchive(params[0],strDestDirect,"");
+#endif
 #ifdef HAS_FILESYSTEM_RAR
     else if (URIUtils::IsRAR(params[0]))
       g_RarManager.ExtractArchive(params[0],strDestDirect);

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -704,7 +704,7 @@ int CXbmcHttp::xbmcGetMediaLocation(int numParas, CStdString paras[])
   // special locations
   bool bSpecial = false;
   CURL url(strLocation);
-  if (url.GetProtocol() == "rar" || url.GetProtocol() == "zip")
+  if (url.GetProtocol() == "archive" || url.GetProtocol() == "rar" || url.GetProtocol() == "zip")
     bSpecial = true;
   if (strType.Equals("music"))
   {

--- a/xbmc/interfaces/python/xbmcmodule/dialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/dialog.cpp
@@ -19,6 +19,10 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
+
 #include "dialog.h"
 
 #include "Application.h"
@@ -185,7 +189,11 @@ namespace PYXBMC
     if (!shares) return NULL;
 
     if (useFileDirectories && !utf8Line[2].size() == 0)
+#ifdef HAVE_LIBARCHIVE
       utf8Line[2] += "|.tar|.gz|.bz|.bz2|.rar|.zip";
+#else
+      utf8Line[2] += "|.rar|.zip";
+#endif
 
     value = cDefault;
 

--- a/xbmc/interfaces/python/xbmcmodule/dialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/dialog.cpp
@@ -185,7 +185,7 @@ namespace PYXBMC
     if (!shares) return NULL;
 
     if (useFileDirectories && !utf8Line[2].size() == 0)
-      utf8Line[2] += "|.rar|.zip";
+      utf8Line[2] += "|.tar|.gz|.bz|.bz2|.rar|.zip";
 
     value = cDefault;
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -622,7 +622,7 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem)
   // add item 2 playlist (make a copy as we alter the queuing state)
   CFileItemPtr item(new CFileItem(*m_vecItems->Get(iItem)));
 
-  if (item->IsRAR() || item->IsZIP())
+  if (item->IsArchive() || item->IsRAR() || item->IsZIP())
     return;
 
   //  Allow queuing of unqueueable items
@@ -660,7 +660,7 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem)
 /// \param pItem The file item to add
 void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItemList &queuedItems)
 {
-  if (!pItem->CanQueue() || pItem->IsRAR() || pItem->IsZIP() || pItem->IsParentFolder()) // no zip/rar enques thank you!
+  if (!pItem->CanQueue() || pItem->IsArchive() || pItem->IsRAR() || pItem->IsZIP() || pItem->IsParentFolder()) // no zip/rar enques thank you!
     return;
 
   // fast lookup is needed here

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -254,10 +254,12 @@ bool CGUIWindowPictures::OnClick(int iItem)
   if ( iItem < 0 || iItem >= (int)m_vecItems->Size() ) return true;
   CFileItemPtr pItem = m_vecItems->Get(iItem);
 
-  if (pItem->IsCBZ() || pItem->IsCBR())
+  if (pItem->IsCBArchive() || pItem->IsCBZ() || pItem->IsCBR())
   {
     CStdString strComicPath;
-    if (pItem->IsCBZ())
+    if (pItem->IsCBArchive())
+      URIUtils::CreateArchivePath(strComicPath, "archive", pItem->m_strPath, "");
+    else if (pItem->IsCBZ())
       URIUtils::CreateArchivePath(strComicPath, "zip", pItem->m_strPath, "");
     else
       URIUtils::CreateArchivePath(strComicPath, "rar", pItem->m_strPath, "");
@@ -315,7 +317,8 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
   for (int i = 0; i < (int)m_vecItems->Size();++i)
   {
     CFileItemPtr pItem = m_vecItems->Get(i);
-    if (!pItem->m_bIsFolder && !(URIUtils::IsRAR(pItem->m_strPath) || 
+    if (!pItem->m_bIsFolder && !(URIUtils::IsArchive(pItem->m_strPath) ||
+          URIUtils::IsRAR(pItem->m_strPath) ||
           URIUtils::IsZIP(pItem->m_strPath)) && (pItem->IsPicture() || (
                                 g_guiSettings.GetBool("pictures.showvideos") &&
                                 pItem->IsVideo())))
@@ -428,7 +431,7 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
     {
       if (item)
       {
-        if (!(item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR()))
+        if (!(item->m_bIsFolder || item->IsArchive() || item->IsZIP() || item->IsRAR() || item->IsCBArchive() || item->IsCBZ() || item->IsCBR()))
           buttons.Add(CONTEXT_BUTTON_INFO, 13406); // picture info
         buttons.Add(CONTEXT_BUTTON_VIEW_SLIDESHOW, item->m_bIsFolder ? 13317 : 13422);      // View Slideshow
         if (item->m_bIsFolder)
@@ -539,7 +542,7 @@ void CGUIWindowPictures::LoadPlayList(const CStdString& strPlayList)
     {
       CFileItemPtr pItem = playlist[i];
       //CLog::Log(LOGDEBUG,"-- playlist item: %s", pItem->m_strPath.c_str());
-      if (pItem->IsPicture() && !(pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBZ() || pItem->IsCBR()))
+      if (pItem->IsPicture() && !(pItem->IsArchive() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBArchive() || pItem->IsCBZ() || pItem->IsCBR()))
         pSlideShow->Add(pItem.get());
     }
 
@@ -553,7 +556,7 @@ void CGUIWindowPictures::LoadPlayList(const CStdString& strPlayList)
 void CGUIWindowPictures::OnInfo(int itemNumber)
 {
   CFileItemPtr item = (itemNumber >= 0 && itemNumber < m_vecItems->Size()) ? m_vecItems->Get(itemNumber) : CFileItemPtr();
-  if (!item || item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR() || !item->IsPicture())
+  if (!item || item->m_bIsFolder || item->IsArchive() || item->IsZIP() || item->IsRAR() || item->IsCBArchive() || item->IsCBZ() || item->IsCBR() || !item->IsPicture())
     return;
   CGUIDialogPictureInfo *pictureInfo = (CGUIDialogPictureInfo *)g_windowManager.GetWindow(WINDOW_DIALOG_PICTURE_INFO);
   if (pictureInfo)

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -889,7 +889,7 @@ void CGUIWindowSlideShow::AddItems(const CStdString &strPath, path_set *recursiv
     {
       AddItems(item->m_strPath, recursivePaths);
     }
-    else if (!item->m_bIsFolder && !URIUtils::IsRAR(item->m_strPath) && !URIUtils::IsZIP(item->m_strPath))
+    else if (!item->m_bIsFolder && !URIUtils::IsArchive(item->m_strPath) && !URIUtils::IsRAR(item->m_strPath) && !URIUtils::IsZIP(item->m_strPath))
     { // add to the slideshow
       Add(item.get());
     }

--- a/xbmc/pictures/PictureInfoLoader.cpp
+++ b/xbmc/pictures/PictureInfoLoader.cpp
@@ -54,7 +54,7 @@ bool CPictureInfoLoader::LoadItem(CFileItem* pItem)
   if (m_pProgressCallback && !pItem->m_bIsFolder)
     m_pProgressCallback->SetProgressAdvance();
 
-  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() || pItem->IsInternetStream() || pItem->IsVideo())
+  if (!pItem->IsPicture() || pItem->IsArchive() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBArchive() || pItem->IsCBR() || pItem->IsCBZ() || pItem->IsInternetStream() || pItem->IsVideo())
     return false;
 
   if (pItem->HasPictureInfoTag())

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -61,12 +61,12 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
   }
 
   CStdString thumb;
-  if (pItem->IsPicture() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
+  if (pItem->IsPicture() && !pItem->IsArchive() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBArchive() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
   { // load the thumb from the image file
     CStdString image = pItem->HasThumbnail() ? pItem->GetThumbnailImage() : CTextureCache::GetWrappedThumbURL(pItem->m_strPath);
     thumb = CTextureCache::Get().CheckAndCacheImage(image);
   }
-  else if (pItem->IsVideo() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
+  else if (pItem->IsVideo() && !pItem->IsArchive() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBArchive() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
   { // video
     thumb = pItem->GetCachedVideoThumb();
     if (CFile::Exists(thumb))
@@ -150,6 +150,11 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
     // first check for a folder.jpg
     CStdString thumb = "folder.jpg";
     CStdString strPath = pItem->m_strPath;
+    if (pItem->IsCBArchive())
+    {
+      URIUtils::CreateArchivePath(strPath,"archive",pItem->m_strPath,"");
+      thumb = "cover.jpg";
+    }
     if (pItem->IsCBR())
     {
       URIUtils::CreateArchivePath(strPath,"rar",pItem->m_strPath,"");
@@ -183,7 +188,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       // count the number of images
       for (int i=0; i < items.Size();)
       {
-        if (!items[i]->IsPicture() || items[i]->IsZIP() || items[i]->IsRAR() || items[i]->IsPlayList())
+        if (!items[i]->IsPicture() || items[i]->IsArchive() || items[i]->IsZIP() || items[i]->IsRAR() || items[i]->IsPlayList())
         {
           items.Remove(i);
         }

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -102,9 +102,14 @@ void CSettings::Initialize()
   m_fPixelRatio = 1.0f;
   m_bNonLinStretch = false;
 
-  m_pictureExtensions = ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.tar|.gz|.bz|.bz2|.zip|.cbr|.rar|.m3u|.dng|.nef|.cr2|.crw|.orf|.arw|.erf|.3fr|.dcr|.x3f|.mef|.raf|.mrw|.pef|.sr2|.rss";
-  m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.mod|.amf|.669|.dmf|.dsm|.far|.gdm|.imf|.it|.m15|.med|.okt|.s3m|.stm|.sfx|.ult|.uni|.xm|.sid|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.tar|.gz|.bz|.bz2|.zip|.rar|.wv|.nsf|.spc|.gym|.adx|.dsp|.adp|.ymf|.ast|.afc|.hps|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.mid|.kar|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.cm3|.cms|.dlt|.brstm|.wtv";
-  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.m3u|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.tar|.gz|.bz|.bz2|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv";
+  m_pictureExtensions = ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.zip|.cbr|.rar|.m3u|.dng|.nef|.cr2|.crw|.orf|.arw|.erf|.3fr|.dcr|.x3f|.mef|.raf|.mrw|.pef|.sr2|.rss";
+  m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.mod|.amf|.669|.dmf|.dsm|.far|.gdm|.imf|.it|.m15|.med|.okt|.s3m|.stm|.sfx|.ult|.uni|.xm|.sid|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.rar|.wv|.nsf|.spc|.gym|.adx|.dsp|.adp|.ymf|.ast|.afc|.hps|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.mid|.kar|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.cm3|.cms|.dlt|.brstm|.wtv";
+  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.m3u|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv";
+#ifdef HAVE_LIBARCHIVE
+  m_pictureExtensions += "|.tar|.gz|.bz|.bz2";
+  m_musicExtensions += "|.tar|.gz|.bz|.bz2";
+  m_videoExtensions += "|.tar|.gz|.bz|.bz2";
+#endif
   m_discStubExtensions = ".disc";
   // internal music extensions
   m_musicExtensions += "|.sidstream|.oggstream|.nsfstream|.asapstream|.cdda";

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -102,9 +102,9 @@ void CSettings::Initialize()
   m_fPixelRatio = 1.0f;
   m_bNonLinStretch = false;
 
-  m_pictureExtensions = ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.zip|.cbr|.rar|.m3u|.dng|.nef|.cr2|.crw|.orf|.arw|.erf|.3fr|.dcr|.x3f|.mef|.raf|.mrw|.pef|.sr2|.rss";
-  m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.mod|.amf|.669|.dmf|.dsm|.far|.gdm|.imf|.it|.m15|.med|.okt|.s3m|.stm|.sfx|.ult|.uni|.xm|.sid|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.rar|.wv|.nsf|.spc|.gym|.adx|.dsp|.adp|.ymf|.ast|.afc|.hps|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.mid|.kar|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.cm3|.cms|.dlt|.brstm|.wtv";
-  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.m3u|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv";
+  m_pictureExtensions = ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.tar|.gz|.bz|.bz2|.zip|.cbr|.rar|.m3u|.dng|.nef|.cr2|.crw|.orf|.arw|.erf|.3fr|.dcr|.x3f|.mef|.raf|.mrw|.pef|.sr2|.rss";
+  m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.mod|.amf|.669|.dmf|.dsm|.far|.gdm|.imf|.it|.m15|.med|.okt|.s3m|.stm|.sfx|.ult|.uni|.xm|.sid|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.tar|.gz|.bz|.bz2|.zip|.rar|.wv|.nsf|.spc|.gym|.adx|.dsp|.adp|.ymf|.ast|.afc|.hps|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.mid|.kar|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.cm3|.cms|.dlt|.brstm|.wtv";
+  m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.m3u|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.tar|.gz|.bz|.bz2|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv";
   m_discStubExtensions = ".disc";
   // internal music extensions
   m_musicExtensions += "|.sidstream|.oggstream|.nsfstream|.asapstream|.cdda";

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -215,7 +215,9 @@ bool URIUtils::GetParentPath(const CStdString& strPath, CStdString& strParent)
 
   CURL url(strPath);
   CStdString strFile = url.GetFileName();
-  if ( ((url.GetProtocol() == "rar") || (url.GetProtocol() == "zip")) && strFile.IsEmpty())
+  if ( ((url.GetProtocol() == "archive")
+    || (url.GetProtocol() == "rar")
+    || (url.GetProtocol() == "zip")) && strFile.IsEmpty())
   {
     strFile = url.GetHostName();
     return GetParentPath(strFile, strParent);
@@ -226,14 +228,18 @@ bool URIUtils::GetParentPath(const CStdString& strPath, CStdString& strParent)
     CFileItemList items;
     dir.GetDirectory(strPath,items);
     GetDirectory(items[0]->m_strPath,items[0]->m_strDVDLabel);
-    if (items[0]->m_strDVDLabel.Mid(0,6).Equals("rar://") || items[0]->m_strDVDLabel.Mid(0,6).Equals("zip://"))
+    if (items[0]->m_strDVDLabel.Mid(0,10).Equals("archive://")
+      || items[0]->m_strDVDLabel.Mid(0,6).Equals("rar://")
+      || items[0]->m_strDVDLabel.Mid(0,6).Equals("zip://"))
       GetParentPath(items[0]->m_strDVDLabel, strParent);
     else
       strParent = items[0]->m_strDVDLabel;
     for( int i=1;i<items.Size();++i)
     {
       GetDirectory(items[i]->m_strPath,items[i]->m_strDVDLabel);
-      if (items[0]->m_strDVDLabel.Mid(0,6).Equals("rar://") || items[0]->m_strDVDLabel.Mid(0,6).Equals("zip://"))
+      if (items[0]->m_strDVDLabel.Mid(0,10).Equals("archive://")
+        || items[0]->m_strDVDLabel.Mid(0,6).Equals("rar://")
+        || items[0]->m_strDVDLabel.Mid(0,6).Equals("zip://"))
         GetParentPath(items[i]->m_strDVDLabel, items[i]->m_strPath);
       else
         items[i]->m_strPath = items[i]->m_strDVDLabel;
@@ -485,6 +491,20 @@ bool URIUtils::IsStack(const CStdString& strFile)
   return strFile.Left(6).Equals("stack:");
 }
 
+bool URIUtils::IsArchive(const CStdString& strFile)
+{
+  CStdString strExtension;
+  GetExtension(strFile,strExtension);
+
+  if (strExtension.CompareNoCase(".tar") == 0
+    || strExtension.CompareNoCase(".gz") == 0
+    || strExtension.CompareNoCase(".bz") == 0
+    || strExtension.CompareNoCase(".bz2") == 0)
+    return true;
+
+  return false;
+}
+
 bool URIUtils::IsRAR(const CStdString& strFile)
 {
   CStdString strExtension;
@@ -504,7 +524,9 @@ bool URIUtils::IsRAR(const CStdString& strFile)
 
 bool URIUtils::IsInArchive(const CStdString &strFile)
 {
-  return IsInZIP(strFile) || IsInRAR(strFile);
+  CURL url(strFile);
+
+  return url.GetProtocol() == "archive" && url.GetFileName() != "";
 }
 
 bool URIUtils::IsInZIP(const CStdString& strFile)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -19,6 +19,9 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
 #include "URIUtils.h"
 #include "Application.h"
 #include "FileItem.h"
@@ -493,6 +496,7 @@ bool URIUtils::IsStack(const CStdString& strFile)
 
 bool URIUtils::IsArchive(const CStdString& strFile)
 {
+#ifdef HAVE_LIBARCHIVE
   CStdString strExtension;
   GetExtension(strFile,strExtension);
 
@@ -501,6 +505,7 @@ bool URIUtils::IsArchive(const CStdString& strFile)
     || strExtension.CompareNoCase(".bz") == 0
     || strExtension.CompareNoCase(".bz2") == 0)
     return true;
+#endif
 
   return false;
 }
@@ -524,9 +529,13 @@ bool URIUtils::IsRAR(const CStdString& strFile)
 
 bool URIUtils::IsInArchive(const CStdString &strFile)
 {
+#ifdef HAVE_LIBARCHIVE
   CURL url(strFile);
 
   return url.GetProtocol() == "archive" && url.GetFileName() != "";
+#else
+  return false;
+#endif
 }
 
 bool URIUtils::IsInZIP(const CStdString& strFile)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -71,6 +71,7 @@ public:
   static bool IsOnDVD(const CStdString& strFile);
   static bool IsOnLAN(const CStdString& strFile);
   static bool IsPlugin(const CStdString& strFile);
+  static bool IsArchive(const CStdString& strFile);
   static bool IsRAR(const CStdString& strFile);
   static bool IsRemote(const CStdString& strFile);
   static bool IsSmb(const CStdString& strFile);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -375,7 +375,7 @@ int CVideoDatabase::GetPathId(const CStdString& strPath)
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strPath1(strPath);
-    if (URIUtils::IsStack(strPath) || strPath.Mid(0,6).Equals("rar://") || strPath.Mid(0,6).Equals("zip://"))
+    if (URIUtils::IsStack(strPath) || strPath.Mid(0,10).Equals("archive://") || strPath.Mid(0,6).Equals("rar://") || strPath.Mid(0,6).Equals("zip://"))
       URIUtils::GetParentPath(strPath,strPath1);
 
     URIUtils::AddSlashAtEnd(strPath1);
@@ -541,7 +541,7 @@ int CVideoDatabase::AddPath(const CStdString& strPath)
     if (NULL == m_pDS.get()) return -1;
 
     CStdString strPath1(strPath);
-    if (URIUtils::IsStack(strPath) || strPath.Mid(0,6).Equals("rar://") || strPath.Mid(0,6).Equals("zip://"))
+    if (URIUtils::IsStack(strPath) || strPath.Mid(0,10).Equals("archive://") || strPath.Mid(0,6).Equals("rar://") || strPath.Mid(0,6).Equals("zip://"))
       URIUtils::GetParentPath(strPath,strPath1);
 
     URIUtils::AddSlashAtEnd(strPath1);
@@ -7651,7 +7651,7 @@ void CVideoDatabase::ConstructPath(CStdString& strDest, const CStdString& strPat
 
 void CVideoDatabase::SplitPath(const CStdString& strFileNameAndPath, CStdString& strPath, CStdString& strFileName)
 {
-  if (URIUtils::IsStack(strFileNameAndPath) || strFileNameAndPath.Mid(0,6).Equals("rar://") || strFileNameAndPath.Mid(0,6).Equals("zip://"))
+  if (URIUtils::IsStack(strFileNameAndPath) || strFileNameAndPath.Mid(0,10).Equals("archive://") || strFileNameAndPath.Mid(0,6).Equals("rar://") || strFileNameAndPath.Mid(0,6).Equals("zip://"))
   {
     URIUtils::GetParentPath(strFileNameAndPath,strPath);
     strFileName = strFileNameAndPath;

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -286,9 +286,9 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
     else
       strPath = g_application.CurrentFileItem().m_strPath;
 
-    CStdString strMask = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.aqt|.jss|.ass|.idx|.rar|.zip";
+    CStdString strMask = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.aqt|.jss|.ass|.idx|.tar|.gz|.bz|.bz2|.rar|.zip";
     if (g_application.GetCurrentPlayer() == EPC_DVDPLAYER)
-      strMask = ".srt|.rar|.zip|.ifo|.smi|.sub|.idx|.ass|.ssa|.txt";
+      strMask = ".srt|.tar|.gz|.bz|.bz2|.rar|.zip|.ifo|.smi|.sub|.idx|.ass|.ssa|.txt";
     VECSOURCES shares(g_settings.m_videoSources);
     if (g_settings.iAdditionalSubtitleDirectoryChecked != -1 && !g_guiSettings.GetString("subtitles.custompath").IsEmpty())
     {

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -19,6 +19,9 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
 #include "system.h"
 #include "GUIDialogAudioSubtitleSettings.h"
 #include "dialogs/GUIDialogFileBrowser.h"
@@ -288,7 +291,11 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
 
     CStdString strMask = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.aqt|.jss|.ass|.idx|.tar|.gz|.bz|.bz2|.rar|.zip";
     if (g_application.GetCurrentPlayer() == EPC_DVDPLAYER)
+#ifdef HAVE_LIBARCHIVE
       strMask = ".srt|.tar|.gz|.bz|.bz2|.rar|.zip|.ifo|.smi|.sub|.idx|.ass|.ssa|.txt";
+#else
+      strMask = ".srt|.rar|.zip|.ifo|.smi|.sub|.idx|.ass|.ssa|.txt";
+#endif
     VECSOURCES shares(g_settings.m_videoSources);
     if (g_settings.iAdditionalSubtitleDirectoryChecked != -1 && !g_guiSettings.GetString("subtitles.custompath").IsEmpty())
     {

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -699,7 +699,7 @@ void CGUIWindowVideoBase::OnQueueItem(int iItem)
 
   // we take a copy so that we can alter the queue state
   CFileItemPtr item(new CFileItem(*m_vecItems->Get(iItem)));
-  if (item->IsRAR() || item->IsZIP())
+  if (item->IsArchive() || item->IsRAR() || item->IsZIP())
     return;
 
   //  Allow queuing of unqueueable items
@@ -723,7 +723,7 @@ void CGUIWindowVideoBase::OnQueueItem(int iItem)
 
 void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItemList &queuedItems)
 {
-  if (!pItem->CanQueue() || pItem->IsRAR() || pItem->IsZIP() || pItem->IsParentFolder()) // no zip/rar enques thank you!
+  if (!pItem->CanQueue() || pItem->IsArchive() || pItem->IsRAR() || pItem->IsZIP() || pItem->IsParentFolder()) // no zip/rar enques thank you!
     return;
 
   if (pItem->m_bIsFolder)

--- a/xbmc/visualizations/Milkdrop/MilkdropXBMC.cpp
+++ b/xbmc/visualizations/Milkdrop/MilkdropXBMC.cpp
@@ -40,8 +40,19 @@ bool lastLockedStatus = false;
 // Sets a new preset file or directory and make it active. Also recovers last state of the preset if it is the same as last time
 void SetPresetDir(const char *pack)
 {
+  /* TODO: code below needs refactoring */
   int len = strlen(pack);
-  if (len >= 4 && strcmp(pack + len - 4, ".zip") == 0)
+  if ((len >= 4 && strcmp(pack + len - 4, ".tar") == 0)
+    || (len >= 3 && strcmp(pack + len - 3, ".gz") == 0)
+    || (len >= 3 && strcmp(pack + len - 3, ".bz") == 0)
+    || (len >= 4 && strcmp(pack + len - 4, ".bz2") == 0))
+  {
+    // Archive file
+    strcpy(g_plugin->m_szPresetDir, PRESETS_DIR);
+    strcat(g_plugin->m_szPresetDir,  pack);
+    strcat(g_plugin->m_szPresetDir, "/");
+  }
+  else if (len >= 4 && strcmp(pack + len - 4, ".zip") == 0)
   {
     // Zip file
     strcpy(g_plugin->m_szPresetDir, PRESETS_DIR);

--- a/xbmc/visualizations/Milkdrop/MilkdropXBMC.cpp
+++ b/xbmc/visualizations/Milkdrop/MilkdropXBMC.cpp
@@ -19,6 +19,9 @@
  *
  */
 
+#if (defined HAVE_CONFIG_H) && (!defined WIN32)
+  #include "config.h"
+#endif
 #include "vis_milkdrop/Plugin.h"
 #include "../../addons/include/xbmc_vis_dll.h"
 #include "XmlDocument.h"
@@ -42,6 +45,7 @@ void SetPresetDir(const char *pack)
 {
   /* TODO: code below needs refactoring */
   int len = strlen(pack);
+#ifdef HAVE_LIBARCHIVE
   if ((len >= 4 && strcmp(pack + len - 4, ".tar") == 0)
     || (len >= 3 && strcmp(pack + len - 3, ".gz") == 0)
     || (len >= 3 && strcmp(pack + len - 3, ".bz") == 0)
@@ -53,6 +57,9 @@ void SetPresetDir(const char *pack)
     strcat(g_plugin->m_szPresetDir, "/");
   }
   else if (len >= 4 && strcmp(pack + len - 4, ".zip") == 0)
+#else
+  if (len >= 4 && strcmp(pack + len - 4, ".zip") == 0)
+#endif
   {
     // Zip file
     strcpy(g_plugin->m_szPresetDir, PRESETS_DIR);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1216,7 +1216,7 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item)
       if (nItem->m_bIsFolder)
         continue;
 
-      if (!nItem->IsPlayList() && !nItem->IsZIP() && !nItem->IsRAR())
+      if (!nItem->IsPlayList() && !nItem->IsArchive() && !nItem->IsZIP() && !nItem->IsRAR())
         queueItems.Add(nItem);
 
       if (nItem == item)
@@ -1279,7 +1279,7 @@ void CGUIMediaWindow::UpdateFileList()
       if (pItem->m_bIsFolder)
         continue;
 
-      if (!pItem->IsPlayList() && !pItem->IsZIP() && !pItem->IsRAR())
+      if (!pItem->IsPlayList() && !pItem->IsArchive() && !pItem->IsZIP() && !pItem->IsRAR())
         g_playlistPlayer.Add(iPlaylist, pItem);
 
       if (pItem->m_strPath == playlistItem.m_strPath &&

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -575,6 +575,12 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
     if (!Update(iList, strPath))
       ShowShareErrorMessage(pItem.get());
   }
+  else if (pItem->IsArchive() || pItem->IsCBArchive()) // mount archive
+  {
+    CStdString strArchivedPath;
+    URIUtils::CreateArchivePath(strArchivedPath, "archive", pItem->m_strPath, "");
+    Update(iList, strArchivedPath);
+  }
   else if (pItem->IsZIP() || pItem->IsCBZ()) // mount zip archive
   {
     CStdString strArcivedPath;
@@ -829,7 +835,7 @@ int CGUIWindowFileManager::GetSelectedItem(int iControl)
 void CGUIWindowFileManager::GoParentFolder(int iList)
 {
   CURL url(m_Directory[iList]->m_strPath);
-  if ((url.GetProtocol() == "rar") || (url.GetProtocol() == "zip"))
+  if ((url.GetProtocol() == "archive") || (url.GetProtocol() == "rar") || (url.GetProtocol() == "zip"))
   {
     // check for step-below, if, unmount rar
     if (url.GetFileName().IsEmpty())


### PR DESCRIPTION
New branch to address davilla's concerns. As before...

This will add support to read from tar, bzip, and gzip files through the use of libarchive. Supported files currently are any file with the extensions .tar, .gz, .bz, and .bzip2. libarchive can handle many more formats, so more extensions should be added, or a better way to detect an archive.

The reads and seeks in libarchive are hooked through the VFS. Archives within archives can be read. This however currently makes browsing archives over the internet slow.
