### PR TITLE
Move all dialogs to the window manager, and get rid of the members in CApplication

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		7C0A7FC813A9E75400AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC413A9E75400AFC2BD /* DirtyRegionSolvers.cpp */; };
 		7C0A7FC913A9E75400AFC2BD /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC613A9E75400AFC2BD /* DirtyRegionTracker.cpp */; };
 		7C0A7FCC13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FCA13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp */; };
+		7C89627013B702F3003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89626E13B702F3003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C99B73F133D372300FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B73D133D372300FC2B16 /* CacheCircular.cpp */; };
 		7C99B7AA134072CD00FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */; };
 		C807119F135DB842002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807119D135DB842002F601B /* InputOperations.cpp */; };
@@ -942,6 +943,8 @@
 		7C0A7FC713A9E75400AFC2BD /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
 		7C0A7FCA13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowDebugInfo.cpp; sourceTree = "<group>"; };
 		7C0A7FCB13A9E76E00AFC2BD /* GUIWindowDebugInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowDebugInfo.h; sourceTree = "<group>"; };
+		7C89626E13B702F3003631FE /* GUIWindowScreensaverDim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowScreensaverDim.cpp; sourceTree = "<group>"; };
+		7C89626F13B702F3003631FE /* GUIWindowScreensaverDim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowScreensaverDim.h; sourceTree = "<group>"; };
 		7C99B73D133D372300FC2B16 /* CacheCircular.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheCircular.cpp; sourceTree = "<group>"; };
 		7C99B73E133D372300FC2B16 /* CacheCircular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheCircular.h; sourceTree = "<group>"; };
 		7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -5219,6 +5222,8 @@
 				F56C77C2131EC154000AD0F6 /* GUIWindowPointer.h */,
 				F56C77C3131EC154000AD0F6 /* GUIWindowScreensaver.cpp */,
 				F56C77C4131EC154000AD0F6 /* GUIWindowScreensaver.h */,
+				7C89626E13B702F3003631FE /* GUIWindowScreensaverDim.cpp */,
+				7C89626F13B702F3003631FE /* GUIWindowScreensaverDim.h */,
 				F56C77C5131EC154000AD0F6 /* GUIWindowStartup.cpp */,
 				F56C77C6131EC154000AD0F6 /* GUIWindowStartup.h */,
 				F56C77C7131EC154000AD0F6 /* GUIWindowSystemInfo.cpp */,
@@ -6688,6 +6693,7 @@
 				DF0DF16C13A3AF82008ED511 /* FileNFS.cpp in Sources */,
 				DF0DF16D13A3AF82008ED511 /* NFSDirectory.cpp in Sources */,
 				F558F66F13AFE81500631E12 /* ThreadLocal.cpp in Sources */,
+				7C89627013B702F3003631FE /* GUIWindowScreensaverDim.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		7C0A7F9D13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7F9B13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp */; };
 		7C0A7FB213A9E72E00AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FAE13A9E72E00AFC2BD /* DirtyRegionSolvers.cpp */; };
 		7C0A7FB313A9E72E00AFC2BD /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FB013A9E72E00AFC2BD /* DirtyRegionTracker.cpp */; };
+		7C89628013B7031E003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89627E13B7031E003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C99B6E9133D36E200FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */; };
 		7C99B7BE1340730000FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */; };
 		C80711AD135DB85F002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C80711AB135DB85F002F601B /* InputOperations.cpp */; };
@@ -943,6 +944,8 @@
 		7C0A7FAF13A9E72E00AFC2BD /* DirtyRegionSolvers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionSolvers.h; sourceTree = "<group>"; };
 		7C0A7FB013A9E72E00AFC2BD /* DirtyRegionTracker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirtyRegionTracker.cpp; sourceTree = "<group>"; };
 		7C0A7FB113A9E72E00AFC2BD /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
+		7C89627E13B7031E003631FE /* GUIWindowScreensaverDim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowScreensaverDim.cpp; sourceTree = "<group>"; };
+		7C89627F13B7031E003631FE /* GUIWindowScreensaverDim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowScreensaverDim.h; sourceTree = "<group>"; };
 		7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheCircular.cpp; sourceTree = "<group>"; };
 		7C99B6E8133D36E200FC2B16 /* CacheCircular.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheCircular.h; sourceTree = "<group>"; };
 		7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -5587,6 +5590,8 @@
 				F56C87AF131F42EC000AD0F6 /* GUIWindowPointer.h */,
 				F56C87B0131F42EC000AD0F6 /* GUIWindowScreensaver.cpp */,
 				F56C87B1131F42EC000AD0F6 /* GUIWindowScreensaver.h */,
+				7C89627E13B7031E003631FE /* GUIWindowScreensaverDim.cpp */,
+				7C89627F13B7031E003631FE /* GUIWindowScreensaverDim.h */,
 				F56C87B2131F42EC000AD0F6 /* GUIWindowStartup.cpp */,
 				F56C87B3131F42EC000AD0F6 /* GUIWindowStartup.h */,
 				F56C87B4131F42EC000AD0F6 /* GUIWindowSystemInfo.cpp */,
@@ -6703,6 +6708,7 @@
 				DF0DF17F13A3AF9F008ED511 /* FileNFS.cpp in Sources */,
 				DF0DF18013A3AF9F008ED511 /* NFSDirectory.cpp in Sources */,
 				F558F61113AFDC3000631E12 /* ThreadLocal.cpp in Sources */,
+				7C89628013B7031E003631FE /* GUIWindowScreensaverDim.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -534,6 +534,8 @@
 		7C7B2B311134F36400713D6D /* mysqldataset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7B2B2E1134F36400713D6D /* mysqldataset.cpp */; };
 		7C84A59E12FA3C1600CD1714 /* SourcesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */; };
 		7C84A59F12FA3C1600CD1714 /* SourcesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */; };
+		7C89619213B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */; };
+		7C89619313B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C8A14561154CB2600E5FCFA /* TextureCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A14541154CB2600E5FCFA /* TextureCache.cpp */; };
 		7C8A14571154CB2600E5FCFA /* TextureCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A14541154CB2600E5FCFA /* TextureCache.cpp */; };
 		7C8A187C115B2A8200E5FCFA /* TextureDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */; };
@@ -2413,6 +2415,8 @@
 		7C7B2B2F1134F36400713D6D /* mysqldataset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mysqldataset.h; sourceTree = "<group>"; };
 		7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SourcesDirectory.cpp; path = xbmc/filesystem/SourcesDirectory.cpp; sourceTree = SOURCE_ROOT; };
 		7C84A59D12FA3C1600CD1714 /* SourcesDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SourcesDirectory.h; path = xbmc/filesystem/SourcesDirectory.h; sourceTree = SOURCE_ROOT; };
+		7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowScreensaverDim.cpp; sourceTree = "<group>"; };
+		7C89619113B6A16F003631FE /* GUIWindowScreensaverDim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowScreensaverDim.h; sourceTree = "<group>"; };
 		7C8A14541154CB2600E5FCFA /* TextureCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureCache.cpp; sourceTree = "<group>"; };
 		7C8A14551154CB2600E5FCFA /* TextureCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureCache.h; sourceTree = "<group>"; };
 		7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureDatabase.cpp; sourceTree = "<group>"; };
@@ -4675,6 +4679,8 @@
 				E38E18220D25F9FA00618676 /* GUIWindowPointer.h */,
 				E38E18250D25F9FA00618676 /* GUIWindowScreensaver.cpp */,
 				E38E18260D25F9FA00618676 /* GUIWindowScreensaver.h */,
+				7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */,
+				7C89619113B6A16F003631FE /* GUIWindowScreensaverDim.h */,
 				E38E18370D25F9FA00618676 /* GUIWindowStartup.cpp */,
 				E38E18380D25F9FA00618676 /* GUIWindowStartup.h */,
 				E38E18390D25F9FA00618676 /* GUIWindowSystemInfo.cpp */,
@@ -8033,6 +8039,7 @@
 				DF0DF15B13A3ADA7008ED511 /* FileNFS.cpp in Sources */,
 				DF0DF15C13A3ADA7008ED511 /* NFSDirectory.cpp in Sources */,
 				F558F51E13AF03AD00631E12 /* ThreadLocal.cpp in Sources */,
+				7C89619213B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8923,6 +8930,7 @@
 				F558F3D013AE663300631E12 /* FileNFS.cpp in Sources */,
 				F558F3D113AE663A00631E12 /* NFSDirectory.cpp in Sources */,
 				F558F51F13AF03AD00631E12 /* ThreadLocal.cpp in Sources */,
+				7C89619313B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1155,6 +1155,7 @@
     <ClCompile Include="..\..\xbmc\windows\GUIWindowLoginScreen.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowPointer.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowScreensaver.cpp" />
