### PR TITLE
Noflip

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2063,8 +2063,6 @@ void CApplication::Render()
         else if (lowfps)
           singleFrameTime = 200;  // 5 fps, <=200 ms latency to wake up
       }
-      else //if vsync is on and we have nothing to render, loop at 25 fps
-        singleFrameTime = 40;
 
       decrement = true;
     }
@@ -2102,6 +2100,9 @@ void CApplication::Render()
   //fps limiter, make sure each frame lasts at least singleFrameTime milliseconds
   if (limitFrames || !hasRendered)
   {
+    if (!limitFrames)
+      singleFrameTime = 40; //if nothing is rendered, loop at 25 fps
+
     unsigned int now = CTimeUtils::GetTimeMS();
     unsigned int frameTime = now - m_lastFrameTime;
     if (frameTime < singleFrameTime)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1914,7 +1914,7 @@ void CApplication::RenderScreenSaver()
   {
     color_t color = ((color_t)(screenSaverFadeAmount * amount * 2.55f) & 0xff) << 24;
     CRect rect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
-    g_windowManager.MarkDirty(rect);
+    g_windowManager.MarkDirty();
     CGUITexture::DrawQuad(rect, color);
   }
 }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -742,6 +742,8 @@ bool CApplication::Create()
 
   g_mediaManager.Initialize();
 
+  m_lastFrameTime = CTimeUtils::GetTimeMS();
+
   return Initialize();
 }
 
@@ -1985,18 +1987,16 @@ void CApplication::Render()
 
   bool decrement = false;
   bool hasRendered = false;
+  bool limitFrames = false;
+  unsigned int singleFrameTime = 10; // default limit 100 fps
 
-  { // frame rate limiter (really bad, but it does the trick :p)
-    static unsigned int lastFrameTime = 0;
-    unsigned int currentTime = CTimeUtils::GetTimeMS();
-    int nDelayTime = 0;
+  {
     // Less fps in DPMS or Black screensaver
     bool lowfps = (m_dpmsIsActive
                    || (m_bScreenSave && m_screenSaver && (m_screenSaver->ID() == "screensaver.xbmc.builtin.black")
                        && (screenSaverFadeAmount >= 100)));
     // Whether externalplayer is playing and we're unfocused
     bool extPlayerActive = m_eCurrentPlayer >= EPC_EXTPLAYER && IsPlaying() && !m_AppFocused;
-    unsigned int singleFrameTime = 10; // default limit 100 fps
 
     m_bPresentFrame = false;
     if (!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !IsPaused())
@@ -2044,13 +2044,13 @@ void CApplication::Render()
     else
     {
       // engage the frame limiter as needed
-      bool limitFrames = lowfps || extPlayerActive;
+      limitFrames = lowfps || extPlayerActive;
       // DXMERGE - we checked for g_videoConfig.GetVSyncMode() before this
       //           perhaps allowing it to be set differently than the UI option??
       if (g_guiSettings.GetInt("videoscreen.vsync") == VSYNC_DISABLED ||
           g_guiSettings.GetInt("videoscreen.vsync") == VSYNC_VIDEO)
         limitFrames = true; // not using vsync.
-      else if ((g_infoManager.GetFPS() > g_graphicsContext.GetFPS() + 10) && g_infoManager.GetFPS() > 1000/singleFrameTime)
+      else if ((g_infoManager.GetFPS() > g_graphicsContext.GetFPS() + 10) && g_infoManager.GetFPS() > 1000 / singleFrameTime)
         limitFrames = true; // using vsync, but it isn't working.
 
       if (limitFrames)
@@ -2062,15 +2062,12 @@ void CApplication::Render()
         }
         else if (lowfps)
           singleFrameTime = 200;  // 5 fps, <=200 ms latency to wake up
-
-        if (lastFrameTime + singleFrameTime > currentTime)
-          nDelayTime = lastFrameTime + singleFrameTime - currentTime;
-        Sleep(nDelayTime);
       }
+      else //if vsync is on and we have nothing to render, loop at 25 fps
+        singleFrameTime = 40;
+
       decrement = true;
     }
-
-    lastFrameTime = CTimeUtils::GetTimeMS();
   }
 
   CSingleLock lock(g_graphicsContext);
@@ -2102,10 +2099,19 @@ void CApplication::Render()
 
   lock.Leave();
 
