### PR TITLE
Introduce ACTION_NAV_BACK as replacement for ACTION_PARENT_DIR

### DIFF
--- a/system/keymaps/appcommand.xml
+++ b/system/keymaps/appcommand.xml
@@ -1,7 +1,7 @@
 <keymap>
   <global>
     <appcommand>
-      <browser_back>ParentDir</browser_back>
+      <browser_back>Back</browser_back>
       <browser_forward/>
       <browser_refresh/>
       <browser_stop>Stop</browser_stop>

--- a/system/keymaps/gamepad.xml
+++ b/system/keymaps/gamepad.xml
@@ -38,7 +38,7 @@
   <global>
     <gamepad>
       <A>Select</A>
-      <B>ParentDir</B>
+      <B>Back</B>
       <X>FullScreen</X>
       <Y>Queue</Y>
       <white>ContextMenu</white>
@@ -72,9 +72,7 @@
   <MyMusicPlaylist>
     <gamepad>
       <Y>Delete</Y>
-      <black>Playlist</black>      <!-- Close playlist -->
-      <back>Playlist</back>      <!-- Close playlist -->
-      <B>Playlist</B>      <!-- Close playlist -->
+      <black>Back</black>
     </gamepad>
   </MyMusicPlaylist>
   <MyMusicPlaylistEditor>
@@ -113,18 +111,16 @@
   </FullscreenVideo>
   <FullscreenInfo>
     <gamepad>
-      <B>Close</B>
       <start>OSD</start>
       <black>CodecInfo</black>
-      <white>Close</white>
+      <white>Back</white>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>
     </gamepad>
   </FullscreenInfo>
   <PlayerControls>
     <gamepad>
-      <back>Close</back>
-      <start>Close</start>
+      <start>Back</start>
     </gamepad>
   </PlayerControls>
   <Visualisation>
@@ -146,8 +142,7 @@
   </Visualisation>
   <MusicOSD>
     <gamepad>
-      <back>Close</back>
-      <start>Close</start>
+      <start>Back</start>
       <black>CodecInfo</black>
       <white>Info</white>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
@@ -156,19 +151,15 @@
   </MusicOSD>
   <VisualisationSettings>
     <gamepad>
-      <B>Close</B>
-      <back>Close</back>
-      <start>Close</start>
+      <start>Back</start>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>
     </gamepad>
   </VisualisationSettings>
   <VisualisationPresetList>
     <gamepad>
-      <B>Close</B>
-      <back>Close</back>
-      <start>Close</start>
-      <Y>Close</Y>
+      <start>Back</start>
+      <Y>Back</Y>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>
     </gamepad>
@@ -197,7 +188,6 @@
       <A>NextCalibration</A>
       <black>ResetCalibration</black>
       <white>NextResolution</white>
-      <B>PreviousMenu</B>
     </gamepad>
   </ScreenCalibration>
   <GUICalibration>
@@ -205,19 +195,11 @@
       <leftthumbstick>AnalogMove</leftthumbstick>
       <A>NextCalibration</A>
       <black>ResetCalibration</black>
-      <B>PreviousMenu</B>
     </gamepad>
   </GUICalibration>
-  <SelectDialog>
-    <gamepad>
-      <back>Close</back>
-    </gamepad>
-  </SelectDialog>
   <VideoOSD>
     <gamepad>
-      <start>Close</start>
-      <back>PreviousMenu</back>
-      <B>PreviousMenu</B>
+      <start>Back</start>
       <black>CodecInfo</black>
       <white>Info</white>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
@@ -229,7 +211,6 @@
       <Y>AspectRatio</Y>
       <B>Stop</B>
       <start>OSD</start>
-      <back>PreviousMenu</back>
       <white>Info</white>
       <black>CodecInfo</black>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
@@ -240,9 +221,7 @@
     <gamepad>
       <X/>
       <Y>AspectRatio</Y>
-      <B>Close</B>
-      <back>Close</back>
-      <start>Close</start>
+      <start>Back</start>
       <black>CodecInfo</black>
       <white>Info</white>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
@@ -253,9 +232,7 @@
     <gamepad>
       <X/>
       <Y>AspectRatio</Y>
-      <B>Close</B>
-      <back>Close</back>
-      <start>Close</start>
+      <start>Back</start>
       <black>CodecInfo</black>
       <white>Info</white>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
@@ -266,9 +243,7 @@
     <gamepad>
       <X/>
       <Y>Delete</Y>
-      <B>Close</B>
-      <back>Close</back>
-      <start>Close</start>
+      <start>Back</start>
       <leftanalogtrigger>AnalogRewind</leftanalogtrigger>
       <rightanalogtrigger>AnalogFastForward</rightanalogtrigger>
     </gamepad>
@@ -287,9 +262,7 @@
   <MyVideoPlaylist>
     <gamepad>
       <Y>Delete</Y>
-      <black>Playlist</black>      <!-- Close playlist -->
-      <back>Playlist</back>      <!-- Close playlist -->
-      <B>Playlist</B>
+      <black>Back</black>
     </gamepad>
   </MyVideoPlaylist>
   <VirtualKeyboard>
@@ -304,8 +277,7 @@
   </VirtualKeyboard>
   <ContextMenu>
     <gamepad>
-      <white>Close</white>
-      <B>Close</B>
+      <white>Back</white>
     </gamepad>
   </ContextMenu>
   <Scripts>
@@ -326,120 +298,20 @@
       <start>Stop</start>      <!-- Enter Password -->
     </gamepad>
   </GamepadInput>
-  <Weather>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </Weather>
-  <Settings>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </Settings>
-  <AddonInformation>
-    <gamepad>
-      <b>Close</b>
-    </gamepad>
-  </AddonInformation>
-  <AddonSettings>
-    <gamepad>
-      <b>Close</b>
-    </gamepad>
-  </AddonSettings>
-  <TextViewer>
-    <gamepad>
-      <b>Close</b>
-    </gamepad>
-  </TextViewer>
-  <MyPicturesSettings>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </MyPicturesSettings>
-  <MyProgramsSettings>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </MyProgramsSettings>
-  <MyWeatherSettings>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </MyWeatherSettings>
-  <MyMusicSettings>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </MyMusicSettings>
-  <SystemSettings>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </SystemSettings>
-  <MyVideosSettings>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </MyVideosSettings>
-  <NetworkSettings>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </NetworkSettings>
-  <AppearanceSettings>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </AppearanceSettings>
-  <Profiles>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </Profiles>
-  <systeminfo>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </systeminfo>
-  <shutdownmenu>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </shutdownmenu>
-  <submenu>
-    <gamepad>
-      <B>PreviousMenu</B>
-    </gamepad>
-  </submenu>
-  <MusicInformation>
-    <gamepad>
-      <B>Close</B>
-    </gamepad>
-  </MusicInformation>
-  <MovieInformation>
-    <gamepad>
-      <B>Close</B>
-    </gamepad>
-  </MovieInformation>
   <LockSettings>
     <gamepad>
-      <start>Close</start>
-      <B>PreviousMenu</B>
-      <back>PreviousMenu</back>
+      <start>Back</start>
     </gamepad>
   </LockSettings>
   <ProfileSettings>
     <gamepad>
-      <start>Close</start>
-      <B>PreviousMenu</B>
-      <back>PreviousMenu</back>
+      <start>Back</start>
     </gamepad>
   </ProfileSettings>
   <PictureInfo>
     <gamepad>
       <dpadleft>PreviousPicture</dpadleft>
       <dpadright>NextPicture</dpadright>
-      <black>Close</black>
     </gamepad>
   </PictureInfo>
 </keymap>

--- a/system/keymaps/joystick.Alienware.Dual.Compatible.Controller.xml
+++ b/system/keymaps/joystick.Alienware.Dual.Compatible.Controller.xml
@@ -42,7 +42,7 @@
     <joystick name="Alienware Alienware Dual Compatible Game Pad">
       <button id="1">FullScreen</button> <!--square -->
       <button id="2">Select</button>  <!--x --> 
-      <button id="3">ParentDir</button>   <!--circle --> 
+      <button id="3">Back</button>   <!--circle --> 
       <button id="4">Queue</button> <!-- tri -->
       <button id="6">PreviousMenu</button> <!-- l1 -->
       <button id="7"></button>  <!-- l2 -->      

--- a/system/keymaps/joystick.AppleRemote.xml
+++ b/system/keymaps/joystick.AppleRemote.xml
@@ -35,7 +35,7 @@
       <!-- left       -->      <button id="3">Left</button>
       <!-- right      -->      <button id="4">Right</button>
       <!-- center     -->      <button id="5">Select</button>
-      <!-- menu       -->      <button id="6">PreviousMenu</button>
+      <!-- menu       -->      <button id="6">Back</button>
       <!-- hold center-->      <button id="7">Fullscreen</button>
       <!-- hold menu  -->      <button id="8">ContextMenu</button>
 
@@ -87,36 +87,6 @@
       <button id="8">ActivateWindow(shutdownmenu)</button>
     </joystick>
   </Home>
-  <Favourites>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </Favourites>
-  <MyPictures>
-    <joystick name="AppleRemote">
-      <button id="6">ParentDir</button>
-    </joystick>
-  </MyPictures>
-  <MyMusicPlaylist>
-    <joystick name="AppleRemote">
-      <button id="6">Playlist</button>
-    </joystick>
-  </MyMusicPlaylist>
-  <MyMusicPlaylistEditor>
-    <joystick name="AppleRemote">
-      <button id="6">ParentDir</button>
-    </joystick>
-  </MyMusicPlaylistEditor>
-  <MyMusicFiles>
-    <joystick name="AppleRemote">
-      <button id="6">ParentDir</button>
-    </joystick>
-  </MyMusicFiles>
-  <MyMusicLibrary>
-    <joystick name="AppleRemote">
-      <button id="6">ParentDir</button>
-    </joystick>
-  </MyMusicLibrary>
   <FullscreenVideo>
     <joystick name="AppleRemote">
       <button id="1">VolumeUp</button>
@@ -141,16 +111,6 @@
       <!-- FlickDown  -->      <button id="88">BigStepBack</button>
     </joystick>
   </FullscreenVideo>
-  <FullscreenInfo>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </FullscreenInfo>
-  <PlayerControls>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </PlayerControls>
   <Visualisation>
     <joystick name="AppleRemote">
       <button id="1">VolumeUp</button>
@@ -167,21 +127,6 @@
       <!-- FlickRight -->      <button id="86">SkipNext</button>
     </joystick>
   </Visualisation>
-  <MusicOSD>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </MusicOSD>
-  <VisualisationSettings>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </VisualisationSettings>
-  <VisualisationPresetList>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </VisualisationPresetList>
   <SlideShow>
     <joystick name="AppleRemote">
       <button id="1">ZoomIn</button>
@@ -202,15 +147,9 @@
       <button id="5">NextCalibration</button>
     </joystick>
   </ScreenCalibration>
-  <SelectDialog>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </SelectDialog>
   <VideoOSD>
     <joystick name="AppleRemote">
-      <button id="6">Close</button>
-      <button id="7">Close</button>
+      <button id="7">Back</button>
     </joystick>
   </VideoOSD>
   <VideoMenu>
@@ -221,97 +160,24 @@
       <button id="8"/>
     </joystick>
   </VideoMenu>
-  <OSDVideoSettings>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </OSDVideoSettings>
-  <OSDAudioSettings>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </OSDAudioSettings>
-  <VideoBookmarks>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </VideoBookmarks>
   <MyVideoLibrary>
     <joystick name="AppleRemote">
-      <button id="6">ParentDir</button>
       <button id="7">Info</button>
     </joystick>
   </MyVideoLibrary>
   <MyVideoFiles>
     <joystick name="AppleRemote">
-      <button id="6">ParentDir</button>
       <button id="7">Info</button>
     </joystick>
   </MyVideoFiles>
-  <MyVideoPlaylist>
-    <joystick name="AppleRemote">
-      <button id="6">Playlist</button>
-    </joystick>
-  </MyVideoPlaylist>
-  <VirtualKeyboard>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </VirtualKeyboard>
-  <ContextMenu>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </ContextMenu>
-  <FileStackingDialog>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </FileStackingDialog>
-  <MusicInformation>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </MusicInformation>
-  <MovieInformation>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </MovieInformation>
   <PictureInfo>
     <joystick name="AppleRemote">
       <button id="3">Left</button>
       <button id="4">Right</button>
-      <button id="6">Close</button>
       <!-- SwipeLeft  -->      <button id="80">Left</button>
       <!-- SwipeRight -->      <button id="81">Right</button>
       <!-- FlickLeft  -->      <button id="85">Left</button>
       <!-- FlickRight -->      <button id="86">Right</button>
     </joystick>
   </PictureInfo>
-  <AddonBrowser>
-    <joystick name="AppleRemote">
-      <button id="6">ParentDir</button>
-    </joystick>
-  </AddonBrowser>
-  <AddonInformation>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </AddonInformation>
-  <AddonSettings>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </AddonSettings>
-  <TextViewer>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </TextViewer>
-  <NumericInput>
-    <joystick name="AppleRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </NumericInput>
 </keymap>

--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -57,7 +57,7 @@
       <!-- Rew       	-->      <button id="41">Rewind</button>
       <!-- Fwd  	-->      <button id="42">FastForward</button>
       <!-- Pause	-->      <button id="26">Pause</button>