+    <ClCompile Include="..\..\xbmc\windows\GUIWindowScreensaverDim.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowStartup.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowSystemInfo.cpp" />
     <ClCompile Include="..\..\xbmc\windows\GUIWindowWeather.cpp" />
@@ -1995,6 +1996,7 @@
     <ClInclude Include="..\..\xbmc\windows\GUIWindowLoginScreen.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowPointer.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowScreensaver.h" />
+    <ClInclude Include="..\..\xbmc\windows\GUIWindowScreensaverDim.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowStartup.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowSystemInfo.h" />
     <ClInclude Include="..\..\xbmc\windows\GUIWindowWeather.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2222,6 +2222,9 @@
     <ClCompile Include="..\..\xbmc\windows\GUIWindowScreensaver.cpp">
       <Filter>windows</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\windows\GUIWindowScreensaverDim.cpp">
+      <Filter>windows</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\windows\GUIWindowStartup.cpp">
       <Filter>windows</Filter>
     </ClCompile>
@@ -4682,6 +4685,9 @@
       <Filter>windows</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\windows\GUIWindowScreensaver.h">
+      <Filter>windows</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\windows\GUIWindowScreensaverDim.h">
       <Filter>windows</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\windows\GUIWindowStartup.h">

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -201,6 +201,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "video/dialogs/GUIDialogFileStacking.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "dialogs/GUIDialogGamepad.h"
@@ -1065,7 +1066,7 @@ bool CApplication::Initialize()
   g_windowManager.Add(&m_guiDialogSeekBar);            // window id = 115
   g_windowManager.Add(new CGUIDialogSubMenu);            // window id = 105
   g_windowManager.Add(new CGUIDialogContextMenu);        // window id = 106
-  g_windowManager.Add(&m_guiDialogKaiToast);           // window id = 107
+  g_windowManager.Add(new CGUIDialogKaiToast);           // window id = 107
   g_windowManager.Add(new CGUIDialogNumeric);            // window id = 109
   g_windowManager.Add(new CGUIDialogGamepad);            // window id = 110
   g_windowManager.Add(new CGUIDialogButtonMenu);         // window id = 111
@@ -1652,7 +1653,6 @@ void CApplication::LoadSkin(const SkinPtr& skin)
   CLog::Log(LOGINFO, "  initialize new skin...");
   m_guiDialogVolumeBar.AllocResources(true);
   m_guiDialogSeekBar.AllocResources(true);
-  m_guiDialogKaiToast.AllocResources(true);
   m_guiDialogMuteBug.AllocResources(true);
   g_windowManager.AddMsgTarget(this);
   g_windowManager.AddMsgTarget(&g_playlistPlayer);
@@ -2641,11 +2641,12 @@ void CApplication::FrameMove()
 
   g_graphicsContext.Lock();
   // check if there are notifications to display
-  if (m_guiDialogKaiToast.DoWork())
+  CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
+  if (toast && toast->DoWork())
   {
-    if (!m_guiDialogKaiToast.IsDialogRunning())
+    if (!toast->IsDialogRunning())
     {
-      m_guiDialogKaiToast.Show();
+      toast->Show();
     }
   }
   g_graphicsContext.Unlock();

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -201,7 +201,10 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "dialogs/GUIDialogSeekBar.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "dialogs/GUIDialogVolumeBar.h"
+#include "dialogs/GUIDialogMuteBug.h"
 #include "video/dialogs/GUIDialogFileStacking.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "dialogs/GUIDialogGamepad.h"
@@ -1062,8 +1065,8 @@ bool CApplication::Initialize()
   g_windowManager.Add(new CGUIDialogYesNo);              // window id = 100
   g_windowManager.Add(new CGUIDialogProgress);           // window id = 101
   g_windowManager.Add(new CGUIDialogKeyboard);           // window id = 103
-  g_windowManager.Add(&m_guiDialogVolumeBar);          // window id = 104
-  g_windowManager.Add(&m_guiDialogSeekBar);            // window id = 115
+  g_windowManager.Add(new CGUIDialogVolumeBar);          // window id = 104
+  g_windowManager.Add(new CGUIDialogSeekBar);            // window id = 115
   g_windowManager.Add(new CGUIDialogSubMenu);            // window id = 105
   g_windowManager.Add(new CGUIDialogContextMenu);        // window id = 106
   g_windowManager.Add(new CGUIDialogKaiToast);           // window id = 107
@@ -1071,7 +1074,8 @@ bool CApplication::Initialize()
   g_windowManager.Add(new CGUIDialogGamepad);            // window id = 110
   g_windowManager.Add(new CGUIDialogButtonMenu);         // window id = 111
   g_windowManager.Add(new CGUIDialogMusicScan);          // window id = 112
-  g_windowManager.Add(new CGUIDialogPlayerControls);     // window id = 113
+  g_windowManager.Add(new CGUIDialogMuteBug);            // window id = 113
+  g_windowManager.Add(new CGUIDialogPlayerControls);     // window id = 114
 #ifdef HAS_KARAOKE
   g_windowManager.Add(new CGUIDialogKaraokeSongSelectorSmall); // window id 143
   g_windowManager.Add(new CGUIDialogKaraokeSongSelectorLarge); // window id 144
@@ -1651,9 +1655,6 @@ void CApplication::LoadSkin(const SkinPtr& skin)
   CLog::Log(LOGDEBUG,"Load Skin XML: %.2fms", 1000.f * (end - start) / freq);
 
   CLog::Log(LOGINFO, "  initialize new skin...");
-  m_guiDialogVolumeBar.AllocResources(true);
-  m_guiDialogSeekBar.AllocResources(true);
-  m_guiDialogMuteBug.AllocResources(true);
   g_windowManager.AddMsgTarget(this);
   g_windowManager.AddMsgTarget(&g_playlistPlayer);
   g_windowManager.AddMsgTarget(&g_infoManager);
@@ -1702,12 +1703,6 @@ void CApplication::UnloadSkin(bool forReload /* = false */)
 
   g_windowManager.DeInitialize();
   CTextureCache::Get().Deinitialize();
-
-  //These windows are not handled by the windowmanager (why not?) so we should unload them manually
-  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
-  m_guiDialogMuteBug.OnMessage(msg);
-  m_guiDialogMuteBug.ResetControlStates();
-  m_guiDialogMuteBug.FreeResources(true);
 
   // remove the skin-dependent window
   g_windowManager.Delete(WINDOW_DIALOG_FULLSCREEN_INFO);
@@ -2579,7 +2574,9 @@ bool CApplication::OnAction(const CAction &action)
   if (IsPlaying() && action.GetAmount() && (action.GetID() == ACTION_ANALOG_SEEK_FORWARD || action.GetID() == ACTION_ANALOG_SEEK_BACK))
   {
     if (!m_pPlayer->CanSeek()) return false;
-    m_guiDialogSeekBar.OnAction(action);
+    CGUIWindow *seekBar = g_windowManager.GetWindow(WINDOW_DIALOG_SEEK_BAR);
+    if (seekBar)
+      seekBar->OnAction(action);
     return true;
   }
   if (action.GetID() == ACTION_GUIPROFILE_BEGIN)
@@ -4888,9 +4885,13 @@ CFileItem& CApplication::CurrentFileItem()
 
 void CApplication::ShowVolumeBar(const CAction *action)
 {
-  m_guiDialogVolumeBar.Show();
-  if (action)
-    m_guiDialogVolumeBar.OnAction(*action);
+  CGUIDialog *volumeBar = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_VOLUME_BAR);
+  if (volumeBar)
+  {
+    volumeBar->Show();
+    if (action)
+      volumeBar->OnAction(*action);
+  }
 }
 
 void CApplication::Mute(void)
@@ -4949,14 +4950,16 @@ void CApplication::SetHardwareVolume(long hardwareVolume)
   if(!g_settings.m_bMute && hardwareVolume <= VOLUME_MINIMUM)
   {
     g_settings.m_bMute = true;
-    if (!m_guiDialogMuteBug.IsDialogRunning())
-      m_guiDialogMuteBug.Show();
+    CGUIDialog *muteBug = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_MUTE_BUG);
+    if (muteBug && !muteBug->IsDialogRunning())
+      muteBug->Show();
   }
   else if(g_settings.m_bMute && hardwareVolume > VOLUME_MINIMUM)
   {
     g_settings.m_bMute = false;
-    if (m_guiDialogMuteBug.IsDialogRunning())
-      m_guiDialogMuteBug.Close();
+    CGUIDialog *muteBug = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_MUTE_BUG);
+    if (muteBug && muteBug->IsDialogRunning())
+      muteBug->Close();
   }
 
   // and tell our player to update the volume

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4948,19 +4948,9 @@ void CApplication::SetHardwareVolume(long hardwareVolume)
 
   // update mute state
   if(!g_settings.m_bMute && hardwareVolume <= VOLUME_MINIMUM)
