### PR TITLE
Move Dim/Black screensavers to the window manager (fixes dirty-region rendering)

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		7C0A7FC813A9E75400AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC413A9E75400AFC2BD /* DirtyRegionSolvers.cpp */; };
 		7C0A7FC913A9E75400AFC2BD /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC613A9E75400AFC2BD /* DirtyRegionTracker.cpp */; };
 		7C0A7FCC13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FCA13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp */; };
+		7C89627013B702F3003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89626E13B702F3003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C99B73F133D372300FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B73D133D372300FC2B16 /* CacheCircular.cpp */; };
 		7C99B7AA134072CD00FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */; };
 		C807119F135DB842002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807119D135DB842002F601B /* InputOperations.cpp */; };
@@ -942,6 +943,8 @@
 		7C0A7FC713A9E75400AFC2BD /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
 		7C0A7FCA13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowDebugInfo.cpp; sourceTree = "<group>"; };
 		7C0A7FCB13A9E76E00AFC2BD /* GUIWindowDebugInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowDebugInfo.h; sourceTree = "<group>"; };
+		7C89626E13B702F3003631FE /* GUIWindowScreensaverDim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowScreensaverDim.cpp; sourceTree = "<group>"; };
+		7C89626F13B702F3003631FE /* GUIWindowScreensaverDim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowScreensaverDim.h; sourceTree = "<group>"; };
 		7C99B73D133D372300FC2B16 /* CacheCircular.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheCircular.cpp; sourceTree = "<group>"; };
 		7C99B73E133D372300FC2B16 /* CacheCircular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheCircular.h; sourceTree = "<group>"; };
 		7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -5219,6 +5222,8 @@
 				F56C77C2131EC154000AD0F6 /* GUIWindowPointer.h */,
 				F56C77C3131EC154000AD0F6 /* GUIWindowScreensaver.cpp */,
 				F56C77C4131EC154000AD0F6 /* GUIWindowScreensaver.h */,
+				7C89626E13B702F3003631FE /* GUIWindowScreensaverDim.cpp */,
+				7C89626F13B702F3003631FE /* GUIWindowScreensaverDim.h */,
 				F56C77C5131EC154000AD0F6 /* GUIWindowStartup.cpp */,
 				F56C77C6131EC154000AD0F6 /* GUIWindowStartup.h */,
 				F56C77C7131EC154000AD0F6 /* GUIWindowSystemInfo.cpp */,
@@ -6688,6 +6693,7 @@
 				DF0DF16C13A3AF82008ED511 /* FileNFS.cpp in Sources */,
 				DF0DF16D13A3AF82008ED511 /* NFSDirectory.cpp in Sources */,
 				F558F66F13AFE81500631E12 /* ThreadLocal.cpp in Sources */,
+				7C89627013B702F3003631FE /* GUIWindowScreensaverDim.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		7C0A7F9D13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7F9B13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp */; };
 		7C0A7FB213A9E72E00AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FAE13A9E72E00AFC2BD /* DirtyRegionSolvers.cpp */; };
 		7C0A7FB313A9E72E00AFC2BD /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FB013A9E72E00AFC2BD /* DirtyRegionTracker.cpp */; };
+		7C89628013B7031E003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89627E13B7031E003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C99B6E9133D36E200FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */; };
 		7C99B7BE1340730000FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */; };
 		C80711AD135DB85F002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C80711AB135DB85F002F601B /* InputOperations.cpp */; };
@@ -943,6 +944,8 @@
 		7C0A7FAF13A9E72E00AFC2BD /* DirtyRegionSolvers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionSolvers.h; sourceTree = "<group>"; };
 		7C0A7FB013A9E72E00AFC2BD /* DirtyRegionTracker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirtyRegionTracker.cpp; sourceTree = "<group>"; };
 		7C0A7FB113A9E72E00AFC2BD /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
+		7C89627E13B7031E003631FE /* GUIWindowScreensaverDim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowScreensaverDim.cpp; sourceTree = "<group>"; };
+		7C89627F13B7031E003631FE /* GUIWindowScreensaverDim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowScreensaverDim.h; sourceTree = "<group>"; };
 		7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheCircular.cpp; sourceTree = "<group>"; };
 		7C99B6E8133D36E200FC2B16 /* CacheCircular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheCircular.h; sourceTree = "<group>"; };
 		7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -5587,6 +5590,8 @@
 				F56C87AF131F42EC000AD0F6 /* GUIWindowPointer.h */,
 				F56C87B0131F42EC000AD0F6 /* GUIWindowScreensaver.cpp */,
 				F56C87B1131F42EC000AD0F6 /* GUIWindowScreensaver.h */,
