### PR TITLE
Add articles to Slovenian translation

### DIFF
--- a/language/Slovenian/langinfo.xml
+++ b/language/Slovenian/langinfo.xml
@@ -21,4 +21,11 @@
       <timezone>CEST</timezone>
     </region>
   </regions>
+
+  <sorttokens>
+    <token>The</token>
+    <token>Der</token>
+    <token>Die</token>
+    <token>Das</token>
+  </sorttokens>
 </language>


### PR DESCRIPTION
As we don't have any movie grabber in Slovenian language I added English and German articles to add ability to sort without them.
