### PR TITLE
Decoupling of mute status and volume level

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -160,8 +160,8 @@ public:
   void ProcessSlow();
   void ResetScreenSaver();
   int GetVolume() const;
-  void SetVolume(int iPercent);
-  void Mute(void);
+  void SetVolume(long iValue, bool isPercentage = true);
+  void ToggleMute(void);
   void ShowVolumeBar(const CAction *action = NULL);
   int GetPlaySpeed() const;
   int GetSubtitleDelay() const;
@@ -344,6 +344,9 @@ protected:
   CCriticalSection m_frameMutex;
   XbmcThreads::ConditionVariable  m_frameCond;
 #endif
+
+  void Mute();
+  void UnMute();
 
   void SetHardwareVolume(long hardwareVolume);
   void UpdateLCD();

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -789,7 +789,7 @@ int CBuiltins::Execute(const CStdString& execString)
   }
   else if (execute.Equals("mute"))
   {
-    g_application.Mute();
+    g_application.ToggleMute();
   }
   else if (execute.Equals("setvolume"))
   {

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -1586,7 +1586,7 @@ int CXbmcHttp::xbmcSeekPercentage(int numParas, CStdString paras[], bool relativ
 
 int CXbmcHttp::xbmcMute()
 {
-  g_application.Mute();
+  g_application.ToggleMute();
   return SetResponse(openTag+"OK");
 }
 

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -1992,7 +1992,7 @@ CUPnPRenderer::OnSetMute(PLT_ActionReference& action)
     NPT_String mute;
     NPT_CHECK_SEVERE(action->GetArgumentValue("DesiredMute",mute));
     if((mute == "1") ^ g_settings.m_bMute)
-        g_application.Mute();
+        g_application.ToggleMute();
     return NPT_SUCCESS;
 }
 


### PR DESCRIPTION
With these changes the mute status and volume level become independant. If audio is muted at 0% volume and then unmuted, volume will be set back to 0% (and not 100% as it was until now).
Furthermore when "Volume Up" or "Volume Down" is executed during muted audio, it will be unmuted and the action will be applied to the restored volume level.
I have checked how this is done on TVs from Samsung, Sony, Phillips and LG and they all do this the same way as this implementation works (so does Win7 and probably any Linux distro and OSX as well but I haven't checked those).

Furthermore I have changed the format of how the volume is displayed from a negative dB value to a positive percentage value. IMO this is much more intuitive for non-geek users. Having your audio at 100% but seeing "0.0 dB" is a bit odd at a quick glance.
