### PR TITLE
fix for dyloaded libs getting unloaded to early on app exit

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3135,7 +3135,6 @@ bool CApplication::Cleanup()
     CAddonMgr::Get().DeInit();
 
     CLog::Log(LOGNOTICE, "unload sections");
-    CSectionLoader::UnloadAll();
 
 #ifdef HAS_PERFORMANCE_SAMPLE
     CLog::Log(LOGNOTICE, "performance statistics");

--- a/xbmc/SectionLoader.cpp
+++ b/xbmc/SectionLoader.cpp
@@ -40,7 +40,9 @@ CSectionLoader::CSectionLoader(void)
 {}
 
 CSectionLoader::~CSectionLoader(void)
-{}
+{
+  UnloadAll();
+}
 
 bool CSectionLoader::IsLoaded(const CStdString& strSection)
 {

--- a/xbmc/SectionLoader.h
+++ b/xbmc/SectionLoader.h
@@ -55,13 +55,16 @@ public:
   static LibraryLoader* LoadDLL(const CStdString& strSection, bool bDelayUnload=true, bool bLoadSymbols=false);
   static void UnloadDLL(const CStdString& strSection);
   static void UnloadDelayed();
-  static void UnloadAll();
 protected:
   std::vector<CSection> m_vecLoadedSections;
   typedef std::vector<CSection>::iterator ivecLoadedSections;
   std::vector<CDll> m_vecLoadedDLLs;
   CCriticalSection m_critSection;
+
+private:
+  void UnloadAll();
 };
 
 XBMC_GLOBAL_REF(CSectionLoader,g_sectionLoader);
+#define g_sectionLoader XBMC_GLOBAL_USE(CSectionLoader)
 


### PR DESCRIPTION
This resolves the folllowing issue:
1. Have a global object which dyloads a lib (say - libnfs _hrhr_)
2. In dtor of the global object try to deinit the lib internas and then unload the dll (covered by test of dll.isLoaded)

What happend before this patch:
1. Application called CSectionLoader::Unloadall() before global object finalisation
2. Finalisation starts and dtor tests "dll.isLoaded" returned true - so try the stuff for deinitialising the dll -> crash

So the CSectionLoader::UnloaderAll() unloaded the libnfs symbols and the dyloader object didn't notice and therefor returned true on "IsLoaded".

Long story short. This is the fix which jcarrol worked out for this and which fixes my special problem here.
