### PR TITLE
Ffmpeg 0.7 changes

### DIFF
--- a/lib/DllPostProc.h
+++ b/lib/DllPostProc.h
@@ -61,11 +61,11 @@ public:
    virtual ~DllPostProcInterface() {}
   virtual void pp_postprocess(uint8_t * src[3], int srcStride[3], uint8_t * dst[3], int dstStride[3],
                    int horizontalSize, int verticalSize, QP_STORE_T *QP_store,  int QP_stride,
-		           pp_mode_t *mode, pp_context_t *ppContext, int pict_type)=0;	           
-  virtual pp_mode_t *pp_get_mode_by_name_and_quality(char *name, int quality)=0;
-  virtual void pp_free_mode(pp_mode_t *mode)=0;
-  virtual pp_context_t *pp_get_context(int width, int height, int flags)=0;
-  virtual void pp_free_context(pp_context_t *ppContext)=0;
+		           pp_mode *mode, pp_context *ppContext, int pict_type)=0;	           
+  virtual pp_mode *pp_get_mode_by_name_and_quality(char *name, int quality)=0;
+  virtual void pp_free_mode(pp_mode *mode)=0;
+  virtual pp_context *pp_get_context(int width, int height, int flags)=0;
+  virtual void pp_free_context(pp_context *ppContext)=0;
 };
 
 #if (defined USE_EXTERNAL_FFMPEG)
@@ -78,11 +78,11 @@ public:
   virtual ~DllPostProc() {}
   virtual void pp_postprocess(uint8_t * src[3], int srcStride[3], uint8_t * dst[3], int dstStride[3],
                   int horizontalSize, int verticalSize, QP_STORE_T *QP_store,  int QP_stride,
-                  pp_mode_t *mode, pp_context_t *ppContext, int pict_type) { ::pp_postprocess((const uint8_t** )src, srcStride, dst, dstStride, horizontalSize, verticalSize, QP_store, QP_stride, mode, ppContext, pict_type); }             
-  virtual pp_mode_t *pp_get_mode_by_name_and_quality(char *name, int quality) { return ::pp_get_mode_by_name_and_quality(name, quality); }
-  virtual void pp_free_mode(pp_mode_t *mode) { ::pp_free_mode(mode); }
-  virtual pp_context_t *pp_get_context(int width, int height, int flags) { return ::pp_get_context(width, height, flags); }
-  virtual void pp_free_context(pp_context_t *ppContext) { ::pp_free_context(ppContext); }
+                  pp_mode *mode, pp_context *ppContext, int pict_type) { ::pp_postprocess((const uint8_t** )src, srcStride, dst, dstStride, horizontalSize, verticalSize, QP_store, QP_stride, mode, ppContext, pict_type); }             
+  virtual pp_mode *pp_get_mode_by_name_and_quality(char *name, int quality) { return ::pp_get_mode_by_name_and_quality(name, quality); }
+  virtual void pp_free_mode(pp_mode *mode) { ::pp_free_mode(mode); }
+  virtual pp_context *pp_get_context(int width, int height, int flags) { return ::pp_get_context(width, height, flags); }
+  virtual void pp_free_context(pp_context *ppContext) { ::pp_free_context(ppContext); }
   
   // DLL faking.
   virtual bool ResolveExports() { return true; }
@@ -99,11 +99,11 @@ class DllPostProc : public DllDynamic, DllPostProcInterface
   DECLARE_DLL_WRAPPER(DllPostProc, DLL_PATH_LIBPOSTPROC)
   DEFINE_METHOD11(void, pp_postprocess, (uint8_t* p1[3], int p2[3], uint8_t * p3[3], int p4[3],
                       int p5, int p6, QP_STORE_T *p7,  int p8,
-                      pp_mode_t *p9, pp_context_t *p10, int p11))
-  DEFINE_METHOD2(pp_mode_t*, pp_get_mode_by_name_and_quality, (char *p1, int p2))
-  DEFINE_METHOD1(void, pp_free_mode, (pp_mode_t *p1))
-  DEFINE_METHOD3(pp_context_t*, pp_get_context, (int p1, int p2, int p3))
-  DEFINE_METHOD1(void, pp_free_context, (pp_context_t *p1))
+                      pp_mode *p9, pp_context *p10, int p11))
+  DEFINE_METHOD2(pp_mode*, pp_get_mode_by_name_and_quality, (char *p1, int p2))
+  DEFINE_METHOD1(void, pp_free_mode, (pp_mode *p1))
+  DEFINE_METHOD3(pp_context*, pp_get_context, (int p1, int p2, int p3))
+  DEFINE_METHOD1(void, pp_free_context, (pp_context *p1))
 
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(pp_postprocess)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -1175,7 +1175,7 @@ int CVDPAU::Decode(AVCodecContext *avctx, AVFrame *pFrame)
     {
       if(method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF
       || method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF
-      || avctx->hurry_up)
+      || avctx->skip_idct || avctx->skip_frame)
         m_mixerstep = 0;
       else
         m_mixerstep = 1;
@@ -1195,7 +1195,7 @@ int CVDPAU::Decode(AVCodecContext *avctx, AVFrame *pFrame)
   else if(m_mixerstep == 1)
   { // no new frame given, output second field of old frame
 
-    if(avctx->hurry_up)
+    if(avctx->skip_idct || avctx->skip_frame)
     {
       ClearUsedForRender(&past[1]);
       m_DVDVideoPics.pop();


### PR DESCRIPTION
ffmpeg 0.7-rc1 removes certain deprecated data types and fields in structs. These commits change the code to use the replacement names and fields, and are compatible with the version of ffmpeg currently in-tree.
