### PR TITLE
Modified "Check and Cache" image function to check cache first.

### DIFF
--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -61,7 +61,7 @@ bool CImageLoader::DoWork()
        || file.GetMimeType().Left(6).Equals("image/")) // ignore non-pictures
     { 
       // Cache the image if necessary
-      loadPath = CTextureCache::Get().CheckAndCacheImage(texturePath);
+      loadPath = CTextureCache::Get().CacheImageFile(texturePath);
       if (loadPath.IsEmpty())
         return false;
     }

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -201,9 +201,23 @@ CStdString CTextureCache::CheckAndCacheImage(const CStdString &url, bool returnD
   {
     return path;
   }
+  return CacheImageFile(url);
+}
 
-  // Uncached image - best we can do for now is cache it so that the texture manager
-  // can load it.
+CStdString CTextureCache::CacheImageFile(const CStdString &url)
+{
+  // Cache image so that the texture manager can load it.
+  CStdString originalFile = GetCacheFile(url);
+
+  CStdString hash = CCacheJob::CacheImage(url, originalFile);
+  if (!hash.IsEmpty())
+  {
+    AddCachedTexture(url, originalFile, hash);
+    if (g_advancedSettings.m_useDDSFanart)
+      AddJob(new CDDSJob(GetCachedPath(originalFile)));
+    return GetCachedPath(originalFile);
+  }
+  return "";
 
   // TODO: In the future we need a cache job to callback when the image is loaded
   //       thus automatically updating the images.  We'd also need fallback code inside
@@ -243,18 +257,6 @@ CStdString CTextureCache::CheckAndCacheImage(const CStdString &url, bool returnD
   // a current image and a new one is loading we currently hold on to the current one and render
   // the current one faded out - we'd need to change this so that the fading only happened once it
   // was ready to render.
-
-  CStdString originalFile = GetCacheFile(url);
-
-  CStdString hash = CCacheJob::CacheImage(url, originalFile);
-  if (!hash.IsEmpty())
-  {
-    AddCachedTexture(url, originalFile, hash);
-    if (g_advancedSettings.m_useDDSFanart)
-      AddJob(new CDDSJob(GetCachedPath(originalFile)));
-    return GetCachedPath(originalFile);
-  }
-  return "";
 }
 
 void CTextureCache::ClearCachedImage(const CStdString &url, bool deleteSource /*= false */)

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -176,7 +176,7 @@ CStdString CTextureCache::GetWrappedThumbURL(const CStdString &image)
   return URIUtils::AddFileToFolder("thumb://" + url, URIUtils::GetFileName(image));
 }
 
-CStdString CTextureCache::CheckAndCacheImage(const CStdString &url, bool returnDDS)
+CStdString CTextureCache::CheckCachedImage(const CStdString &url, bool returnDDS)
 {
   CStdString path(GetCachedImage(url));
   if (!path.IsEmpty())
@@ -189,6 +189,16 @@ CStdString CTextureCache::CheckAndCacheImage(const CStdString &url, bool returnD
       if (g_advancedSettings.m_useDDSFanart)
         AddJob(new CDDSJob(path));
     }
+    return path;
+  }
+  return "";
+}
+
+CStdString CTextureCache::CheckAndCacheImage(const CStdString &url, bool returnDDS)
+{
+  CStdString path(CheckCachedImage(url,returnDDS));
+  if (!path.IsEmpty())
+  {
     return path;
   }
 

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -52,14 +52,25 @@ public:
    */
   void Deinitialize();
 
+  /*! \brief Check whether we already have this image cached
+
+   Check and return URL to cached image if it exists; If not, return empty string.
+   If the image is cached, return URL (for original image or .dds version if requested)
+   Created .dds of image if requested as per settings.
+
+   \param image url of the image to check
+   \param returnDDS if we're allowed to return a DDS version, defaults to true
+   \return cached url of this image
+   \sa GetCachedImage
+   */ 
+   CStdString CheckCachedImage(const CStdString &image, bool returnDDS = true);
+
   /*! \brief check whether we have this image cached, and change it's url if so
 
-   Checks firstly whether the image should be cached (i.e. is the image a .dds file?).
-   If the image isn't a .dds file, we lookup the database for a cached version and use
-   that if available. If the image is not yet in the database it is cached and added
-   to the database.
+   Checks firstly whether an image is already cached, and return URL if so.
+   If the image is not yet in the database it is cached and added to the database.
 
-   \param image url of the image to cache
+   \param image url of the image to check and cache
    \param returnDDS if we're allowed to return a DDS version, defaults to true
    \return cached url of this image
    \sa GetCachedImage

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -65,18 +65,28 @@ public:
    */ 
    CStdString CheckCachedImage(const CStdString &image, bool returnDDS = true);
 
-  /*! \brief check whether we have this image cached, and change it's url if so
-
-   Checks firstly whether an image is already cached, and return URL if so.
-   If the image is not yet in the database it is cached and added to the database.
+  /*! \brief This function is a wrapper around CheckCacheImage and CacheImageFile.
+  
+   Checks firstly whether an image is already cached, and return URL if so [see CheckCacheImage]
+   If the image is not yet in the database it is cached and added to the database [see CacheImageFile]
 
    \param image url of the image to check and cache
    \param returnDDS if we're allowed to return a DDS version, defaults to true
    \return cached url of this image
-   \sa GetCachedImage
+   \sa CheckCacheImage
    */
   CStdString CheckAndCacheImage(const CStdString &image, bool returnDDS = true);
 
+  /*! \brief Take image URL and add it to image cache
+
+   Takes the URL to an image. Caches and adds to the database.
+
+   \param image url of the image to cache
+   \return cached url of this image
+   \sa CCacheJob::CacheImage
+   */  
+  CStdString CacheImageFile(const CStdString &url);
+  
   /*! \brief retrieve the cached version of the given image (if it exists)
    \param image url of the image
    \return cached url of this image, empty if none exists


### PR DESCRIPTION
As discussed at http://forum.xbmc.org/showthread.php?t=81464&page=3 (post 29 onwards)

Modified image loading via CImageLoader::DoWork:
- Added extra mime type check for images that do not have displayed extensions.
- Re-arranged code so that cache is checked before URL validation as cached image URLs have already been validated once before.  

This should reduce the amount of work required to load a cached image.

This change does not alter the cache expiry/invalidation method or .dds file loads.
