### PR TITLE
Refactoring text change test in CGUIEditControl

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -419,12 +419,7 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
     }
 
     changed |= m_label2.SetMaxRect(posX + m_textOffset, m_posY, maxTextWidth - m_textOffset, m_height);
-    if (text != m_lastRenderedText)
-    {
-      m_label2.SetTextW(text);
-      m_lastRenderedText = text;
-      changed = true;
-    }
+    changed |= m_label2.SetTextW(text);
     changed |= m_label2.SetAlign(align);
     changed |= m_label2.SetColor(GetTextColor());
     changed |= m_label2.Process(currentTime);

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -115,6 +115,5 @@ protected:
 
   static const char*        smsLetters[10];
   static const unsigned int smsDelay;
-  CStdStringW m_lastRenderedText; ///< last rendered text
 };
 #endif

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -159,11 +159,15 @@ bool CGUILabel::SetText(const CStdString &label)
 
 bool CGUILabel::SetTextW(const CStdStringW &label)
 {
-  m_textLayout.SetText(label);
-  m_scrollInfo.Reset();
-  UpdateRenderRect();
-  m_invalid = false;
-  return true;
+  if (m_textLayout.UpdateW(label, m_maxRect.Width(), m_invalid))
+  {
+    m_scrollInfo.Reset();
+    UpdateRenderRect();
+    m_invalid = false;
+    return true;
+  }
+  else
+    return false;
 }
 
 void CGUILabel::UpdateRenderRect()

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -195,23 +195,19 @@ void CGUITextLayout::RenderOutline(float x, float y, color_t color, color_t outl
 
 bool CGUITextLayout::Update(const CStdString &text, float maxWidth, bool forceUpdate /*= false*/, bool forceLTRReadingOrder /*= false*/)
 {
-  if (text == m_lastText && !forceUpdate)
-    return false;
-
   // convert to utf16
   CStdStringW utf16;
   utf8ToW(text, utf16);
 
   // update
-  SetText(utf16, maxWidth, forceLTRReadingOrder);
-
-  // and set our parameters to indicate no further update is required
-  m_lastText = text;
-  return true;
+  return UpdateW(utf16, maxWidth, forceUpdate, forceLTRReadingOrder);
 }
 
-void CGUITextLayout::SetText(const CStdStringW &text, float maxWidth, bool forceLTRReadingOrder /*= false*/)
+bool CGUITextLayout::UpdateW(const CStdStringW &text, float maxWidth /*= 0*/, bool forceUpdate /*= false*/, bool forceLTRReadingOrder /*= false*/)
 {
+  if (text.Equals(m_lastText) && !forceUpdate)
+    return false;
+
   vecText parsedText;
 
   // empty out our previous string
@@ -239,6 +235,9 @@ void CGUITextLayout::SetText(const CStdStringW &text, float maxWidth, bool force
 
   // and cache the width and height for later reading
   CalcTextExtent();
+
+  m_lastText = text;
+  return true;
 }
 
 // BidiTransform is used to handle RTL text flipping in the string

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -87,7 +87,7 @@ public:
   
   float GetTextWidth(const CStdStringW &text) const;
   bool Update(const CStdString &text, float maxWidth = 0, bool forceUpdate = false, bool forceLTRReadingOrder = false);
-  void SetText(const CStdStringW &text, float maxWidth = 0, bool forceLTRReadingOrder = false);
+  bool UpdateW(const CStdStringW &text, float maxWidth = 0, bool forceUpdate = false, bool forceLTRReadingOrder = false);
 
   unsigned int GetTextLength() const;
   void GetFirstText(vecText &text) const;
@@ -122,7 +122,7 @@ protected:
   // the default color (may differ from the font objects defaults)
   color_t m_textColor;
 
-  CStdString m_lastText;
+  CStdStringW m_lastText;
   float m_textWidth;
   float m_textHeight;
 private:


### PR DESCRIPTION
This moves testing if text have changed value to CGUITextLayout and making it consistent for CStdString and CStdStringW.

Here is some background: https://github.com/pieh/xbmc/commit/85a47638b69b177e10d077b318faec170a82a75c#L1R425
