### PR TITLE
Addon version checking

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1840B797139968DB007C848B /* JSONVariantWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1840B794139968DB007C848B /* JSONVariantWriter.cpp */; };
 		18ACF8E313597B0000B67371 /* RecentlyAddedJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ACF8E113597B0000B67371 /* RecentlyAddedJob.cpp */; };
 		4D5D2E131301753F006ABC13 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D5D2E121301753F006ABC13 /* CFNetwork.framework */; };
+		7C0A7ECD13A5DBF900AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7ECB13A5DBF900AFC2BD /* AppParamParser.cpp */; };
 		7C99B73F133D372300FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B73D133D372300FC2B16 /* CacheCircular.cpp */; };
 		7C99B7AA134072CD00FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */; };
 		C807119F135DB842002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807119D135DB842002F601B /* InputOperations.cpp */; };
@@ -928,6 +929,8 @@
 		18ACF8E113597B0000B67371 /* RecentlyAddedJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RecentlyAddedJob.cpp; sourceTree = "<group>"; };
 		18ACF8E213597B0000B67371 /* RecentlyAddedJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecentlyAddedJob.h; sourceTree = "<group>"; };
 		4D5D2E121301753F006ABC13 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		7C0A7ECB13A5DBF900AFC2BD /* AppParamParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppParamParser.cpp; sourceTree = "<group>"; };
+		7C0A7ECC13A5DBF900AFC2BD /* AppParamParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppParamParser.h; sourceTree = "<group>"; };
 		7C99B73D133D372300FC2B16 /* CacheCircular.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheCircular.cpp; sourceTree = "<group>"; };
 		7C99B73E133D372300FC2B16 /* CacheCircular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheCircular.h; sourceTree = "<group>"; };
 		7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -4903,6 +4906,8 @@
 				F56C76D2131EC153000AD0F6 /* GUISettings.h */,
 				F56C76D3131EC153000AD0F6 /* AdvancedSettings.cpp */,
 				F56C76D4131EC153000AD0F6 /* AdvancedSettings.h */,
+				7C0A7ECB13A5DBF900AFC2BD /* AppParamParser.cpp */,
+				7C0A7ECC13A5DBF900AFC2BD /* AppParamParser.h */,
 				F56C76D5131EC153000AD0F6 /* GUIWindowSettings.cpp */,
 				F56C76D6131EC153000AD0F6 /* GUIWindowSettings.h */,
 				F56C76D7131EC153000AD0F6 /* GUIWindowSettingsCategory.cpp */,
@@ -6682,6 +6687,7 @@
 				18404DFB1396C43B00863BBA /* Slingbox.cpp in Sources */,
 				1840B796139968DB007C848B /* JSONVariantParser.cpp in Sources */,
 				1840B797139968DB007C848B /* JSONVariantWriter.cpp in Sources */,
+				7C0A7ECD13A5DBF900AFC2BD /* AppParamParser.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		18ACF8FD13597B5700B67371 /* RecentlyAddedJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ACF8FB13597B5700B67371 /* RecentlyAddedJob.cpp */; };
 		3255316612B2D02400837CD2 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3255316512B2D02400837CD2 /* CoreAudio.framework */; };
 		4D5D2E1E1301758F006ABC13 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */; };
+		7C0A7EDE13A5DC2800AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EDC13A5DC2800AFC2BD /* AppParamParser.cpp */; };
 		7C99B6E9133D36E200FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */; };
 		7C99B7BE1340730000FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */; };
 		C80711AD135DB85F002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C80711AB135DB85F002F601B /* InputOperations.cpp */; };
@@ -929,6 +930,8 @@
 		18ACF8FC13597B5700B67371 /* RecentlyAddedJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecentlyAddedJob.h; sourceTree = "<group>"; };
 		3255316512B2D02400837CD2 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		7C0A7EDC13A5DC2800AFC2BD /* AppParamParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppParamParser.cpp; sourceTree = "<group>"; };
+		7C0A7EDD13A5DC2800AFC2BD /* AppParamParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppParamParser.h; sourceTree = "<group>"; };
 		7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheCircular.cpp; sourceTree = "<group>"; };
 		7C99B6E8133D36E200FC2B16 /* CacheCircular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheCircular.h; sourceTree = "<group>"; };
 		7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -5273,6 +5276,8 @@
 				F56C86BD131F42EB000AD0F6 /* GUISettings.h */,
 				F56C86BE131F42EB000AD0F6 /* AdvancedSettings.cpp */,
 				F56C86BF131F42EB000AD0F6 /* AdvancedSettings.h */,
