### PR TITLE
Powerdown System after play

### DIFF
--- a/addons/skin.confluence/720p/DialogButtonMenu.xml
+++ b/addons/skin.confluence/720p/DialogButtonMenu.xml
@@ -34,7 +34,7 @@
 			<posx>470</posx>
 			<posy>0</posy>
 			<width>340</width>
-			<height>720</height>
+			<height>760</height>
 			<onleft>9000</onleft>
 			<onright>9000</onright>
 			<onup>9000</onup>
@@ -63,8 +63,8 @@
 					<onclick>PreviousMenu</onclick>
 					<texturefocus>DialogCloseButton-focus.png</texturefocus>
 					<texturenofocus>DialogCloseButton.png</texturenofocus>
-					<onleft>13</onleft>
-					<onright>13</onright>
+					<onleft>14</onleft>
+					<onright>14</onright>
 					<onup>9</onup>
 					<ondown>2</ondown>
 					<visible>system.getbool(input.enablemouse)</visible>
@@ -103,6 +103,38 @@
 				<label>13016</label>
 			</control>
 			<control type="button" id="4">
+				<description>Shutdown after playback</description>
+				<width>340</width>
+				<height>40</height>
+				<textcolor>grey2</textcolor>
+				<focusedcolor>white</focusedcolor>
+				<align>center</align>
+				<textwidth>290</textwidth>
+				<texturefocus border="25,5,25,5">ShutdownButtonFocus.png</texturefocus>
+				<texturenofocus border="25,5,25,5">ShutdownButtonNoFocus.png</texturenofocus>
+				<onclick>XBMC.PowerdownAfterPlay(true)</onclick>
+				<pulseonselect>no</pulseonselect>
+				<font>font13</font>
+				<label>13017</label>
+				<visible>System.CanPowerDown + !System.PowerdownAfterPlay + [Player.Paused | Player.Playing]</visible>
+			</control>
+			<control type="button" id="5">
+				<description>Cancel shutdown after playback</description>
+				<width>340</width>
+				<height>40</height>
+				<textcolor>grey2</textcolor>
+				<focusedcolor>white</focusedcolor>
+				<align>center</align>
+				<textwidth>290</textwidth>
+				<texturefocus border="25,5,25,5">ShutdownButtonFocus.png</texturefocus>
+				<texturenofocus border="25,5,25,5">ShutdownButtonNoFocus.png</texturenofocus>
+				<onclick>XBMC.PowerdownAfterPlay(false)</onclick>
+				<pulseonselect>no</pulseonselect>
+				<font>font13</font>
+				<label>13018</label>
+				<visible>System.CanPowerDown + System.PowerdownAfterPlay + [Player.Paused | Player.Playing]</visible>
+			</control>
+			<control type="button" id="6">
 				<description>Custom Shutdown Timer</description>
 				<width>340</width>
 				<height>40</height>
@@ -119,7 +151,7 @@
 				<visible>!System.HasAlarm(shutdowntimer)</visible>
 				<visible>System.CanPowerDown</visible>
 			</control>
-			<control type="button" id="5">
+			<control type="button" id="7">
 				<description>Cancel Shutdown Timer</description>
 				<width>340</width>
 				<height>40</height>
@@ -135,7 +167,7 @@
 				<label>20151</label>
 				<visible>System.HasAlarm(shutdowntimer)</visible>
 			</control>
-			<control type="button" id="6">
+			<control type="button" id="8">
 				<description>Suspend button</description>
 				<width>340</width>
 				<height>40</height>
@@ -151,7 +183,7 @@
 				<font>font13</font>
 				<label>13011</label>
 			</control>
-			<control type="button" id="7">
+			<control type="button" id="9">
 				<description>Hibernate button</description>
 				<width>340</width>
 				<height>40</height>
@@ -167,7 +199,7 @@
 				<font>font13</font>
 				<label>13010</label>
 			</control>
-			<control type="button" id="8">
+			<control type="button" id="10">
 				<description>Reboot button</description>
 				<width>340</width>
 				<height>40</height>
