### PR TITLE
An alternative approach to fixing the Event/EventGroup deadlock with less locking and less code.

### DIFF
--- a/xbmc/threads/Condition.h
+++ b/xbmc/threads/Condition.h
@@ -84,11 +84,14 @@ namespace XbmcThreads
       boost::system_time const timeout=boost::get_system_time() + boost::posix_time::milliseconds(milliseconds);
       while ((!predicate) && ret != ConditionVariable::TW_TIMEDOUT)
       {
-        ret = milliseconds ? cond.wait(lock,milliseconds) : 
-          ((!predicate) ? ConditionVariable::TW_TIMEDOUT : ConditionVariable::TW_OK);
-
-        if (((!predicate) && boost::get_system_time() > timeout) || (milliseconds == 0))
-          ret = ConditionVariable::TW_TIMEDOUT;
+        cond.wait(lock,milliseconds);
+        if (milliseconds)
+        {
+          if ((!predicate) && boost::get_system_time() > timeout)
+            ret = ConditionVariable::TW_TIMEDOUT;
+        }
+        else
+          ret = (!predicate) ? ConditionVariable::TW_TIMEDOUT : ConditionVariable::TW_OK;
       }
       return ret;
     }

--- a/xbmc/threads/Event.cpp
+++ b/xbmc/threads/Event.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <stdarg.h>
+#include <limits>
 
 #include "Event.h"
 
@@ -95,7 +96,7 @@ namespace XbmcThreads
    */
   CEvent* CEventGroup::wait() 
   { 
-    return wait(XB_MAX_UNSIGNED_INT);
+    return wait(std::numeric_limits<unsigned int>::max());
   }
 
   /**
@@ -111,7 +112,7 @@ namespace XbmcThreads
     signaled = anyEventsSignaled(); 
     if(!signaled)
     {
-      if (milliseconds == XB_MAX_UNSIGNED_INT)
+      if (milliseconds == std::numeric_limits<unsigned int>::max())
         condVar.wait(mutex); 
       else
         condVar.wait(mutex,milliseconds); 


### PR DESCRIPTION
This change revisits the previous deadlock fix ( https://github.com/xbmc/xbmc/commit/1e1ff6503eac46d330e2263bcff2dadf9df4cd2a ) and accomplishes the same task with less code and less locking. It primarily does the following:

As a quick review, the deadlock was a result of accessing locks in different orders between the CEvent::Set call and the CEventGroup::wait call.

1) Separate the lock used by the condition variable in a CEvent from the lock used to prevent the list of groups the CEvent is part of from being updated.
2) There is no reason to hold a lock around a notify (Set/Signal) on a condition variable. Removing this lock means the helper guard class, whose job it was to lock all of the parents prior to locking the child's condition variable mutex to insure the proper ordering, is no longer needed.
3) The CEventGroup::wait must end up calling the condition variable's wait even when the wait time is zero in order to make sure that cross thread values are synchronized (previously there was an optimization which skipped the condVar.wait call when the timeout was zero).

Effects:
The 'Set' call has less locking. Now the notify/Set/Signal is called without holding any locks and then the group list lock is held to check and see if the CEvent is participating in any groups. If not no more locking is done. If so, each group is also 'Set' which holds the group's condition variable lock. This results in:

when the CEvent is part of a group: CEvent::Set obtains list mutex -> individual group mutex
when the CEvent is alone: CEvent::Set obtains the list mutex only.

This is better than the current which always holds two locks nested when CEvent::Set is called.
