### PR TITLE
New audio codec for pcm streams

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -303,6 +303,7 @@
     <ClCompile Include="..\..\xbmc\BackgroundInfoLoader.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDCodecs\Video\CrystalHD.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamBluray.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\paplayer\PCMCodec.cpp" />
     <ClCompile Include="..\..\xbmc\cores\VideoRenderers\RenderCapture.cpp" />
     <ClCompile Include="..\..\xbmc\cores\VideoRenderers\VideoShaders\WinVideoFilter.cpp" />
     <ClCompile Include="..\..\xbmc\CueDocument.cpp" />
@@ -1191,6 +1192,7 @@
     <ClInclude Include="..\..\xbmc\BackgroundInfoLoader.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDCodecs\Video\CrystalHD.h" />
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamBluray.h" />
+    <ClInclude Include="..\..\xbmc\cores\paplayer\PCMCodec.h" />
     <ClInclude Include="..\..\xbmc\cores\VideoRenderers\RenderCapture.h" />
     <ClInclude Include="..\..\xbmc\cores\VideoRenderers\VideoShaders\WinVideoFilter.h" />
     <ClInclude Include="..\..\xbmc\CueDocument.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2466,6 +2466,9 @@
     <ClCompile Include="..\..\xbmc\threads\ThreadLocal.cpp">
       <Filter>threads</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\paplayer\PCMCodec.cpp">
+      <Filter>cores\paplayer</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -4948,6 +4951,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\threads\ThreadLocal.h">
       <Filter>threads</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\cores\paplayer\PCMCodec.h">