@@ -183,7 +215,7 @@
 				<font>font13</font>
 				<label>13013</label>
 			</control>
-			<control type="button" id="9">
+			<control type="button" id="11">
 				<description>Logoff button</description>
 				<width>340</width>
 				<height>40</height>
@@ -201,7 +233,7 @@
 				<visible>System.HasLoginScreen | IntegerGreaterThan(System.ProfileCount,1)</visible>
 				<visible>System.Loggedon</visible>
 			</control>
-			<control type="togglebutton" id="10">
+			<control type="togglebutton" id="12">
 				<description>Master mode button</description>
 				<width>340</width>
 				<height>40</height>
@@ -222,7 +254,7 @@
 				<font>font13</font>
 				<visible>System.HasLocks</visible>
 			</control>
-			<control type="group" id="11">
+			<control type="group" id="13">
 				<width>340</width>
 				<height>70</height>
 				<visible>System.HasAlarm(shutdowntimer)</visible>
@@ -246,7 +278,7 @@
 					<label>$LOCALIZE[31329] [B]$INFO[System.Alarmpos][/B]</label>
 				</control>
 			</control>
-			<control type="image" id="12">
+			<control type="image" id="14">
 				<description>background bottom image</description>
 				<posx>0</posx>
 				<width>340</width>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1008,6 +1008,8 @@
   <string id="13014">Minimize</string>
   <string id="13015">Power button action</string>
   <string id="13016">Power off System</string>
+  <string id="13017">Power off after play</string>
+  <string id="13018">Cancel power off after play</string>
 
   <string id="13020">Is another session active, perhaps over ssh?</string>
   <string id="13021">Mounted removable harddrive</string>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -377,6 +377,9 @@ CApplication::CApplication(void)
   m_bStandalone = false;
   m_bEnableLegacyRes = false;
   m_bSystemScreenSaverEnable = false;
+  
+  m_bPowerdownAfterPlay = false;
+
   m_pInertialScrollingHandler = new CInertialScrollingHandler();
 #ifdef HAS_DVD_DRIVE
   m_Autorun = new CAutorun();
@@ -1961,6 +1964,17 @@ float CApplication::GetDimScreenSaverLevel() const
   if (!m_screenSaver->GetSetting("level").IsEmpty())
     return 100.0f - (float)atof(m_screenSaver->GetSetting("level"));
   return 100.0f;
+}
+
+void CApplication::SetPowerdownAfterPlay(bool bOnOff)
+{
+  // toggle on m_bPowerdownAfterPlay only if supported
+  m_bPowerdownAfterPlay = g_powerManager.CanPowerdown() && bOnOff;
+}
+
+bool CApplication::GetPowerdownAfterPlay() const
+{
+  return m_bPowerdownAfterPlay;
 }
 
 bool CApplication::WaitFrame(unsigned int timeout)
@@ -4698,6 +4712,19 @@ bool CApplication::OnMessage(CGUIMessage& message)
         g_settings.Save();    // save vis settings
         WakeUpScreenSaverAndDPMS();
         g_windowManager.PreviousWindow();
+      }
+
+      // user wants XBMC to power off system after playing current item(s)
+      if (m_bPowerdownAfterPlay)
+      {
+        // abort power off if playback stopped
+        m_bPowerdownAfterPlay &= (message.GetMessage() != GUI_MSG_PLAYBACK_STOPPED);
+
+        // power off only when player ended playing the (last) item
+        if (m_bPowerdownAfterPlay && (message.GetMessage() == GUI_MSG_PLAYBACK_ENDED) && !IsPlaying())
+        {
+          g_application.getApplicationMessenger().Powerdown();
+        }
       }
 
       if (IsEnableTestMode()) g_application.getApplicationMessenger().Quit();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -284,6 +284,10 @@ public:
   bool ToggleDPMS(bool manual);
 
   float GetDimScreenSaverLevel() const;
+
+  void SetPowerdownAfterPlay(bool bOnOff);
+  bool GetPowerdownAfterPlay() const;
+
 protected:
   bool LoadSkin(const CStdString& skinID);
   void LoadSkin(const boost::shared_ptr<ADDON::CSkinInfo>& skin);