+				7C89627E13B7031E003631FE /* GUIWindowScreensaverDim.cpp */,
+				7C89627F13B7031E003631FE /* GUIWindowScreensaverDim.h */,
 				F56C87B2131F42EC000AD0F6 /* GUIWindowStartup.cpp */,
 				F56C87B3131F42EC000AD0F6 /* GUIWindowStartup.h */,
 				F56C87B4131F42EC000AD0F6 /* GUIWindowSystemInfo.cpp */,
@@ -6703,6 +6708,7 @@
 				DF0DF17F13A3AF9F008ED511 /* FileNFS.cpp in Sources */,
 				DF0DF18013A3AF9F008ED511 /* NFSDirectory.cpp in Sources */,
 				F558F61113AFDC3000631E12 /* ThreadLocal.cpp in Sources */,
+				7C89628013B7031E003631FE /* GUIWindowScreensaverDim.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -534,6 +534,8 @@
 		7C7B2B311134F36400713D6D /* mysqldataset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7B2B2E1134F36400713D6D /* mysqldataset.cpp */; };
 		7C84A59E12FA3C1600CD1714 /* SourcesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */; };
 		7C84A59F12FA3C1600CD1714 /* SourcesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */; };
+		7C89619213B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */; };
+		7C89619313B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C8A14561154CB2600E5FCFA /* TextureCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A14541154CB2600E5FCFA /* TextureCache.cpp */; };
 		7C8A14571154CB2600E5FCFA /* TextureCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A14541154CB2600E5FCFA /* TextureCache.cpp */; };
 		7C8A187C115B2A8200E5FCFA /* TextureDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */; };
@@ -2413,6 +2415,8 @@
 		7C7B2B2F1134F36400713D6D /* mysqldataset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mysqldataset.h; sourceTree = "<group>"; };
 		7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SourcesDirectory.cpp; path = xbmc/filesystem/SourcesDirectory.cpp; sourceTree = SOURCE_ROOT; };
 		7C84A59D12FA3C1600CD1714 /* SourcesDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SourcesDirectory.h; path = xbmc/filesystem/SourcesDirectory.h; sourceTree = SOURCE_ROOT; };
+		7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowScreensaverDim.cpp; sourceTree = "<group>"; };
+		7C89619113B6A16F003631FE /* GUIWindowScreensaverDim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowScreensaverDim.h; sourceTree = "<group>"; };
 		7C8A14541154CB2600E5FCFA /* TextureCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureCache.cpp; sourceTree = "<group>"; };
 		7C8A14551154CB2600E5FCFA /* TextureCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureCache.h; sourceTree = "<group>"; };
 		7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureDatabase.cpp; sourceTree = "<group>"; };
@@ -4675,6 +4679,8 @@
 				E38E18220D25F9FA00618676 /* GUIWindowPointer.h */,
 				E38E18250D25F9FA00618676 /* GUIWindowScreensaver.cpp */,
 				E38E18260D25F9FA00618676 /* GUIWindowScreensaver.h */,
+				7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */,
+				7C89619113B6A16F003631FE /* GUIWindowScreensaverDim.h */,
 				E38E18370D25F9FA00618676 /* GUIWindowStartup.cpp */,
 				E38E18380D25F9FA00618676 /* GUIWindowStartup.h */,
 				E38E18390D25F9FA00618676 /* GUIWindowSystemInfo.cpp */,
@@ -8033,6 +8039,7 @@
 				DF0DF15B13A3ADA7008ED511 /* FileNFS.cpp in Sources */,
 				DF0DF15C13A3ADA7008ED511 /* NFSDirectory.cpp in Sources */,
 				F558F51E13AF03AD00631E12 /* ThreadLocal.cpp in Sources */,
+				7C89619213B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8923,6 +8930,7 @@
 				F558F3D013AE663300631E12 /* FileNFS.cpp in Sources */,
 				F558F3D113AE663A00631E12 /* NFSDirectory.cpp in Sources */,
 				F558F51F13AF03AD00631E12 /* ThreadLocal.cpp in Sources */,
+				7C89619313B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1151,6 +1151,7 @@
     <ClCompile Include="..\..\xbmc\windows\GUIWindowLoginScreen.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowPointer.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowScreensaver.cpp" />
+    <ClCompile Include="..\..\xbmc\windows\GUIWindowScreensaverDim.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowStartup.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowSystemInfo.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowWeather.cpp" />
@@ -1991,6 +1992,7 @@
     <ClInclude Include="..\..\xbmc\windows\GUIWindowLoginScreen.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowPointer.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowScreensaver.h" />