-      <!-- Prev		-->      <button id="32">ParentDir</button>
+      <!-- Prev		-->      <button id="32">Back</button>
       <!-- Guide  	-->      <button id="65">FullScreen</button>
       <!-- Info  	-->      <button id="31">Info</button>
       <!-- Exit 	-->      <button id="51">PreviousMenu</button>
@@ -79,7 +79,7 @@
       <!-- 8 		-->      <button id="34">Number8</button>
       <!-- 9 		-->      <button id="43">Number9</button>
       <!-- 0 		-->      <button id="44">Number0</button>
-      <!-- * clear 	-->      <button id="45">ParentDir</button>
+      <!-- * clear 	-->      <button id="45">Back</button>
       <!-- # enter 	-->      <button id="36">Select</button>
       <!-- Mute		-->      <button id="25">Mute</button>
       <!-- Aspect	-->      <button id="61">AspectRatio</button>
@@ -127,7 +127,6 @@
   </MyFiles>
   <MyMusicPlaylist>
     <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Playlist</button>
       <!-- * clear 	-->      <button id="45">Delete</button>
       <!-- Channel Up  	-->      <button id="71">MoveItemUp</button>
       <!-- Channel Down -->      <button id="72">MoveItemDown</button>
@@ -175,12 +174,12 @@
   </FullscreenVideo>
   <FullscreenInfo>
     <joystick name="Harmony">
-      <!-- Info  	-->      <button id="31">Close</button>
+      <!-- Info  	-->      <button id="31">Back</button>
     </joystick>
   </FullscreenInfo>
   <PlayerControls>
     <joystick name="Harmony">
-      <!-- menu       	-->      <button id="6">Close</button>
+      <!-- menu       	-->      <button id="6">Back</button>
     </joystick>
   </PlayerControls>
   <Visualisation>
@@ -198,21 +197,18 @@
   </Visualisation>
   <MusicOSD>
     <joystick name="Harmony">
-      <!-- menu       	-->      <button id="6">Close</button>
+      <!-- menu       	-->      <button id="6">Back</button>
       <!-- Info  	-->      <button id="31">CodecInfo</button>
-      <!-- Exit 	-->      <button id="51">Close</button>
     </joystick>
   </MusicOSD>
   <VisualisationSettings>
     <joystick name="Harmony">
-      <!-- menu       	-->      <button id="6">Close</button>
-      <!-- Exit 	-->      <button id="51">Close</button>
+      <!-- menu       	-->      <button id="6">Back</button>
     </joystick>
   </VisualisationSettings>
   <VisualisationPresetList>
     <joystick name="Harmony">
-      <!-- menu       	-->      <button id="6">Close</button>
-      <!-- Exit 	-->      <button id="51">Close</button>
+      <!-- menu       	-->      <button id="6">Back</button>
     </joystick>
   </VisualisationPresetList>
   <SlideShow>
@@ -248,44 +244,30 @@
       <!-- # enter 	-->      <button id="36">NextCalibration</button>
     </joystick>
   </GUICalibration>
-  <SelectDialog>
-    <joystick name="Harmony">
-      <!-- Exit 	-->      <button id="51">Close</button>
-      <!-- Prev		-->      <button id="32">Close</button>
-    </joystick>
-  </SelectDialog>
   <VideoOSD>
     <joystick name="Harmony">
-      <!-- menu       	-->      <button id="6">Close</button>
-      <!-- Exit 	-->      <button id="51">Close</button>
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
+      <!-- menu       	-->      <button id="6">Back</button>
     </joystick>
   </VideoOSD>
   <VideoMenu>
     <joystick name="Harmony">
       <!-- menu       	-->      <button id="6">OSD</button>
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
       <!-- Info  	-->      <button id="31">Info</button>
     </joystick>
   </VideoMenu>
   <OSDVideoSettings>
     <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Close</button>
-      <!-- menu       	-->      <button id="6">Close</button>
+      <!-- menu       	-->      <button id="6">Back</button>
     </joystick>
   </OSDVideoSettings>
   <OSDAudioSettings>
     <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Close</button>
-      <!-- menu       	-->      <button id="6">Close</button>
-      <!-- Exit 	-->      <button id="51">Close</button>
+      <!-- menu       	-->      <button id="6">Back</button>
     </joystick>
   </OSDAudioSettings>
   <VideoBookmarks>
     <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Close</button>
-      <!-- menu       	-->      <button id="6">Close</button>
-      <!-- Exit 	-->      <button id="51">Close</button>
+      <!-- menu       	-->      <button id="6">Back</button>
       <!-- * clear 	-->      <button id="45">Delete</button>
     </joystick>
   </VideoBookmarks>
@@ -320,7 +302,6 @@
   </MyVideoFiles>
   <MyVideoPlaylist>
     <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Playlist</button>      <!-- Close playlist -->
       <!-- * clear 	-->      <button id="45">Delete</button>
       <!-- Channel Up  	-->      <button id="71">MoveItemUp</button>
       <!-- Channel Down -->      <button id="72">MoveItemDown</button>
@@ -345,16 +326,6 @@
       <!-- Fwd  	-->      <button id="42">CursorRight</button>
     </joystick>
   </VirtualKeyboard>
-  <ContextMenu>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Close</button>
-    </joystick>
-  </ContextMenu>
-  <FileStackingDialog>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Close</button>
-    </joystick>
-  </FileStackingDialog>
   <Scripts>
     <joystick name="Harmony">
       <!-- Info  	-->      <button id="31">info</button>
@@ -375,121 +346,31 @@
       <!-- Prev		-->      <button id="32">BackSpace</button>
     </joystick>
   </NumericInput>
-  <Weather>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </Weather>
-  <Settings>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </Settings>
-  <MyPicturesSettings>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </MyPicturesSettings>
-  <MyProgramsSettings>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </MyProgramsSettings>
-  <MyWeatherSettings>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </MyWeatherSettings>
-  <MyMusicSettings>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </MyMusicSettings>
-  <SystemSettings>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </SystemSettings>
-  <MyVideosSettings>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </MyVideosSettings>
-  <NetworkSettings>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </NetworkSettings>
-  <AppearanceSettings>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </AppearanceSettings>
-  <Profiles>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </Profiles>
-  <systeminfo>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </systeminfo>
-  <shutdownmenu>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </shutdownmenu>
-  <submenu>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
-    </joystick>
-  </submenu>
   <MusicInformation>
     <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Close</button>
-      <!-- menu       	-->      <button id="6">Close</button>
+      <!-- menu       	-->      <button id="6">Back</button>
     </joystick>
   </MusicInformation>
   <MovieInformation>
     <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Close</button>
-      <!-- menu       	-->      <button id="6">Close</button>
+      <!-- menu       	-->      <button id="6">Back</button>
     </joystick>
   </MovieInformation>
   <LockSettings>
     <joystick name="Harmony">
-      <!-- menu       	-->      <button id="6">Close</button>
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
+      <!-- menu       	-->      <button id="6">Back</button>
     </joystick>
   </LockSettings>
   <ProfileSettings>
     <joystick name="Harmony">
-      <!-- menu       	-->      <button id="6">Close</button>
-      <!-- Prev		-->      <button id="32">PreviousMenu</button>
+      <!-- menu       	-->      <button id="6">Back</button>
     </joystick>
   </ProfileSettings>
   <PictureInfo>
     <joystick name="Harmony">
       <!-- Replay       -->      <button id="91">PreviousPicture</button>
       <!-- Skip      	-->      <button id="92">NextPicture</button>
-      <!-- Info  	-->      <button id="31">Close</button>
-      <!-- Prev		-->      <button id="32">Close</button>
+      <!-- Info  	-->      <button id="31">Back</button>
     </joystick>
   </PictureInfo>
-  <AddonInformation>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Close</button>
-    </joystick>
-  </AddonInformation>
-  <AddonSettings>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Close</button>
-    </joystick>
-  </AddonSettings>
-  <TextViewer>
-    <joystick name="Harmony">
-      <!-- Prev		-->      <button id="32">Close</button>
-    </joystick>
-  </TextViewer>
 </keymap>

--- a/system/keymaps/joystick.Interact.AxisPad.xml
+++ b/system/keymaps/joystick.Interact.AxisPad.xml
@@ -40,7 +40,7 @@
       <altname>Interact AxisPad</altname>
       <button id="1">FullScreen</button> <!--square -->
       <button id="3">Select</button>  <!--x --> 
-      <button id="4">ParentDir</button>   <!--circle --> 
+      <button id="4">Back</button>   <!--circle --> 
       <button id="2">Queue</button> <!-- tri -->
       <button id="5">PreviousMenu</button> <!-- l1 -->
       <button id="7"></button>  <!-- l2 -->      

--- a/system/keymaps/joystick.Logitech.RumblePad.2.xml
+++ b/system/keymaps/joystick.Logitech.RumblePad.2.xml
@@ -4,7 +4,7 @@
       <altname>Logitech Cordless RumblePad 2</altname>
       <button id="1">FullScreen</button>
       <button id="2">Select</button>
-      <button id="3">PreviousMenu</button>
+      <button id="3">Back</button>
       <button id="7">FullScreen</button>
       <button id="8">ContextMenu</button>
       <button id="10">XBMC.ActivateWindow(Home)</button>
@@ -32,31 +32,9 @@
     </joystick>
   </Home>
 
-  <MyPictures>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">ParentDir</button>
-    </joystick>
-  </MyPictures>
-
-  <MyMusicPlaylist>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Playlist</button>
-    </joystick>
-  </MyMusicPlaylist>
-
-  <MyMusicPlaylistEditor>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Playlist</button>
-    </joystick>
-  </MyMusicPlaylistEditor>
-
   <MyMusicFiles>
     <joystick name="Logitech Logitech Cordless RumblePad 2">
       <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">ParentDir</button>
       <button id="4">Queue</button>
     </joystick>
   </MyMusicFiles>
@@ -64,7 +42,6 @@
   <MyMusicLibrary>
     <joystick name="Logitech Logitech Cordless RumblePad 2">
       <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">ParentDir</button>
       <button id="4">Queue</button>
     </joystick>
   </MyMusicLibrary>
@@ -86,20 +63,6 @@
     </joystick>
   </FullscreenVideo>
 
-  <FullscreenInfo>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </FullscreenInfo>
-
-  <PlayerControls>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </PlayerControls>
-
   <Visualisation>
     <joystick name="Logitech Logitech Cordless RumblePad 2">
       <altname>Logitech Cordless RumblePad 2</altname>
@@ -116,27 +79,6 @@
       <hat    id="1" position="left">PreviousPreset</hat>
     </joystick>
   </Visualisation>
-
-  <MusicOSD>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </MusicOSD>
-
-  <VisualisationSettings>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </VisualisationSettings>
-
-  <VisualisationPresetList>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </VisualisationPresetList>
 
   <SlideShow>
     <joystick name="Logitech Logitech Cordless RumblePad 2">
@@ -160,45 +102,9 @@
     </joystick>
   </ScreenCalibration>
 
-  <SelectDialog>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </SelectDialog>
-
-  <VideoOSD>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </VideoOSD>
-
-  <OSDVideoSettings>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </OSDVideoSettings>
-
-  <OSDAudioSettings>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </OSDAudioSettings>
-
-  <VideoBookmarks>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </VideoBookmarks>
-
   <MyVideoLibrary>
     <joystick name="Logitech Logitech Cordless RumblePad 2">
       <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">ParentDir</button>
       <button id="4">Queue</button>
       <button id="5">Info</button>
     </joystick>
@@ -207,18 +113,10 @@
   <MyVideoFiles>
     <joystick name="Logitech Logitech Cordless RumblePad 2">
       <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">ParentDir</button>
       <button id="4">Queue</button>
       <button id="5">Info</button>
     </joystick>
   </MyVideoFiles>
-
-  <MyVideoPlaylist>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Playlist</button>
-    </joystick>
-  </MyVideoPlaylist>
 
   <VirtualKeyboard>
     <joystick name="Logitech Logitech Cordless RumblePad 2">
@@ -228,72 +126,9 @@
       <button id="4">Shift</button>
       <button id="5">CursorLeft</button>
       <button id="6">CursorRight</button>
-      <button id="9">Close</button>
+      <button id="9">Back</button>
       <button id="10">Enter</button>
     </joystick>
   </VirtualKeyboard>
-
-  <ContextMenu>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </ContextMenu>
-
-  <FileStackingDialog>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </FileStackingDialog>
-
-  <MusicInformation>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </MusicInformation>
-
-  <MovieInformation>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </MovieInformation>
-
-  <PictureInfo>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </PictureInfo>
-
-  <AddonInformation>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </AddonInformation>
-
-  <AddonSettings>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </AddonSettings>
-
-  <TextViewer>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </TextViewer>
-
-  <NumericInput>
-    <joystick name="Logitech Logitech Cordless RumblePad 2">
-      <altname>Logitech Cordless RumblePad 2</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </NumericInput>
 
 </keymap>

--- a/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.360.Controller.xml
@@ -38,7 +38,7 @@
   <global>
     <joystick name="Xbox 360 Wireless Receiver">
       <button id="1">Select</button> <!-- A -->
