### PR TITLE
remove hurry_up in VDPAU.cpp

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -326,17 +326,12 @@ void CDVDVideoCodecFFmpeg::SetDropState(bool bDrop)
     //  2 seem to be to high.. it causes video to be ruined on following images
     if( bDrop )
     {
-      // TODO: 'hurry_up' has been deprecated in favor of the skip_* variables
-      // Use those instead.
-
-      //m_pCodecContext->hurry_up = 1;
       m_pCodecContext->skip_frame = AVDISCARD_NONREF;
       m_pCodecContext->skip_idct = AVDISCARD_NONREF;
       m_pCodecContext->skip_loop_filter = AVDISCARD_NONREF;
     }
     else
     {
-      //m_pCodecContext->hurry_up = 0;
       m_pCodecContext->skip_frame = AVDISCARD_DEFAULT;
       m_pCodecContext->skip_idct = AVDISCARD_DEFAULT;
       m_pCodecContext->skip_loop_filter = AVDISCARD_DEFAULT;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -1175,7 +1175,7 @@ int CVDPAU::Decode(AVCodecContext *avctx, AVFrame *pFrame)
     {
       if(method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF
       || method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF
-      || avctx->hurry_up)
+      || avctx->skip_frame == AVDISCARD_NONREF)
         m_mixerstep = 0;
       else
         m_mixerstep = 1;
@@ -1195,7 +1195,7 @@ int CVDPAU::Decode(AVCodecContext *avctx, AVFrame *pFrame)
   else if(m_mixerstep == 1)
   { // no new frame given, output second field of old frame
 
-    if(avctx->hurry_up)
+    if(avctx->skip_frame == AVDISCARD_NONREF)
     {
       ClearUsedForRender(&past[1]);
       m_DVDVideoPics.pop();


### PR DESCRIPTION
in VDPAU.cpp, replaces:
avctx->hurry_up

by:
avctx->skip_frame == AVDISCARD_NONREF