+  //fps limiter, make sure each frame lasts at least singleFrameTime milliseconds
+  if (limitFrames || !hasRendered)
+  {
+    unsigned int now = CTimeUtils::GetTimeMS();
+    unsigned int frameTime = now - m_lastFrameTime;
+    if (frameTime < singleFrameTime)
+      Sleep(singleFrameTime - frameTime);
+  }
+  m_lastFrameTime = CTimeUtils::GetTimeMS();
+
+  //only flip if we have rendered dirty regions
   if (hasRendered)
     g_graphicsContext.Flip();
-  else
-    Sleep(16);
 
   g_renderManager.UpdateResolution();
   g_renderManager.ManageCaptures();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -91,7 +91,7 @@ public:
   virtual bool Initialize();
   virtual void FrameMove();
   virtual void Render();
-  virtual void RenderNoPresent();
+  virtual bool RenderNoPresent();
   virtual void Preflight();
   virtual bool Create();
   virtual bool Cleanup();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -340,6 +340,7 @@ protected:
   int m_nextPlaylistItem;
 
   bool m_bPresentFrame;
+  unsigned int m_lastFrameTime;
 
   bool m_bStandalone;
   bool m_bEnableLegacyRes;

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -515,9 +515,9 @@ void CGUIWindowManager::Process(unsigned int currentTime)
     m_tracker.MarkDirtyRegion(*itr);
 }
 
-void CGUIWindowManager::MarkDirty(const CDirtyRegion &rect)
+void CGUIWindowManager::MarkDirty()
 {
-  m_tracker.MarkDirtyRegion(rect);
+  m_tracker.MarkDirtyRegion(CRect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight()));
 }
 
 void CGUIWindowManager::RenderPass()

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -540,16 +540,20 @@ void CGUIWindowManager::RenderPass()
   }
 }
 
-void CGUIWindowManager::Render()
+bool CGUIWindowManager::Render()
 {
   assert(g_application.IsCurrentThread());
   CSingleLock lock(g_graphicsContext);
 
   CDirtyRegionList dirtyRegions = m_tracker.GetDirtyRegions();
 
+  bool hasRendered = false;
   // If we visualize the regions we will always render the entire viewport
   if (g_advancedSettings.m_guiVisualizeDirtyRegions || g_advancedSettings.m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_NONE)
+  {
     RenderPass();
+    hasRendered = true;
+  }
   else
   {
     for (CDirtyRegionList::const_iterator i = dirtyRegions.begin(); i != dirtyRegions.end(); i++)
@@ -559,6 +563,7 @@ void CGUIWindowManager::Render()
 
       g_graphicsContext.SetScissors(*i);
       RenderPass();
+      hasRendered = true;
     }
     g_graphicsContext.ResetScissors();
   }
@@ -574,6 +579,8 @@ void CGUIWindowManager::Render()
   }
 
   m_tracker.CleanMarkedRegions();
+
+  return hasRendered;
 }
 
 void CGUIWindowManager::FrameMove()

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -72,11 +72,9 @@ public:
    */
   void Process(unsigned int currentTime);
 
-  /*! \brief Mark a region of the screen as dirty - used by the mouse and dim/black screensavers currently
-      Ideally this would be removed and a technique for marking the screen as dirty implemented for ssavers
-      in addition to moving the mouse rendering into the manager.
+  /*! \brief Mark a the screen as dirty, forcing a redraw at the next Render()
    */
-  void MarkDirty(const CDirtyRegion &rect);
+  void MarkDirty();
 
   /*! \brief Rendering of the current window and any dialogs
    Render is called every frame to draw the current window and any dialogs.

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -72,7 +72,7 @@ public:
    */
   void Process(unsigned int currentTime);
 
-  /*! \brief Mark a the screen as dirty, forcing a redraw at the next Render()
+  /*! \brief Mark the screen as dirty, forcing a redraw at the next Render()
    */
   void MarkDirty();
 

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -81,8 +81,9 @@ public:
   /*! \brief Rendering of the current window and any dialogs
    Render is called every frame to draw the current window and any dialogs.
    It should only be called from the application thread.
+   Returns true only if it has rendered something.
    */
