### PR TITLE
Initialize 'loaded' flag in CScraper::Clone constructor.

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -160,7 +160,7 @@ AddonPtr CScraper::Clone(const AddonPtr &self) const
 }
 
 CScraper::CScraper(const CScraper &rhs, const AddonPtr &self)
-  : CAddon(rhs, self)
+  : CAddon(rhs, self), m_fLoaded(false)
 {
   m_pathContent = rhs.m_pathContent;
   m_persistence = rhs.m_persistence;


### PR DESCRIPTION
http://trac.xbmc.org/ticket/11637. I don't actually repro this but based on the call stack this looks to be the correct fix: a cloned CScraper is likely defaulting m_fLoaded to true (since it is not initialized), leading to a crash due to null XML tree pointers from the scraper not actually being loaded.