+    <ClInclude Include="..\..\xbmc\windows\GUIWindowScreensaverDim.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowStartup.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowSystemInfo.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowWeather.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2222,6 +2222,9 @@
     <ClCompile Include="..\..\xbmc\windows\GUIWindowScreensaver.cpp">
       <Filter>windows</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\windows\GUIWindowScreensaverDim.cpp">
+      <Filter>windows</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\windows\GUIWindowStartup.cpp">
       <Filter>windows</Filter>
     </ClCompile>
@@ -4682,6 +4685,9 @@
       <Filter>windows</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\windows\GUIWindowScreensaver.h">
+      <Filter>windows</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\windows\GUIWindowScreensaverDim.h">
       <Filter>windows</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\windows\GUIWindowStartup.h">

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -288,8 +288,9 @@ public:
 
   void Minimize();
   bool ToggleDPMS(bool manual);
+
+  float GetDimScreenSaverLevel() const;
 protected:
-  void RenderScreenSaver();
   bool LoadSkin(const CStdString& skinID);
   void LoadSkin(const boost::shared_ptr<ADDON::CSkinInfo>& skin);
 

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -33,8 +33,7 @@ CGUIFadeLabelControl::CGUIFadeLabelControl(int parentID, int controlID, float po
   ControlType = GUICONTROL_FADELABEL;
   m_scrollOut = scrollOut;
   m_fadeAnim = CAnimation::CreateFader(100, 0, timeToDelayAtEnd, 200);
-  if (m_fadeAnim)
-    m_fadeAnim->ApplyAnimation();
+  m_fadeAnim.ApplyAnimation();
   m_renderTime = 0;
   m_lastLabel = -1;
   m_scrollSpeed = labelInfo.scrollSpeed;  // save it for later
@@ -50,10 +49,8 @@ CGUIFadeLabelControl::CGUIFadeLabelControl(const CGUIFadeLabelControl &from)
   m_scrollSpeed = from.m_scrollSpeed;
   m_resetOnLabelChange = from.m_resetOnLabelChange;
 
-  if (from.m_fadeAnim)
-    m_fadeAnim = new CAnimation(*from.m_fadeAnim);
-  if (m_fadeAnim)
-    m_fadeAnim->ApplyAnimation();
+  m_fadeAnim = from.m_fadeAnim;
+  m_fadeAnim.ApplyAnimation();
   m_currentLabel = 0;
   m_renderTime = 0;
   m_lastLabel = -1;
@@ -62,7 +59,6 @@ CGUIFadeLabelControl::CGUIFadeLabelControl(const CGUIFadeLabelControl &from)
 
 CGUIFadeLabelControl::~CGUIFadeLabelControl(void)
 {
-  delete m_fadeAnim;
 }
 
 void CGUIFadeLabelControl::SetInfo(const vector<CGUIInfoLabel> &infoLabels)
@@ -118,13 +114,13 @@ void CGUIFadeLabelControl::Render()
     if (m_resetOnLabelChange)
     {
       m_scrollInfo.Reset();
-      m_fadeAnim->ResetAnimation();
+      m_fadeAnim.ResetAnimation();
     }
   }
   if (m_currentLabel != m_lastLabel)
   { // new label - reset scrolling
     m_scrollInfo.Reset();
-    m_fadeAnim->QueueAnimation(ANIM_PROCESS_REVERSE);
+    m_fadeAnim.QueueAnimation(ANIM_PROCESS_REVERSE);
     m_lastLabel = m_currentLabel;
   }
 
@@ -152,8 +148,8 @@ void CGUIFadeLabelControl::Render()
       text.erase(text.begin(), text.begin() + min((int)m_scrollInfo.characterPos - 1, (int)text.size()));
     if (m_label.font->GetTextWidth(text) < m_width)
     {
-      if (m_fadeAnim->GetProcess() != ANIM_PROCESS_NORMAL)
-        m_fadeAnim->QueueAnimation(ANIM_PROCESS_NORMAL);
+      if (m_fadeAnim.GetProcess() != ANIM_PROCESS_NORMAL)
+        m_fadeAnim.QueueAnimation(ANIM_PROCESS_NORMAL);
       moveToNextLabel = true;
     }
   }
@@ -162,14 +158,14 @@ void CGUIFadeLabelControl::Render()
 
   // apply the fading animation
   TransformMatrix matrix;
-  m_fadeAnim->Animate(m_renderTime, true);
-  m_fadeAnim->RenderAnimation(matrix);
+  m_fadeAnim.Animate(m_renderTime, true);
+  m_fadeAnim.RenderAnimation(matrix);
   g_graphicsContext.AddTransform(matrix);
 
