### PR TITLE
Movie scrapers: distinguish between abort and no results.

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -134,7 +134,8 @@ int CNfoFile::Scrape(ScraperPtr& scraper)
   catch (const CScraperError &sce)
   {
     CVideoInfoDownloader::ShowErrorDialog(sce);
-    return 2;
+    if (!sce.FAborted())
+      return 2;
   }
 
   if (!m_scurl.m_url.empty())

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -459,6 +459,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CFileCurl &fcurl, const CStd
 
   bool fSort(true);
   std::set<CStdString> stsDupeCheck;
+  bool fResults(false);
   for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
   {
     TiXmlDocument doc;
@@ -475,6 +476,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CFileCurl &fcurl, const CStd
     TiXmlHandle xhResults = xhDoc.FirstChild("results");
     if (!xhResults.Element())
       continue;
+    fResults = true;  // even if empty
 
     // we need to sort if returned results don't specify 'sorted="yes"'
     if (fSort)
@@ -529,6 +531,9 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CFileCurl &fcurl, const CStd
       }
     }
   }
+
+  if (!fResults)
+    throw CScraperError();  // scraper aborted
 
   if (fSort)
     std::sort(vcscurl.begin(), vcscurl.end(), RelevanceSortFunction);

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -232,21 +232,21 @@ void CScraper::ClearCache()
 // returns a vector of strings: the first is the XML output by the function; the rest
 // is XML output by chained functions, possibly recursively
 // the CFileCurl object is passed in so that URL fetches can be canceled from other threads