-  {
     g_settings.m_bMute = true;
-    CGUIDialog *muteBug = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_MUTE_BUG);
-    if (muteBug && !muteBug->IsDialogRunning())
-      muteBug->Show();
-  }
   else if(g_settings.m_bMute && hardwareVolume > VOLUME_MINIMUM)
-  {
     g_settings.m_bMute = false;
-    CGUIDialog *muteBug = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_MUTE_BUG);
-    if (muteBug && muteBug->IsDialogRunning())
-      muteBug->Close();
-  }
 
   // and tell our player to update the volume
   if (m_pPlayer)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -288,8 +288,9 @@ public:
 
   void Minimize();
   bool ToggleDPMS(bool manual);
+
+  float GetDimScreenSaverLevel() const;
 protected:
-  void RenderScreenSaver();
   bool LoadSkin(const CStdString& skinID);
   void LoadSkin(const boost::shared_ptr<ADDON::CSkinInfo>& skin);
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -36,10 +36,6 @@ namespace ADDON
   typedef boost::shared_ptr<IAddon> AddonPtr;
 }
 
-#include "dialogs/GUIDialogSeekBar.h"
-#include "dialogs/GUIDialogVolumeBar.h"
-#include "dialogs/GUIDialogMuteBug.h"
-
 #include "cores/IPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "PlayListPlayer.h"
@@ -211,10 +207,6 @@ public:
 #ifdef HAS_PERFORMANCE_SAMPLE
   CPerformanceStats &GetPerformanceStats();
 #endif
-
-  CGUIDialogVolumeBar m_guiDialogVolumeBar;
-  CGUIDialogSeekBar m_guiDialogSeekBar;
-  CGUIDialogMuteBug m_guiDialogMuteBug;
 
 #ifdef HAS_DVD_DRIVE
   MEDIA_DETECT::CAutorun m_Autorun;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -37,7 +37,6 @@ namespace ADDON
 }
 
 #include "dialogs/GUIDialogSeekBar.h"
-#include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogVolumeBar.h"
 #include "dialogs/GUIDialogMuteBug.h"
 
@@ -215,7 +214,6 @@ public:
 
   CGUIDialogVolumeBar m_guiDialogVolumeBar;
   CGUIDialogSeekBar m_guiDialogSeekBar;
-  CGUIDialogKaiToast m_guiDialogKaiToast;
   CGUIDialogMuteBug m_guiDialogMuteBug;
 
 #ifdef HAS_DVD_DRIVE

--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -73,10 +73,6 @@
 
 #define GUI_MSG_SCAN_FINISHED           GUI_MSG_USER + 13
 
-//  Mute activated by the user
-#define GUI_MSG_MUTE_ON                 GUI_MSG_USER + 14
-#define GUI_MSG_MUTE_OFF                GUI_MSG_USER + 15
-
 //  Player has requested the next item for caching purposes (PAPlayer)
 #define GUI_MSG_QUEUE_NEXT_ITEM         GUI_MSG_USER + 16
 

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -35,6 +35,7 @@
 #include "guilib/GUIWindowManager.h"      // for callback
 #include "GUIUserMessages.h"              // for callback
 #include "utils/StringUtils.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 using namespace std;
 using namespace XFILE;
@@ -191,7 +192,7 @@ bool CAddonInstaller::DoInstall(const AddonPtr &addon, const CStdString &hash, b
   //       missing deps.
   if (!CheckDependencies(addon))
   {
-    g_application.m_guiDialogKaiToast.QueueNotification(addon->Icon(), addon->Name(), g_localizeStrings.Get(24044), TOAST_DISPLAY_TIME, false);
+    CGUIDialogKaiToast::QueueNotification(addon->Icon(), addon->Name(), g_localizeStrings.Get(24044), TOAST_DISPLAY_TIME, false);
     return false;
   }
 
@@ -225,7 +226,7 @@ bool CAddonInstaller::InstallFromZip(const CStdString &path)
   URIUtils::CreateArchivePath(zipDir, "zip", path, "");
   if (!CDirectory::GetDirectory(zipDir, items) || items.Size() != 1 || !items[0]->m_bIsFolder)
   {
-    g_application.m_guiDialogKaiToast.QueueNotification("", path, g_localizeStrings.Get(24045), TOAST_DISPLAY_TIME, false);
+    CGUIDialogKaiToast::QueueNotification("", path, g_localizeStrings.Get(24045), TOAST_DISPLAY_TIME, false);
     return false;
   }
 
@@ -242,7 +243,7 @@ bool CAddonInstaller::InstallFromZip(const CStdString &path)
     // install the addon
     return DoInstall(addon);
   }
-  g_application.m_guiDialogKaiToast.QueueNotification("", path, g_localizeStrings.Get(24045), TOAST_DISPLAY_TIME, false);
+  CGUIDialogKaiToast::QueueNotification("", path, g_localizeStrings.Get(24045), TOAST_DISPLAY_TIME, false);
   return false;
 }
 
@@ -473,11 +474,11 @@ void CAddonInstallJob::OnPostInstall(bool reloadAddon)
 {
   if (m_addon->Type() < ADDON_VIZ_LIBRARY && g_settings.m_bAddonNotifications)
   {
-    g_application.m_guiDialogKaiToast.QueueNotification(m_addon->Icon(),
-                                                        m_addon->Name(),
-                                                        g_localizeStrings.Get(m_update ? 24065 : 24064),
-                                                        TOAST_DISPLAY_TIME,false,
-                                                        TOAST_DISPLAY_TIME);
+    CGUIDialogKaiToast::QueueNotification(m_addon->Icon(),
+                                          m_addon->Name(),
+                                          g_localizeStrings.Get(m_update ? 24065 : 24064),
+                                          TOAST_DISPLAY_TIME,false,
+                                          TOAST_DISPLAY_TIME);
   }
   if (m_addon->Type() == ADDON_SKIN)
   {
@@ -485,8 +486,12 @@ void CAddonInstallJob::OnPostInstall(bool reloadAddon)
                                                         g_localizeStrings.Get(24099),"","")))
     {
       g_guiSettings.SetString("lookandfeel.skin",m_addon->ID().c_str());
-      g_application.m_guiDialogKaiToast.ResetTimer();
-      g_application.m_guiDialogKaiToast.Close(true);
+      CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
+      if (toast)
+      {
+        toast->ResetTimer();
+        toast->Close(true);
+      }
       g_application.getApplicationMessenger().ExecBuiltIn("ReloadSkin");
     }
   }
@@ -503,19 +508,17 @@ void CAddonInstallJob::ReportInstallError(const CStdString& addonID,
   {
     AddonPtr addon2;
     CAddonMgr::Get().GetAddon(addonID, addon2);
-    g_application.m_guiDialogKaiToast.QueueNotification(
-                                                        addon->Icon(),
-                                                        addon->Name(),
-                                                        g_localizeStrings.Get(addon2 ? 113 : 114),
-                                                        TOAST_DISPLAY_TIME, false);
+    CGUIDialogKaiToast::QueueNotification(addon->Icon(),
+                                          addon->Name(),
+                                          g_localizeStrings.Get(addon2 ? 113 : 114),
+                                          TOAST_DISPLAY_TIME, false);
   }
   else
   {
-    g_application.m_guiDialogKaiToast.QueueNotification(
-                                                        CGUIDialogKaiToast::Error,
-                                                        fileName,
-                                                        g_localizeStrings.Get(114),
-                                                        TOAST_DISPLAY_TIME, false);
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
+                                          fileName,
+                                          g_localizeStrings.Get(114),
+                                          TOAST_DISPLAY_TIME, false);
   }
 }
 

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -23,7 +23,6 @@
 #include "tinyXML/tinyxml.h"
 #include "filesystem/File.h"
 #include "AddonDatabase.h"
-#include "Application.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
 #include "utils/JobManager.h"
@@ -31,6 +30,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 using namespace XFILE;
 using namespace ADDON;
@@ -212,9 +212,9 @@ bool CRepositoryUpdateJob::DoWork()
       }
       else if (g_settings.m_bAddonNotifications)
       {
-        g_application.m_guiDialogKaiToast.QueueNotification(addon->Icon(),
-                                                            g_localizeStrings.Get(24061),
-                                                            addon->Name(),TOAST_DISPLAY_TIME,false,TOAST_DISPLAY_TIME);
+        CGUIDialogKaiToast::QueueNotification(addon->Icon(),
+                                              g_localizeStrings.Get(24061),
+                                              addon->Name(),TOAST_DISPLAY_TIME,false,TOAST_DISPLAY_TIME);
       }
     }
     if (!addons[i]->Props().broken.IsEmpty())