@@ -310,6 +314,8 @@ protected:
   CStopWatch m_slowTimer;
   CStopWatch m_screenSaverTimer;
   CStopWatch m_shutdownTimer;
+
+  bool m_bPowerdownAfterPlay;
 
   DPMSSupport* m_dpms;
   bool m_dpmsIsActive;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -218,6 +218,7 @@ const infomap system_labels[] =  {{ "hasnetwork",       SYSTEM_ETHERNET_LINK_ACT
                                   { "cansuspend",       SYSTEM_CAN_SUSPEND },
                                   { "canhibernate",     SYSTEM_CAN_HIBERNATE },
                                   { "canreboot",        SYSTEM_CAN_REBOOT },
+                                  { "powerdownafterplay", SYSTEM_POWERDOWN_AFTER_PLAY },
                                   { "screensaveractive",SYSTEM_SCREENSAVER_ACTIVE },
                                   { "cputemperature",   SYSTEM_CPU_TEMPERATURE },     // labels from here
                                   { "cpuusage",         SYSTEM_CPU_USAGE },
@@ -1908,7 +1909,8 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     bReturn = g_powerManager.CanReboot();
   else if (condition == SYSTEM_SCREENSAVER_ACTIVE)
     bReturn = g_application.IsInScreenSaver();
-
+  else if (condition == SYSTEM_POWERDOWN_AFTER_PLAY)
+    bReturn = g_application.GetPowerdownAfterPlay();
   else if (condition == PLAYER_SHOWINFO)
     bReturn = m_playerShowInfo;
   else if (condition == PLAYER_SHOWCODEC)

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -374,6 +374,7 @@ namespace INFO
 #define SYSTEM_IDLE_TIME            715
 #define SYSTEM_FRIENDLY_NAME        716
 #define SYSTEM_SCREENSAVER_ACTIVE   717
+#define SYSTEM_POWERDOWN_AFTER_PLAY 718
 
 #define LIBRARY_HAS_MUSIC           720
 #define LIBRARY_HAS_VIDEO           721

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -108,6 +108,7 @@ const BUILT_IN commands[] = {
   { "Restart",                    false,  "Restart the xbox (power cycle)" },
   { "ShutDown",                   false,  "Shutdown the xbox" },
   { "Powerdown",                  false,  "Powerdown system" },
+  { "PowerdownAfterPlay",         false,  "Powerdown system when playback ends" },
   { "Quit",                       false,  "Quit XBMC" },
   { "Hibernate",                  false,  "Hibernates the system" },
   { "Suspend",                    false,  "Suspends the system" },
@@ -274,6 +275,15 @@ int CBuiltins::Execute(const CStdString& execString)
   else if (execute.Equals("minimize"))
   {
     g_application.getApplicationMessenger().Minimize();
+  }
+  else if (execute.Equals("powerdownafterplay"))
+  {
+    bool powerOffAfterPlay = false;
+    if (params.size() > 0)
+    {
+      powerOffAfterPlay = params[0].Equals("true");
+    }
+    g_application.SetPowerdownAfterPlay(powerOffAfterPlay);
   }
   else if (execute.Equals("loadprofile"))
   {


### PR DESCRIPTION
Updated on **2011.Oct.12**

This is an alternative shutdown method. When video, music or playlist is playing than power menu displays a new button "Power off after play" pressing this button will shut down computer when playback ends. After above mentioned button is pressed "Cancel power off after play" button appears to be able to cancel shutdown.

@jmarshallnz & @topfs2 & @pieh: Better aletrantive to https://github.com/xbmc/xbmc/pull/237 because:
1. Is not included in the video player GUI (no button added there).
2. Powers off system on video, audio, even playlist end, not just on currently played video end.
3. If power down is not supported on a system new button won't even show up in shutdown menu.

**NOTE:** To easily access this feature press button that brings up "Shutdown Menu" ([S] on Keyboard) while playing something.

Updated on **2012.March.19**

@jmarshallnz: Moved bool from Settings to Application