+// throws CScraperError abort on internal failures (e.g., parse errors)
 vector<CStdString> CScraper::Run(const CStdString& function,
                                  const CScraperUrl& scrURL,
                                  CFileCurl& http,
                                  const vector<CStdString>* extras)
 {
-  vector<CStdString> result;
   if (!Load())
-    return result;
+    throw CScraperError();
 
   CStdString strXML = InternalRun(function,scrURL,http,extras);
   if (strXML.IsEmpty())
   {
     if (function != "NfoUrl")
       CLog::Log(LOGERROR, "%s: Unable to parse web site",__FUNCTION__);
-    return result;
+    throw CScraperError();
   }
 
   CLog::Log(LOGDEBUG,"scraper: %s returned %s",function.c_str(),strXML.c_str());
@@ -259,9 +259,10 @@ vector<CStdString> CScraper::Run(const CStdString& function,
   if (!doc.RootElement())
   {
     CLog::Log(LOGERROR, "%s: Unable to parse XML",__FUNCTION__);
-    return result; 
+    throw CScraperError();
   }
 
+  vector<CStdString> result;
   result.push_back(strXML);
   TiXmlElement* xchain = doc.RootElement()->FirstChildElement();
   // skip children of the root element until <url> or <chain>
@@ -280,7 +281,7 @@ vector<CStdString> CScraper::Run(const CStdString& function,
         extras.push_back(xchain->FirstChild()->Value());
       else
         scrURL2.ParseElement(xchain);
-      vector<CStdString> result2 = Run(szFunction,scrURL2,http,&extras);
+      vector<CStdString> result2 = RunNoThrow(szFunction,scrURL2,http,&extras);
       result.insert(result.end(),result2.begin(),result2.end());
     }
     xchain = xchain->NextSiblingElement();
@@ -290,6 +291,25 @@ vector<CStdString> CScraper::Run(const CStdString& function,
   }
   
   return result;
+}
+
+// just like Run, but returns an empty list instead of throwing in case of error
+// don't use in new code; errors should be handled appropriately
+std::vector<CStdString> CScraper::RunNoThrow(const CStdString& function,
+  const CScraperUrl& url,
+  XFILE::CFileCurl& http,
+  const std::vector<CStdString>* extras)
+{
+  std::vector<CStdString> vcs;
+  try
+  {
+    vcs = Run(function, url, http, extras);
+  }
+  catch (const CScraperError &sce)
+  {
+    ASSERT(sce.FAborted());  // the only kind we should get
+  }
+  return vcs;
 }
 
 CStdString CScraper::InternalRun(const CStdString& function,
@@ -388,7 +408,7 @@ CScraperUrl CScraper::NfoUrl(const CStdString &sNfoContent)
     CLog::Log(LOGWARNING, "%s: scraper returned multiple results; using first", __FUNCTION__);
 
   // parse returned XML: either <error> element on error, blank on failure,
-  // or <url>...</url> or <TAG><url>...</url><id>...</id></TAG> (for any TAG) on success
+  // or <url>...</url> or <url>...</url><id>...</id> on success
   for (unsigned int i=0; i < vcsOut.size(); ++i)
   {
     TiXmlDocument doc;
@@ -448,7 +468,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CFileCurl &fcurl, const CStd
   if (vcsOut.empty())
   {
     CLog::Log(LOGDEBUG, "%s: CreateSearchUrl failed", __FUNCTION__);
-    return vcscurl;
+    throw CScraperError();
   }
   scurl.ParseString(vcsOut[0]);
 
@@ -559,7 +579,7 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CFileCurl &fcurl, const CStdStr
   CURL::Encode(extras[0]);
   CURL::Encode(extras[1]);
   CScraperUrl scurl;
-  vector<CStdString> vcsOut = Run("CreateAlbumSearchUrl", scurl, fcurl, &extras);
+  vector<CStdString> vcsOut = RunNoThrow("CreateAlbumSearchUrl", scurl, fcurl, &extras);
   if (vcsOut.size() > 1)
     CLog::Log(LOGWARNING, "%s: scraper returned multiple results; using first", __FUNCTION__);
 
@@ -580,7 +600,7 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CFileCurl &fcurl, const CStdStr
   //  </entity>
   //  ...
   // </results>
-  vcsOut = Run("GetAlbumSearchResults", scurl, fcurl);
+  vcsOut = RunNoThrow("GetAlbumSearchResults", scurl, fcurl);
 
   // parse the returned XML into a vector of album objects
   for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
@@ -648,7 +668,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CFileCurl &fcurl,
   g_charsetConverter.utf8To(SearchStringEncoding(), sArtist, extras[0]);
   CURL::Encode(extras[0]);
   CScraperUrl scurl;
-  vector<CStdString> vcsOut = Run("CreateArtistSearchUrl", scurl, fcurl, &extras);
+  vector<CStdString> vcsOut = RunNoThrow("CreateArtistSearchUrl", scurl, fcurl, &extras);
 
   std::vector<CMusicArtistInfo> vcari;
   if (vcsOut.empty() || vcsOut[0].empty())
@@ -666,7 +686,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CFileCurl &fcurl,
   //  </entity>
   //  ...
   // </results>
-  vcsOut = Run("GetArtistSearchResults", scurl, fcurl);
+  vcsOut = RunNoThrow("GetArtistSearchResults", scurl, fcurl);
 
   // parse the returned XML into a vector of artist objects
   for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
@@ -718,7 +738,7 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CFileCurl &fcurl, const CScraperUrl 
 
   vector<CStdString> vcsIn;
   vcsIn.push_back(scurl.m_url[0].m_url);
-  vector<CStdString> vcsOut = Run("GetEpisodeList", scurl, fcurl, &vcsIn);
+  vector<CStdString> vcsOut = RunNoThrow("GetEpisodeList", scurl, fcurl, &vcsIn);
 
   // parse the XML response
   for (CStdStringArray::const_iterator i = vcsOut.begin(); i != vcsOut.end(); ++i)
@@ -798,7 +818,7 @@ bool CScraper::GetVideoDetails(XFILE::CFileCurl &fcurl, const CScraperUrl &scurl
   vector<CStdString> vcsIn;
   vcsIn.push_back(scurl.strId);
   vcsIn.push_back(scurl.m_url[0].m_url);
-  vector<CStdString> vcsOut = Run(sFunc, scurl, fcurl, &vcsIn);
+  vector<CStdString> vcsOut = RunNoThrow(sFunc, scurl, fcurl, &vcsIn);
 
   // parse XML output
   bool fRet(false);
@@ -833,7 +853,7 @@ bool CScraper::GetAlbumDetails(CFileCurl &fcurl, const CScraperUrl &scurl, CAlbu
     scurl.m_url[0].m_url.c_str(), Name().c_str(), Path().c_str(),
     ADDON::TranslateContent(Content()).c_str(), Version().c_str());
 
-  vector<CStdString> vcsOut = Run("GetAlbumDetails", scurl, fcurl);
+  vector<CStdString> vcsOut = RunNoThrow("GetAlbumDetails", scurl, fcurl);
 
   // parse the returned XML into an album object (see CAlbum::Load for details)
   bool fRet(false);
@@ -866,7 +886,7 @@ bool CScraper::GetArtistDetails(CFileCurl &fcurl, const CScraperUrl &scurl,
   vcIn.push_back(sSearch);
   CURL::Encode(vcIn[0]);
 
-  vector<CStdString> vcsOut = Run("GetArtistDetails", scurl, fcurl, &vcIn);
+  vector<CStdString> vcsOut = RunNoThrow("GetArtistDetails", scurl, fcurl, &vcIn);
 
   // ok, now parse the xml file
   bool fRet(false);

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -146,6 +146,10 @@ private:
                               const CScraperUrl& url,
                               XFILE::CFileCurl& http,
                               const std::vector<CStdString>* extras = NULL);
+  std::vector<CStdString> RunNoThrow(const CStdString& function,
+                              const CScraperUrl& url,
+                              XFILE::CFileCurl& http,
+                              const std::vector<CStdString>* extras = NULL);
   CStdString InternalRun(const CStdString& function,
                          const CScraperUrl& url,
                          XFILE::CFileCurl& http,

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -61,17 +61,20 @@ CStdString TranslateContent(const CONTENT_TYPE &content, bool pretty=false);
 CONTENT_TYPE TranslateContent(const CStdString &string);
 TYPE ScraperTypeFromContent(const CONTENT_TYPE &content);
 
-// thrown as exception to show error dialog
+// thrown as exception to signal abort or show error dialog
 class CScraperError
 {
 public:
+  CScraperError() : m_fAborted(true) {}
   CScraperError(const CStdString &sTitle, const CStdString &sMessage) :
-    m_sTitle(sTitle), m_sMessage(sMessage) {}
+    m_fAborted(false), m_sTitle(sTitle), m_sMessage(sMessage) {}
 
+  bool FAborted() const { return m_fAborted; }
   const CStdString &Title() const { return m_sTitle; }
   const CStdString &Message() const { return m_sMessage; }
 
 private:
+  bool m_fAborted;
   CStdString m_sTitle;
   CStdString m_sMessage;
 };


### PR DESCRIPTION
Fix for http://trac.xbmc.org/ticket/11649.

The scraper refactor lost the distinction between no results (empty result tag) and no result XML at all due to an error condition, causing scans to terminate in the non-error no results case. This restores it by updating CScraperError to transmit this result.

I have verified that this still works when results do come back, but I don't have a test for nothing coming back (my test harness isn't there yet), but this should restore previous behavior: return 1 for any success, including no results; -1 for scraper error via error XML; and 0 for any other scraper return.