--- a/xbmc/cores/AudioRenderers/NullDirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/NullDirectSound.cpp
@@ -21,9 +21,9 @@
 
 #include "NullDirectSound.h"
 #include "guilib/AudioContext.h"
-#include "Application.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 #define BUFFER CHUNKLEN * 20
 #define CHUNKLEN 512
@@ -51,7 +51,7 @@ bool CNullDirectSound::Initialize(IAudioCallback* pCallback, const CStdString& d
   g_audioContext.SetupSpeakerConfig(iChannels, bAudioOnAllSpeakers, bIsMusic);
   g_audioContext.SetActiveDevice(CAudioContext::DIRECTSOUND_DEVICE);
 
-  g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Error, "Failed to initialize audio device", "Check your audiosettings", TOAST_DISPLAY_TIME, false);
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, "Failed to initialize audio device", "Check your audiosettings", TOAST_DISPLAY_TIME, false);
   m_timePerPacket = 1.0f / (float)(iChannels*(uiBitsPerSample/8) * uiSamplesPerSec);
   m_packetsSent = 0;
   m_paused = 0;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -35,6 +35,7 @@
 #include "VideoShaders/YUV2RGBShader.h"
 #include "VideoShaders/VideoFilterShader.h"
 #include "windowing/WindowingFactory.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/Texture.h"
 #include "threads/SingleLock.h"
 #include "DllSwScale.h"
@@ -912,7 +913,7 @@ void CLinuxRendererGL::UpdateVideoFilter()
     break;
   }
 
-  g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Error, "Video Renderering", "Failed to init video filters/scalers, falling back to bilinear scaling");
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, "Video Renderering", "Failed to init video filters/scalers, falling back to bilinear scaling");
   CLog::Log(LOGERROR, "GL: Falling back to bilinear due to failure to init scaler");
   if (m_pVideoFilterShader)
   {

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -22,7 +22,6 @@
 #ifdef HAS_DX
 
 #include "WinRenderer.h"
-#include "Application.h"
 #include "Util.h"
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"
@@ -37,6 +36,7 @@
 #include "VideoShaders/WinVideoFilter.h"
 #include "DllSwScale.h"
 #include "guilib/LocalizeStrings.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 typedef struct {
   RenderMethod  method;
@@ -154,7 +154,7 @@ void CWinRenderer::SelectRenderMethod()
           else
           {
             CLog::Log(LOGNOTICE, "D3D: unable to load test shader - D3D installation is most likely incomplete");
-            g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Warning, "DirectX", g_localizeStrings.Get(2101));
+            CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, "DirectX", g_localizeStrings.Get(2101));
             shader->Release();
           }
         }
@@ -551,7 +551,7 @@ void CWinRenderer::UpdatePSVideoFilter()
     if (!m_scalerShader->Create(m_scalingMethod))
     {
       SAFE_RELEASE(m_scalerShader);
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Error, "Video Renderering", "Failed to init video scaler, falling back to bilinear scaling.");
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, "Video Renderering", "Failed to init video scaler, falling back to bilinear scaling.");
       m_bUseHQScaler = false;
     }
   }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
@@ -26,7 +26,7 @@
 #include "DVDDemuxHTSP.h"
 #include "DVDDemuxUtils.h"
 #include "DVDClock.h"
-#include "Application.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "utils/log.h"
 #include <arpa/inet.h>
 
@@ -350,7 +350,7 @@ void CDVDDemuxHTSP::SubscriptionStatus(htsmsg_t *m)
     m_StatusCount++;
     m_Status = status;
     CLog::Log(LOGDEBUG, "CDVDDemuxHTSP::SubscriptionStatus - %s", status);
-    g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, "TVHeadend Status", status, TOAST_DISPLAY_TIME, false);
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, "TVHeadend Status", status, TOAST_DISPLAY_TIME, false);
   }
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -65,6 +65,7 @@
 #include "utils/StreamDetails.h"
 #include "storage/MediaManager.h"
 #include "dialogs/GUIDialogBusy.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "utils/StringUtils.h"
 #include "Util.h"
 