+				7C0A7EDC13A5DC2800AFC2BD /* AppParamParser.cpp */,
+				7C0A7EDD13A5DC2800AFC2BD /* AppParamParser.h */,
 				F56C86C0131F42EB000AD0F6 /* GUIWindowSettings.cpp */,
 				F56C86C1131F42EB000AD0F6 /* GUIWindowSettings.h */,
 				F56C86C2131F42EB000AD0F6 /* GUIWindowSettingsCategory.cpp */,
@@ -6699,6 +6704,7 @@
 				18404DD61396C3F300863BBA /* Slingbox.cpp in Sources */,
 				1840B77A1399616D007C848B /* JSONVariantParser.cpp in Sources */,
 				1840B77B1399616D007C848B /* JSONVariantWriter.cpp in Sources */,
+				7C0A7EDE13A5DC2800AFC2BD /* AppParamParser.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -500,6 +500,8 @@
 		43EA4297136C1D9E002C82A5 /* RenderCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F56579AD13060D1E0085ED7F /* RenderCapture.cpp */; };
 		43EA429B136C1E2F002C82A5 /* xbmcvfsmodule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 189047D11301DEAB00C11012 /* xbmcvfsmodule.cpp */; };
 		43EA42B0136C2274002C82A5 /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807114B135DB5CC002F601B /* InputOperations.cpp */; };
+		7C0A7EC013A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */; };
+		7C0A7EC113A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */; };
 		7C2D6AE40F35453E00DD2E85 /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
 		7C45DBE910F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
 		7C45DBEA10F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
@@ -2366,6 +2368,8 @@
 		6E97BDC10DA2B620003A2A89 /* EventServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventServer.h; sourceTree = "<group>"; };
 		6E97BDC30DA2B620003A2A89 /* Fanart.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fanart.h; sourceTree = "<group>"; };
 		6E97BDC40DA2B620003A2A89 /* Socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Socket.h; sourceTree = "<group>"; };
+		7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppParamParser.cpp; sourceTree = "<group>"; };
+		7C0A7EBF13A5DBCE00AFC2BD /* AppParamParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppParamParser.h; sourceTree = "<group>"; };
 		7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpecialProtocol.cpp; sourceTree = "<group>"; };
 		7C2D6AE30F35453E00DD2E85 /* SpecialProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialProtocol.h; sourceTree = "<group>"; };
 		7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DAVDirectory.cpp; sourceTree = "<group>"; };
@@ -6602,6 +6606,8 @@
 				18B7C8C312942451009E7A26 /* GUISettings.h */,
 				18B7C3A612942132009E7A26 /* AdvancedSettings.cpp */,
 				18B7C3A712942132009E7A26 /* AdvancedSettings.h */,
+				7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */,
+				7C0A7EBF13A5DBCE00AFC2BD /* AppParamParser.h */,
 				18B7C39612942114009E7A26 /* GUIWindowSettings.cpp */,
 				18B7C39712942114009E7A26 /* GUIWindowSettings.h */,
 				18B7C39812942114009E7A26 /* GUIWindowSettingsCategory.cpp */,
@@ -8012,6 +8018,7 @@
 				18404D9E1396C13500863BBA /* Slingbox.cpp in Sources */,
 				1840B74D13993D8A007C848B /* JSONVariantParser.cpp in Sources */,
 				1840B75313993DA0007C848B /* JSONVariantWriter.cpp in Sources */,
+				7C0A7EC013A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8899,6 +8906,7 @@
 				18404E701396E05D00863BBA /* Slingbox.cpp in Sources */,
 				1840B74E13993D8A007C848B /* JSONVariantParser.cpp in Sources */,
 				1840B75413993DA0007C848B /* JSONVariantWriter.cpp in Sources */,
+				7C0A7EC113A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -283,6 +283,7 @@
     <ClCompile Include="..\..\lib\tinyXML\tinyxmlparser.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonDatabase.cpp" />
     <ClCompile Include="..\..\xbmc\addons\AddonInstaller.cpp" />
+    <ClCompile Include="..\..\xbmc\addons\AddonVersion.cpp" />
     <ClCompile Include="..\..\xbmc\addons\GUIDialogAddonInfo.cpp" />
     <ClCompile Include="..\..\xbmc\addons\GUIDialogAddonSettings.cpp" />
     <ClCompile Include="..\..\xbmc\addons\GUIViewStateAddonBrowser.cpp" />
@@ -1163,6 +1164,7 @@
     <ClInclude Include="..\..\lib\tinyXML\tinyxml.h" />
     <ClInclude Include="..\..\xbmc\addons\AddonDatabase.h" />
     <ClInclude Include="..\..\xbmc\addons\AddonInstaller.h" />