-  if (m_fadeAnim->GetState() == ANIM_STATE_APPLIED)
-    m_fadeAnim->ResetAnimation();
+  if (m_fadeAnim.GetState() == ANIM_STATE_APPLIED)
+    m_fadeAnim.ResetAnimation();
 
-  m_scrollInfo.SetSpeed((m_fadeAnim->GetProcess() == ANIM_PROCESS_NONE) ? m_scrollSpeed : 0);
+  m_scrollInfo.SetSpeed((m_fadeAnim.GetProcess() == ANIM_PROCESS_NONE) ? m_scrollSpeed : 0);
 
   if (!m_scrollOut && m_shortText)
   {
@@ -185,12 +181,12 @@ void CGUIFadeLabelControl::Render()
 
   if (moveToNextLabel)
   { // increment the label and reset scrolling
-    if (m_fadeAnim->GetProcess() != ANIM_PROCESS_NORMAL)
+    if (m_fadeAnim.GetProcess() != ANIM_PROCESS_NORMAL)
     {
       if (++m_currentLabel >= m_infoLabels.size())
         m_currentLabel = 0;
       m_scrollInfo.Reset();
-      m_fadeAnim->QueueAnimation(ANIM_PROCESS_REVERSE);
+      m_fadeAnim.QueueAnimation(ANIM_PROCESS_REVERSE);
     }
   }
 

--- a/xbmc/guilib/GUIFadeLabelControl.h
+++ b/xbmc/guilib/GUIFadeLabelControl.h
@@ -77,7 +77,7 @@ protected:
 
   CScrollInfo m_scrollInfo;
   CGUITextLayout m_textLayout;
-  CAnimation *m_fadeAnim;
+  CAnimation m_fadeAnim;
   unsigned int m_renderTime;
   unsigned int m_scrollSpeed;
   bool m_resetOnLabelChange;

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -332,7 +332,7 @@ void CGUITextBox::SetAutoScrolling(const TiXmlNode *node)
       m_autoScrollCondition = g_infoManager.TranslateString(scroll->FirstChild()->ValueStr());
     int repeatTime;
     if (scroll->Attribute("repeat", &repeatTime))
-      m_autoScrollRepeatAnim = CAnimation::CreateFader(100, 0, repeatTime, 1000);
+      m_autoScrollRepeatAnim = new CAnimation(CAnimation::CreateFader(100, 0, repeatTime, 1000));
   }
 }
 

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -571,9 +571,10 @@ void CAnimation::QueueAnimation(ANIMATION_PROCESS process)
   m_queuedProcess = process;
 }
 
-CAnimation CAnimation::CreateFader(float start, float end, unsigned int delay, unsigned int length)
+CAnimation CAnimation::CreateFader(float start, float end, unsigned int delay, unsigned int length, ANIMATION_TYPE type)
 {
   CAnimation anim;
+  anim.m_type = type;
   anim.AddEffect(new CFadeEffect(start, end, delay, length));
   return anim;
 }

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -571,15 +571,10 @@ void CAnimation::QueueAnimation(ANIMATION_PROCESS process)
   m_queuedProcess = process;
 }
 
-CAnimation *CAnimation::CreateFader(float start, float end, unsigned int delay, unsigned int length)
+CAnimation CAnimation::CreateFader(float start, float end, unsigned int delay, unsigned int length)
 {
-  CAnimation *anim = new CAnimation();
-  if (anim)
-  {
-    CFadeEffect *effect = new CFadeEffect(start, end, delay, length);
-    if (effect)
-      anim->AddEffect(effect);
-  }
+  CAnimation anim;
+  anim.AddEffect(new CFadeEffect(start, end, delay, length));
   return anim;
 }
 

--- a/xbmc/guilib/VisibleEffect.h
+++ b/xbmc/guilib/VisibleEffect.h
@@ -149,7 +149,7 @@ public:
 
   const CAnimation &operator=(const CAnimation &src);
 
-  static CAnimation CreateFader(float start, float end, unsigned int delay, unsigned int length);
+  static CAnimation CreateFader(float start, float end, unsigned int delay, unsigned int length, ANIMATION_TYPE type = ANIM_TYPE_NONE);
 
   void Create(const TiXmlElement *node, const CRect &rect);
 

--- a/xbmc/guilib/VisibleEffect.h
+++ b/xbmc/guilib/VisibleEffect.h
@@ -149,7 +149,7 @@ public:
 
   const CAnimation &operator=(const CAnimation &src);
 
