### PR TITLE
fix AddonVersion comparison

### DIFF
--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -72,40 +72,37 @@ namespace ADDON
    */
   int AddonVersion::CompareComponent(const char *a, const char *b)
   {
-    while (*a && *b) {
-
-      while (*a && *b && !isdigit(*a) && !isdigit(*b)) {
-        if (*a != *b) {
-          if (*a == '~') return -1;
-          if (*b == '~') return 1;
-          return *a < *b ? -1 : 1;
+    long iA, iB;
+    while (*a || *b)
+    {
+      iA = iB = 0;
+      if (*a)
+      {
+        if (!isdigit(*a))
+          a++;
+        else
+        {
+          char *next;
+          iA = strtol(a, &next, 10);
+          a = next;
         }
-        a++;
-        b++;
       }
-      if (*a && *b && (!isdigit(*a) || !isdigit(*b))) {
-        if (*a == '~') return -1;
-        if (*b == '~') return 1;
-        return isdigit(*a) ? -1 : 1;
+      if (*b)
+      {
+        if (!isdigit(*b))
+          b++;
+        else
+        {
+          char *next;
+          iB = strtol(b, &next, 10);
+          b = next;
+        }
       }
-
-      char *next_a, *next_b;
-      long int num_a = strtol(a, &next_a, 10);
-      long int num_b = strtol(b, &next_b, 10);
-      if (num_a != num_b) {
-        return num_a < num_b ? -1 : 1;
-      }
-      a = next_a;
-      b = next_b;
-
+    
+      if (iA != iB)
+        return iA < iB ? -1 : 1;
     }
-    if (!*a && !*b) {
-      return 0;
-    } else if (*a) {
-      return *a == '~' ? -1 : 1;
-    } else {
-      return *b == '~' ? 1 : -1;
-    }
+    return 0;
   }
 
   bool AddonVersion::operator<(const AddonVersion& other) const


### PR DESCRIPTION
This commit re-writes the AddonVersion comparison logic. The problem we were running into was that e.g. "2.0.0" was not equal to "2.0" which is not very intuitive IMO. This new implementation also uses strtol to read as many numbers as possible and compares them. If it runs into a character that is not a number or if there is no character anymore it is treated as a 0. So in the above example this is what is compared:

"2.0" : "2.0.0"
"2" : "2: => 2 : 2
"." : "." => 0 : 0
"0" : "0" => 0 : 0
"" : "." => 0 : 0
"" : "0" => 0 : 0

I'd be glad if anyone interested could check the logic again. I discussed with Jonathan whether to explicitly check for "." as a delimiter but we concluded that it doesn't really matter and every addon uses "." as a separator anyway. Furthermore it would be difficult to decide what to do if there was a parsing error (is that smaller, bigger or equal?). So theoretically with this implementation "2x00x1" is equal to "2.00.1" and "2.0.1" and "2.0.1.0.0" and so on.