@@ -1336,7 +1337,7 @@ void CDVDPlayer::HandlePlaySpeed()
     {
       if(level  < 0.0)
       {
-        g_application.m_guiDialogKaiToast.QueueNotification("Cache full", "Cache filled before reaching required amount for continous playback");
+        CGUIDialogKaiToast::QueueNotification("Cache full", "Cache filled before reaching required amount for continous playback");
         caching = CACHESTATE_INIT;
       }
       if(level >= 1.0)

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -22,6 +22,7 @@
 #include "GUIDialogKaiToast.h"
 #include "guilib/GUIImage.h"
 #include "guilib/GUIAudioManager.h"
+#include "guilib/GUIWindowManager.h"
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
 
@@ -76,20 +77,9 @@ void CGUIDialogKaiToast::OnWindowLoaded()
 
 void CGUIDialogKaiToast::QueueNotification(eMessageType eType, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
 {
-  CGUIImage *image    = NULL;
-
-  if (eType == Info)
-    image = (CGUIImage *)GetControl(POPUP_ICON_INFO);
-  else if (eType == Warning)
-    image = (CGUIImage *)GetControl(POPUP_ICON_WARNING);
-  else if (eType == Error)
-    image = (CGUIImage *)GetControl(POPUP_ICON_ERROR);
-
-  CStdString strImage;
-  if (image)
-    strImage = image->GetFileName();
-
-  QueueNotification(strImage, aCaption, aDescription, displayTime, withSound, messageTime);
+  CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
+  if (toast)
+    toast->AddToQueue(eType, aCaption, aDescription, displayTime, withSound, messageTime);
 }
 
 void CGUIDialogKaiToast::QueueNotification(const CStdString& aCaption, const CStdString& aDescription)
@@ -98,6 +88,31 @@ void CGUIDialogKaiToast::QueueNotification(const CStdString& aCaption, const CSt
 }
 
 void CGUIDialogKaiToast::QueueNotification(const CStdString& aImageFile, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
+{
+  CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
+  if (toast)
+    toast->AddToQueue(aImageFile, aCaption, aDescription, displayTime, withSound, messageTime);
+}
+
+void CGUIDialogKaiToast::AddToQueue(eMessageType eType, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
+{
+  CGUIImage *image    = NULL;
+  
+  if (eType == Info)
+    image = (CGUIImage *)GetControl(POPUP_ICON_INFO);
+  else if (eType == Warning)
+    image = (CGUIImage *)GetControl(POPUP_ICON_WARNING);
+  else if (eType == Error)
+    image = (CGUIImage *)GetControl(POPUP_ICON_ERROR);
+  
+  CStdString strImage;
+  if (image)
+    strImage = image->GetFileName();
+  
+  AddToQueue(strImage, aCaption, aDescription, displayTime, withSound, messageTime);
+}
+
+void CGUIDialogKaiToast::AddToQueue(const CStdString& aImageFile, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime /*= TOAST_DISPLAY_TIME*/, bool withSound /*= true*/, unsigned int messageTime /*= TOAST_MESSAGE_TIME*/)
 {
   CSingleLock lock(m_critical);
 

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -37,6 +37,9 @@ CGUIDialogKaiToast::CGUIDialogKaiToast(void)
 {
   m_defaultIcon = "";
   m_loadOnDemand = false;
+  m_timer = 0;
+  m_toastDisplayTime = 0;
+  m_toastMessageTime = 0;
 }
 
 CGUIDialogKaiToast::~CGUIDialogKaiToast(void)

--- a/xbmc/dialogs/GUIDialogKaiToast.h
+++ b/xbmc/dialogs/GUIDialogKaiToast.h
@@ -46,9 +46,9 @@ public:
 
   enum eMessageType { Info = 0, Warning, Error };
 
-  void QueueNotification(eMessageType eType, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime = TOAST_DISPLAY_TIME, bool withSound = true, unsigned int messageTime = TOAST_MESSAGE_TIME);
-  void QueueNotification(const CStdString& aCaption, const CStdString& aDescription);
-  void QueueNotification(const CStdString& aImageFile, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime = TOAST_DISPLAY_TIME, bool withSound = true, unsigned int messageTime = TOAST_MESSAGE_TIME);
+  static void QueueNotification(eMessageType eType, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime = TOAST_DISPLAY_TIME, bool withSound = true, unsigned int messageTime = TOAST_MESSAGE_TIME);
+  static void QueueNotification(const CStdString& aCaption, const CStdString& aDescription);
+  static void QueueNotification(const CStdString& aImageFile, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime = TOAST_DISPLAY_TIME, bool withSound = true, unsigned int messageTime = TOAST_MESSAGE_TIME);
   bool DoWork();
 
   virtual bool OnMessage(CGUIMessage& message);
@@ -57,6 +57,8 @@ public:
   void ResetTimer();
 
 protected:
+  void AddToQueue(eMessageType eType, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime, bool withSound, unsigned int messageTime);
+  void AddToQueue(const CStdString& aImageFile, const CStdString& aCaption, const CStdString& aDescription, unsigned int displayTime, bool withSound, unsigned int messageTime);
 
   unsigned int m_timer;
 

--- a/xbmc/dialogs/GUIDialogMuteBug.cpp
+++ b/xbmc/dialogs/GUIDialogMuteBug.cpp
@@ -21,6 +21,7 @@
 
 #include "GUIDialogMuteBug.h"
 #include "GUIUserMessages.h"
+#include "settings/Settings.h"
 
 // the MuteBug is a true modeless dialog
 
@@ -33,3 +34,10 @@ CGUIDialogMuteBug::CGUIDialogMuteBug(void)
 CGUIDialogMuteBug::~CGUIDialogMuteBug(void)
 {}
 
+void CGUIDialogMuteBug::UpdateVisibility()
+{
+  if (g_settings.m_bMute)
+    Show();
+  else
+    Close();
+}

--- a/xbmc/dialogs/GUIDialogMuteBug.cpp
+++ b/xbmc/dialogs/GUIDialogMuteBug.cpp
@@ -24,8 +24,6 @@
 
 // the MuteBug is a true modeless dialog
 
-#define MUTEBUG_IMAGE     901
-
 CGUIDialogMuteBug::CGUIDialogMuteBug(void)
     : CGUIDialog(WINDOW_DIALOG_MUTE_BUG, "DialogMuteBug.xml")
 {
@@ -35,25 +33,3 @@ CGUIDialogMuteBug::CGUIDialogMuteBug(void)
 CGUIDialogMuteBug::~CGUIDialogMuteBug(void)
 {}
 
-bool CGUIDialogMuteBug::OnMessage(CGUIMessage& message)
-{
-  switch ( message.GetMessage() )
-  {
-  case GUI_MSG_MUTE_OFF:
-    {
-      Close();
-      return true;
-    }
-    break;
-
-  case GUI_MSG_MUTE_ON:
-    {
-      // this is handled in g_application
-      // non-active modeless window can not get messages
-      //Show();
-      return true;
-    }
-    break;
-  }
-  return CGUIDialog::OnMessage(message);
-}

--- a/xbmc/dialogs/GUIDialogMuteBug.h
+++ b/xbmc/dialogs/GUIDialogMuteBug.h
@@ -29,4 +29,5 @@ public:
   CGUIDialogMuteBug(void);
   virtual ~CGUIDialogMuteBug(void);
 protected:
+  virtual void UpdateVisibility();
 };

--- a/xbmc/dialogs/GUIDialogMuteBug.h
+++ b/xbmc/dialogs/GUIDialogMuteBug.h
@@ -28,6 +28,5 @@ class CGUIDialogMuteBug : public CGUIDialog
 public:
   CGUIDialogMuteBug(void);
   virtual ~CGUIDialogMuteBug(void);
-  virtual bool OnMessage(CGUIMessage& message);
 protected:
 };

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -33,8 +33,7 @@ CGUIFadeLabelControl::CGUIFadeLabelControl(int parentID, int controlID, float po
   ControlType = GUICONTROL_FADELABEL;
   m_scrollOut = scrollOut;
   m_fadeAnim = CAnimation::CreateFader(100, 0, timeToDelayAtEnd, 200);
-  if (m_fadeAnim)
-    m_fadeAnim->ApplyAnimation();
+  m_fadeAnim.ApplyAnimation();
   m_renderTime = 0;
   m_lastLabel = -1;
   m_scrollSpeed = labelInfo.scrollSpeed;  // save it for later
@@ -50,10 +49,8 @@ CGUIFadeLabelControl::CGUIFadeLabelControl(const CGUIFadeLabelControl &from)
   m_scrollSpeed = from.m_scrollSpeed;
   m_resetOnLabelChange = from.m_resetOnLabelChange;
 
-  if (from.m_fadeAnim)
-    m_fadeAnim = new CAnimation(*from.m_fadeAnim);
-  if (m_fadeAnim)
-    m_fadeAnim->ApplyAnimation();
+  m_fadeAnim = from.m_fadeAnim;
+  m_fadeAnim.ApplyAnimation();
   m_currentLabel = 0;
   m_renderTime = 0;
   m_lastLabel = -1;
@@ -62,7 +59,6 @@ CGUIFadeLabelControl::CGUIFadeLabelControl(const CGUIFadeLabelControl &from)
 
 CGUIFadeLabelControl::~CGUIFadeLabelControl(void)
 {
-  delete m_fadeAnim;
 }
 
 void CGUIFadeLabelControl::SetInfo(const vector<CGUIInfoLabel> &infoLabels)
@@ -118,13 +114,13 @@ void CGUIFadeLabelControl::Render()
     if (m_resetOnLabelChange)
     {
       m_scrollInfo.Reset();
-      m_fadeAnim->ResetAnimation();
+      m_fadeAnim.ResetAnimation();
     }
   }
   if (m_currentLabel != m_lastLabel)
   { // new label - reset scrolling
     m_scrollInfo.Reset();
-    m_fadeAnim->QueueAnimation(ANIM_PROCESS_REVERSE);
+    m_fadeAnim.QueueAnimation(ANIM_PROCESS_REVERSE);
     m_lastLabel = m_currentLabel;
   }
 
@@ -152,8 +148,8 @@ void CGUIFadeLabelControl::Render()
       text.erase(text.begin(), text.begin() + min((int)m_scrollInfo.characterPos - 1, (int)text.size()));
     if (m_label.font->GetTextWidth(text) < m_width)
     {
-      if (m_fadeAnim->GetProcess() != ANIM_PROCESS_NORMAL)
-        m_fadeAnim->QueueAnimation(ANIM_PROCESS_NORMAL);
+      if (m_fadeAnim.GetProcess() != ANIM_PROCESS_NORMAL)
+        m_fadeAnim.QueueAnimation(ANIM_PROCESS_NORMAL);
       moveToNextLabel = true;
     }
   }
@@ -162,14 +158,14 @@ void CGUIFadeLabelControl::Render()
 
   // apply the fading animation
   TransformMatrix matrix;
-  m_fadeAnim->Animate(m_renderTime, true);
-  m_fadeAnim->RenderAnimation(matrix);
+  m_fadeAnim.Animate(m_renderTime, true);
+  m_fadeAnim.RenderAnimation(matrix);
   g_graphicsContext.AddTransform(matrix);
 
-  if (m_fadeAnim->GetState() == ANIM_STATE_APPLIED)
-    m_fadeAnim->ResetAnimation();
+  if (m_fadeAnim.GetState() == ANIM_STATE_APPLIED)
+    m_fadeAnim.ResetAnimation();
 
-  m_scrollInfo.SetSpeed((m_fadeAnim->GetProcess() == ANIM_PROCESS_NONE) ? m_scrollSpeed : 0);
+  m_scrollInfo.SetSpeed((m_fadeAnim.GetProcess() == ANIM_PROCESS_NONE) ? m_scrollSpeed : 0);
 
   if (!m_scrollOut && m_shortText)
   {
@@ -185,12 +181,12 @@ void CGUIFadeLabelControl::Render()
 
   if (moveToNextLabel)
   { // increment the label and reset scrolling
-    if (m_fadeAnim->GetProcess() != ANIM_PROCESS_NORMAL)
+    if (m_fadeAnim.GetProcess() != ANIM_PROCESS_NORMAL)
     {
       if (++m_currentLabel >= m_infoLabels.size())
         m_currentLabel = 0;
       m_scrollInfo.Reset();
-      m_fadeAnim->QueueAnimation(ANIM_PROCESS_REVERSE);
+      m_fadeAnim.QueueAnimation(ANIM_PROCESS_REVERSE);
     }
   }
 

--- a/xbmc/guilib/GUIFadeLabelControl.h
+++ b/xbmc/guilib/GUIFadeLabelControl.h
@@ -77,7 +77,7 @@ protected:
 
   CScrollInfo m_scrollInfo;
   CGUITextLayout m_textLayout;
-  CAnimation *m_fadeAnim;
+  CAnimation m_fadeAnim;
   unsigned int m_renderTime;
   unsigned int m_scrollSpeed;
   bool m_resetOnLabelChange;

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -332,7 +332,7 @@ void CGUITextBox::SetAutoScrolling(const TiXmlNode *node)
       m_autoScrollCondition = g_infoManager.TranslateString(scroll->FirstChild()->ValueStr());
     int repeatTime;
     if (scroll->Attribute("repeat", &repeatTime))
-      m_autoScrollRepeatAnim = CAnimation::CreateFader(100, 0, repeatTime, 1000);
+      m_autoScrollRepeatAnim = new CAnimation(CAnimation::CreateFader(100, 0, repeatTime, 1000));
   }
 }
 

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -571,9 +571,10 @@ void CAnimation::QueueAnimation(ANIMATION_PROCESS process)
   m_queuedProcess = process;
 }
 
-CAnimation CAnimation::CreateFader(float start, float end, unsigned int delay, unsigned int length)
+CAnimation CAnimation::CreateFader(float start, float end, unsigned int delay, unsigned int length, ANIMATION_TYPE type)
 {
   CAnimation anim;
+  anim.m_type = type;
   anim.AddEffect(new CFadeEffect(start, end, delay, length));
   return anim;
 }

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -571,15 +571,10 @@ void CAnimation::QueueAnimation(ANIMATION_PROCESS process)
   m_queuedProcess = process;
 }
 