-      <button id="2">ParentDir</button> <!-- B -->
+      <button id="2">Back</button> <!-- B -->
       <button id="3"></button> <!-- X -->
       <button id="4"></button> <!-- Y -->
       <button id="5"></button> <!-- LB -->
@@ -74,9 +74,7 @@
   </MyFiles>
   <MyMusicPlaylist>
     <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">Playlist</button>
-      <button id="3">Playlist</button>
-      <button id="17">Playlist</button>
+      <button id="3">Back</button>
       <button id="5">Delete</button>
     </joystick>
   </MyMusicPlaylist>
@@ -111,9 +109,8 @@
   </FullscreenVideo>
   <FullscreenInfo>
     <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">Close</button>
       <button id="3">CodecInfo</button>
-      <button id="6">Close</button>
+      <button id="6">Back</button>
       <button id="9">OSD</button>
       <axis limit="0" id="3">AnalogRewind</axis>
       <axis limit="0" id="6">AnalogFastForward</axis>
@@ -121,8 +118,7 @@
   </FullscreenInfo>
   <PlayerControls>
     <joystick name="Xbox 360 Wireless Receiver">
-      <button id="9">Close</button>
-      <button id="17">Close</button>
+      <button id="9">Back</button>
     </joystick>
   </PlayerControls>
   <Visualisation>
@@ -143,25 +139,22 @@
   </Visualisation>
   <MusicOSD>
     <joystick name="Xbox 360 Wireless Receiver">
-      <button id="17">Close</button>
-      <button id="19">Close</button>
+      <button id="19">Back</button>
       <button id="3">CodecInfo</button>
       <button id="6">Info</button>
     </joystick>
   </MusicOSD>
   <VisualisationSettings>
     <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">Close</button>
-      <button id="3">Close</button>
-      <button id="9">Close</button>
+      <button id="3">Back</button>
+      <button id="9">Back</button>
     </joystick>
   </VisualisationSettings>
   <VisualisationPresetList>
     <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">Close</button>
-      <button id="3">Close</button>
-      <button id="5">Close</button>
-      <button id="9">Close</button>
+      <button id="3">Back</button>
+      <button id="5">Back</button>
+      <button id="9">Back</button>
     </joystick>
   </VisualisationPresetList>
   <SlideShow>
@@ -184,7 +177,6 @@
       <button id="1">NextCalibration</button>
       <button id="3">ResetCalibration</button>
       <button id="6">NextResolution</button>
-      <button id="2">PreviousMenu</button>
     </joystick>
   </ScreenCalibration>
   <GUICalibration>
@@ -192,19 +184,11 @@
       <button id="1">NextCalibration</button>
       <button id="3">ResetCalibration</button>
       <button id="6">NextResolution</button>
-      <button id="2">PreviousMenu</button>
     </joystick>
   </GUICalibration>
-  <SelectDialog>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="17">Close</button>
-    </joystick>
-  </SelectDialog>
   <VideoOSD>
     <joystick name="Xbox 360 Wireless Receiver">
-      <button id="9">Close</button>
-      <button id="17">PreviousMenu</button>
-      <button id="2">PreviousMenu</button>
+      <button id="9">Back</button>
     </joystick>
   </VideoOSD>
   <VideoMenu>
@@ -212,7 +196,6 @@
       <button id="5">AspectRatio</button>
       <button id="2">Stop</button>
       <button id="9">OSD</button>
-      <button id="17">PreviousMenu</button>
       <button id="6">Info</button>
       <button id="3">CodecInfo</button>
     </joystick>
@@ -221,27 +204,21 @@
     <joystick name="Xbox 360 Wireless Receiver">
       <button id="4"/>
       <button id="5">AspectRatio</button>
-      <button id="2">Close</button>
-      <button id="17">Close</button>
-      <button id="19">Close</button>
+      <button id="19">Back</button>
     </joystick>
   </OSDVideoSettings>
   <OSDAudioSettings>
     <joystick name="Xbox 360 Wireless Receiver">
       <button id="4"/>
       <button id="5">AspectRatio</button>
-      <button id="2">Close</button>
-      <button id="17">Close</button>
-      <button id="19">Close</button>
+      <button id="19">Back</button>
     </joystick>
   </OSDAudioSettings>
   <VideoBookmarks>
     <joystick name="Xbox 360 Wireless Receiver">
       <button id="4"/>
       <button id="5">Delete</button>
-      <button id="2">Close</button>
-      <button id="17">Close</button>
-      <button id="19">Close</button>
+      <button id="19">Back</button>
     </joystick>
   </VideoBookmarks>
   <MyVideoLibrary>
@@ -258,9 +235,7 @@
   <MyVideoPlaylist>
     <joystick name="Xbox 360 Wireless Receiver">
       <button id="5">Delete</button>
-      <button id="3">Playlist</button>
-      <button id="17">Playlist</button>
-      <button id="2">Playlist</button>
+      <button id="3">Back</button>
     </joystick>
   </MyVideoPlaylist>
   <VirtualKeyboard>
@@ -273,8 +248,7 @@
   </VirtualKeyboard>
   <ContextMenu>
     <joystick name="Xbox 360 Wireless Receiver">
-      <button id="6">Close</button>
-      <button id="2">Close</button>
+      <button id="6">Back</button>
     </joystick>
   </ContextMenu>
   <Scripts>
@@ -293,113 +267,14 @@
       <button id="9">Stop</button>      <!-- Enter Password -->
     </joystick>
   </GamepadInput>
-  <Weather>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </Weather>
-  <Settings>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </Settings>
-  <AddonInformation>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">Close</button>
-    </joystick>
-  </AddonInformation>
-  <AddonSettings>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">Close</button>
-    </joystick>
-  </AddonSettings>
-  <TextViewer>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">Close</button>
-    </joystick>
-  </TextViewer>
-  <MyPicturesSettings>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </MyPicturesSettings>
-  <MyProgramsSettings>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </MyProgramsSettings>
-  <MyWeatherSettings>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </MyWeatherSettings>
-  <MyMusicSettings>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </MyMusicSettings>
-  <SystemSettings>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </SystemSettings>
-  <MyVideosSettings>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </MyVideosSettings>
-  <NetworkSettings>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </NetworkSettings>
-  <AppearanceSettings>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </AppearanceSettings>
-  <Profiles>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </Profiles>
-  <systeminfo>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </systeminfo>
-  <shutdownmenu>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </shutdownmenu>
-  <submenu>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </submenu>
-  <MusicInformation>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">Close</button>
-    </joystick>
-  </MusicInformation>
-  <MovieInformation>
-    <joystick name="Xbox 360 Wireless Receiver">
-      <button id="2">Close</button>
-    </joystick>
-  </MovieInformation>
   <LockSettings>
     <joystick name="Xbox 360 Wireless Receiver">
-      <button id="9">Close</button>
-      <button id="2">PreviousMenu</button>
-      <button id="17">PreviousMenu</button>
+      <button id="9">Back</button>
     </joystick>
   </LockSettings>
   <ProfileSettings>
     <joystick name="Xbox 360 Wireless Receiver">
-      <button id="9">Close</button>
-      <button id="2">PreviousMenu</button>
-      <button id="17">PreviousMenu</button>
+      <button id="9">Back</button>
     </joystick>
   </ProfileSettings>
 </keymap>

--- a/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
+++ b/system/keymaps/joystick.Microsoft.Xbox.Controller.S.xml
@@ -41,7 +41,7 @@
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
       <button id="1">Select</button>
-      <button id="2">ParentDir</button>
+      <button id="2">Back</button>
       <button id="3"/>
       <button id="4">FullScreen</button>
       <button id="5">Queue</button>
@@ -86,9 +86,7 @@
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">Playlist</button>
-      <button id="3">Playlist</button>
-      <button id="17">Playlist</button>
+      <button id="3">Back</button>
       <button id="5">Delete</button>
     </joystick>
   </MyMusicPlaylist>
@@ -135,9 +133,8 @@
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">Close</button>
       <button id="3">CodecInfo</button>
-      <button id="6">Close</button>
+      <button id="6">Back</button>
       <button id="9">OSD</button>
       <axis limit="0" id="3">AnalogRewind</axis>
       <axis limit="0" id="6">AnalogFastForward</axis>
@@ -148,8 +145,7 @@
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="9">Close</button>
-      <button id="17">Close</button>
+      <button id="9">Back</button>
     </joystick>
   </PlayerControls>
   <Visualisation>
@@ -176,8 +172,7 @@
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="17">Close</button>
-      <button id="19">Close</button>
+      <button id="19">Back</button>
       <button id="3">CodecInfo</button>
       <button id="6">Info</button>
     </joystick>
@@ -187,9 +182,8 @@
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">Close</button>
-      <button id="3">Close</button>
-      <button id="9">Close</button>
+      <button id="3">Back</button>
+      <button id="9">Back</button>
     </joystick>
   </VisualisationSettings>
   <VisualisationPresetList>
@@ -197,10 +191,9 @@
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">Close</button>
-      <button id="3">Close</button>
-      <button id="5">Close</button>
-      <button id="9">Close</button>
+      <button id="3">Back</button>
+      <button id="5">Back</button>
+      <button id="9">Back</button>
     </joystick>
   </VisualisationPresetList>
   <SlideShow>
@@ -229,7 +222,6 @@
       <button id="1">NextCalibration</button>
       <button id="3">ResetCalibration</button>
       <button id="6">NextResolution</button>
-      <button id="2">PreviousMenu</button>
     </joystick>
   </ScreenCalibration>
   <GUICalibration>
@@ -240,25 +232,14 @@
       <button id="1">NextCalibration</button>
       <button id="3">ResetCalibration</button>
       <button id="6">NextResolution</button>
-      <button id="2">PreviousMenu</button>
     </joystick>
   </GUICalibration>
-  <SelectDialog>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="17">Close</button>
-    </joystick>
-  </SelectDialog>
   <VideoOSD>
     <joystick name="Microsoft Xbox Controller S">
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="9">Close</button>
-      <button id="17">PreviousMenu</button>
-      <button id="2">PreviousMenu</button>
+      <button id="9">Back</button>
     </joystick>
   </VideoOSD>
   <VideoMenu>
@@ -269,7 +250,6 @@
       <button id="5">AspectRatio</button>
       <button id="2">Stop</button>
       <button id="9">OSD</button>
-      <button id="17">PreviousMenu</button>
       <button id="6">Info</button>
       <button id="3">CodecInfo</button>
     </joystick>
@@ -281,9 +261,7 @@
       <altname>Microsoft X-Box pad (Japan)</altname> 
       <button id="4"/>
       <button id="5">AspectRatio</button>
-      <button id="2">Close</button>
-      <button id="17">Close</button>
-      <button id="19">Close</button>
+      <button id="19">Back</button>
     </joystick>
   </OSDVideoSettings>
   <OSDAudioSettings>
@@ -293,9 +271,7 @@
       <altname>Microsoft X-Box pad (Japan)</altname> 
       <button id="4"/>
       <button id="5">AspectRatio</button>
-      <button id="2">Close</button>
-      <button id="17">Close</button>
-      <button id="19">Close</button>
+      <button id="19">Back</button>
     </joystick>
   </OSDAudioSettings>
   <VideoBookmarks>
@@ -305,9 +281,7 @@
       <altname>Microsoft X-Box pad (Japan)</altname> 
       <button id="4"/>
       <button id="5">Delete</button>
-      <button id="2">Close</button>
-      <button id="17">Close</button>
-      <button id="19">Close</button>
+      <button id="19">Back</button>
     </joystick>
   </VideoBookmarks>
   <MyVideoLibrary>
@@ -333,9 +307,7 @@
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
       <button id="5">Delete</button>
-      <button id="3">Playlist</button>
-      <button id="17">Playlist</button>
-      <button id="2">Playlist</button>
+      <button id="3">Back</button>
     </joystick>
   </MyVideoPlaylist>
   <VirtualKeyboard>
@@ -354,8 +326,7 @@
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="6">Close</button>
-      <button id="2">Close</button>
+      <button id="6">Back</button>
     </joystick>
   </ContextMenu>
   <Scripts>
@@ -383,166 +354,12 @@
       <button id="9">Stop</button>      <!-- Enter Password -->
     </joystick>
   </GamepadInput>
-  <Weather>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </Weather>
-  <Settings>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </Settings>
-  <AddonInformation>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">Close</button>
-    </joystick>
-  </AddonInformation>
-  <AddonSettings>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">Close</button>
-    </joystick>
-  </AddonSettings>
-  <TextViewer>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">Close</button>
-    </joystick>
-  </TextViewer>
-  <MyPicturesSettings>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </MyPicturesSettings>
-  <MyProgramsSettings>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </MyProgramsSettings>
-  <MyWeatherSettings>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </MyWeatherSettings>
-  <MyMusicSettings>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </MyMusicSettings>
-  <SystemSettings>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </SystemSettings>
-  <MyVideosSettings>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </MyVideosSettings>
-  <NetworkSettings>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </NetworkSettings>
-  <AppearanceSettings>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </AppearanceSettings>
-  <Profiles>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </Profiles>
-  <systeminfo>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </systeminfo>
-  <shutdownmenu>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </shutdownmenu>
-  <submenu>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">PreviousMenu</button>
-    </joystick>
-  </submenu>
-  <MusicInformation>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">Close</button>
-    </joystick>
-  </MusicInformation>
-  <MovieInformation>
-    <joystick name="Microsoft Xbox Controller S">
-      <altname>Mad Catz MicroCON</altname>
-      <altname>Logitech Xbox Cordless Controller</altname>
-      <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="2">Close</button>
-    </joystick>
-  </MovieInformation>
   <LockSettings>
     <joystick name="Microsoft Xbox Controller S">
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="9">Close</button>
-      <button id="2">PreviousMenu</button>
-      <button id="17">PreviousMenu</button>
+      <button id="9">Back</button>
     </joystick>
   </LockSettings>
   <ProfileSettings>