+    <ClInclude Include="..\..\xbmc\addons\AddonVersion.h" />
     <ClInclude Include="..\..\xbmc\addons\DllLibCPluff.h" />
     <ClInclude Include="..\..\xbmc\addons\GUIDialogAddonInfo.h" />
     <ClInclude Include="..\..\xbmc\addons\GUIDialogAddonSettings.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -691,6 +691,7 @@
     <ClCompile Include="..\..\xbmc\rendering\RenderSystem.cpp" />
     <ClCompile Include="..\..\xbmc\SectionLoader.cpp" />
     <ClCompile Include="..\..\xbmc\settings\AdvancedSettings.cpp" />
+    <ClCompile Include="..\..\xbmc\settings\AppParamParser.cpp" />
     <ClCompile Include="..\..\xbmc\settings\GUIDialogContentSettings.cpp" />
     <ClCompile Include="..\..\xbmc\settings\GUIDialogLockSettings.cpp" />
     <ClCompile Include="..\..\xbmc\settings\GUIDialogProfileSettings.cpp" />
@@ -1522,6 +1523,7 @@
     <ClInclude Include="..\..\xbmc\rendering\RenderSystem.h" />
     <ClInclude Include="..\..\xbmc\SectionLoader.h" />
     <ClInclude Include="..\..\xbmc\settings\AdvancedSettings.h" />
+    <ClInclude Include="..\..\xbmc\settings\AppParamParser.h" />
     <ClInclude Include="..\..\xbmc\settings\GUIDialogContentSettings.h" />
     <ClInclude Include="..\..\xbmc\settings\GUIDialogLockSettings.h" />
     <ClInclude Include="..\..\xbmc\settings\GUIDialogProfileSettings.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2451,6 +2451,9 @@
     <ClCompile Include="..\..\xbmc\utils\JSONVariantWriter.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\settings\AppParamParser.cpp">
+      <Filter>settings</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -4906,6 +4909,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\JSONVariantWriter.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\settings\AppParamParser.h">
+      <Filter>settings</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2454,6 +2454,9 @@
     <ClCompile Include="..\..\xbmc\settings\AppParamParser.cpp">
       <Filter>settings</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\addons\AddonVersion.cpp">
+      <Filter>addons</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -4912,6 +4915,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\settings\AppParamParser.h">
       <Filter>settings</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\addons\AddonVersion.h">
+      <Filter>addons</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -120,48 +120,6 @@ const CStdString GetIcon(const ADDON::TYPE& type)
   return "";
 }
 
