### PR TITLE
Build fix for latest ffmpeg library

### DIFF
--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -45,7 +45,9 @@ extern "C" {
 #if (defined USE_EXTERNAL_FFMPEG)
   #if (defined HAVE_LIBAVCODEC_AVCODEC_H)
     #include <libavcodec/avcodec.h>
-    #include <libavcodec/opt.h>
+    #if (defined HAVE_LIBAVCODEC_OPT_H)
+      #include <libavcodec/opt.h>
+    #endif
     #if (defined AVPACKET_IN_AVFORMAT)
       #include <libavformat/avformat.h>
     #endif
@@ -76,7 +78,7 @@ extern "C" {
 
 /* Some convenience macros introduced at this particular revision of libavcodec.
  */
-#if LIBAVCODEC_VERSION_INT < (52<<16 | 25<<8)
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(52,25,0)
 #define CH_LAYOUT_5POINT0_BACK      (CH_LAYOUT_SURROUND|CH_BACK_LEFT|CH_BACK_RIGHT)
 #define CH_LAYOUT_5POINT1_BACK      (CH_LAYOUT_5POINT0_BACK|CH_LOW_FREQUENCY)
 #undef CH_LAYOUT_7POINT1_WIDE
@@ -84,7 +86,7 @@ extern "C" {
                                            CH_FRONT_LEFT_OF_CENTER|CH_FRONT_RIGHT_OF_CENTER)
 #endif
 
-#if LIBAVCORE_VERSION_INT < AV_VERSION_INT(52,64,0)
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(52,64,0)
 // API added on: 2010-03-31
 #define AVMediaType		CodecType
 #define AVMEDIA_TYPE_UNKNOWN    CODEC_TYPE_UNKNOWN
@@ -132,7 +134,6 @@ public:
   virtual void avpicture_free(AVPicture *picture)=0;
   virtual void av_free_packet(AVPacket *pkt)=0;
   virtual int avpicture_alloc(AVPicture *picture, PixelFormat pix_fmt, int width, int height)=0;
-  virtual const AVOption *av_set_string(void *obj, const char *name, const char *val)=0;
   virtual enum PixelFormat avcodec_default_get_format(struct AVCodecContext *s, const enum PixelFormat *fmt)=0;
   virtual int avcodec_default_get_buffer(AVCodecContext *s, AVFrame *pic)=0;
   virtual void avcodec_default_release_buffer(AVCodecContext *s, AVFrame *pic)=0;
@@ -221,7 +222,6 @@ public:
   virtual void avpicture_free(AVPicture *picture) { ::avpicture_free(picture); }
   virtual void av_free_packet(AVPacket *pkt) { ::av_free_packet(pkt); }
   virtual int avpicture_alloc(AVPicture *picture, PixelFormat pix_fmt, int width, int height) { return ::avpicture_alloc(picture, pix_fmt, width, height); }
-  virtual const AVOption *av_set_string(void *obj, const char *name, const char *val) { return ::av_set_string(obj, name, val); }
   virtual int avcodec_default_get_buffer(AVCodecContext *s, AVFrame *pic) { return ::avcodec_default_get_buffer(s, pic); }
   virtual void avcodec_default_release_buffer(AVCodecContext *s, AVFrame *pic) { ::avcodec_default_release_buffer(s, pic); }
   virtual enum PixelFormat avcodec_default_get_format(struct AVCodecContext *s, const enum PixelFormat *fmt) { return ::avcodec_default_get_format(s, fmt); }
@@ -298,7 +298,6 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
   DEFINE_METHOD1(void, av_bitstream_filter_close, (AVBitStreamFilterContext *p1))
   DEFINE_METHOD1(void, av_free_packet, (AVPacket *p1))
   DEFINE_METHOD4(int, avpicture_alloc, (AVPicture *p1, PixelFormat p2, int p3, int p4))
-  DEFINE_METHOD3(const AVOption*, av_set_string, (void *p1, const char *p2, const char *p3))
   DEFINE_METHOD2(int, avcodec_default_get_buffer, (AVCodecContext *p1, AVFrame *p2))
   DEFINE_METHOD2(void, avcodec_default_release_buffer, (AVCodecContext *p1, AVFrame *p2))
   DEFINE_METHOD2(enum PixelFormat, avcodec_default_get_format, (struct AVCodecContext *p1, const enum PixelFormat *p2))
@@ -338,7 +337,6 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
     RESOLVE_METHOD(avpicture_free)
     RESOLVE_METHOD(avpicture_alloc)
     RESOLVE_METHOD(av_free_packet)
-    RESOLVE_METHOD(av_set_string)
     RESOLVE_METHOD(avcodec_default_get_buffer)
     RESOLVE_METHOD(avcodec_default_release_buffer)
     RESOLVE_METHOD(avcodec_default_get_format)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -176,7 +176,7 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
       if(pCodec->id == hints.codec
       && pCodec->capabilities & CODEC_CAP_HWACCEL_VDPAU)
       {
-        if ((pCodec->id == CODEC_ID_MPEG4 || pCodec->id == CODEC_ID_XVID) && !g_advancedSettings.m_videoAllowMpeg4VDPAU)
+        if ((pCodec->id == CODEC_ID_MPEG4) && !g_advancedSettings.m_videoAllowMpeg4VDPAU)
           continue;
 
         CLog::Log(LOGNOTICE,"CDVDVideoCodecFFmpeg::Open() Creating VDPAU(%ix%i, %d)",hints.width, hints.height, hints.codec);
@@ -252,7 +252,7 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   // set any special options
   for(CDVDCodecOptions::iterator it = options.begin(); it != options.end(); it++)
   {
-    m_dllAvCodec.av_set_string(m_pCodecContext, it->m_name.c_str(), it->m_value.c_str());
+    m_dllAvUtil.av_set_string3(m_pCodecContext, it->m_name.c_str(), it->m_value.c_str(), 0, NULL);
   }
 
 #if defined(__APPLE__) && defined(__arm__)
@@ -329,17 +329,17 @@ void CDVDVideoCodecFFmpeg::SetDropState(bool bDrop)
       // TODO: 'hurry_up' has been deprecated in favor of the skip_* variables
       // Use those instead.
 
-      m_pCodecContext->hurry_up = 1;
-      //m_pCodecContext->skip_frame = AVDISCARD_NONREF;
-      //m_pCodecContext->skip_idct = AVDISCARD_NONREF;
-      //m_pCodecContext->skip_loop_filter = AVDISCARD_NONREF;
+      //m_pCodecContext->hurry_up = 1;
+      m_pCodecContext->skip_frame = AVDISCARD_NONREF;
+      m_pCodecContext->skip_idct = AVDISCARD_NONREF;
+      m_pCodecContext->skip_loop_filter = AVDISCARD_NONREF;
     }
     else
     {
-      m_pCodecContext->hurry_up = 0;
-      //m_pCodecContext->skip_frame = AVDISCARD_DEFAULT;
-      //m_pCodecContext->skip_idct = AVDISCARD_DEFAULT;
-      //m_pCodecContext->skip_loop_filter = AVDISCARD_DEFAULT;
+      //m_pCodecContext->hurry_up = 0;
+      m_pCodecContext->skip_frame = AVDISCARD_DEFAULT;
+      m_pCodecContext->skip_idct = AVDISCARD_DEFAULT;
+      m_pCodecContext->skip_loop_filter = AVDISCARD_DEFAULT;
     }
   }
 }