-  static CAnimation *CreateFader(float start, float end, unsigned int delay, unsigned int length);
+  static CAnimation CreateFader(float start, float end, unsigned int delay, unsigned int length);
 
   void Create(const TiXmlElement *node, const CRect &rect);
 

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -40,7 +40,7 @@ CGUIWindowDebugInfo::CGUIWindowDebugInfo(void)
   m_loadOnDemand = false;
   m_needsScaling = false;
   m_layout = NULL;
-  m_renderOrder = INT_MAX - 1;
+  m_renderOrder = INT_MAX - 2;
 }
 
 CGUIWindowDebugInfo::~CGUIWindowDebugInfo(void)

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -31,7 +31,7 @@ CGUIWindowPointer::CGUIWindowPointer(void)
   m_loadOnDemand = false;
   m_needsScaling = false;
   m_active = false;
-  m_renderOrder = INT_MAX;
+  m_renderOrder = INT_MAX - 1;
 }
 
 CGUIWindowPointer::~CGUIWindowPointer(void)
@@ -72,7 +72,7 @@ void CGUIWindowPointer::OnWindowLoaded()
   CGUIWindow::OnWindowLoaded();
   DynamicResourceAlloc(false);
   m_pointer = 0;
-  m_renderOrder = INT_MAX;
+  m_renderOrder = INT_MAX - 1;
 }
 
 void CGUIWindowPointer::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)

--- a/xbmc/windows/GUIWindowScreensaverDim.cpp
+++ b/xbmc/windows/GUIWindowScreensaverDim.cpp
@@ -1,0 +1,72 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "GUIWindowScreensaverDim.h"
+#include "guilib/GraphicContext.h"
+#include "guilib/GUITexture.h"
+#include "Application.h"
+#include <climits>
+
+CGUIWindowScreensaverDim::CGUIWindowScreensaverDim(void)
+    : CGUIDialog(97, "")
+{
+  m_loadOnDemand = false;
+  m_needsScaling = false;
+  m_dimLevel = 100.0f;
+  m_animations.push_back(CAnimation::CreateFader(0, 100, 0, 1000, ANIM_TYPE_WINDOW_OPEN));
+  m_animations.push_back(CAnimation::CreateFader(100, 0, 0, 1000, ANIM_TYPE_WINDOW_CLOSE));
+  m_renderOrder = INT_MAX;
+}
+
+CGUIWindowScreensaverDim::~CGUIWindowScreensaverDim(void)
+{
+}
+
+void CGUIWindowScreensaverDim::UpdateVisibility()
+{
+  float level = g_application.GetDimScreenSaverLevel();
+  if (level)
+  {
+    m_dimLevel = level;
+    Show();
+  }
+  else
+    Close();
+}
+
+void CGUIWindowScreensaverDim::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
+{
+  CGUIDialog::Process(currentTime, dirtyregions);
+  m_renderRegion.SetRect(0, 0, g_graphicsContext.GetWidth(), g_graphicsContext.GetHeight());
+}
+
+void CGUIWindowScreensaverDim::Render()
+{
+  g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), false);
+  g_graphicsContext.SetTransform(m_cachedTransform);
+  // draw a translucent black quad - fading is handled by the window animation
+  color_t color = ((color_t)(m_dimLevel * 2.55f) & 0xff) << 24;
+  color = g_graphicsContext.MergeAlpha(color);
+  CRect rect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
+  CGUITexture::DrawQuad(rect, color);
+  g_graphicsContext.RemoveTransform();
+  CGUIDialog::Render();
+}

--- a/xbmc/windows/GUIWindowScreensaverDim.h
+++ b/xbmc/windows/GUIWindowScreensaverDim.h
@@ -1,0 +1,38 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "guilib/GUIDialog.h"
+
+class CGUIWindowScreensaverDim :
+      public CGUIDialog
+{
+public:
+  CGUIWindowScreensaverDim();
+  virtual ~CGUIWindowScreensaverDim();
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
+  virtual void Render();
+protected:
+  virtual void UpdateVisibility();
+private:
+  float m_dimLevel;
+};

--- a/xbmc/windows/Makefile
+++ b/xbmc/windows/Makefile
@@ -5,6 +5,7 @@ SRCS=GUIMediaWindow.cpp \
      GUIWindowLoginScreen.cpp \
      GUIWindowPointer.cpp \
      GUIWindowScreensaver.cpp \
+     GUIWindowScreensaverDim.cpp \
      GUIWindowStartup.cpp \
      GUIWindowSystemInfo.cpp \
      GUIWindowWeather.cpp \


### PR DESCRIPTION
The below commits move the dim/black screensaver to guilib, thus fixing the dirty-region rendering, and allowing the rendering reduction to kick in during these screensavers.

Needs Linux/Win32 build check (should be fine - just haven't tested)