-/**
- * AddonVersion
- *
- */
-
-bool AddonVersion::operator==(const AddonVersion &rhs) const
-{
-  return str.Equals(rhs.str);
-}
-
-bool AddonVersion::operator!=(const AddonVersion &rhs) const
-{
-  return !(*this == rhs);
-}
-
-bool AddonVersion::operator>(const AddonVersion &rhs) const
-{
-  return (strverscmp(str.c_str(), rhs.str.c_str()) > 0);
-}
-
-bool AddonVersion::operator>=(const AddonVersion &rhs) const
-{
-  return (*this == rhs) || (*this > rhs);
-}
-
-bool AddonVersion::operator<(const AddonVersion &rhs) const
-{
-  return (strverscmp(str.c_str(), rhs.str.c_str()) < 0);
-}
-
-bool AddonVersion::operator<=(const AddonVersion &rhs) const
-{
-  return (*this == rhs) || !(*this > rhs);
-}
-
-CStdString AddonVersion::Print() const
-{
-  CStdString out;
-  out.Format("%s %s", g_localizeStrings.Get(24051), str); // "Version <str>"
-  return CStdString(out);
-}
-
 #define EMPTY_IF(x,y) \
   { \
     CStdString fan=CAddonMgr::Get().GetExtValue(metadata->configuration, x); \

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -21,6 +21,7 @@
  */
 
 #include "IAddon.h"
+#include "addons/AddonVersion.h"
 #include "tinyXML/tinyxml.h"
 #include "Util.h"
 #include "URL.h"
@@ -43,22 +44,6 @@ const CStdString    GetIcon(const TYPE &type);
       TYPE          TranslateType(const CStdString &string);
 const CStdString    UpdateVideoScraper(const CStdString &scraper);
 const CStdString    UpdateMusicScraper(const CStdString &scraper);
-
-class AddonVersion
-{
-public:
-  AddonVersion(const CStdString &str) : str(str) {}
-  bool operator==(const AddonVersion &rhs) const;
-  bool operator!=(const AddonVersion &rhs) const;
-  bool operator>(const AddonVersion &rhs) const;
-  bool operator>=(const AddonVersion &rhs) const;
-  bool operator<(const AddonVersion &rhs) const;
-  bool operator<=(const AddonVersion &rhs) const;
-  CStdString Print() const;
-  const char *c_str() const { return str.c_str(); };
-private:
-  CStdString str;
-};
 
 class AddonProps
 {

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -1,0 +1,129 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+#include "AddonVersion.h"
+#include "guilib/LocalizeStrings.h"
+
+namespace ADDON
+{
+  AddonVersion::AddonVersion(CStdString version)
+  {
+    m_originalVersion = version;
+    const char *epoch_end = strchr(version, ':');
+    if (epoch_end != NULL) {
+      mEpoch = atoi(version);
+    } else {
+      mEpoch = 0;
+    }
+
+    const char *upstream_start;
+    if (epoch_end) {
+      upstream_start = epoch_end + 1;
+    } else {
+      upstream_start = version;
+    }
+
+    const char *upstream_end = strrchr(upstream_start, '-');
+    size_t upstream_size;
+    if (upstream_end == NULL) {
+      upstream_size = strlen(upstream_start);
+    } else {
+      upstream_size = upstream_end - upstream_start;
+    }
+
+    mUpstream = (char*) malloc(upstream_size + 1);
+    strncpy(mUpstream, upstream_start, upstream_size);
+    mUpstream[upstream_size] = '\0';
+
+    if (upstream_end == NULL) {
+      mRevision = strdup("0");
+    } else {
+      mRevision = strdup(upstream_end + 1);
+    }
+  }
+
+  /**Compare two components of a Debian-style version.  Return -1, 0, or 1
+   * if a is less than, equal to, or greater than b, respectively.
+   */
+  int AddonVersion::CompareComponent(const char *a, const char *b)
+  {
+    while (*a && *b) {
+
+      while (*a && *b && !isdigit(*a) && !isdigit(*b)) {
+        if (*a != *b) {
+          if (*a == '~') return -1;
+          if (*b == '~') return 1;
+          return *a < *b ? -1 : 1;
+        }
+        a++;
+        b++;
+      }
+      if (*a && *b && (!isdigit(*a) || !isdigit(*b))) {
+        if (*a == '~') return -1;
+        if (*b == '~') return 1;
+        return isdigit(*a) ? -1 : 1;
+      }
+
+      char *next_a, *next_b;
+      long int num_a = strtol(a, &next_a, 10);
+      long int num_b = strtol(b, &next_b, 10);
+      if (num_a != num_b) {
+        return num_a < num_b ? -1 : 1;
+      }
+      a = next_a;
+      b = next_b;
+
+    }
+    if (!*a && !*b) {
+      return 0;
+    } else if (*a) {
+      return *a == '~' ? -1 : 1;
+    } else {
+      return *b == '~' ? 1 : -1;
+    }
+  }
+
+  bool AddonVersion::operator<(const AddonVersion& other) const
+  {
+    if (Epoch() != other.Epoch()) {
+      return Epoch() < other.Epoch();
+    }
+
+    int result = CompareComponent(Upstream(), other.Upstream());
+    if (result) {
+      return -1 == result;
+    }
+
+    return -1 == CompareComponent(Revision(), other.Revision());
+  }
+
+  CStdString AddonVersion::Print() const
+  {
+    CStdString out;
+    out.Format("%s %s", g_localizeStrings.Get(24051), m_originalVersion); // "Version <str>"
+    return CStdString(out);
+  }
+}

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -1,0 +1,78 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <stdlib.h>
+#include <iostream>
+#include <boost/operators.hpp>
+
+namespace ADDON
+{
+  class AddonVersion : public boost::totally_ordered<AddonVersion> {
+  public:
+    AddonVersion() : mEpoch(0), mUpstream(NULL), mRevision(NULL) {}
+    AddonVersion(const AddonVersion& other) { *this = other; }
+    explicit AddonVersion(CStdString version);
+    ~AddonVersion();
+
+    int Epoch() const { return mEpoch; }
+    const char *Upstream() const { return mUpstream; }
+    const char *Revision() const { return mRevision; }
+
+    void Epoch(int new_epoch) { mEpoch = new_epoch; }
+    void Upstream(const char *new_upstream) { free(mUpstream); mUpstream = strdup(new_upstream); }
+    void Revision(const char *new_revision) { free(mRevision); mRevision = strdup(new_revision); }
+    void ClearRevision() { Revision("0"); }
+
+    AddonVersion& operator=(const AddonVersion& other);
+    bool operator<(const AddonVersion& other) const;
+    bool operator==(const AddonVersion& other) const;
+    CStdString Print() const;
+    const char *c_str() const { return m_originalVersion.c_str(); };
+  protected:
+    CStdString m_originalVersion;
+    int mEpoch;
+    char *mUpstream;
+    char *mRevision;
+
+    static int CompareComponent(const char *a, const char *b);
+  };
+
+  inline AddonVersion::~AddonVersion()
+  {
+    free(mUpstream);
+    free(mRevision);
+  }
+
+  inline bool AddonVersion::operator==(const AddonVersion& other) const
+  {
+    return Epoch() == other.Epoch()
+      && strcmp(Upstream(), other.Upstream()) == 0
+      && strcmp(Revision(), other.Revision()) == 0;
+  }
+
+  inline AddonVersion& AddonVersion::operator=(const AddonVersion& other)
+  {
+    mEpoch = other.Epoch();
+    mUpstream = strdup(other.Upstream());
+    mRevision = strdup(other.Revision());
+    return *this;
+  }
+}

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -278,6 +278,8 @@ void CAdvancedSettings::Initialize()
   m_jsonTcpPort = 9090;
 
   m_enableMultimediaKeys = false;
+
+  m_canWindowed = true;
 }
 
 bool CAdvancedSettings::Load()
@@ -645,6 +647,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
 #endif
   XMLUtils::GetBoolean(pRootElement, "splash", m_splashImage);
   XMLUtils::GetBoolean(pRootElement, "showexitbutton", m_showExitButton);
+  XMLUtils::GetBoolean(pRootElement, "canwindowed", m_canWindowed);
 
   XMLUtils::GetInt(pRootElement, "songinfoduration", m_songInfoDuration, 0, INT_MAX);
   XMLUtils::GetInt(pRootElement, "busydialogdelay", m_busyDialogDelay, 0, 5000);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -286,37 +286,44 @@ bool CAdvancedSettings::Load()
   //       it should instead use the versions of GetString/Integer/Float that
   //       don't take defaults in.  Defaults are set in the constructor above
   Initialize(); // In case of profile switch.
-  CStdString advancedSettingsXML;
-  advancedSettingsXML  = g_settings.GetUserDataItem("advancedsettings.xml");
+  ParseSettingsFile("special://xbmc/system/advancedsettings.xml");
+  for (unsigned int i = 0; i < m_settingsFiles.size(); i++)
+    ParseSettingsFile(m_settingsFiles[i]);
+  ParseSettingsFile(g_settings.GetUserDataItem("advancedsettings.xml"));
+  return true;
+}
+
+void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
+{
   TiXmlDocument advancedXML;
-  if (!CFile::Exists(advancedSettingsXML))
-  { // tell the user it doesn't exist
-    CLog::Log(LOGNOTICE, "No advancedsettings.xml to load (%s)", advancedSettingsXML.c_str());
-    return false;
+  if (!CFile::Exists(file))
+  {
+    CLog::Log(LOGNOTICE, "No settings file to load to load (%s)", file.c_str());
+    return;
   }
 
-  if (!advancedXML.LoadFile(advancedSettingsXML))
+  if (!advancedXML.LoadFile(file))
   {
-    CLog::Log(LOGERROR, "Error loading %s, Line %d\n%s", advancedSettingsXML.c_str(), advancedXML.ErrorRow(), advancedXML.ErrorDesc());
-    return false;
+    CLog::Log(LOGERROR, "Error loading %s, Line %d\n%s", file.c_str(), advancedXML.ErrorRow(), advancedXML.ErrorDesc());
+    return;
   }
 
   TiXmlElement *pRootElement = advancedXML.RootElement();
   if (!pRootElement || strcmpi(pRootElement->Value(),"advancedsettings") != 0)
   {
-    CLog::Log(LOGERROR, "Error loading %s, no <advancedsettings> node", advancedSettingsXML.c_str());
-    return false;
+    CLog::Log(LOGERROR, "Error loading %s, no <advancedsettings> node", file.c_str());
+    return;
   }
 
   // succeeded - tell the user it worked
-  CLog::Log(LOGNOTICE, "Loaded advancedsettings.xml from %s", advancedSettingsXML.c_str());
+  CLog::Log(LOGNOTICE, "Loaded settings file from %s", file.c_str());
 
   // Dump contents of AS.xml to debug log
   TiXmlPrinter printer;
   printer.SetLineBreak("\n");
   printer.SetIndent("  ");
   advancedXML.Accept(&printer);
-  CLog::Log(LOGNOTICE, "Contents of %s are...\n%s", advancedSettingsXML.c_str(), printer.CStr());
+  CLog::Log(LOGNOTICE, "Contents of %s are...\n%s", file.c_str(), printer.CStr());
 
   TiXmlElement *pElement = pRootElement->FirstChildElement("audio");
   if (pElement)
@@ -884,8 +891,6 @@ bool CAdvancedSettings::Load()
 
   // load in the GUISettings overrides:
   g_guiSettings.LoadXML(pRootElement, true);  // true to hide the settings we read in
-
-  return true;
 }
 
 void CAdvancedSettings::Clear()
@@ -1007,3 +1012,7 @@ void CAdvancedSettings::GetCustomExtensions(TiXmlElement *pRootElement, CStdStri
   }
 }
 