+      <Filter>cores\paplayer</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -118,7 +118,7 @@ ICodec* CodecFactory::CreateCodecDemux(const CStdString& strFile, const CStdStri
   if( strContent.Equals("audio/mpeg")
   ||  strContent.Equals("audio/mp3") )
     return new MP3Codec();
-  else if ((strContent.Find("audio/L16") == 0) || (strContent.Find("audio/l16") == 0))
+  else if (strContent.Left(9).Equals("audio/l16"))
   {
     PCMCodec * pcm_codec = new PCMCodec();
     pcm_codec->SetMimeParams(strContent);

--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -41,11 +41,14 @@
 #endif
 #include "URL.h"
 #include "DVDPlayerCodec.h"
+#include "PCMCodec.h"
 
 ICodec* CodecFactory::CreateCodec(const CStdString& strFileType)
 {
   if (strFileType.Equals("mp3") || strFileType.Equals("mp2"))
     return new MP3Codec();
+  else if (strFileType.Equals("pcm") || strFileType.Equals("l16"))
+    return new PCMCodec();
   else if (strFileType.Equals("ape") || strFileType.Equals("mac"))
     return new DVDPlayerCodec();
   else if (strFileType.Equals("cdda"))
@@ -115,6 +118,12 @@ ICodec* CodecFactory::CreateCodecDemux(const CStdString& strFile, const CStdStri
   if( strContent.Equals("audio/mpeg")
   ||  strContent.Equals("audio/mp3") )
     return new MP3Codec();
+  else if ((strContent.Find("audio/L16") == 0) || (strContent.Find("audio/l16") == 0))
+  {
+    PCMCodec * pcm_codec = new PCMCodec();
+    pcm_codec->SetMimeParams(strContent);
+    return pcm_codec;
+  }
   else if( strContent.Equals("audio/aac")
     || strContent.Equals("audio/aacp") )
   {

--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -26,6 +26,7 @@
 #include "OGGcodec.h"
 #include "FLACcodec.h"
 #include "WAVcodec.h"
+#include "PCMCodec.h"
 #include "ModplugCodec.h"
 #include "NSFCodec.h"
 #ifdef HAS_SPC_CODEC
@@ -41,7 +42,6 @@
 #endif
 #include "URL.h"
 #include "DVDPlayerCodec.h"
-#include "PCMCodec.h"
 
 ICodec* CodecFactory::CreateCodec(const CStdString& strFileType)
 {

--- a/xbmc/cores/paplayer/PCMCodec.cpp
+++ b/xbmc/cores/paplayer/PCMCodec.cpp
@@ -1,0 +1,93 @@
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "pch.h"
+#include "PCMCodec.h"
+#include "utils/log.h"
+
+PCMCodec::PCMCodec()
+{
+	m_CodecName = "PCM";
+	m_TotalTime = 0;
+	m_SampleRate = 44100;
+	m_Channels = 2;
+	m_BitsPerSample = 16;
+	m_Bitrate = m_SampleRate * m_Channels * m_BitsPerSample;
+	iBytesPerSecond = m_Bitrate / 8;
+}
+
+PCMCodec::~PCMCodec()
+{
+	DeInit();
+}
+
+bool PCMCodec::Init(const CStdString &strFile, unsigned int filecache)
+{
+	m_file.Close();
+	if (!m_file.Open(strFile, READ_CACHED))
+	{
+		CLog::Log(LOGERROR, "PCMCodec::Init - Failed to open file");
+		return false;
+	}
+	int64_t length = m_file.GetLength();
+	m_TotalTime = (int)(((float)length / iBytesPerSecond) * 1000);
+	m_file.Seek(0, SEEK_SET);
+	return true;
+}
+
+void PCMCodec::DeInit()
+{
+	m_file.Close();
+}
+
+__int64 PCMCodec::Seek(__int64 iSeekTime)
+{
+	m_file.Seek((iSeekTime / 1000) * iBytesPerSecond);
+	return iSeekTime;
+}
+
+int PCMCodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
+{
+	*actualsize = 0;
+	int iAmountRead = m_file.Read(pBuffer, size);
+	if (iAmountRead > 0)
+	{
+		*actualsize = iAmountRead;
+		return READ_SUCCESS;
+	}
+	return READ_ERROR;
+}
+
+bool PCMCodec::CanInit()
+{
+	return true;
+}
+
+void PCMCodec::SetMimeParams(const CStdString& strMimeParams)
+{
+	if (strMimeParams.Find("rate=48000") > 0)
+		m_SampleRate = 48000;
+	if (strMimeParams.Find("channels=1") > 0)
+		m_Channels = 1;
+
+	m_Bitrate = m_SampleRate * m_Channels * m_BitsPerSample;
+	iBytesPerSecond = m_Bitrate / 8;
+}

--- a/xbmc/cores/paplayer/PCMCodec.cpp
+++ b/xbmc/cores/paplayer/PCMCodec.cpp
@@ -19,7 +19,6 @@
  *
  */
 
-#include "pch.h"
 #include "PCMCodec.h"
 #include "utils/log.h"
 #include "EndianSwap.h"

--- a/xbmc/cores/paplayer/PCMCodec.cpp
+++ b/xbmc/cores/paplayer/PCMCodec.cpp
@@ -108,21 +108,20 @@ void PCMCodec::SetMimeParams(const CStdString& strMimeParams)
 	{
 		for (int i = 0; i < paramCount; i++)
 		{
-			if (mimeParams[i].Find("rate=") >= 0)
-			{
-				CStdStringArray rate;
+			CStdStringArray thisParam;
 
-				int strCount = StringUtils::SplitString(mimeParams[i], "=", rate, 2);
-				if (strCount > 1)
-					m_SampleRate = atoi(rate[1].Trim());
-			}
-			else if (mimeParams[i].Find("channels=") >= 0)
+			int strCount = StringUtils::SplitString(mimeParams[i], "=", thisParam, 2);
+			
+			if (strCount > 1)
 			{
-				CStdStringArray channel;
-
-				int strCount = StringUtils::SplitString(mimeParams[i], "=", channel, 2);
-				if (strCount > 1)
-					m_Channels = atoi(channel[1].Trim());
+				if (thisParam[0] == "rate")
+				{
+					m_SampleRate = atoi(thisParam[1].Trim());
+				}
+				else if (thisParam[0] == "channels")
+				{
+					m_Channels = atoi(thisParam[1].Trim());
+				}
 			}
 		}
 	}

--- a/xbmc/cores/paplayer/PCMCodec.cpp
+++ b/xbmc/cores/paplayer/PCMCodec.cpp
@@ -22,6 +22,7 @@
 #include "pch.h"
 #include "PCMCodec.h"
 #include "utils/log.h"
+#include "EndianSwap.h"
 
 PCMCodec::PCMCodec()
 {
@@ -30,7 +31,7 @@ PCMCodec::PCMCodec()
 	m_SampleRate = 44100;
 	m_Channels = 2;
 	m_BitsPerSample = 16;
-	m_Bitrate = m_SampleRate*m_Channels*m_BitsPerSample;
+	m_Bitrate = m_SampleRate * m_Channels * m_BitsPerSample;
 }
 
 PCMCodec::~PCMCodec()
@@ -61,7 +62,7 @@ void PCMCodec::DeInit()
 
 __int64 PCMCodec::Seek(__int64 iSeekTime)
 {
-	m_file.Seek((iSeekTime/1000)*(m_Bitrate/8));
+	m_file.Seek((iSeekTime / 1000) * (m_Bitrate / 8));
 	return iSeekTime;
 }
 
@@ -72,12 +73,11 @@ int PCMCodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
 	int iAmountRead = m_file.Read(pBuffer, size);
 	if (iAmountRead > 0)
 	{
-		WORD *x, *first;
-		first = (WORD*)pBuffer;
+		uint16_t *buffer = (uint16_t*) pBuffer;
 
-		for (x = first; x < (first + (iAmountRead/2)); x++)
-			*x = ((*x << 8) | (*x >> 8));
-
+		for (int i = 0; i < (iAmountRead / 2); i++)
+		  buffer[i] = Endian_Swap16(buffer[i]);
+ 
 		*actualsize = iAmountRead;
 		return READ_SUCCESS;
 	}
@@ -97,5 +97,5 @@ void PCMCodec::SetMimeParams(const CStdString& strMimeParams)
 	if (strMimeParams.Find("channels=1") > 0)
 		m_Channels = 1;
 
-	m_Bitrate = m_SampleRate*m_Channels*m_BitsPerSample;
+	m_Bitrate = m_SampleRate * m_Channels * m_BitsPerSample;
 }

--- a/xbmc/cores/paplayer/PCMCodec.h
+++ b/xbmc/cores/paplayer/PCMCodec.h
@@ -1,0 +1,38 @@
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#pragma once
+#include "CachingCodec.h"
+
+class PCMCodec : public CachingCodec
+{
+public:
+	PCMCodec(void);
+	virtual ~PCMCodec(void);
+	virtual bool Init(const CStdString &strFile, unsigned int filecache);
+	virtual void DeInit();
+	virtual __int64 Seek(__int64 iSeekTime);
+	virtual int ReadPCM(BYTE *pBuffer, int size, int *actualsize);
+	virtual bool CanInit();
+	virtual void SetMimeParams(const CStdString& strMimeParams);
+private:
+	int iBytesPerSecond;
+};

--- a/xbmc/cores/paplayer/PCMCodec.h
+++ b/xbmc/cores/paplayer/PCMCodec.h
@@ -33,6 +33,4 @@ public:
 	virtual int ReadPCM(BYTE *pBuffer, int size, int *actualsize);
 	virtual bool CanInit();
 	virtual void SetMimeParams(const CStdString& strMimeParams);
-private:
-	int iBytesPerSecond;
 };


### PR DESCRIPTION
Hi, 
I created a new audio codec for processing pcm files and streams.
This is needed because remote UPnP / DLNA media servers deliver pcm by default.
The pcm format has mime type audio/L16 and file extensions .pcm or .l16.
Regards,
AndrewFG