-CAnimation *CAnimation::CreateFader(float start, float end, unsigned int delay, unsigned int length)
+CAnimation CAnimation::CreateFader(float start, float end, unsigned int delay, unsigned int length)
 {
-  CAnimation *anim = new CAnimation();
-  if (anim)
-  {
-    CFadeEffect *effect = new CFadeEffect(start, end, delay, length);
-    if (effect)
-      anim->AddEffect(effect);
-  }
+  CAnimation anim;
+  anim.AddEffect(new CFadeEffect(start, end, delay, length));
   return anim;
 }
 

--- a/xbmc/guilib/VisibleEffect.h
+++ b/xbmc/guilib/VisibleEffect.h
@@ -149,7 +149,7 @@ public:
 
   const CAnimation &operator=(const CAnimation &src);
 
-  static CAnimation CreateFader(float start, float end, unsigned int delay, unsigned int length);
+  static CAnimation CreateFader(float start, float end, unsigned int delay, unsigned int length, ANIMATION_TYPE type = ANIM_TYPE_NONE);
 
   void Create(const TiXmlElement *node, const CRect &rect);
 

--- a/xbmc/guilib/VisibleEffect.h
+++ b/xbmc/guilib/VisibleEffect.h
@@ -149,7 +149,7 @@ public:
 
   const CAnimation &operator=(const CAnimation &src);
 
-  static CAnimation *CreateFader(float start, float end, unsigned int delay, unsigned int length);
+  static CAnimation CreateFader(float start, float end, unsigned int delay, unsigned int length);
 
   void Create(const TiXmlElement *node, const CRect &rect);
 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -29,6 +29,7 @@
 #include "addons/GUIDialogAddonSettings.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogKeyboard.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "music/dialogs/GUIDialogMusicScan.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "dialogs/GUIDialogProgress.h"
@@ -288,13 +289,13 @@ int CBuiltins::Execute(const CStdString& execString)
     {
       g_passwordManager.bMasterUser = false;
       g_passwordManager.LockSources(true);
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(20052),g_localizeStrings.Get(20053));
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(20052),g_localizeStrings.Get(20053));
     }
     else if (g_passwordManager.IsMasterLockUnlocked(true))
     {
       g_passwordManager.LockSources(false);
       g_passwordManager.bMasterUser = true;
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(20052),g_localizeStrings.Get(20054));
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(20052),g_localizeStrings.Get(20054));
     }
 
     CUtil::DeleteVideoDatabaseDirectoryCache();
@@ -881,11 +882,11 @@ int CBuiltins::Execute(const CStdString& execString)
     if (params.size() < 2)
       return -1;
     if (params.size() == 4)
-      g_application.m_guiDialogKaiToast.QueueNotification(params[3],params[0],params[1],atoi(params[2].c_str()));
+      CGUIDialogKaiToast::QueueNotification(params[3],params[0],params[1],atoi(params[2].c_str()));
     else if (params.size() == 3)
-      g_application.m_guiDialogKaiToast.QueueNotification("",params[0],params[1],atoi(params[2].c_str()));
+      CGUIDialogKaiToast::QueueNotification("",params[0],params[1],atoi(params[2].c_str()));
     else
-      g_application.m_guiDialogKaiToast.QueueNotification(params[0],params[1]);
+      CGUIDialogKaiToast::QueueNotification(params[0],params[1]);
   }
   else if (execute.Equals("cancelalarm"))
   {
@@ -1132,7 +1133,7 @@ int CBuiltins::Execute(const CStdString& execString)
     g_passwordManager.bMasterUser = false;
     g_windowManager.ActivateWindow(WINDOW_LOGIN_SCREEN);
     if (!g_application.StartEventServer()) // event server could be needed in some situations
-      g_application.m_guiDialogKaiToast.QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
+      CGUIDialogKaiToast::QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
   }
   else if (execute.Equals("pagedown"))
   {

--- a/xbmc/linux/HALManager.cpp
+++ b/xbmc/linux/HALManager.cpp
@@ -22,7 +22,6 @@
 #include "system.h"
 #ifdef HAS_HAL
 #include "HALManager.h"
-#include "Application.h"
 #include "interfaces/Builtins.h"
 #include <libhal-storage.h>
 #include "threads/SingleLock.h"
@@ -30,6 +29,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "powermanagement/PowerManager.h"
 #include "settings/AdvancedSettings.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 #ifdef HAS_SDL_JOYSTICK
 #include <SDL/SDL.h>
@@ -396,7 +396,7 @@ void CHALManager::UpdateDevice(const char *udi)
         if (g_advancedSettings.m_handleMounting)  // If the device was mounted by XBMC before it's still mounted by XBMC.
             dev.MountedByXBMC = m_Volumes[i].MountedByXBMC;
         if (!dev.Mounted && m_Volumes[i].Mounted)
-          g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13023), dev.FriendlyName.c_str(), TOAST_DISPLAY_TIME, false);
+          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13023), dev.FriendlyName.c_str(), TOAST_DISPLAY_TIME, false);
         m_Volumes[i] = dev;
 
         break;
@@ -462,7 +462,7 @@ void CHALManager::HandleNewVolume(CStorageDevice *dev)
         {
           CLog::Log(LOGINFO, "HAL: mounted %s on %s", dev->FriendlyName.c_str(), dev->MountPoint.c_str());
           if (m_Notifications)
-            g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13021), dev->FriendlyName.c_str(), TOAST_DISPLAY_TIME, false);
+            CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13021), dev->FriendlyName.c_str(), TOAST_DISPLAY_TIME, false);
         }
       }
       libhal_free_string_array(capability);
@@ -525,7 +525,7 @@ void CHALManager::AddDevice(const char *udi)
 
           g_Joystick.Initialize();
           if (m_Notifications)
-            g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13024), dev.FriendlyName.c_str(), TOAST_DISPLAY_TIME, false);
+            CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13024), dev.FriendlyName.c_str(), TOAST_DISPLAY_TIME, false);
         }
       }
     }
@@ -561,7 +561,7 @@ bool CHALManager::RemoveDevice(const char *udi)
         if (g_advancedSettings.m_handleMounting)
           UnMount(m_Volumes[i]);
         if (m_Notifications)
-          g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13022), m_Volumes[i].FriendlyName.c_str());
+          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13022), m_Volumes[i].FriendlyName.c_str());
         CLog::Log(LOGNOTICE, "HAL: Unsafe drive removal");
       }
       m_Volumes.erase(m_Volumes.begin() + i);
@@ -589,7 +589,7 @@ bool CHALManager::RemoveDevice(const char *udi)
         }
 
         g_Joystick.Initialize();
-        g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13025), m_Joysticks[i].FriendlyName.c_str(), TOAST_DISPLAY_TIME, false);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13025), m_Joysticks[i].FriendlyName.c_str(), TOAST_DISPLAY_TIME, false);
       }
       m_Joysticks.erase(m_Joysticks.begin() + i);
       return true;

--- a/xbmc/music/LastFmManager.cpp
+++ b/xbmc/music/LastFmManager.cpp
@@ -34,6 +34,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "URL.h"
 #include "guilib/GUIWindowManager.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogOK.h"
@@ -809,13 +810,13 @@ bool CLastFmManager::Love(bool askConfirmation)
         if (Love(*infoTag))
         {
           strMessage.Format(g_localizeStrings.Get(15289), strTitle);
-          g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(15200), strMessage, 7000, false);
+          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(15200), strMessage, 7000, false);
           return true;
         }
         else
         {
           strMessage.Format(g_localizeStrings.Get(15290), strTitle);
-          g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(15200), strMessage, 7000, false);
+          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(15200), strMessage, 7000, false);
           return false;
         }
       }