+void CAdvancedSettings::AddSettingsFile(const CStdString &filename)
+{
+  m_settingsFiles.push_back(filename);
+}

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -249,6 +249,7 @@ class CAdvancedSettings
     bool m_fullScreen;
     bool m_startFullScreen;
 	bool m_showExitButton; /* Ideal for appliances to hide a 'useless' button */
+    bool m_canWindowed;
     bool m_splashImage;
     bool m_alwaysOnTop;  /* makes xbmc to run always on top .. osx/win32 only .. */
     int m_playlistRetries;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -68,7 +68,7 @@ class CAdvancedSettings
     static CAdvancedSettings* getInstance();
 
     void Initialize();
-
+    void AddSettingsFile(const CStdString &filename);
     bool Load();
     void Clear();
 
@@ -290,6 +290,8 @@ class CAdvancedSettings
     unsigned int m_jsonTcpPort;
 
     bool m_enableMultimediaKeys;
+    std::vector<CStdString> m_settingsFiles;
+    void ParseSettingsFile(const CStdString &file);
 };
 
 XBMC_GLOBAL(CAdvancedSettings,g_advancedSettings);

--- a/xbmc/settings/AppParamParser.cpp
+++ b/xbmc/settings/AppParamParser.cpp
@@ -110,6 +110,8 @@ void CAppParamParser::ParseArg(const CStdString &arg)
     g_application.SetEnableLegacyRes(true);
   else if (arg == "--test")
     m_testmode = true;