@@ -550,9 +367,7 @@
       <altname>Mad Catz MicroCON</altname>
       <altname>Logitech Xbox Cordless Controller</altname>
       <altname>Microsoft X-Box pad (Japan)</altname> 
-      <button id="9">Close</button>
-      <button id="2">PreviousMenu</button>
-      <button id="17">PreviousMenu</button>
+      <button id="9">Back</button>
     </joystick>
   </ProfileSettings>
 </keymap>

--- a/system/keymaps/joystick.PS3.Remote.Keyboard.xml
+++ b/system/keymaps/joystick.PS3.Remote.Keyboard.xml
@@ -41,7 +41,7 @@
       <altname>MoSart PS3 Remote Keyboard</altname>
       <button id="1">Info</button>
       <button id="2">Select</button>
-      <button id="3">ParentDir</button>
+      <button id="3">Back</button>
       <button id="4">ContextMenu</button>
       <button id="5">SkipPrevious</button>
       <button id="6">SkipNext</button>
@@ -82,19 +82,10 @@
     <joystick name="PLAYSTATION(R)3 Remote Keyboard">
       <altname>PS3 Remote Keyboard</altname>
       <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="4">Close</button>
-      <button id="3">Close</button>
+      <button id="4">Back</button>
     </joystick>
   </MusicOSD>
 
-  <FullscreenInfo>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </FullscreenInfo>
-  
   <FullscreenVideo>
     <joystick name="PLAYSTATION(R)3 Remote Keyboard">
       <altname>PS3 Remote Keyboard</altname>
@@ -116,200 +107,14 @@
       <altname>PS3 Remote Keyboard</altname>
       <altname>MoSart PS3 Remote Keyboard</altname>
       <button id="1">Info</button>
-      <button id="3">Close</button>
       <button id="4">OSD</button>
     </joystick>
   </VideoOSD>
   
-   <OSDVideoSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </OSDVideoSettings>
-  
-  <OSDAudioSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </OSDAudioSettings>
-  
-  <ContextMenu>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </ContextMenu>
-
-  <shutdownmenu>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </shutdownmenu>
-  
-  <submenu>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </submenu>
-
-    <Settings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </Settings>
-
-  <AddonInformation>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </AddonInformation>
-
-  <AddonSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </AddonSettings>
-
-  <TextViewer>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </TextViewer>
-
-  <MyPicturesSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </MyPicturesSettings>
-
-  <MyProgramsSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </MyProgramsSettings>
-
-  <MyWeatherSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </MyWeatherSettings>
-
-  <MyMusicSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </MyMusicSettings>
-
-  <SystemSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </SystemSettings>
-
-  <MyVideosSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </MyVideosSettings>
-
-  <NetworkSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </NetworkSettings>
-
-  <AppearanceSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="32">PreviousMenu</button>
-    </joystick>
-  </AppearanceSettings>
-
-  <Profiles>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </Profiles>
-
-  <systeminfo>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </systeminfo>
-
-  <MusicInformation>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </MusicInformation>
-
-  <MovieInformation>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </MovieInformation>
-
-  <LockSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </LockSettings>
-
-  <ProfileSettings>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">PreviousMenu</button>
-    </joystick>
-  </ProfileSettings>
-
   <PictureInfo>
     <joystick name="PLAYSTATION(R)3 Remote Keyboard">
       <altname>PS3 Remote Keyboard</altname>
       <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
       <hat    id="1" position="left">PreviousPicture</hat>
       <hat    id="1" position="right">NextPicture</hat>
     </joystick>
@@ -319,16 +124,9 @@
     <joystick name="PLAYSTATION(R)3 Remote Keyboard">
       <altname>PS3 Remote Keyboard</altname>
       <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="1">Close</button>
+      <button id="1">Back</button>
       <button id="4">OSD</button>
     </joystick>
   </FullscreenInfo>
 
-  <NumericInput>
-    <joystick name="PLAYSTATION(R)3 Remote Keyboard">
-      <altname>PS3 Remote Keyboard</altname>
-      <altname>MoSart PS3 Remote Keyboard</altname>
-      <button id="3">Close</button>
-    </joystick>
-  </NumericInput>
 </keymap>

--- a/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
+++ b/system/keymaps/joystick.Sony.PLAYSTATION(R)3.Controller.xml
@@ -40,7 +40,7 @@
       <altname>PS3 Controller</altname>
       <altname>Sony Computer Entertainment Wireless Controller</altname>
       <button id="15">Select</button>
-      <button id="14">ParentDir</button>
+      <button id="14">Back</button>
       <button id="16">FullScreen</button>
       <button id="13">Queue</button>
       <button id="11">PreviousMenu</button>

--- a/system/keymaps/joystick.WiiRemote.xml
+++ b/system/keymaps/joystick.WiiRemote.xml
@@ -42,7 +42,7 @@
       <button id="3">Left</button>
       <button id="4">Right</button>
       <button id="5">Select</button>
-      <button id="6">PreviousMenu</button>
+      <button id="6">Back</button>
       <button id="7">VolumeDown</button>
       <button id="8">XBMC.ActivateWindow(Home)</button>
       <button id="9">VolumeUp</button>
@@ -59,7 +59,6 @@
   </Home>
   <MyFiles>
     <joystick name="WiiRemote">
-      <button id="6">ParentDir</button>
       <button id="7">Move</button>
       <button id="9">Copy</button>
       <button id="11">Highlight</button>
@@ -67,7 +66,6 @@
   </MyFiles>
   <MyMusicPlaylist>
     <joystick name="WiiRemote">
-      <button id="6">Playlist</button>
       <button id="7">MoveItemUp</button>
       <button id="9">MoveItemDown</button>
       <button id="11">Delete</button>
@@ -75,7 +73,6 @@
   </MyMusicPlaylist>
   <MyMusicPlaylistEditor>
     <joystick name="WiiRemote">
-      <button id="6">Playlist</button>
       <button id="7">MoveItemUp</button>
       <button id="9">MoveItemDown</button>
       <button id="11">Delete</button>
@@ -83,13 +80,11 @@
   </MyMusicPlaylistEditor>
   <MyMusicFiles>
     <joystick name="WiiRemote">
-      <button id="6">ParentDir</button>
       <button id="11">Playlist</button>
     </joystick>
   </MyMusicFiles>
   <MyMusicLibrary>
     <joystick name="WiiRemote">
-      <button id="6">ParentDir</button>
       <button id="11">Playlist</button>
     </joystick>
   </MyMusicLibrary>
@@ -108,14 +103,8 @@
   <FullscreenInfo>
     <joystick name="WiiRemote">
       <button id="5">CodecInfo</button>
-      <button id="6">Close</button>
     </joystick>
   </FullscreenInfo>
-  <PlayerControls>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </PlayerControls>
   <Visualisation>
     <joystick name="WiiRemote">
       <button id="1">Pause</button>
@@ -131,23 +120,16 @@
   </Visualisation>
   <MusicOSD>
     <joystick name="WiiRemote">
-      <button id="6">Close</button>
       <button id="10">CodecInfo</button>
       <button id="11">Info</button>
     </joystick>
   </MusicOSD>
   <VisualisationSettings>
     <joystick name="WiiRemote">
-      <button id="6">Close</button>
       <button id="10">XBMC.ActivateWindow(VisualisationPresetList)</button>
       <button id="11">XBMC.ActivateWindow(MusicPlaylist)</button>
     </joystick>
   </VisualisationSettings>
-  <VisualisationPresetList>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </VisualisationPresetList>
   <SlideShow>
     <joystick name="WiiRemote">
       <button id="1">Pause</button>
@@ -167,16 +149,6 @@
       <button id="11">ResetResolution</button>
     </joystick>
   </ScreenCalibration>
-  <SelectDialog>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </SelectDialog>
-  <VideoOSD>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </VideoOSD>
   <VideoMenu>
     <joystick name="WiiRemote">
       <button id="5">Select</button>
@@ -184,37 +156,23 @@
       <button id="11">AspectRatio</button>
     </joystick>
   </VideoMenu>
-  <OSDVideoSettings>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </OSDVideoSettings>
-  <OSDAudioSettings>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </OSDAudioSettings>
   <VideoBookmarks>
     <joystick name="WiiRemote">
-      <button id="6">Close</button>
       <button id="11">Delete</button>
     </joystick>
   </VideoBookmarks>
   <MyVideoLibrary>
     <joystick name="WiiRemote">
-      <button id="6">ParentDir</button>
       <button id="11">Playlist</button>
     </joystick>
   </MyVideoLibrary>
   <MyVideoFiles>
     <joystick name="WiiRemote">
-      <button id="6">ParentDir</button>
       <button id="11">Playlist</button>
     </joystick>
   </MyVideoFiles>
   <MyVideoPlaylist>
     <joystick name="WiiRemote">
-      <button id="6">Playlist</button>
       <button id="7">MoveItemDown</button>
       <button id="9">MoveItemUp</button>
       <button id="11">Delete</button>
@@ -229,11 +187,6 @@
       <button id="11">BackSpace</button>
     </joystick>
   </VirtualKeyboard>
-  <ContextMenu>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </ContextMenu>
   <Scripts>
     <joystick name="WiiRemote">
       <button id="11">info</button>
@@ -247,46 +200,10 @@
       <button id="11">BackSpace</button>
     </joystick>
   </NumericInput>
-  <MusicInformation>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </MusicInformation>
-  <MovieInformation>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </MovieInformation>
   <PictureInfo>
     <joystick name="WiiRemote">
       <button id="3">PreviousPicture</button>
       <button id="4">NextPicture</button>
-      <button id="6">Close</button>
     </joystick>
   </PictureInfo>
-  <MyPictures>
-    <joystick name="WiiRemote">
-      <button id="6">ParentDir</button>
-    </joystick>
-  </MyPictures>
-  <AddonBrowser>
-    <joystick name="WiiRemote">
-      <button id="6">ParentDir</button>
-    </joystick>
-  </AddonBrowser>
-  <AddonInformation>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </AddonInformation>
-  <AddonSettings>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </AddonSettings>
-  <TextViewer>
-    <joystick name="WiiRemote">
-      <button id="6">Close</button>
-    </joystick>
-  </TextViewer>
 </keymap>

--- a/system/keymaps/keyboard.nyxboard.xml
+++ b/system/keymaps/keyboard.nyxboard.xml
@@ -38,7 +38,8 @@
       <pagedown>PageDown</pagedown>
       <return>Select</return>
       <enter>Select</enter>
-      <backspace>ParentDir</backspace>
+      <backspace>Back</backspace>
+      <key id='65446'>Back</key>
       <m>ActivateWindow(PlayerControls)</m>
       <s>ActivateWindow(shutdownmenu)</s>
       <escape>PreviousMenu</escape>
@@ -125,11 +126,10 @@
   </MyFiles>
   <MyMusicPlaylist>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <space>Playlist</space>      <!-- Close playlist -->
+      <space>Back</space>
       <delete>Delete</delete>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>
-      <backspace>Playlist</backspace>      <!-- Close playlist -->
     </keyboard>
   </MyMusicPlaylist>
   <MyMusicPlaylistEditor>
@@ -190,17 +190,15 @@
       <f>FastForward</f>
       <r>Rewind</r>
       <period>StepForward</period>
-      <backspace>Close</backspace>
       <o>CodecInfo</o>
-      <i>Close</i>
-      <d mod="ctrl">Close</d>
+      <i>Back</i>
+      <d mod="ctrl">Back</d>
       <m>OSD</m>
     </keyboard>
   </FullscreenInfo>
   <PlayerControls>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <escape>Close</escape>
-      <m>close</m>
+      <m>Back</m>
     </keyboard>
   </PlayerControls>
   <Visualisation>
@@ -227,12 +225,11 @@
   </Visualisation>
   <MusicOSD>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <escape>Close</escape>
       <f>FastForward</f>
       <r>Rewind</r>
       <period>SkipNext</period>
       <comma>SkipPrevious</comma>
-      <m>Close</m>
+      <m>Back</m>
       <i>Info</i>
       <o>CodecInfo</o>
       <p>ActivateWindow(VisualisationPresetList)</p>
@@ -242,31 +239,29 @@
   </MusicOSD>
   <VisualisationSettings>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <escape>Close</escape>
       <f>FastForward</f>
       <r>Rewind</r>
       <period>SkipNext</period>
       <comma>SkipPrevious</comma>
-      <m>Close</m>
+      <m>Back</m>
       <i>Info</i>
       <o>CodecInfo</o>
       <p>ActivateWindow(VisualisationPresetList)</p>
