### PR TITLE
jsonrpc: fix limitation handling for AudioLibrary.GetAlbums

### DIFF
--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -91,13 +91,9 @@ JSON_STATUS CAudioLibrary::GetAlbums(const CStdString &method, ITransportLayer *
 
   int artistID  = (int)parameterObject["artistid"].asInteger();
   int genreID   = (int)parameterObject["genreid"].asInteger();
-  int start     = (int)parameterObject["limits"]["start"].asInteger();
-  int end       = (int)parameterObject["limits"]["end"].asInteger();
-  if (end == 0)
-    end = -1;
 
   CFileItemList items;
-  if (musicdatabase.GetAlbumsNav("", items, genreID, artistID, start, end))
+  if (musicdatabase.GetAlbumsNav("", items, genreID, artistID, -1, -1))
     HandleFileItemList("albumid", false, "albums", items, parameterObject, result);
 
   musicdatabase.Close();


### PR DESCRIPTION
This commit fixes the way AudioLibrary.GetAlbums retrieves the list of albums from the database. The only reason I post this as a pull request is because of the following ticket: http://trac.xbmc.org/ticket/10146
There is a discussion that it may take too long to retrieve all album information if only a few are needed (because the jsonrpc caller provides some limits). Unfortunately trying to save retrieval time breaks quite a few things:
- the "total" fields in the jsonrpc response does not provide the correct value
- any special ordering requested by the jsonrpc caller is ignored
- the limits actually don't work properly because they are applied twice, once at the call to the db and once again in jsonrpc's internal logic to handle sorting and limiting

I don't know why the ticket has been closed as fixed because it isn't but this commit would fix all of the mentioned problems.

For me it is more important to provide a correct but slow instead of a fast but broken behaviour. I'd like to get some other opinions before I merge this into master. Thanks.