@@ -842,13 +843,13 @@ bool CLastFmManager::Ban(bool askConfirmation)
         if (Ban(*infoTag))
         {
           strMessage.Format(g_localizeStrings.Get(15291), strTitle);
-          g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(15200), strMessage, 7000, false);
+          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(15200), strMessage, 7000, false);
           return true;
         }
         else
         {
           strMessage.Format(g_localizeStrings.Get(15292), strTitle);
-          g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(15200), strMessage, 7000, false);
+          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(15200), strMessage, 7000, false);
           return false;
         }
       }

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -25,7 +25,6 @@
 
 #include "EventClient.h"
 #include "EventPacket.h"
-#include "Application.h"
 #include "threads/SingleLock.h"
 #include "input/ButtonTranslator.h"
 #include <map>
@@ -33,6 +32,8 @@
 #include "filesystem/File.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
+#include "dialogs/GUIDialogKaiToast.h"
+#include "guilib/GraphicContext.h"
 
 using namespace EVENTCLIENT;
 using namespace EVENTPACKET;
@@ -333,14 +334,14 @@ bool CEventClient::OnPacketHELO(CEventPacket *packet)
   m_bGreeted = true;
   if (m_eLogoType == LT_NONE)
   {
-    g_application.m_guiDialogKaiToast.QueueNotification("Detected New Connection",
-                                                        m_deviceName.c_str());
+    CGUIDialogKaiToast::QueueNotification("Detected New Connection",
+                                          m_deviceName.c_str());
   }
   else
   {
-    g_application.m_guiDialogKaiToast.QueueNotification(iconfile.c_str(),
-                                                        "Detected New Connection",
-                                                        m_deviceName.c_str());
+    CGUIDialogKaiToast::QueueNotification(iconfile.c_str(),
+                                          "Detected New Connection",
+                                          m_deviceName.c_str());
   }
   return true;
 }
@@ -604,14 +605,14 @@ bool CEventClient::OnPacketNOTIFICATION(CEventPacket *packet)
 
   if (m_eLogoType == LT_NONE)
   {
-    g_application.m_guiDialogKaiToast.QueueNotification(title.c_str(),
-                                                        message.c_str());
+    CGUIDialogKaiToast::QueueNotification(title.c_str(),
+                                          message.c_str());
   }
   else
   {
-    g_application.m_guiDialogKaiToast.QueueNotification(iconfile.c_str(),
-                                                        title.c_str(),
-                                                        message.c_str());
+    CGUIDialogKaiToast::QueueNotification(iconfile.c_str(),
+                                          title.c_str(),
+                                          message.c_str());
   }
   return true;
 }

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -27,6 +27,7 @@
 #include "utils/RssReader.h"
 #include "utils/log.h"
 #include "guilib/LocalizeStrings.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -274,21 +275,21 @@ void CNetwork::StartServices()
 #endif
 #ifdef HAS_WEB_SERVER
   if (!g_application.StartWebServer())
-    g_application.m_guiDialogKaiToast.QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33101), g_localizeStrings.Get(33100));
+    CGUIDialogKaiToast::QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33101), g_localizeStrings.Get(33100));
 #endif
 #ifdef HAS_UPNP
   g_application.StartUPnP();
 #endif
 #ifdef HAS_EVENT_SERVER
   if (!g_application.StartEventServer())
-    g_application.m_guiDialogKaiToast.QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
+    CGUIDialogKaiToast::QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
 #endif
 #ifdef HAS_DBUS_SERVER
   g_application.StartDbusServer();
 #endif
 #ifdef HAS_JSONRPC
   if (!g_application.StartJSONRPCServer())
-    g_application.m_guiDialogKaiToast.QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33103), g_localizeStrings.Get(33100));
+    CGUIDialogKaiToast::QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33103), g_localizeStrings.Get(33100));
 #endif
 #ifdef HAS_ZEROCONF
   g_application.StartZeroconf();

--- a/xbmc/network/libscrobbler/lastfmscrobbler.cpp
+++ b/xbmc/network/libscrobbler/lastfmscrobbler.cpp
@@ -20,12 +20,12 @@
  */
 
 #include "lastfmscrobbler.h"
-#include "Application.h"
 #include "threads/Atomics.h"
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
 #include "utils/URIUtils.h"
 #include "guilib/LocalizeStrings.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 long CLastfmScrobbler::m_instanceLock = 0;
 CLastfmScrobbler *CLastfmScrobbler::m_pInstance = NULL;
@@ -85,13 +85,13 @@ void CLastfmScrobbler::NotifyUser(int error)
       strText = g_localizeStrings.Get(15206);
       m_bBadAuth = true;
       strAudioScrobbler = g_localizeStrings.Get(15200);  // AudioScrobbler
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Error, strAudioScrobbler, strText, 10000);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, strAudioScrobbler, strText, 10000);
       break;
     case SCROBBLER_USER_ERROR_BANNED:
       strText = g_localizeStrings.Get(15205);
       m_bBanned = true;
       strAudioScrobbler = g_localizeStrings.Get(15200);  // AudioScrobbler
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Error, strAudioScrobbler, strText, 10000);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, strAudioScrobbler, strText, 10000);
       break;
     default:
       break;

--- a/xbmc/network/libscrobbler/librefmscrobbler.cpp
+++ b/xbmc/network/libscrobbler/librefmscrobbler.cpp
@@ -20,12 +20,12 @@
  */
 
 #include "librefmscrobbler.h"
-#include "Application.h"
 #include "threads/Atomics.h"
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
 #include "utils/URIUtils.h"
 #include "guilib/LocalizeStrings.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 long CLibrefmScrobbler::m_instanceLock = 0;
 CLibrefmScrobbler *CLibrefmScrobbler::m_pInstance = NULL;
@@ -85,13 +85,13 @@ void CLibrefmScrobbler::NotifyUser(int error)
       strText = g_localizeStrings.Get(15206);
       m_bBadAuth = true;
       strAudioScrobbler = g_localizeStrings.Get(15220);  // Libre.fm
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Error, strAudioScrobbler, strText, 10000);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, strAudioScrobbler, strText, 10000);
       break;
     case SCROBBLER_USER_ERROR_BANNED:
       strText = g_localizeStrings.Get(15205);
       m_bBanned = true;
       strAudioScrobbler = g_localizeStrings.Get(15220);  // Libre.fm
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Error, strAudioScrobbler, strText, 10000);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, strAudioScrobbler, strText, 10000);
       break;
     default:
       break;

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -30,6 +30,8 @@
 #include "interfaces/Builtins.h"
 #include "interfaces/AnnouncementManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "guilib/GraphicContext.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 #ifdef HAS_LCD
 #include "utils/LCDFactory.h"
@@ -240,7 +242,7 @@ void CPowerManager::OnLowBattery()
 {
   CLog::Log(LOGNOTICE, "%s: Running low battery jobs", __FUNCTION__);
 
-  g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13050), "");
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13050), "");
 
   CAnnouncementManager::Announce(System, "xbmc", "OnLowBattery");
 }

--- a/xbmc/settings/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/GUIDialogContentSettings.cpp
@@ -24,13 +24,13 @@
 #include "GUISettings.h"
 #include "guilib/GUIWindowManager.h"
 #include "addons/IAddon.h"
-#include "Application.h"
 #include "FileItem.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoScanner.h"
 #include "GUISettings.h"
 #include "interfaces/Builtins.h"
 #include "filesystem/AddonsDirectory.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 #define CONTROL_CONTENT_TYPE        3
 #define CONTROL_SCRAPER_LIST        4
@@ -398,7 +398,7 @@ bool CGUIDialogContentSettings::Show(ADDON::ScraperPtr& scraper, VIDEO::SScanSet
     dialog->m_scraper = scraper;
     // toast selected but disabled scrapers
     if (!scraper->Enabled())
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24023), scraper->Name(), 2000, true);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24023), scraper->Name(), 2000, true);
   }
 
   dialog->m_bRunScan = bRunScan;

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -55,6 +55,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogProgress.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "addons/Visualisation.h"
 #include "addons/AddonManager.h"
 #include "storage/MediaManager.h"