-      <v>Close</v>
+      <v>Back</v>
       <n>ActivateWindow(MusicPlaylist)</n>
     </keyboard>
   </VisualisationSettings>
   <VisualisationPresetList>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <escape>Close</escape>
       <f>FastForward</f>
       <r>Rewind</r>
       <period>SkipNext</period>
       <comma>SkipPrevious</comma>
-      <m>Close</m>
+      <m>Back</m>
       <i>Info</i>
       <o>CodecInfo</o>
-      <p>Close</p>
-      <v>Close</v>
+      <p>Back</p>
+      <v>Back</v>
       <n>ActivateWindow(MusicPlaylist)</n>
     </keyboard>
   </VisualisationPresetList>
@@ -289,7 +284,6 @@
       <plus>ZoomIn</plus>
       <minus>ZoomOut</minus>
       <r>Rotate</r>
-      <backspace>PreviousMenu</backspace>
     </keyboard>
   </SlideShow>
   <ScreenCalibration>
@@ -307,18 +301,10 @@
       <d>ResetCalibration</d>
     </keyboard>
   </GUICalibration>
-  <SelectDialog>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-      <escape>Close</escape>
-    </keyboard>
-  </SelectDialog>
   <VideoOSD>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-      <escape>Close</escape>
-      <m>Close</m>
-      <g mod="ctrl">close</g> <!-- MCE Guide button -->
+      <m>Back</m>
+      <g mod="ctrl">Back</g> <!-- MCE Guide button -->
       <i>Info</i>
       <o>CodecInfo</o>
     </keyboard>
@@ -337,29 +323,22 @@
       <escape>Fullscreen</escape>
       <return>Select</return>
       <enter>Select</enter>      <!-- backspace>Fullscreen</backspace -->
-      <backspace>PreviousMenu</backspace>
     </keyboard>
   </VideoMenu>
   <OSDVideoSettings>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-      <escape>Close</escape>
       <i>Info</i>
       <o>CodecInfo</o>
     </keyboard>
   </OSDVideoSettings>
   <OSDAudioSettings>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-      <escape>Close</escape>
       <i>Info</i>
       <o>CodecInfo</o>
     </keyboard>
   </OSDAudioSettings>
   <VideoBookmarks>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-      <escape>Close</escape>
       <delete>Delete</delete>
     </keyboard>
   </VideoBookmarks>
@@ -379,8 +358,7 @@
   </MyVideoFiles>
   <MyVideoPlaylist>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Playlist</backspace>      <!-- Close playlist -->
-      <space>Playlist</space>      <!-- Close playlist -->
+      <space>Back</space>
       <delete>Delete</delete>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>
@@ -393,163 +371,46 @@
   </MyPictures>
   <ContextMenu>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <c>Close</c>
-      <menu>Close</menu>
-      <backspace>Close</backspace>
+      <c>Back</c>
+      <menu>Back</menu>
     </keyboard>
   </ContextMenu>
-  <FileStackingDialog>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-    </keyboard>
-  </FileStackingDialog>
   <Scripts>
     <keyboard name="Motorola Nyxboard Hybrid">
       <i>info</i>
     </keyboard>
   </Scripts>
-  <Weather>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-      <key id='65446'>PreviousMenu</key>
-    </keyboard>
-  </Weather>
-  <Settings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </Settings>
-  <MyPicturesSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </MyPicturesSettings>
-  <MyProgramsSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </MyProgramsSettings>
-  <MyWeatherSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </MyWeatherSettings>
-  <MyMusicSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </MyMusicSettings>
-  <SystemSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </SystemSettings>
-  <MyVideosSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </MyVideosSettings>
-  <NetworkSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </NetworkSettings>
-  <AppearanceSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </AppearanceSettings>
-  <Profiles>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </Profiles>
-  <systeminfo>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </systeminfo>
   <shutdownmenu>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-      <s>Close</s>  
+      <s>Back</s>  
     </keyboard>
   </shutdownmenu>
-  <submenu>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </submenu>
   <MusicInformation>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-      <i>Close</i>
-      <d mod="ctrl">Close</d>
-      <key id='65446'>Close</key>
+      <i>Back</i>
+      <d mod="ctrl">Back</d>
     </keyboard>
   </MusicInformation>
   <MovieInformation>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-      <i>Close</i>
-      <key id='65446'>Close</key>
+      <i>Back</i>
     </keyboard>
   </MovieInformation>
-  <AddonInformation>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-    </keyboard>
-  </AddonInformation>
-  <AddonSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-    </keyboard>
-  </AddonSettings>
-  <TextViewer>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-    </keyboard>
-  </TextViewer>
-  <LockSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <escape>Close</escape>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </LockSettings>
-  <ProfileSettings>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <escape>Close</escape>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </ProfileSettings>
   <PictureInfo>
     <keyboard name="Motorola Nyxboard Hybrid">
       <period>NextPicture</period>
       <comma>PreviousPicture</comma>
-      <i>Close</i>
-      <d mod="ctrl">Close</d>
-      <o>Close</o>
-      <backspace>Close</backspace>
+      <i>Back</i>
+      <d mod="ctrl">Back</d>
+      <o>Back</o>
       <space>Pause</space>
     </keyboard>
   </PictureInfo>
   <Teletext>
     <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-      <escape>Close</escape>
-      <v>Close</v>
+      <v>Back</v>
     </keyboard>
   </Teletext>
-  <Favourites>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-    </keyboard>
-  </Favourites>
-  <NumericInput>
-    <keyboard name="Motorola Nyxboard Hybrid">
-      <backspace>Close</backspace>
-    </keyboard>
-  </NumericInput>
   <FileBrowser>
     <keyboard name="Motorola Nyxboard Hybrid">
       <space>Highlight</space>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -233,14 +233,14 @@
       <r>Rewind</r>
       <period>StepForward</period>
       <o>CodecInfo</o>
-      <i>Close</i>
-      <d mod="ctrl">Close</d>
+      <i>Back</i>
+      <d mod="ctrl">Back</d>
       <m>OSD</m>
     </keyboard>
   </FullscreenInfo>
   <PlayerControls>
     <keyboard>
-      <m>close</m>
+      <m>Back</m>
     </keyboard>
   </PlayerControls>
   <Visualisation>
@@ -271,7 +271,7 @@
       <r>Rewind</r>
       <period>SkipNext</period>
       <comma>SkipPrevious</comma>
-      <m>Close</m>
+      <m>Back</m>
       <i>Info</i>
       <o>CodecInfo</o>
       <p>ActivateWindow(VisualisationPresetList)</p>
@@ -285,11 +285,11 @@
       <r>Rewind</r>
       <period>SkipNext</period>
       <comma>SkipPrevious</comma>
-      <m>Close</m>
+      <m>Back</m>
       <i>Info</i>
       <o>CodecInfo</o>
       <p>ActivateWindow(VisualisationPresetList)</p>
-      <v>Close</v>
+      <v>Back</v>
       <n>ActivateWindow(MusicPlaylist)</n>
     </keyboard>
   </VisualisationSettings>
@@ -299,11 +299,11 @@
       <r>Rewind</r>
       <period>SkipNext</period>
       <comma>SkipPrevious</comma>
-      <m>Close</m>
+      <m>Back</m>
       <i>Info</i>
       <o>CodecInfo</o>
-      <p>Close</p>
-      <v>Close</v>
+      <p>Back</p>
+      <v>Back</v>
       <n>ActivateWindow(MusicPlaylist)</n>
     </keyboard>
   </VisualisationPresetList>
@@ -345,8 +345,8 @@
   </GUICalibration>
   <VideoOSD>
     <keyboard>
-      <m>Close</m>
-      <g mod="ctrl">close</g> <!-- MCE Guide button -->
+      <m>Back</m>
+      <g mod="ctrl">Back</g> <!-- MCE Guide button -->
       <i>Info</i>
       <o>CodecInfo</o>
     </keyboard>
@@ -413,8 +413,8 @@
   </MyPictures>
   <ContextMenu>
     <keyboard>
-      <c>Close</c>
-      <menu>Close</menu>
+      <c>Back</c>
+      <menu>Back</menu>
     </keyboard>
   </ContextMenu>
   <Scripts>
@@ -424,28 +424,28 @@
   </Scripts>
   <MusicInformation>
     <keyboard>
-      <i>Close</i>
-      <d mod="ctrl">Close</d>
+      <i>Back</i>
+      <d mod="ctrl">Back</d>
     </keyboard>
   </MusicInformation>
   <MovieInformation>
     <keyboard>
-      <i>Close</i>
+      <i>Back</i>
     </keyboard>
   </MovieInformation>
   <PictureInfo>
     <keyboard>
       <period>NextPicture</period>
       <comma>PreviousPicture</comma>
-      <i>Close</i>
-      <d mod="ctrl">Close</d>
-      <o>Close</o>
+      <i>Back</i>
+      <d mod="ctrl">Back</d>
+      <o>Back</o>
       <space>Pause</space>
     </keyboard>
   </PictureInfo>
   <Teletext>
     <keyboard>
-      <v>Close</v>
+      <v>Back</v>
     </keyboard>
   </Teletext>
   <FileBrowser>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -168,7 +168,7 @@
   </MyFiles>
   <MyMusicPlaylist>
     <keyboard>
-      <space>Playlist</space>      <!-- Close playlist -->
+      <space>Back</space>
       <delete>Delete</delete>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>
@@ -400,7 +400,7 @@
   </MyVideoFiles>
   <MyVideoPlaylist>
     <keyboard>
-      <space>Playlist</space>      <!-- Close playlist -->
+      <space>Back</space>
       <delete>Delete</delete>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -51,7 +51,8 @@
       <pagedown>PageDown</pagedown>
       <return>Select</return>
       <enter>Select</enter>
-      <backspace>ParentDir</backspace>
+      <backspace>Back</backspace>
+      <key id='65446'>Back</key>
       <m>ActivateWindow(PlayerControls)</m>
       <s>ActivateWindow(shutdownmenu)</s>
       <escape>PreviousMenu</escape>
@@ -93,7 +94,7 @@
       <home>FirstPage</home>
       <end>LastPage</end>
       <!-- Multimedia keyboard keys -->
-      <browser_back>ParentDir</browser_back>
+      <browser_back>Back</browser_back>
       <browser_forward/>
       <browser_refresh/>
       <browser_stop/>
@@ -171,7 +172,6 @@
       <delete>Delete</delete>
       <u>MoveItemUp</u>
       <d>MoveItemDown</d>
-      <backspace>Playlist</backspace>      <!-- Close playlist -->
     </keyboard>
   </MyMusicPlaylist>
   <MyMusicPlaylistEditor>
@@ -232,7 +232,6 @@
       <f>FastForward</f>
       <r>Rewind</r>
       <period>StepForward</period>
-      <backspace>Close</backspace>
       <o>CodecInfo</o>
       <i>Close</i>
       <d mod="ctrl">Close</d>
@@ -241,7 +240,6 @@
   </FullscreenInfo>
   <PlayerControls>
     <keyboard>
-      <escape>Close</escape>
       <m>close</m>
     </keyboard>
   </PlayerControls>
@@ -269,7 +267,6 @@
   </Visualisation>
   <MusicOSD>
     <keyboard>
-      <escape>Close</escape>
       <f>FastForward</f>
       <r>Rewind</r>
       <period>SkipNext</period>
@@ -284,7 +281,6 @@
   </MusicOSD>
   <VisualisationSettings>
     <keyboard>
-      <escape>Close</escape>
       <f>FastForward</f>
       <r>Rewind</r>
       <period>SkipNext</period>
@@ -299,7 +295,6 @@
   </VisualisationSettings>
   <VisualisationPresetList>
     <keyboard>
-      <escape>Close</escape>
       <f>FastForward</f>
       <r>Rewind</r>
       <period>SkipNext</period>
@@ -331,7 +326,6 @@
       <plus>ZoomIn</plus>
       <minus>ZoomOut</minus>
       <r>Rotate</r>
-      <backspace>PreviousMenu</backspace>
     </keyboard>
   </SlideShow>
   <ScreenCalibration>
@@ -349,16 +343,8 @@
       <d>ResetCalibration</d>
     </keyboard>
   </GUICalibration>
-  <SelectDialog>
-    <keyboard>
-      <backspace>Close</backspace>
-      <escape>Close</escape>
-    </keyboard>
-  </SelectDialog>
   <VideoOSD>
     <keyboard>
-      <backspace>Close</backspace>
-      <escape>Close</escape>
       <m>Close</m>
       <g mod="ctrl">close</g> <!-- MCE Guide button -->
       <i>Info</i>
@@ -379,29 +365,22 @@
       <escape>Fullscreen</escape>
       <return>Select</return>
       <enter>Select</enter>      <!-- backspace>Fullscreen</backspace -->
-      <backspace>PreviousMenu</backspace>
     </keyboard>
   </VideoMenu>
   <OSDVideoSettings>
     <keyboard>
-      <backspace>Close</backspace>
-      <escape>Close</escape>
       <i>Info</i>
       <o>CodecInfo</o>
     </keyboard>
   </OSDVideoSettings>
   <OSDAudioSettings>
     <keyboard>
-      <backspace>Close</backspace>
-      <escape>Close</escape>
       <i>Info</i>
       <o>CodecInfo</o>
     </keyboard>
   </OSDAudioSettings>
   <VideoBookmarks>
     <keyboard>