-  void Render();
+  bool Render();
 
   /*! \brief Per-frame updating of the current window and any dialogs
    FrameMove is called every frame to update the current window and any dialogs

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -23,6 +23,7 @@
 #include "WinEvents.h"
 #include "WinEventsSDL.h"
 #include "Application.h"
+#include "guilib/GUIWindowManager.h"
 #ifdef HAS_SDL_JOYSTICK
 #include "input/SDLJoystick.h"
 #endif
@@ -369,6 +370,12 @@ bool CWinEventsSDL::MessagePump()
         newEvent.user.code = event.user.code;
         ret |= g_application.OnEvent(newEvent);
         break;
+      }
+      case SDL_VIDEOEXPOSE:
+      {
+        //some other app has painted over our window, mark everything as dirty
+        CRect rect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
+        g_windowManager.MarkDirty(rect);
       }
     }
     memset(&event, 0, sizeof(XBMC_Event));

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -372,11 +372,8 @@ bool CWinEventsSDL::MessagePump()
         break;
       }
       case SDL_VIDEOEXPOSE:
-      {
-        //some other app has painted over our window, mark everything as dirty
-        CRect rect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
-        g_windowManager.MarkDirty(rect);
-      }
+        g_windowManager.MarkDirty();
+        break;
     }
     memset(&event, 0, sizeof(XBMC_Event));
   }

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -671,7 +671,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       }
     case WM_PAINT:
       //some other app has painted over our window, mark everything as dirty
-      g_windowManager.MarkDirty(CRect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight()));
+      g_windowManager.MarkDirty();
       break;
   }
   return(DefWindowProc(hWnd, uMsg, wParam, lParam));

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -667,6 +667,12 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           break;
       }
       break;
+    case WM_PAINT:
+      //some other app has painted over our window, mark everything as dirty
+      //WARNING: this code is still untested
+      CRect rect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
+      g_windowManager.MarkDirty(rect);
+      break;
   }
   return(DefWindowProc(hWnd, uMsg, wParam, lParam));
 }

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -650,28 +650,28 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       }
       break;
     case WM_DEVICECHANGE:
-      PDEV_BROADCAST_DEVICEINTERFACE b = (PDEV_BROADCAST_DEVICEINTERFACE) lParam;
-      CStdString dbcc_name(b->dbcc_name);
-      dbcc_name = dbcc_name.Mid(dbcc_name.find_last_of('\\')+1, dbcc_name.find_last_of('#') - dbcc_name.find_last_of('\\'));
-      switch (wParam)
       {
-        case DBT_DEVICEARRIVAL:
-          CKeymapLoader().DeviceAdded(dbcc_name);
-          break;
-        case DBT_DEVICEREMOVECOMPLETE:
-          CKeymapLoader().DeviceRemoved(dbcc_name);
-          break;
-        case DBT_DEVNODES_CHANGED:
-          //CLog::Log(LOGDEBUG, "HID Device Changed");
-          //We generally don't care about Change notifications, only need to know if a device is removed or added to rescan the device list
-          break;
+        PDEV_BROADCAST_DEVICEINTERFACE b = (PDEV_BROADCAST_DEVICEINTERFACE) lParam;
+        CStdString dbcc_name(b->dbcc_name);
+        dbcc_name = dbcc_name.Mid(dbcc_name.find_last_of('\\')+1, dbcc_name.find_last_of('#') - dbcc_name.find_last_of('\\'));
+        switch (wParam)
+        {
+          case DBT_DEVICEARRIVAL:
+            CKeymapLoader().DeviceAdded(dbcc_name);
+            break;
+          case DBT_DEVICEREMOVECOMPLETE:
+            CKeymapLoader().DeviceRemoved(dbcc_name);
+            break;
+          case DBT_DEVNODES_CHANGED:
+            //CLog::Log(LOGDEBUG, "HID Device Changed");
+            //We generally don't care about Change notifications, only need to know if a device is removed or added to rescan the device list
+            break;
+        }
+        break;
       }
-      break;
     case WM_PAINT:
       //some other app has painted over our window, mark everything as dirty
-      //WARNING: this code is still untested
-      CRect rect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
-      g_windowManager.MarkDirty(rect);
+      g_windowManager.MarkDirty(CRect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight()));
       break;
   }
   return(DefWindowProc(hWnd, uMsg, wParam, lParam));


### PR DESCRIPTION
When dirty region rendering is on, only flip when something has rendered, this saves cpu and gpu cycles.
When not flipping, run the game loop at 25 fps, this does not seem to introduce a noticeable delay in keyboard input.