@@ -697,7 +698,7 @@ void CGUIWindowSettingsCategory::UpdateSettings()
       {
         g_guiSettings.SetBool("services.esenabled", true);
         if (!g_application.StartEventServer())
-          g_application.m_guiDialogKaiToast.QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
+          CGUIDialogKaiToast::QueueNotification("DefaultIconWarning.png", g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
       }
 
       // if XBMC helper is running, prompt user before effecting change

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -43,7 +43,7 @@
 #include "tinyXML/tinyxml.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
-#include "Application.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "utils/JobManager.h"
 #include "AutorunMediaJob.h"
 #include "settings/GUISettings.h"
@@ -479,15 +479,15 @@ void CMediaManager::OnStorageAdded(const CStdString &label, const CStdString &pa
   if (g_guiSettings.GetBool("audiocds.autorun") || g_guiSettings.GetBool("dvds.autorun"))
     CJobManager::GetInstance().AddJob(new CAutorunMediaJob(label, path), this, CJob::PRIORITY_HIGH);
   else
-    g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13021), label, TOAST_DISPLAY_TIME, false);
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13021), label, TOAST_DISPLAY_TIME, false);
 }
 
 void CMediaManager::OnStorageSafelyRemoved(const CStdString &label)
 {
-  g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13023), label, TOAST_DISPLAY_TIME, false);
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13023), label, TOAST_DISPLAY_TIME, false);
 }
 
 void CMediaManager::OnStorageUnsafelyRemoved(const CStdString &label)
 {
-  g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13022), label);
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13022), label);
 }

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -24,6 +24,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "threads/SingleLock.h"
 #include "log.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 using namespace std;
 
@@ -69,7 +70,7 @@ void CAlarmClock::Start(const CStdString& strName, float n_secs, const CStdStrin
   strMessage.Format(strStarted.c_str(),static_cast<int>(event.m_fSecs)/60);
 
   if(!bSilent)
-     g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, strAlarmClock, strMessage);
+     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, strAlarmClock, strMessage);
 
   event.watch.StartZero();
   CSingleLock lock(m_events);
@@ -108,7 +109,7 @@ void CAlarmClock::Stop(const CStdString& strName, bool bSilent /* false */)
   if (iter->second.m_strCommand.IsEmpty() || iter->second.m_fSecs > iter->second.watch.GetElapsedSeconds())
   {
     if(!bSilent)
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, strAlarmClock, strMessage);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, strAlarmClock, strMessage);
   }
   else
     g_application.getApplicationMessenger().ExecBuiltIn(iter->second.m_strCommand);

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -31,6 +31,7 @@
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
 #include "filesystem/SpecialProtocol.h"
+#include "guilib/GraphicContext.h"
 
 #ifndef HAS_SDL
 #define SDL_memset4(dst, val, len) memset(dst, val, (len)*4)

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -27,6 +27,7 @@
 #include "guilib/Texture.h"
 #include "settings/Settings.h"
 #include "guilib/LocalizeStrings.h"
+#include "dialogs/GUIDialogKaiToast.h"
 
 using namespace std;
 
@@ -65,7 +66,7 @@ bool CGUIDialogTeletext::OnMessage(CGUIMessage& message)
     if (!g_application.m_pPlayer->GetTeletextCache())
     {
       Close();
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(23049), "", 1500, false);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(23049), "", 1500, false);
       return true;
     }
   }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -37,6 +37,7 @@
 #include "video/dialogs/GUIDialogFullScreenInfo.h"
 #include "video/dialogs/GUIDialogAudioSubtitleSettings.h"
 #include "dialogs/GUIDialogNumeric.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUISliderControl.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
@@ -262,8 +263,8 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
         g_application.m_pPlayer->GetSubtitleName(g_application.m_pPlayer->GetSubtitle(),sub);
       else
         sub = g_localizeStrings.Get(1223);
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info,
-                                                          g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
+                                            g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
     }
     return true;
     break;
@@ -309,7 +310,7 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
         g_application.m_pPlayer->GetSubtitleName(g_settings.m_currentVideoSettings.m_SubtitleStream,sub);
       else
         sub = g_localizeStrings.Get(1223);
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
     }
     return true;
     break;
@@ -385,7 +386,7 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
       g_application.m_pPlayer->SetAudioStream(g_settings.m_currentVideoSettings.m_AudioStream);    // Set the audio stream to the one selected
       CStdString aud;
       g_application.m_pPlayer->GetAudioStreamName(g_settings.m_currentVideoSettings.m_AudioStream,aud);
-      g_application.m_guiDialogKaiToast.QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(460), aud, DisplTime, false, MsgTime);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(460), aud, DisplTime, false, MsgTime);
       return true;
     }
     break;

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -40,7 +40,7 @@ CGUIWindowDebugInfo::CGUIWindowDebugInfo(void)
   m_loadOnDemand = false;
   m_needsScaling = false;
   m_layout = NULL;
-  m_renderOrder = INT_MAX - 1;
+  m_renderOrder = INT_MAX - 2;
 }
 
 CGUIWindowDebugInfo::~CGUIWindowDebugInfo(void)

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -31,7 +31,7 @@ CGUIWindowPointer::CGUIWindowPointer(void)
   m_loadOnDemand = false;
   m_needsScaling = false;
   m_active = false;
-  m_renderOrder = INT_MAX;
+  m_renderOrder = INT_MAX - 1;
 }
 
 CGUIWindowPointer::~CGUIWindowPointer(void)
@@ -72,7 +72,7 @@ void CGUIWindowPointer::OnWindowLoaded()
   CGUIWindow::OnWindowLoaded();
   DynamicResourceAlloc(false);
   m_pointer = 0;
-  m_renderOrder = INT_MAX;
+  m_renderOrder = INT_MAX - 1;
 }
 
 void CGUIWindowPointer::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)

--- a/xbmc/windows/GUIWindowScreensaverDim.cpp
+++ b/xbmc/windows/GUIWindowScreensaverDim.cpp
@@ -1,0 +1,72 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "GUIWindowScreensaverDim.h"
+#include "guilib/GraphicContext.h"
+#include "guilib/GUITexture.h"
+#include "Application.h"
+#include <climits>
+
+CGUIWindowScreensaverDim::CGUIWindowScreensaverDim(void)
+    : CGUIDialog(97, "")
+{
+  m_loadOnDemand = false;
+  m_needsScaling = false;
+  m_dimLevel = 100.0f;
+  m_animations.push_back(CAnimation::CreateFader(0, 100, 0, 1000, ANIM_TYPE_WINDOW_OPEN));
+  m_animations.push_back(CAnimation::CreateFader(100, 0, 0, 1000, ANIM_TYPE_WINDOW_CLOSE));
+  m_renderOrder = INT_MAX;
+}
+
+CGUIWindowScreensaverDim::~CGUIWindowScreensaverDim(void)
+{
+}
+
+void CGUIWindowScreensaverDim::UpdateVisibility()
+{
+  float level = g_application.GetDimScreenSaverLevel();
+  if (level)
+  {
+    m_dimLevel = level;
+    Show();
+  }
+  else
+    Close();
+}
+
+void CGUIWindowScreensaverDim::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
+{
+  CGUIDialog::Process(currentTime, dirtyregions);
+  m_renderRegion.SetRect(0, 0, g_graphicsContext.GetWidth(), g_graphicsContext.GetHeight());
+}
+
+void CGUIWindowScreensaverDim::Render()
+{
+  g_graphicsContext.SetRenderingResolution(g_graphicsContext.GetResInfo(), false);
+  g_graphicsContext.SetTransform(m_cachedTransform);
+  // draw a translucent black quad - fading is handled by the window animation
+  color_t color = ((color_t)(m_dimLevel * 2.55f) & 0xff) << 24;
+  color = g_graphicsContext.MergeAlpha(color);
+  CRect rect(0, 0, (float)g_graphicsContext.GetWidth(), (float)g_graphicsContext.GetHeight());
+  CGUITexture::DrawQuad(rect, color);
+  g_graphicsContext.RemoveTransform();
+  CGUIDialog::Render();
+}

--- a/xbmc/windows/GUIWindowScreensaverDim.h
+++ b/xbmc/windows/GUIWindowScreensaverDim.h
@@ -1,0 +1,38 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "guilib/GUIDialog.h"
+
+class CGUIWindowScreensaverDim :
+      public CGUIDialog
+{
+public:
+  CGUIWindowScreensaverDim();
+  virtual ~CGUIWindowScreensaverDim();
+  virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
+  virtual void Render();
+protected:
+  virtual void UpdateVisibility();
+private:
+  float m_dimLevel;
+};

--- a/xbmc/windows/Makefile
+++ b/xbmc/windows/Makefile
@@ -5,6 +5,7 @@ SRCS=GUIMediaWindow.cpp \
      GUIWindowLoginScreen.cpp \
      GUIWindowPointer.cpp \
      GUIWindowScreensaver.cpp \
+     GUIWindowScreensaverDim.cpp \
      GUIWindowStartup.cpp \
      GUIWindowSystemInfo.cpp \
      GUIWindowWeather.cpp \


### PR DESCRIPTION
This fixes the problem with the Mute dialog not being shown correctly since dirty-region was merged (thanks to Montellese for identifying the cause!)

It also moves members of CApplication out as they're really not required.

Needs build testing on win32 and linux, in case I missed an include.