-      <backspace>Close</backspace>
-      <escape>Close</escape>
       <delete>Delete</delete>
     </keyboard>
   </VideoBookmarks>
@@ -421,7 +400,6 @@
   </MyVideoFiles>
   <MyVideoPlaylist>
     <keyboard>
-      <backspace>Playlist</backspace>      <!-- Close playlist -->
       <space>Playlist</space>      <!-- Close playlist -->
       <delete>Delete</delete>
       <u>MoveItemUp</u>
@@ -437,133 +415,24 @@
     <keyboard>
       <c>Close</c>
       <menu>Close</menu>
-      <backspace>Close</backspace>
     </keyboard>
   </ContextMenu>
-  <FileStackingDialog>
-    <keyboard>
-      <backspace>Close</backspace>
-    </keyboard>
-  </FileStackingDialog>
   <Scripts>
     <keyboard>
       <i>info</i>
     </keyboard>
   </Scripts>
-  <Weather>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-      <key id='65446'>PreviousMenu</key>
-    </keyboard>
-  </Weather>
-  <Settings>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </Settings>
-  <MyPicturesSettings>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </MyPicturesSettings>
-  <MyProgramsSettings>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </MyProgramsSettings>
-  <MyWeatherSettings>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </MyWeatherSettings>
-  <MyMusicSettings>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </MyMusicSettings>
-  <SystemSettings>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </SystemSettings>
-  <MyVideosSettings>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </MyVideosSettings>
-  <NetworkSettings>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </NetworkSettings>
-  <AppearanceSettings>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </AppearanceSettings>
-  <Profiles>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </Profiles>
-  <systeminfo>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </systeminfo>
-  <shutdownmenu>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-      <s>Close</s>  
-    </keyboard>
-  </shutdownmenu>
-  <submenu>
-    <keyboard>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </submenu>
   <MusicInformation>
     <keyboard>
-      <backspace>Close</backspace>
       <i>Close</i>
       <d mod="ctrl">Close</d>
-      <key id='65446'>Close</key>
     </keyboard>
   </MusicInformation>
   <MovieInformation>
     <keyboard>
-      <backspace>Close</backspace>
       <i>Close</i>
-      <key id='65446'>Close</key>
     </keyboard>
   </MovieInformation>
-  <AddonInformation>
-    <keyboard>
-      <backspace>Close</backspace>
-    </keyboard>
-  </AddonInformation>
-  <AddonSettings>
-    <keyboard>
-      <backspace>Close</backspace>
-    </keyboard>
-  </AddonSettings>
-  <TextViewer>
-    <keyboard>
-      <backspace>Close</backspace>
-    </keyboard>
-  </TextViewer>
-  <LockSettings>
-    <keyboard>
-      <escape>Close</escape>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </LockSettings>
-  <ProfileSettings>
-    <keyboard>
-      <escape>Close</escape>
-      <backspace>PreviousMenu</backspace>
-    </keyboard>
-  </ProfileSettings>
   <PictureInfo>
     <keyboard>
       <period>NextPicture</period>
@@ -571,27 +440,14 @@
       <i>Close</i>
       <d mod="ctrl">Close</d>
       <o>Close</o>
-      <backspace>Close</backspace>
       <space>Pause</space>
     </keyboard>
   </PictureInfo>
   <Teletext>
     <keyboard>
-      <backspace>Close</backspace>
-      <escape>Close</escape>
       <v>Close</v>
     </keyboard>
   </Teletext>
-  <Favourites>
-    <keyboard>
-      <backspace>Close</backspace>
-    </keyboard>
-  </Favourites>
-  <NumericInput>
-    <keyboard>
-      <backspace>Close</backspace>
-    </keyboard>
-  </NumericInput>
   <FileBrowser>
     <keyboard>
       <space>Highlight</space>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -50,7 +50,7 @@
       <enter>FullScreen</enter> 
       <pageplus>PageUp</pageplus>
       <pageminus>PageDown</pageminus>
-      <back>ParentDir</back>
+      <back>Back</back>
       <menu>PreviousMenu</menu>
       <title>ContextMenu</title>
       <info>Info</info>
@@ -100,7 +100,6 @@
   </MyFiles>
   <MyMusicPlaylist>
     <remote>
-      <back>Playlist</back>      <!-- Close playlist -->
       <clear>Delete</clear>
       <zero>Delete</zero>
     </remote>
@@ -160,13 +159,13 @@
   <FullscreenInfo>
     <remote>
       <title>CodecInfo</title>
-      <info>Close</info>
+      <info>Back</info>
       <menu>OSD</menu>
     </remote>
   </FullscreenInfo>
   <PlayerControls>
     <remote>
-      <menu>Close</menu>
+      <menu>Back</menu>
     </remote>
   </PlayerControls>
   <Visualisation>
@@ -185,21 +184,19 @@
   </Visualisation>
   <MusicOSD>
     <remote>
-      <menu>Close</menu>
+      <menu>Back</menu>
       <title>Info</title>
       <info>CodecInfo</info>
     </remote>
   </MusicOSD>
   <VisualisationSettings>
     <remote>
-      <menu>Close</menu>
-      <back>Close</back>
+      <menu>Back</menu>
     </remote>
   </VisualisationSettings>
   <VisualisationPresetList>
     <remote>
-      <menu>Close</menu>
-      <back>Close</back>
+      <menu>Back</menu>
     </remote>
   </VisualisationPresetList>
   <SlideShow>
@@ -219,7 +216,6 @@
       <skipminus>PreviousPicture</skipminus>
       <title>Info</title>
       <select>Rotate</select>
-      <back>PreviousMenu</back>
     </remote>
   </SlideShow>
   <ScreenCalibration>
@@ -236,22 +232,15 @@
       <zero>ResetCalibration</zero>
     </remote>
   </GUICalibration>
-  <SelectDialog>
-    <remote>
-      <back>Close</back>
-    </remote>
-  </SelectDialog>
   <VideoOSD>
     <remote>
-      <back>PreviousMenu</back>
-      <menu>Close</menu>
-      <start>Close</start>
+      <menu>Back</menu>
+      <start>Back</start>
     </remote>
   </VideoOSD>
   <VideoMenu>
     <remote>
       <menu>OSD</menu>
-      <back>PreviousMenu</back>
       <info>Info</info>
       <title>CodecInfo</title>
       <zero>Number0</zero>
@@ -269,23 +258,20 @@
   </VideoMenu>
   <OSDVideoSettings>
     <remote>
-      <back>Close</back>
-      <menu>Close</menu>
-      <start>Close</start>
+      <menu>Back</menu>
+      <start>Back</start>
     </remote>
   </OSDVideoSettings>
   <OSDAudioSettings>
     <remote>
-      <back>Close</back>
-      <menu>Close</menu>
-      <start>Close</start>
+      <menu>Back</menu>
+      <start>Back</start>
     </remote>
   </OSDAudioSettings>
   <VideoBookmarks>
     <remote>
-      <back>Close</back>
-      <menu>Close</menu>
-      <start>Close</start>
+      <menu>Back</menu>
+      <start>Back</start>
       <zero>Delete</zero>
     </remote>
   </VideoBookmarks>
@@ -303,7 +289,6 @@
   </MyVideoFiles>
   <MyVideoPlaylist>
     <remote>
-      <back>Playlist</back>      <!-- Close playlist -->
       <clear>Delete</clear>
       <zero>Delete</zero>
     </remote>
@@ -330,15 +315,9 @@
   </VirtualKeyboard>
   <ContextMenu>
     <remote>
-      <title>Close</title>
-      <back>Close</back>
+      <title>Back</title>
     </remote>
   </ContextMenu>
-  <FileStackingDialog>
-    <remote>
-      <back>Close</back>
-    </remote>
-  </FileStackingDialog>
   <Scripts>
     <remote>
       <info>info</info>
@@ -360,125 +339,31 @@
       <back>BackSpace</back>
     </remote>
   </NumericInput>
-  <Weather>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </Weather>
-  <Settings>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </Settings>
-  <AddonBrowser>
-    <remote>
-    </remote>
-  </AddonBrowser>
-  <AddonInformation>
-    <remote>
-      <back>Close</back>
-    </remote>
-  </AddonInformation>
-  <AddonSettings>
-    <remote>
-      <back>Close</back>
-    </remote>
-  </AddonSettings>
-  <TextViewer>
-    <remote>
-      <back>Close</back>
-    </remote>
-  </TextViewer>
-  <MyPicturesSettings>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </MyPicturesSettings>
-  <MyProgramsSettings>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </MyProgramsSettings>
-  <MyWeatherSettings>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </MyWeatherSettings>
-  <MyMusicSettings>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </MyMusicSettings>
-  <SystemSettings>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </SystemSettings>
-  <MyVideosSettings>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </MyVideosSettings>
-  <NetworkSettings>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </NetworkSettings>
-  <AppearanceSettings>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </AppearanceSettings>
-  <Profiles>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </Profiles>
-  <systeminfo>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </systeminfo>
-  <shutdownmenu>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </shutdownmenu>
-  <submenu>
-    <remote>
-      <back>PreviousMenu</back>
-    </remote>
-  </submenu>
   <MusicInformation>
     <remote>
-      <back>Close</back>
-      <info>Close</info>
+      <info>Back</info>
     </remote>
   </MusicInformation>
   <MovieInformation>
     <remote>
-      <info>Close</info>
-      <back>Close</back>
+      <info>Back</info>
     </remote>
   </MovieInformation>
   <LockSettings>
     <remote>
-      <menu>Close</menu>
-      <back>PreviousMenu</back>
+      <menu>Back</menu>
     </remote>
   </LockSettings>
   <ProfileSettings>
     <remote>
-      <menu>Close</menu>
-      <back>PreviousMenu</back>
+      <menu>Back</menu>
     </remote>
   </ProfileSettings>
   <PictureInfo>
     <remote>
       <skipplus>NextPicture</skipplus>
       <skipminus>PreviousPicture</skipminus>
-      <info>Close</info>
-      <back>Close</back>
+      <info>Back</info>
     </remote>
   </PictureInfo>
   <Teletext>
@@ -498,15 +383,9 @@
       <yellow>Yellow</yellow>
       <blue>Blue</blue>
       <info>Info</info>
-      <back>Close</back>
-      <menu>Close</menu>
-      <start>Close</start>
-      <teletext>Close</teletext>
+      <menu>Back</menu>
+      <start>Back</start>
+      <teletext>Back</teletext>
     </remote>
   </Teletext>
-  <Favourites>
-    <remote>
-      <back>Close</back>
-    </remote>
-  </Favourites>
 </keymap>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2180,7 +2180,7 @@ bool CApplication::OnKey(const CKey& key)
               action.GetID() == ACTION_SELECT_ITEM ||
               action.GetID() == ACTION_ENTER ||
               action.GetID() == ACTION_PREVIOUS_MENU ||
-              action.GetID() == ACTION_CLOSE_DIALOG))
+              action.GetID() == ACTION_NAV_BACK))
         {
           // the action isn't plain navigation - check for a keyboard-specific keymap
           action = CButtonTranslator::GetInstance().GetAction(WINDOW_DIALOG_KEYBOARD, key, false);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3242,6 +3242,7 @@ bool CDVDPlayer::OnAction(const CAction &action)
         g_infoManager.SetDisplayAfterSeek();
         return true;
       case ACTION_PREVIOUS_MENU:
+      case ACTION_NAV_BACK:
         {
           THREAD_ACTION(action);
           CLog::Log(LOGDEBUG, " - menu back");

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -81,12 +81,10 @@ CGUIDialogFileBrowser::~CGUIDialogFileBrowser()
 
 bool CGUIDialogFileBrowser::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PARENT_DIR)
+  if (action.GetID() == ACTION_PARENT_DIR ||
+     (action.GetID() == ACTION_NAV_BACK && !m_vecItems->IsVirtualDirectoryRoot()))
   {
-    if (m_vecItems->IsVirtualDirectoryRoot() && g_advancedSettings.m_bUseEvilB)
-      Close();
-    else
-      GoParentFolder();
+    GoParentFolder();
     return true;
   }
   if ((action.GetID() == ACTION_CONTEXT_MENU || action.GetID() == ACTION_MOUSE_RIGHT_CLICK) && m_Directory->m_strPath.IsEmpty())

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -72,7 +72,7 @@ bool CGUIDialogGamepad::OnAction(const CAction &action)
     SetLine(2, strHiddenInput);
     return true;
   }
