### PR TITLE
Python cleanup

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -489,7 +489,7 @@ case TMSG_POWERDOWN:
           break;
 
         case 3:
-          g_application.getApplicationMessenger().RebootToDashBoard();
+          g_application.getApplicationMessenger().Quit();
           break;
 
         case 4:
@@ -1016,12 +1016,6 @@ void CApplicationMessenger::Reset()
 void CApplicationMessenger::RestartApp()
 {
   ThreadMessage tMsg = {TMSG_RESTARTAPP};
-  SendMessage(tMsg);
-}
-
-void CApplicationMessenger::RebootToDashBoard()
-{
-  ThreadMessage tMsg = {TMSG_DASHBOARD};
   SendMessage(tMsg);
 }
 

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -64,7 +64,6 @@ class CGUIDialog;
 #define TMSG_SHUTDOWN             300
 #define TMSG_POWERDOWN            301
 #define TMSG_QUIT                 302
-#define TMSG_DASHBOARD            TMSG_QUIT
 #define TMSG_HIBERNATE            303
 #define TMSG_SUSPEND              304
 #define TMSG_RESTART              305
@@ -167,7 +166,6 @@ public:
   void Hibernate();
   void Suspend();
   void Restart();
-  void RebootToDashBoard();
   void RestartApp();
   void Reset();
   void SwitchToFullscreen(); //

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -236,11 +236,11 @@ void XBPython::UnloadExtensionLibs()
         "\tdef __init__(self, loglevel=xbmc.LOGNOTICE):\n" \
         "\t\tself.ll=loglevel\n" \
         "\tdef write(self, data):\n" \
-        "\t\txbmc.output(data,self.ll)\n" \
+        "\t\txbmc.log(data,self.ll)\n" \
         "\tdef close(self):\n" \
-        "\t\txbmc.output('.')\n" \
+        "\t\txbmc.log('.')\n" \
         "\tdef flush(self):\n" \
-        "\t\txbmc.output('.')\n" \
+        "\t\txbmc.log('.')\n" \
         "import sys\n" \
         "sys.stdout = xbmcout()\n" \
         "sys.stderr = xbmcout(xbmc.LOGERROR)\n"

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -151,22 +151,6 @@ namespace PYXBMC
     return Py_None;
   }
 
-  // dashboard() method
-  PyDoc_STRVAR(dashboard__doc__,
-    "dashboard() -- Boot to dashboard as set in My Pograms/General.\n"
-    "\n"
-    "example:\n"
-    "  - xbmc.dashboard()\n");
-
-  PyObject* XBMC_Dashboard(PyObject *self, PyObject *args)
-  {
-    ThreadMessage tMsg = {TMSG_DASHBOARD};
-    g_application.getApplicationMessenger().SendMessage(tMsg);
-
-    Py_INCREF(Py_None);
-    return Py_None;
-  }
-
   // restart() method
   PyDoc_STRVAR(restart__doc__,
     "restart() -- Restart the xbox.\n"
@@ -947,7 +931,6 @@ namespace PYXBMC
 
     {(char*)"sleep", (PyCFunction)XBMC_Sleep, METH_VARARGS, sleep__doc__},
     {(char*)"shutdown", (PyCFunction)XBMC_Shutdown, METH_VARARGS, shutdown__doc__},
-    {(char*)"dashboard", (PyCFunction)XBMC_Dashboard, METH_VARARGS, dashboard__doc__},
     {(char*)"restart", (PyCFunction)XBMC_Restart, METH_VARARGS, restart__doc__},
     {(char*)"getSkinDir", (PyCFunction)XBMC_GetSkinDir, METH_VARARGS, getSkinDir__doc__},
     {(char*)"getLocalizedString", (PyCFunction)XBMC_GetLocalizedString, METH_VARARGS, getLocalizedString__doc__},

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -52,6 +52,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/FileUtils.h"
 #include "pythreadstate.h"
+#include "utils/log.h"
 
 // include for constants
 #include "pyutil.h"
@@ -74,53 +75,6 @@ namespace PYXBMC
 /*****************************************************************
  * start of xbmc methods
  *****************************************************************/
-
-  // output() method
-  PyDoc_STRVAR(output__doc__,
-    "output(msg[, level]) -- Write a string to XBMC's log file and the debug window.\n"
-    "\n"
-    "msg            : string - text to output.\n"
-    "level          : [opt] integer - log level to ouput at. (default=LOGNOTICE)\n"
-    "\n"
-    "*Note, You can use the above as keywords for arguments and skip certain optional arguments.\n"
-    "       Once you use a keyword, all following arguments require the keyword.\n"
-    "\n"
-    "       Text is written to the log for the following conditions.\n"
-    "         XBMC loglevel == -1 (NONE, nothing at all is logged)"
-    "         XBMC loglevel == 0 (NORMAL, shows LOGNOTICE, LOGERROR, LOGSEVERE and LOGFATAL)"
-    "         XBMC loglevel == 1 (DEBUG, shows all)"
-    "       See pydocs for valid values for level.\n"
-    "\n"
-    "example:\n"
-    "  - xbmc.output(msg='This is a test string.', level=xbmc.LOGDEBUG)\n");
-
-  PyObject* XBMC_Output(PyObject *self, PyObject *args, PyObject *kwds)
-  {
-    static const char *keywords[] = {
-      "msg",
-      "level",
-      NULL};
-
-    char *s_line = NULL;
-    int iLevel = LOGNOTICE;
-    if (!PyArg_ParseTupleAndKeywords(
-      args,
-      kwds,
-      (char*)"s|i",
-      (char**)keywords,
-      &s_line,
-      &iLevel))
-    {
-      return NULL;
-    }
-    // check for a valid loglevel
-    if (iLevel < LOGDEBUG || iLevel > LOGNONE)
-      iLevel = LOGNOTICE;
-    CLog::Log(iLevel, "%s", s_line);
-
-    Py_INCREF(Py_None);
-    return Py_None;
-  }
 
   // log() method
   PyDoc_STRVAR(log__doc__,
@@ -170,6 +124,17 @@ namespace PYXBMC
     return Py_None;
   }
 
+  // output() method
+  PyDoc_STRVAR(output__doc__,
+               "'xbmc.output()' is depreciated and will be removed in future releases,\n"
+               "please use 'xbmc.log()' instead");
+  
+  PyObject* XBMC_Output(PyObject *self, PyObject *args, PyObject *kwds)
+  {
+    CLog::Log(LOGWARNING,"'xbmc.output()' is depreciated and will be removed in future releases, please use 'xbmc.log()' instead");
+    return XBMC_Log(self, args, kwds);
+  }
+  
   // shutdown() method
   PyDoc_STRVAR(shutdown__doc__,
     "shutdown() -- Shutdown the xbox.\n"


### PR DESCRIPTION
hi All,

here is some Python code cleanup in 3 parts.
1. remove duplicate code in xbmcmodule.cpp for xbmc.output() and warn that it will be depreciated soon, reason is that the code was the same in both and its pointless having both to confuse the addon developers
2. use xbmc.log() instead of xbmc.output() in XBPython.cpp, goes with the first commit. if we depreciate xbmc.output() we cant call it ourselves
3. xbmc.dashboard() removal, also the core code was removed as well. its old xbox code so we are not going to need it anymore... hopefully :)
