### PR TITLE
GetCached*Thumb refactoring

### DIFF
--- a/xbmc/ThumbnailCache.h
+++ b/xbmc/ThumbnailCache.h
@@ -25,6 +25,14 @@
 #include <map>
 
 class CCriticalSection;
+class CVideoInfoTag;
+namespace MUSIC_INFO 
+{
+  class CMusicInfoTag;
+}
+class CAlbum;
+class CArtist;
+class CFileItem;
 
 class CThumbnailCache
 {
@@ -38,6 +46,24 @@ public:
   void Add(const CStdString& strFileName, bool bExists);
   void Clear();
   bool IsCached(const CStdString& strFileName);
+
+  static CStdString GetMusicThumb(const CStdString &path);
+  static CStdString GetAlbumThumb(const CFileItem &item);
+  static CStdString GetAlbumThumb(const MUSIC_INFO::CMusicInfoTag *musicInfo);
+  static CStdString GetAlbumThumb(const CAlbum &album);
+  static CStdString GetAlbumThumb(const CStdString &album, const CStdString &artist);
+  static CStdString GetArtistThumb(const CArtist &artist);
+  static CStdString GetArtistThumb(const CFileItem &item);
+  static CStdString GetArtistThumb(const CStdString &label);
+  static CStdString GetActorThumb(const CFileItem &item);
+  static CStdString GetActorThumb(const CStdString &label);
+  static CStdString GetSeasonThumb(const CFileItem &item);
+  static CStdString GetSeasonThumb(const CStdString &label, const CVideoInfoTag *videoInfo = NULL);
+  static CStdString GetEpisodeThumb(const CFileItem &item);
+  static CStdString GetEpisodeThumb(const CVideoInfoTag *videoInfo);
+  static CStdString GetVideoThumb(const CFileItem &item);
+  static CStdString GetFanart(const CFileItem &item);
+  static CStdString GetThumb(const CStdString &path, const CStdString &path2, bool split = false);
 protected:
 
   static CThumbnailCache* m_pCacheInstance;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1892,28 +1892,6 @@ bool CUtil::SupportsFileOperations(const CStdString& strPath)
   return false;
 }
 
