### PR TITLE
Add builtins: Weather.Refresh, Weather.LocationNext, etc

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -191,6 +191,10 @@ const BUILT_IN commands[] = {
   { "UpdateAddonRepos",           false,  "Check add-on repositories for updates" },
   { "UpdateLocalAddons",          false,  "Check for local add-on changes" },
   { "ToggleDPMS",                 false,  "Toggle DPMS mode manually"},
+  { "Weather.Refresh",            false,  "Force weather data refresh"},
+  { "Weather.LocationNext",       false,  "Switch to next weather location"},
+  { "Weather.LocationPrevious",   false,  "Switch to previous weather location"},
+  { "Weather.LocationSet",        true,   "Switch to given weather location (parameter can be 1-3)"},
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
   { "LIRC.Stop",                  false,  "Removes XBMC as LIRC client" },
   { "LIRC.Start",                 false,  "Adds XBMC as LIRC client" },
@@ -1483,6 +1487,27 @@ int CBuiltins::Execute(const CStdString& execString)
     g_lcd->Resume();
   }
 #endif
+  else if (execute.Equals("weather.locationset"))
+  {
+    int loc = atoi(params[0]);
+    CGUIMessage msg(GUI_MSG_ITEM_SELECT, 0, 0, loc - 1);
+    g_windowManager.SendMessage(msg, WINDOW_WEATHER);
+  }
+  else if (execute.Equals("weather.locationnext"))
+  {
+    CGUIMessage msg(GUI_MSG_MOVE_OFFSET, 0, 0, 1);
+    g_windowManager.SendMessage(msg, WINDOW_WEATHER);
+  }
+  else if (execute.Equals("weather.locationprevious"))
+  {
+    CGUIMessage msg(GUI_MSG_MOVE_OFFSET, 0, 0, -1);
+    g_windowManager.SendMessage(msg, WINDOW_WEATHER);
+  }
+  else if (execute.Equals("weather.refresh"))
+  {
+    CGUIMessage msg(GUI_MSG_MOVE_OFFSET, 0, 0, 0);
+    g_windowManager.SendMessage(msg, WINDOW_WEATHER);
+  }
   else
     return -1;
   return 0;

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -109,18 +109,8 @@ bool CGUIWindowWeather::OnMessage(CGUIMessage& message)
 
         CGUIMessage msg(GUI_MSG_ITEM_SELECTED,GetID(),CONTROL_SELECTLOCATION);
         g_windowManager.SendMessage(msg);
-        m_iCurWeather = msg.GetParam1();
 
-        CStdString strLabel=g_weatherManager.GetLocation(m_iCurWeather);
-        int iPos = strLabel.ReverseFind(", ");
-        if (iPos)
-        {
-          CStdString strLabel2(strLabel);
-          strLabel = strLabel2.substr(0,iPos);
-        }
-
-        SET_CONTROL_LABEL(CONTROL_SELECTLOCATION,strLabel);
-        Refresh();
+        SetLocation(msg.GetParam1());
       }
     }
     break;
@@ -146,6 +136,26 @@ bool CGUIWindowWeather::OnMessage(CGUIMessage& message)
       {
         CGUIDialogOK::ShowAndGetInput(8,21451,20022,20022);
         g_windowManager.PreviousWindow();
+        return true;
+      }
+    }
+    break;
+  case GUI_MSG_ITEM_SELECT:
+    {
+      if (message.GetSenderId() == 0) //handle only message from builtin
+      {
+        SetLocation(message.GetParam1());
+        return true;
+      }
+    }
+    break;
+  case GUI_MSG_MOVE_OFFSET:
+    {
+      if (message.GetSenderId() == 0) //handle only message from builtin
+      {
+        int v = (message.GetParam1() + (int)m_iCurWeather) % MAX_LOCATION;
+        if (v < 0) v+= MAX_LOCATION;
+        SetLocation(v);
         return true;
       }
     }
@@ -255,6 +265,21 @@ void CGUIWindowWeather::FrameMove()
   }
 
   CGUIWindow::FrameMove();
+}
+
+void CGUIWindowWeather::SetLocation(int loc)
+{
+  if (loc < 0 || loc >= MAX_LOCATION)
+    return;
+
+  m_iCurWeather = loc;
+  CStdString strLabel=g_weatherManager.GetLocation(m_iCurWeather);
+  int iPos = strLabel.ReverseFind(", ");
+  if (iPos)
+    strLabel = strLabel.substr(0,iPos);
+
+  SET_CONTROL_LABEL(CONTROL_SELECTLOCATION,strLabel);
+  Refresh();
 }
 
 //Do a complete download, parse and update

--- a/xbmc/windows/GUIWindowWeather.h
+++ b/xbmc/windows/GUIWindowWeather.h
@@ -40,6 +40,7 @@ protected:
   void UpdateLocations();
   void SetProperties();
   void CallScript();
+  void SetLocation(int loc);
 
   void Refresh();
 


### PR DESCRIPTION
Add builtins: Weather.Refresh, Weather.LocationNext, Weather.LocationPrevious, Weather.LocationSet(id)

This pull request is mostly to review builtin command names and method used to interact with CGUIWindowWeather.