-  else if (action.GetButtonCode() == KEY_BUTTON_BACK || action.GetID() == ACTION_CLOSE_DIALOG || action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
+  else if (action.GetButtonCode() == KEY_BUTTON_BACK || action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
   {
     m_bConfirmed = false;
     m_bCanceled = true;

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -72,7 +72,7 @@ bool CGUIDialogGamepad::OnAction(const CAction &action)
     SetLine(2, strHiddenInput);
     return true;
   }
-  else if (action.GetButtonCode() == KEY_BUTTON_BACK || action.GetID() == ACTION_CLOSE_DIALOG || action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_PARENT_DIR)
+  else if (action.GetButtonCode() == KEY_BUTTON_BACK || action.GetID() == ACTION_CLOSE_DIALOG || action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
   {
     m_bConfirmed = false;
     m_bCanceled = true;

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -60,7 +60,8 @@ CGUIDialogMediaSource::~CGUIDialogMediaSource()
 
 bool CGUIDialogMediaSource::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
+  if (action.GetID() == ACTION_PREVIOUS_MENU ||
+      action.GetID() == ACTION_NAV_BACK)
   {
     m_confirmed = false;
   }

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -55,7 +55,7 @@ CGUIDialogNumeric::~CGUIDialogNumeric(void)
 
 bool CGUIDialogNumeric::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_CLOSE_DIALOG || action.GetID() == ACTION_PREVIOUS_MENU)
+  if (action.GetID() == ACTION_NAV_BACK || action.GetID() == ACTION_PREVIOUS_MENU)
     OnCancel();
   else if (action.GetID() == ACTION_NEXT_ITEM)
     OnNext();

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -139,7 +139,7 @@ bool CGUIDialogProgress::OnMessage(CGUIMessage& message)
 
 bool CGUIDialogProgress::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_CLOSE_DIALOG || action.GetID() == ACTION_PREVIOUS_MENU)
+  if (action.GetID() == ACTION_NAV_BACK || action.GetID() == ACTION_PREVIOUS_MENU)
   {
     if (m_bCanCancel)
     {

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -80,7 +80,8 @@ CGUIDialogSmartPlaylistEditor::~CGUIDialogSmartPlaylistEditor()
 
 bool CGUIDialogSmartPlaylistEditor::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
+  if (action.GetID() == ACTION_PREVIOUS_MENU ||
+      action.GetID() == ACTION_NAV_BACK)
     m_cancelled = true;
   return CGUIDialog::OnAction(action);
 }

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -53,7 +53,8 @@ CGUIDialogSmartPlaylistRule::~CGUIDialogSmartPlaylistRule()
 
 bool CGUIDialogSmartPlaylistRule::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
+  if (action.GetID() == ACTION_PREVIOUS_MENU ||
+      action.GetID() == ACTION_NAV_BACK)
     m_cancelled = true;
   return CGUIDialog::OnAction(action);
 }

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -63,7 +63,8 @@ bool CGUIDialogYesNo::OnMessage(CGUIMessage& message)
 
 bool CGUIDialogYesNo::OnAction(const CAction& action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
+  if (action.GetID() == ACTION_PREVIOUS_MENU ||
+      action.GetID() == ACTION_NAV_BACK)
   {
     m_bCanceled = true;
     m_bConfirmed = false;

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -74,7 +74,7 @@ bool CGUIDialog::OnAction(const CAction &action)
   if (!action.IsMouse() && m_autoClosing)
     SetAutoClose(m_showDuration);
 
-  if (action.GetID() == ACTION_CLOSE_DIALOG || action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_PARENT_DIR)
+  if (action.GetID() == ACTION_CLOSE_DIALOG || action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
   {
     Close();
     return true;

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -74,7 +74,7 @@ bool CGUIDialog::OnAction(const CAction &action)
   if (!action.IsMouse() && m_autoClosing)
     SetAutoClose(m_showDuration);
 
-  if (action.GetID() == ACTION_CLOSE_DIALOG || action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
+  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
   {
     Close();
     return true;

--- a/xbmc/guilib/GUIStandardWindow.cpp
+++ b/xbmc/guilib/GUIStandardWindow.cpp
@@ -34,13 +34,7 @@ CGUIStandardWindow::~CGUIStandardWindow(void)
 
 bool CGUIStandardWindow::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
-  {
-    g_windowManager.PreviousWindow();
-    return true;
-  }
-
-  if (action.GetID() == ACTION_PARENT_DIR && g_advancedSettings.m_bUseEvilB)
+  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
   {
     g_windowManager.PreviousWindow();
     return true;

--- a/xbmc/guilib/GUIStandardWindow.cpp
+++ b/xbmc/guilib/GUIStandardWindow.cpp
@@ -31,14 +31,3 @@ CGUIStandardWindow::CGUIStandardWindow(int id, const CStdString &xmlFile) : CGUI
 CGUIStandardWindow::~CGUIStandardWindow(void)
 {
 }
-
-bool CGUIStandardWindow::OnAction(const CAction &action)
-{
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
-  {
-    g_windowManager.PreviousWindow();
-    return true;
-  }
-
-  return CGUIWindow::OnAction(action);
-}

--- a/xbmc/guilib/GUIStandardWindow.h
+++ b/xbmc/guilib/GUIStandardWindow.h
@@ -34,6 +34,4 @@ class CGUIStandardWindow :
 public:
   CGUIStandardWindow(int id, const CStdString &xmlFile);
   virtual ~CGUIStandardWindow(void);
-
-  virtual bool OnAction(const CAction &action);
 };

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -335,7 +335,7 @@ bool CGUIWindow::OnAction(const CAction &action)
   }
 
   // default implementations
-  if (action.GetID() == ACTION_NAV_BACK)
+  if (action.GetID() == ACTION_NAV_BACK || action.GetID() == ACTION_PREVIOUS_MENU)
   {
     g_windowManager.PreviousWindow();
     return true;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -322,12 +322,24 @@ bool CGUIWindow::OnAction(const CAction &action)
 
   CGUIControl *focusedControl = GetFocusedControl();
   if (focusedControl)
-    return focusedControl->OnAction(action);
+  {
+    if (focusedControl->OnAction(action))
+      return true;
+  }
+  else
+  {
+    // no control has focus?
+    // set focus to the default control then
+    CGUIMessage msg(GUI_MSG_SETFOCUS, GetID(), m_defaultControl);
+    OnMessage(msg);
+  }
 
-  // no control has focus?
-  // set focus to the default control then
-  CGUIMessage msg(GUI_MSG_SETFOCUS, GetID(), m_defaultControl);
-  OnMessage(msg);
+  // default implementations
+  if (action.GetID() == ACTION_NAV_BACK)
+  {
+    g_windowManager.PreviousWindow();
+    return true;
+  }
   return false;
 }
 

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -139,7 +139,7 @@
 #define ACTION_CALIBRATE_RESET        48 // reset calibration to defaults. Can b used in: settingsScreenCalibration.xml windowid=11/settingsUICalibration.xml windowid=10
 #define ACTION_ANALOG_MOVE            49 // analog thumbstick move. Can b used in: slideshow.xml window id=2007/settingsScreenCalibration.xml windowid=11/settingsUICalibration.xml windowid=10
 #define ACTION_ROTATE_PICTURE         50 // rotate current picture during slideshow. Can b used in slideshow.xml window id=2007
-#define ACTION_CLOSE_DIALOG           51 // action for closing the dialog. Can b used in any dialog
+
 #define ACTION_SUBTITLE_DELAY_MIN     52 // Decrease subtitle/movie Delay.  Can b used in videoFullScreen.xml window id=2005
 #define ACTION_SUBTITLE_DELAY_PLUS    53 // Increase subtitle/movie Delay.  Can b used in videoFullScreen.xml window id=2005
 #define ACTION_AUDIO_DELAY_MIN        54 // Increase avsync delay.  Can b used in videoFullScreen.xml window id=2005

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -183,6 +183,7 @@
 #define ACTION_VOLUME_UP            88
 #define ACTION_VOLUME_DOWN          89
 #define ACTION_MUTE                 91
+#define ACTION_NAV_BACK             92
 
 #define ACTION_MOUSE_START            100
 #define ACTION_MOUSE_LEFT_CLICK       100

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -54,7 +54,8 @@ static const ActionMapping actions[] =
         {"pagedown"          , ACTION_PAGE_DOWN},
         {"select"            , ACTION_SELECT_ITEM},
         {"highlight"         , ACTION_HIGHLIGHT_ITEM},
-        {"parentdir"         , ACTION_PARENT_DIR},
+        {"parentdir"         , ACTION_NAV_BACK},       // backward compatibility
+        {"parentfolder"      , ACTION_PARENT_DIR},
         {"back"              , ACTION_NAV_BACK},
         {"previousmenu"      , ACTION_PREVIOUS_MENU},
         {"info"              , ACTION_SHOW_INFO},

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -55,6 +55,7 @@ static const ActionMapping actions[] =
         {"select"            , ACTION_SELECT_ITEM},
         {"highlight"         , ACTION_HIGHLIGHT_ITEM},
         {"parentdir"         , ACTION_PARENT_DIR},
+        {"back"              , ACTION_NAV_BACK},
         {"previousmenu"      , ACTION_PREVIOUS_MENU},
         {"info"              , ACTION_SHOW_INFO},
         {"pause"             , ACTION_PAUSE},

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -92,7 +92,7 @@ static const ActionMapping actions[] =
         {"resetcalibration"  , ACTION_CALIBRATE_RESET},
         {"analogmove"        , ACTION_ANALOG_MOVE},
         {"rotate"            , ACTION_ROTATE_PICTURE},
-        {"close"             , ACTION_CLOSE_DIALOG},
+        {"close"             , ACTION_NAV_BACK}, // backwards compatibility
         {"subtitledelayminus", ACTION_SUBTITLE_DELAY_MIN},
         {"subtitledelay"     , ACTION_SUBTITLE_DELAY},
         {"subtitledelayplus" , ACTION_SUBTITLE_DELAY_PLUS},

--- a/xbmc/interfaces/json-rpc/InputOperations.cpp
+++ b/xbmc/interfaces/json-rpc/InputOperations.cpp
@@ -84,7 +84,7 @@ JSON_STATUS CInputOperations::Select(const CStdString &method, ITransportLayer *
 
 JSON_STATUS CInputOperations::Back(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  return sendAction(ACTION_PARENT_DIR);  
+  return sendAction(ACTION_NAV_BACK);  
 }
 
 JSON_STATUS CInputOperations::Home(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)

--- a/xbmc/interfaces/python/xbmcmodule/window.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/window.cpp
@@ -472,16 +472,16 @@ namespace PYXBMC
     "\n"
     "This method will recieve all actions that the main program will send\n"
     "to this window.\n"
-    "By default, only the PREVIOUS_MENU action is handled.\n"
+    "By default, only the PREVIOUS_MENU and NAV_BACK actions are handled.\n"
     "Overwrite this method to let your script handle all actions.\n"
-    "Don't forget to capture ACTION_PREVIOUS_MENU, else the user can't close this window.");
+    "Don't forget to capture ACTION_PREVIOUS_MENU or ACTION_NAV_BACK, else the user can't close this window.");
 
   PyObject* Window_OnAction(Window *self, PyObject *args)
   {
     Action* action;
     if (!PyArg_ParseTuple(args, (char*)"O", &action)) return NULL;
 
-    if(action->id == ACTION_PREVIOUS_MENU)
+    if(action->id == ACTION_PREVIOUS_MENU || action->id == ACTION_NAV_BACK)
     {
       Window_Close(self, args);
     }

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -142,7 +142,8 @@ bool CGUIDialogSongInfo::OnAction(const CAction &action)
       SetRating(rating - 1);
     return true;
   }
-  else if (action.GetID() == ACTION_PREVIOUS_MENU)
+  else if (action.GetID() == ACTION_PREVIOUS_MENU ||
+           action.GetID() == ACTION_NAV_BACK)
     m_cancelled = true;
   return CGUIDialog::OnAction(action);
 }

--- a/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
+++ b/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
@@ -155,7 +155,6 @@ bool CGUIDialogKaraokeSongSelector::OnAction(const CAction & action)
 
     case ACTION_DELETE_ITEM:
     case ACTION_BACKSPACE:
-    case ACTION_PARENT_DIR:
       OnBackspace();
       break;
   }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -88,7 +88,8 @@ CGUIWindowMusicBase::~CGUIWindowMusicBase ()
 /// \param action Action that can be reacted on.
 bool CGUIWindowMusicBase::OnAction(const CAction& action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
+  if (action.GetID() == ACTION_PREVIOUS_MENU ||
+      action.GetID() == ACTION_NAV_BACK)
   {
     CGUIDialogMusicScan *musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
     if (musicScan && !musicScan->IsDialogRunning())

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -218,7 +218,7 @@ bool CGUIWindowMusicPlayList::OnAction(const CAction &action)
     // Playlist has no parent dirs
     return true;
   }
-  if (action.GetID() == ACTION_SHOW_PLAYLIST)
+  if (action.GetID() == ACTION_SHOW_PLAYLIST || action.GetID() == ACTION_NAV_BACK)
   {
     g_windowManager.PreviousWindow();
     return true;

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -61,10 +61,9 @@ CGUIWindowMusicPlaylistEditor::~CGUIWindowMusicPlaylistEditor(void)
 
 bool CGUIWindowMusicPlaylistEditor::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PARENT_DIR && !m_viewControl.HasControl(GetFocusedControlID()))
-  { // don't go to parent folder unless we're on the list in question
-    g_windowManager.PreviousWindow();
-    return true;
+  if (action.GetID() == ACTION_NAV_BACK && !m_viewControl.HasControl(GetFocusedControlID()))
+  { // base class would normally go up a folder here, but we don't do this
+    return CGUIWindow::OnAction(action);
   }
   return CGUIWindowMusicBase::OnAction(action);
 }

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -53,7 +53,8 @@ CGUIDialogNetworkSetup::~CGUIDialogNetworkSetup()
 
 bool CGUIDialogNetworkSetup::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
+  if (action.GetID() == ACTION_PREVIOUS_MENU ||
+      action.GetID() == ACTION_NAV_BACK)
     m_confirmed = false;
   return CGUIDialog::OnAction(action);
 }

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -521,6 +521,7 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
     }
     break;
   case ACTION_PREVIOUS_MENU:
+  case ACTION_NAV_BACK:
   case ACTION_STOP:
     g_windowManager.PreviousWindow();
     break;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -206,8 +206,6 @@ void CAdvancedSettings::Initialize()
   m_bVideoLibraryImportWatchedState = false;
   m_bVideoScannerIgnoreErrors = false;
 
-  m_bUseEvilB = true;
-
   m_iTuxBoxStreamtsPort = 31339;
   m_bTuxBoxAudioChannelSelection = false;
   m_bTuxBoxSubMenuSelection = false;
@@ -657,7 +655,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   XMLUtils::GetInt(pRootElement, "playlistretries", m_playlistRetries, -1, 5000);
   XMLUtils::GetInt(pRootElement, "playlisttimeout", m_playlistTimeout, 0, 5000);
 
-  XMLUtils::GetBoolean(pRootElement,"rootovershoot",m_bUseEvilB);
   XMLUtils::GetBoolean(pRootElement,"glrectanglehack", m_GLRectangleHack);
   XMLUtils::GetInt(pRootElement,"skiploopfilter", m_iSkipLoopFilter, -16, 48);
   XMLUtils::GetFloat(pRootElement, "forcedswaptime", m_ForcedSwapTime, 0.0, 100.0);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -214,7 +214,6 @@ class CAdvancedSettings
 
     bool m_bVideoScannerIgnoreErrors;
 
-    bool m_bUseEvilB;
     std::vector<CStdString> m_vecTokens; // cleaning strings tied to language
     //TuxBox
     int m_iTuxBoxStreamtsPort;

--- a/xbmc/settings/GUIDialogSettings.cpp
+++ b/xbmc/settings/GUIDialogSettings.cpp
@@ -203,7 +203,8 @@ void CGUIDialogSettings::UpdateSetting(unsigned int id)
 
 bool CGUIDialogSettings::OnAction(const CAction& action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
+  if (action.GetID() == ACTION_PREVIOUS_MENU ||
+      action.GetID() == ACTION_NAV_BACK)
   {
     OnCancel();
     Close();

--- a/xbmc/settings/GUIWindowSettings.cpp
+++ b/xbmc/settings/GUIWindowSettings.cpp
@@ -21,7 +21,6 @@
 
 #include "system.h"
 #include "GUIWindowSettings.h"
-#include "guilib/GUIWindowManager.h"
 #include "guilib/Key.h"
 
 CGUIWindowSettings::CGUIWindowSettings(void)
@@ -32,15 +31,3 @@ CGUIWindowSettings::CGUIWindowSettings(void)
 CGUIWindowSettings::~CGUIWindowSettings(void)
 {
 }
-
-bool CGUIWindowSettings::OnAction(const CAction &action)
-{
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
-  {
-    g_windowManager.PreviousWindow();
-    return true;
-  }
-
-  return CGUIWindow::OnAction(action);
-}
-

--- a/xbmc/settings/GUIWindowSettings.cpp
+++ b/xbmc/settings/GUIWindowSettings.cpp
@@ -35,7 +35,7 @@ CGUIWindowSettings::~CGUIWindowSettings(void)
 
 bool CGUIWindowSettings::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_PARENT_DIR)
+  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
   {
     g_windowManager.PreviousWindow();
     return true;

--- a/xbmc/settings/GUIWindowSettings.h
+++ b/xbmc/settings/GUIWindowSettings.h
@@ -29,5 +29,4 @@ class CGUIWindowSettings :
 public:
   CGUIWindowSettings(void);
   virtual ~CGUIWindowSettings(void);
-  virtual bool OnAction(const CAction &action);
 };

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -159,7 +159,7 @@ CGUIWindowSettingsCategory::~CGUIWindowSettingsCategory(void)
 
 bool CGUIWindowSettingsCategory::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_PARENT_DIR)
+  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
   {
     g_settings.Save();
     if (m_iWindowBeforeJump!=WINDOW_INVALID)

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -168,8 +168,6 @@ bool CGUIWindowSettingsCategory::OnAction(const CAction &action)
       return true;
     }
     m_lastControlID = 0; // don't save the control as we go to a different window each time
-    g_windowManager.PreviousWindow();
-    return true;
   }
   return CGUIWindow::OnAction(action);
 }

--- a/xbmc/settings/GUIWindowSettingsProfile.cpp
+++ b/xbmc/settings/GUIWindowSettingsProfile.cpp
@@ -54,17 +54,6 @@ CGUIWindowSettingsProfile::~CGUIWindowSettingsProfile(void)
   delete m_listItems;
 }
 