+  else if (arg.substr(0, 11) == "--settings=")
+    g_advancedSettings.AddSettingsFile(arg.substr(11));
   else if (arg.length() != 0 && arg[0] != '-')
   {
     if (m_testmode)

--- a/xbmc/settings/AppParamParser.cpp
+++ b/xbmc/settings/AppParamParser.cpp
@@ -1,0 +1,133 @@
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "AppParamParser.h"
+#include "AdvancedSettings.h"
+#include "PlayListPlayer.h"
+#include "FileItem.h"
+#include "Application.h"
+#include "log.h"
+#ifdef _WIN32
+#include "WIN32Util.h"
+#endif
+#ifdef HAS_LIRC
+#include "input/linux/LIRC.h"
+#endif
+
+CAppParamParser::CAppParamParser()
+{
+  m_testmode = false;
+}
+
+void CAppParamParser::Parse(const char* argv[], int nArgs)
+{
+  if (nArgs > 1)
+  {
+    for (int i = 1; i < nArgs; i++)
+    {
+      ParseArg(argv[i]);
+#ifdef HAS_LIRC
+      if (strnicmp(argv[i], "-l", 2) == 0 || strnicmp(argv[i], "--lircdev", 9) == 0)
+      {
+        // check the next arg with the proper value.
+        int next=i+1;
+        if (next < nArgs)
+        {
+          if ((argv[next][0] != '-' ) && (argv[next][0] == '/' ))
+          {
+            g_RemoteControl.setDeviceName(argv[next]);
+            i++;
+          }
+        }
+      }
+      else if (strnicmp(argv[i], "-n", 2) == 0 || strnicmp(argv[i], "--nolirc", 8) == 0)
+         g_RemoteControl.setUsed(false);
+#endif
+    }
+  }
+  PlayPlaylist();
+}
+
+void CAppParamParser::DisplayHelp()
+{
+  printf("Usage: xbmc [OPTION]... [FILE]...\n\n");
+  printf("Arguments:\n");
+  printf("  -fs\t\t\tRuns XBMC in full screen\n");
+  printf("  --standalone\t\tXBMC runs in a stand alone environment without a window \n");
+  printf("\t\t\tmanager and supporting applications. For example, that\n");
+  printf("\t\t\tenables network settings.\n");
+  printf("  -p or --portable\tXBMC will look for configurations in install folder instead of ~/.xbmc\n");
+  printf("  --legacy-res\t\tEnables screen resolutions such as PAL, NTSC, etc.\n");
+#ifdef HAS_LIRC
+  printf("  -l or --lircdev\tLircDevice to use default is "LIRC_DEVICE" .\n");
+  printf("  -n or --nolirc\tdo not use Lirc, i.e. no remote input.\n");
+#endif
+  printf("  --debug\t\tEnable debug logging\n");
+  printf("  --test\t\tEnable test mode. [FILE] required.\n");
+  printf("  --settings=<filename>\t\tLoads specified file after advancedsettings.xml replacing any settings specified\n");
+  printf("  \t\t\t\tspecified file must exist in special://xbmc/system/\n");
+  exit(0);
+}
+
+void CAppParamParser::EnableDebugMode()
+{
+  g_advancedSettings.m_logLevel     = LOG_LEVEL_DEBUG;
+  g_advancedSettings.m_logLevelHint = LOG_LEVEL_DEBUG;
+  CLog::SetLogLevel(g_advancedSettings.m_logLevel);
+}
+
+void CAppParamParser::ParseArg(const CStdString &arg)
+{
+  if (arg == "-fs" || arg == "--fullscreen")
+    g_advancedSettings.m_startFullScreen = true;
+  else if (arg == "-h" || arg == "--help")
+    DisplayHelp();
+  else if (arg == "--standalone")
+    g_application.SetStandAlone(true);
+  else if (arg == "-p" || arg  == "--portable")
+    g_application.EnablePlatformDirectories(false);
+  else if (arg == "--debug")
+    EnableDebugMode();
+  else if (arg == "--legacy-res")
+    g_application.SetEnableLegacyRes(true);
+  else if (arg == "--test")
+    m_testmode = true;
+  else if (arg.length() != 0 && arg[0] != '-')
+  {
+    if (m_testmode)
+      g_application.SetEnableTestMode(true);
+    CFileItemPtr pItem(new CFileItem(arg));
+    pItem->m_strPath = arg;
+    m_playlist.Add(pItem);
+  }
+}
+
+void CAppParamParser::PlayPlaylist()
+{
+  if (m_playlist.Size() > 0)
+  {
+    g_playlistPlayer.Add(0, m_playlist);
+    g_playlistPlayer.SetCurrentPlaylist(0);
+  }
+
+  ThreadMessage tMsg = {TMSG_PLAYLISTPLAYER_PLAY, (DWORD) -1};
+  g_application.getApplicationMessenger().SendMessage(tMsg, false);
+}

--- a/xbmc/settings/AppParamParser.h
+++ b/xbmc/settings/AppParamParser.h
@@ -1,0 +1,38 @@
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "StdString.h"
+#include "FileItem.h"
+
+class CAppParamParser
+{
+  public:
+    CAppParamParser();
+    void Parse(const char* argv[], int nArgs);
+
+  private:
+    bool m_testmode;
+    CFileItemList m_playlist;
+    void ParseArg(const CStdString &arg);
+    void DisplayHelp();
+    void EnableDebugMode();
+    void PlayPlaylist();
+};

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -2322,7 +2322,8 @@ DisplayMode CGUIWindowSettingsCategory::FillInScreens(CStdString strSetting, RES
   pControl->Clear();
 
   CStdString strScreen;
-  pControl->AddLabel(g_localizeStrings.Get(242), -1);
+  if (g_advancedSettings.m_canWindowed)
+    pControl->AddLabel(g_localizeStrings.Get(242), -1);
 
   for (int idx = 0; idx < g_Windowing.GetNumScreens(); idx++)
   {

--- a/xbmc/settings/Makefile
+++ b/xbmc/settings/Makefile
@@ -1,4 +1,5 @@
 SRCS=AdvancedSettings.cpp \
+     AppParamParser.cpp \
      GUIDialogContentSettings.cpp \
      GUIDialogLockSettings.cpp \
      GUIDialogProfileSettings.cpp \

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -304,7 +304,7 @@ CStdString CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFileI
       value.Format("%i kbps", item->m_dwSize);
     break;
    case 'W': // Listeners
-    if( !item->m_bIsFolder && music->GetListeners() != 0 )
+    if( !item->m_bIsFolder && music && music->GetListeners() != 0 )
      value.Format("%i %s", music->GetListeners(), g_localizeStrings.Get(music->GetListeners() == 1 ? 20454 : 20455));
     break;    
   }

--- a/xbmc/xbmc.cpp
+++ b/xbmc/xbmc.cpp
@@ -28,6 +28,7 @@
 //
 
 #include "system.h"
+#include "settings/AppParamParser.h"
 #include "settings/AdvancedSettings.h"
 #include "FileItem.h"
 #include "Application.h"
@@ -58,7 +59,6 @@ int main(int argc, char* argv[])
 #endif
   CLog::SetLogLevel(g_advancedSettings.m_logLevel);
 
-  CFileItemList playlist;
 #ifdef _LINUX
 #if defined(DEBUG)
   struct rlimit rlim;
@@ -76,97 +76,17 @@ int main(int argc, char* argv[])
 #endif
   setlocale(LC_NUMERIC, "C");
   g_advancedSettings.Initialize();
-  bool testmode = 0;
-  if (argc > 1)
-  {
-    for (int i = 1; i < argc; i++)
-    {
-      if (strnicmp(argv[i], "-fs", 3) == 0 || strnicmp(argv[i], "--fullscreen", 12) == 0)
-      {
-        g_advancedSettings.m_startFullScreen = true;
-      }
-      else if (strnicmp(argv[i], "-h", 2) == 0 || strnicmp(argv[i], "--help", 6) == 0)
-      {
-        printf("Usage: %s [OPTION]... [FILE]...\n\n", argv[0]);
-        printf("Arguments:\n");
-        printf("  -fs\t\t\tRuns XBMC in full screen\n");
-        printf("  --standalone\t\tXBMC runs in a stand alone environment without a window \n");
-        printf("\t\t\tmanager and supporting applications. For example, that\n");
-        printf("\t\t\tenables network settings.\n");
-        printf("  -p or --portable\tXBMC will look for configurations in install folder instead of ~/.xbmc\n");
-        printf("  --legacy-res\t\tEnables screen resolutions such as PAL, NTSC, etc.\n");
-#ifdef HAS_LIRC
-        printf("  -l or --lircdev\tLircDevice to use default is "LIRC_DEVICE" .\n");
-        printf("  -n or --nolirc\tdo not use Lirc, aka no remote input.\n");
+  
+#ifndef _WIN32
+  CAppParamParser appParamParser;
+  appParamParser.Parse((const char **)argv, argc);
 #endif
-        printf("  --debug\t\tEnable debug logging\n");
-        printf("  --test\t\tEnable test mode. [FILE] required.\n");
-        exit(0);
-      }
-      else if (strnicmp(argv[i], "--standalone", 12) == 0)
-      {
-        g_application.SetStandAlone(true);
-      }
-      else if (strnicmp(argv[i], "-p", 2) == 0 || strnicmp(argv[i], "--portable", 10) == 0)
-      {
-        g_application.EnablePlatformDirectories(false);
-      }
-      else if (strnicmp(argv[i], "--legacy-res", 12) == 0)
-      {
-        g_application.SetEnableLegacyRes(true);
-      }
-      else if (strnicmp(argv[i], "--test", 6) == 0)
-      {
-        testmode=1;
-      }
-#ifdef HAS_LIRC
-      else if (strnicmp(argv[i], "-l", 2) == 0 || strnicmp(argv[i], "--lircdev", 9) == 0)
-      {
-        // check the next arg with the proper value.
-        int next=i+1;
-        if (next < argc)
-        {
-          if ((argv[next][0] != '-' ) && (argv[next][0] == '/' ))
-          {
-            g_RemoteControl.setDeviceName(argv[next]);
-            i++;
-          }
-        }
-      }
-      else if (strnicmp(argv[i], "-n", 2) == 0 || strnicmp(argv[i], "--nolirc", 8) == 0)
-         g_RemoteControl.setUsed(false);
-#endif
-      else if (strnicmp(argv[i], "--debug", 7) == 0)
-      {
-        g_advancedSettings.m_logLevel     = LOG_LEVEL_DEBUG;
-        g_advancedSettings.m_logLevelHint = LOG_LEVEL_DEBUG;
-        CLog::SetLogLevel(g_advancedSettings.m_logLevel);
-      }
-      else if (strlen(argv[i]) != 0 && argv[i][0] != '-')
-      {
-        CFileItemPtr pItem(new CFileItem(argv[i]));
-        pItem->m_strPath = argv[i];
-        if (testmode) g_application.SetEnableTestMode(true);
-        playlist.Add(pItem);
-      }
-    }
-  }
-
   g_application.Preflight();
   if (!g_application.Create())
   {
     fprintf(stderr, "ERROR: Unable to create application. Exiting\n");
     return status;
   }
-
-  if (playlist.Size() > 0)
-  {
-    g_playlistPlayer.Add(0,playlist);
-    g_playlistPlayer.SetCurrentPlaylist(0);
-  }
-
-  ThreadMessage tMsg = {TMSG_PLAYLISTPLAYER_PLAY, (DWORD) -1};
-  g_application.getApplicationMessenger().SendMessage(tMsg, false);
 
   try
   {


### PR DESCRIPTION
Changed logic so that we can accept a wider range of version numbers, this was inspired by an issue where we have 3.0 and 3.00 that are not the same (this does fix that, however 3.0 <= 3.00 == TRUE and 3.0 >= 3.00 == TRUE, however 3.0 == 3.00 != TRUE)

Full details of the reference code can be found here: http://codingcastles.blogspot.com/2009/05/comparing-version-numbers.html
