### PR TITLE
add GUI setting to choose volume unit (dB or %)

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -498,7 +498,7 @@
   <string id="546">Passthrough output device</string>
   <string id="547">No biography for this artist</string>
   <string id="548">Downmix multichannel audio to stereo</string>
-
+  <string id="549">Displayed volume unit</string>
   <string id="550">Sort by: %s</string>
   <string id="551">Name</string>
   <string id="552">Date</string>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4890,7 +4890,7 @@ void CApplication::ToggleMute(void)
 
 void CApplication::Mute()
 {
-  g_settings.m_iPreMuteVolumeLevel = GetVolume();
+  g_settings.m_iPreMuteVolumeLevel = (int)GetVolume();
   SetVolume(0);
   g_settings.m_bMute = true;
 }
@@ -4945,10 +4945,13 @@ void CApplication::SetHardwareVolume(long hardwareVolume)
   }
 }
 
-int CApplication::GetVolume() const
+float CApplication::GetVolume(bool percentage /* = true */) const
 {
-  // converts the hardware volume (in mB) to a percentage
-  return int(((float)(g_settings.m_nVolumeLevel + g_settings.m_dynamicRangeCompressionLevel - VOLUME_MINIMUM)) / (VOLUME_MAXIMUM - VOLUME_MINIMUM)*100.0f + 0.5f);
+  if (percentage)
+    // converts the hardware volume (in mB) to a percentage
+    return (float)int(((float)(g_settings.m_nVolumeLevel + g_settings.m_dynamicRangeCompressionLevel - VOLUME_MINIMUM)) / (VOLUME_MAXIMUM - VOLUME_MINIMUM)*100.0f + 0.5f);
+
+  return (g_settings.m_nVolumeLevel + g_settings.m_dynamicRangeCompressionLevel) * 0.01f;
 }
 
 int CApplication::GetSubtitleDelay() const

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -159,7 +159,7 @@ public:
   virtual void Process();
   void ProcessSlow();
   void ResetScreenSaver();
-  int GetVolume() const;
+  float GetVolume(bool percentage = true) const;
   void SetVolume(long iValue, bool isPercentage = true);
   void ToggleMute(void);
   void ShowVolumeBar(const CAction *action = NULL);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1063,7 +1063,10 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
     strLabel.Format("%02.2f", m_fps);
     break;
   case PLAYER_VOLUME:
-    strLabel.Format("%2.1f dB", (float)(g_settings.m_nVolumeLevel + g_settings.m_dynamicRangeCompressionLevel) * 0.01f);
+    if (g_guiSettings.GetInt("audiooutput.volumeunit") == VOLUME_UNIT_PERCENTAGE)
+      strLabel.Format("%d %%", g_application.GetVolume());
+    else
+      strLabel.Format("%2.1f dB", (float)g_application.GetVolume(false));
     break;
   case PLAYER_SUBTITLE_DELAY:
     strLabel.Format("%2.3f s", g_settings.m_currentVideoSettings.m_SubtitleDelay);
@@ -1632,7 +1635,7 @@ int CGUIInfoManager::GetInt(int info, int contextWindow) const
   switch( info )
   {
     case PLAYER_VOLUME:
-      return g_application.GetVolume();
+      return (int)g_application.GetVolume();
     case PLAYER_SUBTITLE_DELAY:
       return g_application.GetSubtitleDelay();
     case PLAYER_AUDIO_DELAY:

--- a/xbmc/interfaces/json-rpc/XBMCOperations.cpp
+++ b/xbmc/interfaces/json-rpc/XBMCOperations.cpp
@@ -37,7 +37,7 @@ JSON_STATUS CXBMCOperations::GetVolume(const CStdString &method, ITransportLayer
 
 JSON_STATUS CXBMCOperations::SetVolume(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  int oldVolume = g_application.GetVolume();
+  int oldVolume = (int)g_application.GetVolume();
   int volume = (int)parameterObject["value"].asInteger();
   
   g_application.SetVolume(volume);

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -1661,7 +1661,7 @@ CUPnPRenderer::UpdateState()
         volume = g_settings.m_iPreMuteVolumeLevel;
     } else {
         rct->SetStateVariable("Mute", "0");
-        volume = g_application.GetVolume();
+        volume = (int)g_application.GetVolume();
     }
 
     buffer.Format("%d", volume);

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -472,6 +472,7 @@ void CGUISettings::Initialize()
 #elif defined(_WIN32)
   AddString(ao, "audiooutput.audiodevice", 545, "Default", SPIN_CONTROL_TEXT);
 #endif
+  AddInt(ao, "audiooutput.volumeunit", 549, VOLUME_UNIT_DECIBEL, VOLUME_UNIT_DECIBEL, 1, VOLUME_UNIT_PERCENTAGE, SPIN_CONTROL_TEXT);
 
   CSettingsCategory* in = AddCategory(4, "input", 14094);
 #if defined(__APPLE__)

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -187,6 +187,12 @@ enum VideoSelectAction
   SELECT_ACTION_MORE,
   SELECT_ACTION_PLAY
 };
+ 
+enum VolumeUnit
+{
+  VOLUME_UNIT_DECIBEL,
+  VOLUME_UNIT_PERCENTAGE
+};
 
 // replay gain settings struct for quick access by the player multiple
 // times per second (saves doing settings lookup)

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -577,6 +577,14 @@ void CGUIWindowSettingsCategory::CreateSettings()
     {
       FillInAudioDevices(pSetting,true);
     }
+    else if (strSetting.Equals("audiooutput.volumeunit"))
+    {
+      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      pControl->AddLabel("dB", VOLUME_UNIT_DECIBEL);
+      pControl->AddLabel("%", VOLUME_UNIT_PERCENTAGE);
+      pControl->SetValue(pSettingInt->GetData());
+    }
     else if (strSetting.Equals("videoplayer.pauseafterrefreshchange"))
     {
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.h
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.h
@@ -32,7 +32,7 @@ public:
   virtual void FrameMove();
 
   static CStdString FormatDelay(float value, float minimum);
-  static CStdString FormatDecibel(float value, float minimum);
+  static CStdString FormatVolume(float value, float minimum);
 
 protected:
   virtual void CreateSettings();


### PR DESCRIPTION
This is a re-worked version of the second commit of the "Decoupling mute status and volume level" pull request as some people mentioned they prefer the volume level to be presented in dB. This commit adds a GUI Setting to choose between dB and %. There are a few things I'm unsure about and would like to get some feedback:
1. Is this even a valid GUI Setting or should it be in AS?
2. What should be the default setting? dB (as is now) or %?
3. Where should the setting be located in the Settings screen? I put it under Settings > System > Audio Output