-bool CGUIWindowSettingsProfile::OnAction(const CAction &action)
-{
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
-  {
-    g_windowManager.PreviousWindow();
-    return true;
-  }
-
-  return CGUIWindow::OnAction(action);
-}
-
 int CGUIWindowSettingsProfile::GetSelectedItem()
 {
   CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_PROFILES);

--- a/xbmc/settings/GUIWindowSettingsProfile.h
+++ b/xbmc/settings/GUIWindowSettingsProfile.h
@@ -30,7 +30,6 @@ public:
   CGUIWindowSettingsProfile(void);
   virtual ~CGUIWindowSettingsProfile(void);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
 
 protected:
   virtual void OnInitWindow();

--- a/xbmc/settings/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/GUIWindowSettingsScreenCalibration.cpp
@@ -59,13 +59,6 @@ bool CGUIWindowSettingsScreenCalibration::OnAction(const CAction &action)
 {
   switch (action.GetID())
   {
-  case ACTION_PREVIOUS_MENU:
-    {
-      g_windowManager.PreviousWindow();
-      return true;
-    }
-    break;
-
   case ACTION_CALIBRATE_SWAP_ARROWS:
     {
       NextControl();

--- a/xbmc/settings/GUIWindowTestPattern.cpp
+++ b/xbmc/settings/GUIWindowTestPattern.cpp
@@ -39,13 +39,6 @@ bool CGUIWindowTestPattern::OnAction(const CAction &action)
 {
   switch (action.GetID())
   {
-  case ACTION_PREVIOUS_MENU:
-    {
-      g_windowManager.PreviousWindow();
-      return true;
-    }
-    break;
-
   case ACTION_MOVE_UP:
   case ACTION_MOVE_LEFT:
      m_pattern = m_pattern > 0 ? m_pattern - 1 : TEST_PATTERNS_COUNT - 1;

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -46,7 +46,7 @@ CGUIDialogTeletext::~CGUIDialogTeletext()
 
 bool CGUIDialogTeletext::OnAction(const CAction& action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_CLOSE_DIALOG)
+  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
   {
     m_bClose = true;
     return true;

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -199,7 +199,7 @@ bool CGUIWindowVideoPlaylist::OnAction(const CAction &action)
     // Playlist has no parent dirs
     return true;
   }
-  if (action.GetID() == ACTION_SHOW_PLAYLIST)
+  if (action.GetID() == ACTION_SHOW_PLAYLIST || action.GetID() == ACTION_NAV_BACK)
   {
     g_windowManager.PreviousWindow();
     return true;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -159,12 +159,6 @@ bool CGUIMediaWindow::OnAction(const CAction &action)
     return true;
   }
 
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
-  {
-    g_windowManager.PreviousWindow();
-    return true;
-  }
-
   // the non-contextual menu can be called at any time
   if (action.GetID() == ACTION_CONTEXT_MENU && !m_viewControl.HasControl(GetFocusedControlID()))
   {

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -152,12 +152,10 @@ CFileItemPtr CGUIMediaWindow::GetCurrentListItem(int offset)
 
 bool CGUIMediaWindow::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PARENT_DIR)
+  if (action.GetID() == ACTION_PARENT_DIR ||
+     (action.GetID() == ACTION_NAV_BACK && !(m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->m_strPath == m_startDirectory)))
   {
-    if ((m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->m_strPath == m_startDirectory) && g_advancedSettings.m_bUseEvilB)
-      g_windowManager.PreviousWindow();
-    else
-      GoParentFolder();
+    GoParentFolder();
     return true;
   }
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -178,11 +178,6 @@ bool CGUIWindowFileManager::OnAction(const CAction &action)
 #endif
     }
   }
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
-  {
-    g_windowManager.PreviousWindow();
-    return true;
-  }
   return CGUIWindow::OnAction(action);
 }
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -164,12 +164,10 @@ bool CGUIWindowFileManager::OnAction(const CAction &action)
       }
       return true;
     }
-    if (action.GetID() == ACTION_PARENT_DIR)
+    if (action.GetID() == ACTION_PARENT_DIR ||
+       (action.GetID() == ACTION_NAV_BACK && !m_vecItems[list]->IsVirtualDirectoryRoot()))
     {
-      if (m_vecItems[list]->IsVirtualDirectoryRoot())
-        g_windowManager.PreviousWindow();
-      else
-        GoParentFolder(list);
+      GoParentFolder(list);
       return true;
     }
     if (action.GetID() == ACTION_PLAYER_PLAY)

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -92,8 +92,6 @@ bool CGUIWindowLoginScreen::OnMessage(CGUIMessage& message)
 
           return bResult;
         }
-        else if (iAction == ACTION_PREVIOUS_MENU || iAction == ACTION_NAV_BACK) // oh no u don't
-          return false;
         else if (iAction == ACTION_SELECT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK)
         {
           int iItem = m_viewControl.GetSelectedItem();
@@ -139,6 +137,8 @@ bool CGUIWindowLoginScreen::OnAction(const CAction &action)
       CBuiltins::Execute(action.GetName());
     return true;
   }
+  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
+    return false; // no escape from the login window
   return CGUIWindow::OnAction(action);
 }
 

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -92,7 +92,7 @@ bool CGUIWindowLoginScreen::OnMessage(CGUIMessage& message)
 
           return bResult;
         }
-        else if (iAction == ACTION_PREVIOUS_MENU) // oh no u don't
+        else if (iAction == ACTION_PREVIOUS_MENU || iAction == ACTION_NAV_BACK) // oh no u don't
           return false;
         else if (iAction == ACTION_SELECT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK)
         {

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -47,15 +47,6 @@ CGUIWindowSystemInfo::CGUIWindowSystemInfo(void)
 CGUIWindowSystemInfo::~CGUIWindowSystemInfo(void)
 {
 }
-bool CGUIWindowSystemInfo::OnAction(const CAction &action)
-{
-  if (action.GetID() == ACTION_PREVIOUS_MENU)
-  {
-    g_windowManager.PreviousWindow();
-    return true;
-  }
-  return CGUIWindow::OnAction(action);
-}
 bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
 {
   switch ( message.GetMessage() )

--- a/xbmc/windows/GUIWindowSystemInfo.h
+++ b/xbmc/windows/GUIWindowSystemInfo.h
@@ -29,7 +29,6 @@ public:
   CGUIWindowSystemInfo(void);
   virtual ~CGUIWindowSystemInfo(void);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
   virtual void FrameMove();
 private:
   unsigned int m_section;

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -80,16 +80,6 @@ CGUIWindowWeather::CGUIWindowWeather(void)
 CGUIWindowWeather::~CGUIWindowWeather(void)
 {}
 
-bool CGUIWindowWeather::OnAction(const CAction &action)
-{
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
-  {
-    g_windowManager.PreviousWindow();
-    return true;
-  }
-  return CGUIWindow::OnAction(action);
-}
-
 bool CGUIWindowWeather::OnMessage(CGUIMessage& message)
 {
   switch ( message.GetMessage() )

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -82,7 +82,7 @@ CGUIWindowWeather::~CGUIWindowWeather(void)
 
 bool CGUIWindowWeather::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_PARENT_DIR)
+  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
   {
     g_windowManager.PreviousWindow();
     return true;

--- a/xbmc/windows/GUIWindowWeather.h
+++ b/xbmc/windows/GUIWindowWeather.h
@@ -30,7 +30,6 @@ public:
   CGUIWindowWeather(void);
   virtual ~CGUIWindowWeather(void);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
   virtual void FrameMove();
 
 protected:


### PR DESCRIPTION
The attached commits introduce a new action ACTION_NAV_BACK that essentially does what ACTION_PARENT_DIR has been doing to date, when combined with the <rootovershoot> advancedsetting which was on by default.

The idea is that ACTION_NAV_BACK will go "back" no matter where you are.  In a list and it will parent dir.  Once you hit the root (or the path you came into the window with) you'll go back Home.

I've left the existing actions ACTION_PARENT_DIR to just do parent dir, and ACTION_PREVIOUS_MENU to just do previous menu.  We may consider to retire one or both of these in future.

I've only implemented keyboard.xml, other keymaps will also require changes, ofcourse - this pull req is to get comments before I let the monkey loose on the others.

There is no backward compatibility available, except for the "close" action which is now mapped to "back".  So folk that rely on ParentDir through a keymap not in master will need to edit their keymap.

If we want backward compatibility, then we'd need to remove the existing ACTION_PARENT_DIR and remap the "parentdir" action to "back" in the code.
