### PR TITLE
Add <hinttext> tag to Edit Control.

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1072,6 +1072,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       parentID, id, posX, posY, width, height, textureFocus, textureNoFocus,
       labelInfo, strLabel);
 
+    CGUIInfoLabel hint_text;
+    GetInfoLabel(pControlNode, "hinttext", hint_text);
+    ((CGUIEditControl *) control)->SetHint(hint_text);
+
     if (bPassword)
       ((CGUIEditControl *) control)->SetInputType(CGUIEditControl::INPUT_TYPE_PASSWORD, 0);
     ((CGUIEditControl *) control)->SetTextChangeActions(textChangeActions);

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -419,7 +419,10 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
     }
 
     changed |= m_label2.SetMaxRect(posX + m_textOffset, m_posY, maxTextWidth - m_textOffset, m_height);
-    changed |= m_label2.SetTextW(text);
+    if (text.IsEmpty())
+      changed |= m_label2.SetText(m_hintInfo.GetLabel(GetParentID()));
+    else
+      changed |= m_label2.SetTextW(text);
     changed |= m_label2.SetAlign(align);
     changed |= m_label2.SetColor(GetTextColor());
     changed |= m_label2.Process(currentTime);
@@ -427,6 +430,11 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
   }
   if (changed)
     MarkDirtyRegion();
+}
+
+void CGUIEditControl::SetHint(const CGUIInfoLabel& hint)
+{
+  m_hintInfo = hint;
 }
 
 CStdStringW CGUIEditControl::GetDisplayedText() const

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -65,6 +65,7 @@ public:
 
   virtual void SetLabel(const std::string &text);
   virtual void SetLabel2(const std::string &text);
+  void SetHint(const CGUIInfoLabel& hint);
 
   virtual CStdString GetLabel2() const;
 
@@ -94,6 +95,7 @@ protected:
   
   CStdStringW m_text2;
   CStdString  m_text;
+  CGUIInfoLabel m_hintInfo;
   float m_textOffset;
   float m_textWidth;
 


### PR DESCRIPTION
This allow displaying hint when Edit Control value is empty and control isn't focused. Closes #11610.