-CStdString CUtil::GetCachedAlbumThumb(const CStdString& album, const CStdString& artist)
-{
-  if (album.IsEmpty())
-    return GetCachedMusicThumb("unknown"+artist);
-  if (artist.IsEmpty())
-    return GetCachedMusicThumb(album+"unknown");
-  return GetCachedMusicThumb(album+artist);
-}
-
-CStdString CUtil::GetCachedMusicThumb(const CStdString& path)
-{
-  Crc32 crc;
-  CStdString noSlashPath(path);
-  URIUtils::RemoveSlashAtEnd(noSlashPath);
-  crc.ComputeFromLowerCase(noSlashPath);
-  CStdString hex;
-  hex.Format("%08x", (unsigned __int32) crc);
-  CStdString thumb;
-  thumb.Format("%c/%s.tbn", hex[0], hex.c_str());
-  return URIUtils::AddFileToFolder(g_settings.GetMusicThumbFolder(), thumb);
-}
-
 CStdString CUtil::GetDefaultFolderThumb(const CStdString &folderThumb)
 {
   if (g_TextureManager.HasTexture(folderThumb))

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -135,9 +135,6 @@ public:
   static double AlbumRelevance(const CStdString& strAlbumTemp1, const CStdString& strAlbum1, const CStdString& strArtistTemp1, const CStdString& strArtist1);
   static bool MakeShortenPath(CStdString StrInput, CStdString& StrOutput, int iTextMaxLength);
   static bool SupportsFileOperations(const CStdString& strPath);
-
-  static CStdString GetCachedMusicThumb(const CStdString &path);
-  static CStdString GetCachedAlbumThumb(const CStdString &album, const CStdString &artist);
   static CStdString GetDefaultFolderThumb(const CStdString &folderThumb);
 
 #ifdef UNIT_TESTING

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -43,6 +43,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "TextureCache.h"
 #include "video/windows/GUIWindowVideoBase.h"
+#include "ThumbnailCache.h"
 
 #ifdef _WIN32
 #include "WIN32Util.h"
@@ -465,7 +466,7 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
         {
           cachedThumb = item->m_strPath;
           URIUtils::RemoveSlashAtEnd(cachedThumb);
-          cachedThumb = CUtil::GetCachedMusicThumb(cachedThumb);
+          cachedThumb = CThumbnailCache::GetMusicThumb(cachedThumb);
         }
         else if (type == "video")
           cachedThumb = item->GetCachedVideoThumb();

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -51,6 +51,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "TextureCache.h"
+#include "ThumbnailCache.h"
 
 #ifdef _WIN32
 extern "C" FILE *fopen_utf8(const char *_Filename, const char *_Mode);
@@ -1815,7 +1816,7 @@ int CXbmcHttp::xbmcGetThumbFilename(int numParas, CStdString paras[])
 
   if (numParas>1)
   {
-    thumbFilename = CUtil::GetCachedAlbumThumb(paras[0], paras[1]);
+    thumbFilename = CThumbnailCache::GetAlbumThumb(paras[0], paras[1]);
     return SetResponse(openTag+thumbFilename ) ;
   }
   else

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -76,8 +76,7 @@ JSON_STATUS CAudioLibrary::GetArtistDetails(const CStdString &method, ITransport
   m_artistItem->GetMusicInfoTag()->SetArtist(m_artistItem->GetLabel());
   m_artistItem->GetMusicInfoTag()->SetDatabaseId(artistID);
   CMusicDatabase::SetPropertiesFromArtist(*m_artistItem, artist);
-  if (CFile::Exists(m_artistItem->GetCachedArtistThumb()))
-    m_artistItem->SetThumbnailImage(m_artistItem->GetCachedArtistThumb());
+  m_artistItem->SetCachedArtistThumb();
   HandleFileItem("artistid", false, "artistdetails", m_artistItem, parameterObject, parameterObject["fields"], result, false);
 
   musicdatabase.Close();

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -265,7 +265,8 @@ namespace JSONRPC
       "\"items\": { \"type\": \"object\","
         "\"properties\": {"
           "\"name\": { \"type\": \"string\", \"required\": true },"
-          "\"role\": { \"type\": \"string\", \"required\": true }"
+          "\"role\": { \"type\": \"string\", \"required\": true },"
+          "\"thumbnail\": { \"type\": \"string\" }"
         "}"
       "}"
     "}",

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -237,7 +237,8 @@
     "items": { "type": "object",
       "properties": {
         "name": { "type": "string", "required": true },
-        "role": { "type": "string", "required": true }
+        "role": { "type": "string", "required": true },
+        "thumbnail": { "type": "string" }
       }
     }
   },

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -41,6 +41,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "TextureCache.h"
+#include "ThumbnailCache.h"
 
 using namespace std;
 using namespace XFILE;
@@ -318,7 +319,7 @@ void CGUIDialogMusicInfo::RefreshThumb()
     if (m_bArtistInfo)
       thumbImage = m_albumItem->GetCachedArtistThumb();
     else
-      thumbImage = CUtil::GetCachedAlbumThumb(m_album.strAlbum, m_album.strArtist);
+      thumbImage = CThumbnailCache::GetAlbumThumb(m_album);
 
     if (!CFile::Exists(thumbImage))
     {
@@ -442,7 +443,7 @@ void CGUIDialogMusicInfo::OnGetThumb()
   if (m_bArtistInfo)
     cachedThumb = m_albumItem->GetCachedArtistThumb();
   else
-    cachedThumb = CUtil::GetCachedAlbumThumb(m_album.strAlbum, m_album.strArtist);
+    cachedThumb = CThumbnailCache::GetAlbumThumb(m_album);
 
   CTextureCache::Get().ClearCachedImage(cachedThumb, true);
   if (result.Left(14) == "thumb://Remote")
@@ -480,7 +481,7 @@ void CGUIDialogMusicInfo::OnGetFanart()
 {
   CFileItemList items;
 
-  CStdString cachedThumb(CFileItem::GetCachedThumb(m_artist.strArtist,g_settings.GetMusicFanartFolder()));
+  CStdString cachedThumb(CThumbnailCache::GetThumb(m_artist.strArtist,g_settings.GetMusicFanartFolder()));
   if (CFile::Exists(cachedThumb))
   {
     CFileItemPtr itemCurrent(new CFileItem("fanart://Current",false));

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -39,6 +39,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "TextureCache.h"
 #include "music/Album.h"
+#include "ThumbnailCache.h"
 
 using namespace XFILE;
 
@@ -284,7 +285,7 @@ void CGUIDialogSongInfo::OnGetThumb()
   // delete the thumbnail if that's what the user wants, else overwrite with the
   // new thumbnail
 
-  CStdString cachedThumb(CUtil::GetCachedAlbumThumb(m_song->GetMusicInfoTag()->GetAlbum(), m_song->GetMusicInfoTag()->GetArtist()));
+  CStdString cachedThumb(CThumbnailCache::GetAlbumThumb(m_song->GetMusicInfoTag()));
 
   CTextureCache::Get().ClearCachedImage(cachedThumb, true);
   if (result == "thumb://None")

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -47,6 +47,7 @@
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "ThumbnailCache.h"
 
 #include <algorithm>
 
@@ -712,13 +713,13 @@ void CMusicInfoScanner::UpdateFolderThumb(const VECSONGS &songs, const CStdStrin
   CStdString album, artist;
   if (!HasSingleAlbum(songs, album, artist)) return;
   // Was the album art of this album read during scan?
-  CStdString albumCoverArt(CUtil::GetCachedAlbumThumb(album, artist));
+  CStdString albumCoverArt(CThumbnailCache::GetAlbumThumb(album, artist));
   if (CUtil::ThumbExists(albumCoverArt))
   {
     CStdString folderPath1(folderPath);
     // Folder art is cached without the slash at end
     URIUtils::RemoveSlashAtEnd(folderPath1);
-    CStdString folderCoverArt(CUtil::GetCachedMusicThumb(folderPath1));
+    CStdString folderCoverArt(CThumbnailCache::GetMusicThumb(folderPath1));
     // copy as directory thumb as well
     if (CFile::Cache(albumCoverArt, folderCoverArt))
       CUtil::ThumbCacheAdd(folderCoverArt, true);
@@ -1018,7 +1019,7 @@ void CMusicInfoScanner::GetAlbumArtwork(long id, const CAlbum &album)
     CStdString thumb;
     if (!m_musicDatabase.GetAlbumThumb(id, thumb) || thumb.IsEmpty() || !XFILE::CFile::Exists(thumb))
     {
-      thumb = CUtil::GetCachedAlbumThumb(album.strAlbum,album.strArtist);
+      thumb = CThumbnailCache::GetAlbumThumb(album);
       CScraperUrl::DownloadThumbnail(thumb,album.thumbURL.m_url[0]);
       m_musicDatabase.SaveAlbumThumb(id, thumb);
     }

--- a/xbmc/music/tags/FlacTag.cpp
+++ b/xbmc/music/tags/FlacTag.cpp
@@ -26,6 +26,7 @@
 #include "filesystem/File.h"
 #include "utils/log.h"
 #include "utils/EndianSwap.h"
+#include "ThumbnailCache.h"
 
 
 #define BYTES_TO_CHECK_FOR_BAD_TAGS 16384
@@ -113,9 +114,9 @@ bool CFlacTag::Read(const CStdString& strFile)
 
   CStdString strCoverArt;
   if (!m_musicInfoTag.GetAlbum().IsEmpty() && (!m_musicInfoTag.GetAlbumArtist().IsEmpty() || !m_musicInfoTag.GetArtist().IsEmpty()))
-    strCoverArt = CUtil::GetCachedAlbumThumb(m_musicInfoTag.GetAlbum(), m_musicInfoTag.GetAlbumArtist().IsEmpty() ? m_musicInfoTag.GetArtist() : m_musicInfoTag.GetAlbumArtist());
+    strCoverArt = CThumbnailCache::GetAlbumThumb(&m_musicInfoTag);
   else
-    strCoverArt = CUtil::GetCachedMusicThumb(m_musicInfoTag.GetURL());
+    strCoverArt = CThumbnailCache::GetMusicThumb(m_musicInfoTag.GetURL());
 
   if (cover && !CUtil::ThumbExists(strCoverArt))
   {

--- a/xbmc/music/tags/Id3Tag.cpp
+++ b/xbmc/music/tags/Id3Tag.cpp
@@ -27,6 +27,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
+#include "ThumbnailCache.h"
 
 #include <set>
 
@@ -167,9 +168,9 @@ bool CID3Tag::Parse()
   // other non-tagged files don't get this album image
   CStdString strCoverArt;
   if (!tag.GetAlbum().IsEmpty() && (!tag.GetAlbumArtist().IsEmpty() || !tag.GetArtist().IsEmpty()))
-    strCoverArt = CUtil::GetCachedAlbumThumb(tag.GetAlbum(), tag.GetAlbumArtist().IsEmpty() ? tag.GetArtist() : tag.GetAlbumArtist());
+    strCoverArt = CThumbnailCache::GetAlbumThumb(&tag);
   else
-    strCoverArt = CUtil::GetCachedMusicThumb(tag.GetURL());
+    strCoverArt = CThumbnailCache::GetMusicThumb(tag.GetURL());
   if (bFound && !CUtil::ThumbExists(strCoverArt))
   {
     CStdString strExtension=GetPictureMimeType(pictype);

--- a/xbmc/music/tags/MusicInfoTagLoaderMP4.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderMP4.cpp
@@ -27,6 +27,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/AutoPtrHandle.h"
 #include "utils/log.h"
+#include "ThumbnailCache.h"
 
 using namespace XFILE;
 using namespace AUTOPTR;
@@ -396,9 +397,9 @@ bool CMusicInfoTagLoaderMP4::Load(const CStdString& strFileName, CMusicInfoTag& 
       // other non-tagged files don't get this album image
       CStdString strCoverArt;
       if (!tag.GetAlbum().IsEmpty() && (!tag.GetAlbumArtist().IsEmpty() || !tag.GetArtist().IsEmpty()))
-        strCoverArt = CUtil::GetCachedAlbumThumb(tag.GetAlbum(), tag.GetAlbumArtist().IsEmpty() ? tag.GetArtist() : tag.GetAlbumArtist());
+        strCoverArt = CThumbnailCache::GetAlbumThumb(&tag);
       else
-        strCoverArt = CUtil::GetCachedMusicThumb(tag.GetURL());
+        strCoverArt = CThumbnailCache::GetMusicThumb(tag.GetURL());
       if (!CUtil::ThumbExists(strCoverArt))
       {
         if (CPicture::CreateThumbnailFromMemory( m_thumbData, m_thumbSize, "", strCoverArt ) )

--- a/xbmc/music/tags/MusicInfoTagLoaderWMA.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderWMA.cpp
@@ -28,6 +28,7 @@
 #include "utils/AutoPtrHandle.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
+#include "ThumbnailCache.h"
 
 using namespace AUTOPTR;
 using namespace XFILE;
@@ -516,9 +517,9 @@ void CMusicInfoTagLoaderWMA::SetTagValueBinary(const CStdString& strFrameName, c
       // other non-tagged files don't get this album image
       CStdString strCoverArt;
       if (!tag.GetAlbum().IsEmpty() && (!tag.GetAlbumArtist().IsEmpty() || !tag.GetArtist().IsEmpty()))
-        strCoverArt = CUtil::GetCachedAlbumThumb(tag.GetAlbum(), tag.GetAlbumArtist().IsEmpty() ? tag.GetArtist() : tag.GetAlbumArtist());
+        strCoverArt = CThumbnailCache::GetAlbumThumb(&tag);
       else
-        strCoverArt = CUtil::GetCachedMusicThumb(tag.GetURL());
+        strCoverArt = CThumbnailCache::GetMusicThumb(tag.GetURL());
       if (!CUtil::ThumbExists(strCoverArt))
       {
         int nPos = strExtension.Find('/');

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -60,6 +60,7 @@
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "ThumbnailCache.h"
 
 using namespace std;
 using namespace XFILE;
@@ -1201,7 +1202,7 @@ void CGUIWindowMusicBase::UpdateThumb(const CAlbum &album, const CStdString &pat
     saveDirThumb = false;
   }
 
-  CStdString albumThumb(CUtil::GetCachedAlbumThumb(album.strAlbum, album.strArtist));
+  CStdString albumThumb(CThumbnailCache::GetAlbumThumb(album));
 
   // Update the thumb in the music database (songs + albums)
   CStdString albumPath(path);
@@ -1249,7 +1250,7 @@ void CGUIWindowMusicBase::UpdateThumb(const CAlbum &album, const CStdString &pat
     CStdString album, artist;
     if (CMusicInfoScanner::HasSingleAlbum(songs, album, artist))
     { // can cache as the folder thumb
-      CStdString folderThumb(CUtil::GetCachedMusicThumb(albumPath));
+      CStdString folderThumb(CThumbnailCache::GetMusicThumb(albumPath));
       CFile::Cache(albumThumb, folderThumb);
     }
   }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -49,6 +49,7 @@
 #include "addons/AddonInstaller.h"
 #include "interfaces/AnnouncementManager.h"
 #include "dbwrappers/dataset.h"
+#include "ThumbnailCache.h"
 
 using namespace std;
 using namespace dbiplus;
@@ -4097,7 +4098,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
           if (!items.Contains(pItem->m_strPath))
           {
             pItem->GetVideoInfoTag()->m_strArtist = m_pDS->fv(2).get_asString();
-            CStdString strThumb = CUtil::GetCachedAlbumThumb(pItem->GetLabel(),pItem->GetVideoInfoTag()->m_strArtist);
+            CStdString strThumb = CThumbnailCache::GetAlbumThumb(*pItem);
             if (CFile::Exists(strThumb))
               pItem->SetThumbnailImage(strThumb);
             items.Add(pItem);
@@ -4120,7 +4121,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
           if (!items.Contains(pItem->m_strPath))
           {
             pItem->GetVideoInfoTag()->m_strArtist = m_pDS->fv(2).get_asString();
-            CStdString strThumb = CUtil::GetCachedAlbumThumb(pItem->GetLabel(),m_pDS->fv(2).get_asString());
+            CStdString strThumb = CThumbnailCache::GetAlbumThumb(pItem->GetLabel(), m_pDS->fv(2).get_asString());
             if (CFile::Exists(strThumb))
               pItem->SetThumbnailImage(strThumb);
             items.Add(pItem);

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -27,6 +27,8 @@
 #include "utils/log.h"
 #include "utils/Variant.h"
 #include "utils/CharsetConverter.h"
+#include "ThumbnailCache.h"
+#include "filesystem/File.h"
 
 #include <sstream>
 
@@ -396,6 +398,9 @@ void CVideoInfoTag::Serialize(CVariant& value)
     CVariant actor;
     actor["name"] = m_cast[i].strName;
     actor["role"] = m_cast[i].strRole;
+    CStdString thumb = CThumbnailCache::GetActorThumb(m_cast[i].strName);
+    if (XFILE::CFile::Exists(thumb))
+      actor["thumbnail"] = thumb;
     value["cast"].push_back(actor);
   }
   value["set"] = m_strSet;


### PR DESCRIPTION
The first commit "refactors" the GetCached_Thumb() methods from CFileItem and CUtil and moves them to CThumbnailCache so that the logic for all those methods is in one place. Furthermore if possible it introduces convenience methods which do not need a CFileItem object to work. To keep the number of changes small the GetCached_Thumb() methods are left in CFileItem but call the methods which were moved to CThumbnailCache.

The second commit uses the new method of CThumbnailCache to expose the thumbnails of actors to jsonrpc.

I'm planning on refactoring more code which has to do with image caching to get that part of XBMC better organised. This pull request is meant as a first step to get some feedback on whether the direction this takes is alright or if it should stay the way it is or if it should be improved in a different way.
