### PR TITLE
added: setting to use multimedia keyboard actions in windows from deviceidmappings

### DIFF
--- a/system/deviceidmappings.xml
+++ b/system/deviceidmappings.xml
@@ -1,3 +1,3 @@
 <devicemappings>
-	<device id="HID#VID_1915&PID_003B&MI_00#7&314e95d&0&0000#" keymap="Motorola Nyxboard Hybrid" />
+	<device id="HID#VID_1915&PID_003B&MI_00#7&314e95d&0&0000#" keymap="Motorola Nyxboard Hybrid" usemultimediakeys="true" />
 </devicemappings>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -596,16 +596,16 @@ bool CApplication::Create()
 
   g_powerManager.Initialize();
 
-#ifdef _WIN32
-  CWIN32USBScan();
-#endif
-
   CLog::Log(LOGNOTICE, "load settings...");
 
   g_guiSettings.Initialize();  // Initialize default Settings - don't move
   g_powerManager.SetDefaults();
   if (!g_settings.Load())
     FatalErrorHandler(true, true, true);
+
+#ifdef _WIN32
+  CWIN32USBScan();
+#endif
 
   CLog::Log(LOGINFO, "creating subdirectories");
   CLog::Log(LOGINFO, "userdata folder: %s", g_settings.GetProfileUserDataFolder().c_str());

--- a/xbmc/input/KeymapLoader.h
+++ b/xbmc/input/KeymapLoader.h
@@ -26,11 +26,17 @@
 class CKeymapLoader
 {
   public:
+    class KeyMapProfile
+    {
+      public:
+        CStdString KeymapName;
+        bool UseMultimediaKeys;
+    };
     static void DeviceRemoved(const CStdString& deviceID);
     static void DeviceAdded(const CStdString& deviceID);
     static CStdString ParseWin32HIDName(const CStdString& deviceLongName);
   private:
     static void ParseDeviceMappings();
-    static bool FindMappedDevice(const CStdString& deviceId, CStdString& keymapName);
+    static bool FindMappedDevice(const CStdString& deviceId, KeyMapProfile& keymapProfile);
     static bool parsedMappings;
 };

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -69,7 +69,7 @@ int CWinEventsWin32::m_lastGesturePosY = 0;
 #define WM_MEDIA_CHANGE (WM_USER + 666)
 SHChangeNotifyEntry shcne;
 
-void DIB_InitOSKeymap()
+void CWinEventsWin32::DIB_InitOSKeymap()
 {
   char current_layout[KL_NAMELENGTH];
 

--- a/xbmc/windowing/windows/WinEventsWin32.h
+++ b/xbmc/windowing/windows/WinEventsWin32.h
@@ -29,6 +29,7 @@
 class CWinEventsWin32 : public CWinEventsBase
 {
 public:
+  static void DIB_InitOSKeymap();
   static bool MessagePump();
   static LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 private:


### PR DESCRIPTION
added: setting to use multimedia keyboard actions in windows. 
changed: load multimedia keyboard actions in windows if setting is found in deviceidmappings.xml
