### PR TITLE
Fix aspect ratio being incorrect.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1004,10 +1004,7 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
         }
         st->iWidth = pStream->codec->width;
         st->iHeight = pStream->codec->height;
-        if (pStream->sample_aspect_ratio.num == 0)
-          st->fAspect = 0.0;
-        else
-          st->fAspect = av_q2d(pStream->sample_aspect_ratio) * pStream->codec->width / pStream->codec->height;
+		st->fAspect = 0.0;
         st->iLevel = pStream->codec->level;
         st->iProfile = pStream->codec->profile;
 


### PR DESCRIPTION
**Note:** Please see discussion on http://trac.xbmc.org/ticket/11640. I'm not 100% confident in this fix, even though it works for me.

The aspect ratio being calculated is a combination of both PAR and DAR,
which causes streams that have a non-square PAR defined to come out with
the wrong aspect ratio. The ratio is calculated correctly within
CDVDVideoCodecFFmpeg::GetVideoAspect() and the picture correctly scaled
anyway.

This patch simply sets CDemuxStreamVideoFFmpeg::fAspect to 0.0 as I
can't immediately see a way of getting just the DAR in this location.

Fixes: #11640