@@ -412,7 +412,7 @@ int CDVDVideoCodecFFmpeg::Decode(BYTE* pData, int iSize, double dts, double pts)
     return VC_ERROR;
   }
 
-  if (len != iSize && !m_pCodecContext->hurry_up)
+  if (len != iSize && m_pCodecContext->skip_frame != AVDISCARD_NONREF)
     CLog::Log(LOGWARNING, "%s - avcodec_decode_video didn't consume the full packet. size: %d, consumed: %d", __FUNCTION__, iSize, len);
 
   if (!iGotPicture)

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -124,7 +124,7 @@ protected:
   void UpdateCurrentPTS();
 
   CRITICAL_SECTION m_critSection;
-  // #define MAX_STREAMS 42 // from avformat.h
+  #define MAX_STREAMS 100
   CDemuxStream* m_streams[MAX_STREAMS]; // maximum number of streams that ffmpeg can handle
 
   ByteIOContext* m_ioContext;


### PR DESCRIPTION
This patch fixes XBMC to build and work with latest ffmpeg; the patch also works fine with the internal ffmpeg. Patch coded by Fneufneu and alexb38; see: http://forum.xbmc.org/showthread.php?t=100601. I just packaged it for submission and verified that it builds and runs with both ffmpegs.

I am not sure if this is the correct final fix; but I would at least like to start a discussion about the fix (here or continued at the above forum link); it's an annoyance to have to continue to manage this fix as a separate branch.
