### PR TITLE
This is a fix for the CEventGroup deadlock.

### DIFF
--- a/xbmc/threads/Event.cpp
+++ b/xbmc/threads/Event.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <stdarg.h>
+#include <limits>
 
 #include "Event.h"
 
@@ -95,7 +96,7 @@ namespace XbmcThreads
    */
   CEvent* CEventGroup::wait() 
   { 
-    return wait(XB_MAX_UNSIGNED_INT);
+    return wait(std::numeric_limits<unsigned int>::max());
   }
 
   /**
@@ -111,7 +112,7 @@ namespace XbmcThreads
     signaled = anyEventsSignaled(); 
     if(!signaled)
     {
-      if (milliseconds == XB_MAX_UNSIGNED_INT)
+      if (milliseconds == std::numeric_limits<unsigned int>::max())
         condVar.wait(mutex); 
       else
         condVar.wait(mutex,milliseconds); 

--- a/xbmc/threads/Event.cpp
+++ b/xbmc/threads/Event.cpp
@@ -24,6 +24,7 @@
 
 void CEvent::groupSet()
 {
+  // no locking, the lock should already be held
   if (groups)
   {
     for (std::vector<XbmcThreads::CEventGroup*>::iterator iter = groups->begin(); 
@@ -34,7 +35,7 @@ void CEvent::groupSet()
 
 void CEvent::addGroup(XbmcThreads::CEventGroup* group)
 {
-  CSingleLock lock(mutex);
+  CSingleLock lock(groupListMutex);
   if (groups == NULL)
     groups = new std::vector<XbmcThreads::CEventGroup*>();
 
@@ -43,7 +44,7 @@ void CEvent::addGroup(XbmcThreads::CEventGroup* group)
 
 void CEvent::removeGroup(XbmcThreads::CEventGroup* group)
 {
-  CSingleLock lock(mutex);
+  CSingleLock lock(groupListMutex);
   if (groups)
   {
     for (std::vector<XbmcThreads::CEventGroup*>::iterator iter = groups->begin(); iter != groups->end(); iter++)
@@ -63,8 +64,27 @@ void CEvent::removeGroup(XbmcThreads::CEventGroup* group)
   }
 }
 
-#define XB_MAX_UNSIGNED_INT ((unsigned int)-1)
+void CEvent::lockGroups()
+{
+  CSingleLock lock(groupListMutex);
+  if (groups)
+  {
+    for (std::vector<XbmcThreads::CEventGroup*>::iterator iter = groups->begin(); iter != groups->end(); iter++)
+      (*iter)->mutex.lock();
+  }
+}
 
+void CEvent::unlockGroups()
+{
+  CSingleLock lock(groupListMutex);
+  if (groups)
+  {
+    for (std::vector<XbmcThreads::CEventGroup*>::iterator iter = groups->begin(); iter != groups->end(); iter++)
+      (*iter)->mutex.unlock();
+  }
+}
+
+#define XB_MAX_UNSIGNED_INT ((unsigned int)-1)
 
 namespace XbmcThreads
 {


### PR DESCRIPTION
There are several ways to do this. The easiest would have been simply to change the scope of the lock in the wait method on the CEventGroup so that it didn't include the reset (WaitMSec) calls on the child events. This would have made it the same as the older code (WaitForMultipleObjects here: https://github.com/xbmc/xbmc/commit/bb8858364ce3fcc64b87cdf1e08136fd5f8cb3dd#diff-92 ) but there is the potential for a race condition.

In order to avoid the race condition I prefered to make it so that whenever the group lock and child event lock are both required, they are always obtained in the same order. This required doing the following:

1) Adding a lock for gating access to the CEventGroup's list of child CEvents
2) Making sure that the Set call on the CEvent and the CEventGroup::wait call both obtain the group's lock, followed by the child lock. The CEventGroup::wait already did this so code was added so that the CEvent::Set method could grab all of it's parent locks before grabbing it's own.

@elupus, please let me know if this makes sense to you. I tested it on the slideshow but I suspect the original deadlock was a rare occurance. I could go back and simply change the lock scope. If you're satisfied with this feel free to auto-merge it.
