### PR TITLE
Auto-select "best" audio track

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -498,7 +498,7 @@
   <string id="546">Passthrough output device</string>
   <string id="547">No biography for this artist</string>
   <string id="548">Downmix multichannel audio to stereo</string>
-
+  <string id="549">Auto-Select highest quality audio</string>
   <string id="550">Sort by: %s</string>
   <string id="551">Name</string>
   <string id="552">Date</string>

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -191,6 +191,7 @@ void CLangInfo::CRegion::SetGlobalLocale()
 CLangInfo::CLangInfo()
 {
   SetDefaults();
+  SetIsoLangMap();
 }
 
 CLangInfo::~CLangInfo()
@@ -362,6 +363,213 @@ void CLangInfo::SetDefaults()
   m_currentRegion=&m_defaultRegion;
 }
 
+void CLangInfo::SetIsoLangMap()
+{
+  m_isoLangMap["aar"] = "aa";
+  m_isoLangMap["abk"] = "ab";
+  m_isoLangMap["ave"] = "ae";
+  m_isoLangMap["afr"] = "af";
+  m_isoLangMap["aka"] = "ak";
+  m_isoLangMap["amh"] = "am";
+  m_isoLangMap["arg"] = "an";
+  m_isoLangMap["ara"] = "ar";
+  m_isoLangMap["asm"] = "as";
+  m_isoLangMap["ava"] = "av";
+  m_isoLangMap["aym"] = "ay";
+  m_isoLangMap["aze"] = "az";
+  m_isoLangMap["bak"] = "ba";
+  m_isoLangMap["bel"] = "be";
+  m_isoLangMap["bul"] = "bg";
+  m_isoLangMap["bih"] = "bh";
+  m_isoLangMap["bis"] = "bi";
+  m_isoLangMap["bam"] = "bm";
+  m_isoLangMap["ben"] = "bn";
+  m_isoLangMap["bod"] = "bo";
+  m_isoLangMap["tib"] = "bo"; // Alternate.
+  m_isoLangMap["bre"] = "br";
+  m_isoLangMap["bos"] = "bs";
+  m_isoLangMap["cat"] = "ca";
+  m_isoLangMap["che"] = "ce";
+  m_isoLangMap["cha"] = "ch";
+  m_isoLangMap["cos"] = "co";
+  m_isoLangMap["cre"] = "cr";
+  m_isoLangMap["ces"] = "cs";
+  m_isoLangMap["cze"] = "cs";
+  m_isoLangMap["chu"] = "cu";
+  m_isoLangMap["chv"] = "cv";
+  m_isoLangMap["cym"] = "cy";
+  m_isoLangMap["wel"] = "cy"; // Alternate.
+  m_isoLangMap["dan"] = "da";
+  m_isoLangMap["deu"] = "de";
+  m_isoLangMap["ger"] = "de"; // Alternate.
+  m_isoLangMap["div"] = "dv";
+  m_isoLangMap["dzo"] = "dz";
+  m_isoLangMap["ewe"] = "ee";
+  m_isoLangMap["ell"] = "el";
+  m_isoLangMap["gre"] = "el"; // Alternate.
+  m_isoLangMap["eng"] = "en";
+  m_isoLangMap["epo"] = "eo";
+  m_isoLangMap["spa"] = "es";
+  m_isoLangMap["est"] = "et";
+  m_isoLangMap["eus"] = "eu";
+  m_isoLangMap["baq"] = "eu"; // Alternate.
+  m_isoLangMap["fas"] = "fa";
+  m_isoLangMap["per"] = "fa"; // Alternate.
+  m_isoLangMap["ful"] = "ff";
+  m_isoLangMap["fin"] = "fi";
+  m_isoLangMap["fij"] = "fj";
+  m_isoLangMap["fao"] = "fo";
+  m_isoLangMap["fra"] = "fr";
+  m_isoLangMap["fre"] = "fr"; // Alternate.
+  m_isoLangMap["fry"] = "fy";
+  m_isoLangMap["gle"] = "ga";
+  m_isoLangMap["gla"] = "gd";
+  m_isoLangMap["glg"] = "gl";
+  m_isoLangMap["grn"] = "gn";
+  m_isoLangMap["guj"] = "gu";
+  m_isoLangMap["glv"] = "gv";
+  m_isoLangMap["hau"] = "ha";
+  m_isoLangMap["heb"] = "he";
+  m_isoLangMap["hin"] = "hi";
+  m_isoLangMap["hmo"] = "ho";
+  m_isoLangMap["hrv"] = "hr";
+  m_isoLangMap["hat"] = "ht";
+  m_isoLangMap["hun"] = "hu";
+  m_isoLangMap["hye"] = "hy";
+  m_isoLangMap["arm"] = "hy"; // Alternate.
+  m_isoLangMap["her"] = "hz";
+  m_isoLangMap["ina"] = "ia";
+  m_isoLangMap["ind"] = "id";
+  m_isoLangMap["ile"] = "ie";
+  m_isoLangMap["ibo"] = "ig";
+  m_isoLangMap["iii"] = "ii";
+  m_isoLangMap["ipk"] = "ik";
+  m_isoLangMap["ido"] = "io";
+  m_isoLangMap["isl"] = "is";
+  m_isoLangMap["ice"] = "is";
+  m_isoLangMap["ita"] = "it";
+  m_isoLangMap["iku"] = "iu";
+  m_isoLangMap["jpn"] = "ja";
+  m_isoLangMap["jav"] = "jv";
+  m_isoLangMap["kat"] = "ka";
+  m_isoLangMap["geo"] = "ka";
+  m_isoLangMap["kon"] = "kg";
+  m_isoLangMap["kik"] = "ki";
+  m_isoLangMap["kua"] = "kj";
+  m_isoLangMap["kaz"] = "kk";
+  m_isoLangMap["kal"] = "kl";
+  m_isoLangMap["khm"] = "km";
+  m_isoLangMap["kan"] = "kn";
+  m_isoLangMap["kor"] = "ko";
+  m_isoLangMap["kau"] = "kr";
+  m_isoLangMap["kas"] = "ks";
+  m_isoLangMap["kur"] = "ku";
+  m_isoLangMap["kom"] = "kv";
+  m_isoLangMap["cor"] = "kw";
+  m_isoLangMap["kir"] = "ky";
+  m_isoLangMap["lat"] = "la";
+  m_isoLangMap["ltz"] = "lb";
+  m_isoLangMap["lug"] = "lg";
+  m_isoLangMap["lim"] = "li";
+  m_isoLangMap["lin"] = "ln";
+  m_isoLangMap["lao"] = "lo";
+  m_isoLangMap["lit"] = "lt";
+  m_isoLangMap["lub"] = "lu";
+  m_isoLangMap["lav"] = "lv";
+  m_isoLangMap["mlg"] = "mg";
+  m_isoLangMap["mah"] = "mh";
+  m_isoLangMap["mri"] = "mi";
+  m_isoLangMap["mao"] = "mi"; // Alternate.
+  m_isoLangMap["mkd"] = "mk";
+  m_isoLangMap["mac"] = "mk"; // Alternate.
+  m_isoLangMap["mal"] = "ml";
+  m_isoLangMap["mon"] = "mn";
+  m_isoLangMap["mar"] = "mr";
+  m_isoLangMap["msa"] = "ms";
+  m_isoLangMap["may"] = "ms"; // Alternate.
+  m_isoLangMap["mlt"] = "mt";
+  m_isoLangMap["mya"] = "my";
+  m_isoLangMap["bur"] = "my"; // Alternate.
+  m_isoLangMap["nau"] = "na";
+  m_isoLangMap["nob"] = "nb";
+  m_isoLangMap["nde"] = "nd";
+  m_isoLangMap["nep"] = "ne";
+  m_isoLangMap["ndo"] = "ng";
+  m_isoLangMap["nld"] = "nl";
+  m_isoLangMap["dut"] = "nl"; // Alternate.
+  m_isoLangMap["nno"] = "nn";
+  m_isoLangMap["nor"] = "no";
+  m_isoLangMap["nbl"] = "nr";
+  m_isoLangMap["nav"] = "nv";
+  m_isoLangMap["nya"] = "ny";
+  m_isoLangMap["oci"] = "oc";
+  m_isoLangMap["oji"] = "oj";
+  m_isoLangMap["orm"] = "om";
+  m_isoLangMap["ori"] = "or";
+  m_isoLangMap["oss"] = "os";
+  m_isoLangMap["pan"] = "pa";
+  m_isoLangMap["pli"] = "pi";
+  m_isoLangMap["pol"] = "pl";
+  m_isoLangMap["pus"] = "ps";
+  m_isoLangMap["por"] = "pt";
+  m_isoLangMap["que"] = "qu";
+  m_isoLangMap["roh"] = "rm";
+  m_isoLangMap["run"] = "rn";
+  m_isoLangMap["ron"] = "ro";
+  m_isoLangMap["rum"] = "ro"; // Alternate.
+  m_isoLangMap["rus"] = "ru";
+  m_isoLangMap["kin"] = "rw";
+  m_isoLangMap["san"] = "sa";
+  m_isoLangMap["srd"] = "sc";
+  m_isoLangMap["snd"] = "sd";
+  m_isoLangMap["sme"] = "se";
+  m_isoLangMap["sag"] = "sg";
+  m_isoLangMap["sin"] = "si";
+  m_isoLangMap["slk"] = "sk";
+  m_isoLangMap["slo"] = "sk"; // Alternate.
+  m_isoLangMap["slv"] = "sl";
+  m_isoLangMap["smo"] = "sm";
+  m_isoLangMap["sna"] = "sn";
+  m_isoLangMap["som"] = "so";
+  m_isoLangMap["sqi"] = "sq";
+  m_isoLangMap["srp"] = "sr";
+  m_isoLangMap["ssw"] = "ss";
+  m_isoLangMap["sot"] = "st";
+  m_isoLangMap["sun"] = "su";
+  m_isoLangMap["swe"] = "sv";
+  m_isoLangMap["swa"] = "sw";
+  m_isoLangMap["tam"] = "ta";
+  m_isoLangMap["tel"] = "te";
+  m_isoLangMap["tgk"] = "tg";
+  m_isoLangMap["tha"] = "th";
+  m_isoLangMap["tir"] = "ti";
+  m_isoLangMap["tuk"] = "tk";
+  m_isoLangMap["tgl"] = "tl";
+  m_isoLangMap["tsn"] = "tn";
+  m_isoLangMap["ton"] = "to";
+  m_isoLangMap["tur"] = "tr";
+  m_isoLangMap["tso"] = "ts";
+  m_isoLangMap["tat"] = "tt";
+  m_isoLangMap["twi"] = "tw";
+  m_isoLangMap["tah"] = "ty";
+  m_isoLangMap["uig"] = "ug";
+  m_isoLangMap["ukr"] = "uk";
+  m_isoLangMap["urd"] = "ur";
+  m_isoLangMap["uzb"] = "uz";
+  m_isoLangMap["ven"] = "ve";
+  m_isoLangMap["vie"] = "vi";
+  m_isoLangMap["vol"] = "vo";
+  m_isoLangMap["wln"] = "wa";
+  m_isoLangMap["wol"] = "wo";
+  m_isoLangMap["xho"] = "xh";
+  m_isoLangMap["yid"] = "yi";
+  m_isoLangMap["yor"] = "yo";
+  m_isoLangMap["zha"] = "za";
+  m_isoLangMap["zho"] = "zh";
+  m_isoLangMap["chi"] = "zh"; // Alternate.
+  m_isoLangMap["zul"] = "zu";
+}
+
 CStdString CLangInfo::GetGuiCharSet() const
 {
   CStdString strCharSet;
@@ -488,4 +696,16 @@ CLangInfo::SPEED_UNIT CLangInfo::GetSpeedUnit() const
 const CStdString& CLangInfo::GetSpeedUnitString() const
 {
   return g_localizeStrings.Get(SPEED_UNIT_STRINGS+m_currentRegion->m_speedUnit);
+}
+
+CStdString CLangInfo::ConvertIso6392ToIso6391(const CStdString& language)
+{
+  ITMAPSTRINGS it = m_isoLangMap.find(language);
+  if (it != m_isoLangMap.end())
+  {
+    CStdString converted(it->second);
+    return converted;
+  }
+
+  return "";
 }

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -98,9 +98,12 @@ public:
   void SetCurrentRegion(const CStdString& strName);
   const CStdString& GetCurrentRegion() const;
 
+  CStdString ConvertIso6392ToIso6391(const CStdString& language);
+
   static void LoadTokens(const TiXmlNode* pTokens, std::vector<CStdString>& vecTokens);
 protected:
   void SetDefaults();
+  void SetIsoLangMap();
 
 protected:
 
@@ -141,6 +144,10 @@ protected:
   MAPREGIONS m_regions;
   CRegion* m_currentRegion; // points to the current region
   CRegion m_defaultRegion; // default, will be used if no region available via langinfo.xml
+
+  typedef std::map<const CStdString, CStdString> MAPSTRINGS;
+  typedef std::map<const CStdString, CStdString>::iterator ITMAPSTRINGS;
+  MAPSTRINGS m_isoLangMap;
 };
 
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -102,6 +102,7 @@ typedef struct
   CDemuxStream::EFlags flags;
   int          source;
   int          id;
+  std::string  codec;
 } SelectionStream;
 
 class CSelectionStreams

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -458,6 +458,7 @@ void CGUISettings::Initialize()
   AddBool(NULL, "audiooutput.passthroughmp1", 300, false);
   AddBool(NULL, "audiooutput.passthroughmp2", 301, false);
   AddBool(NULL, "audiooutput.passthroughmp3", 302, false);
+  AddBool(ao, "audiooutput.autoselectaudio", 549, false);
 
 #ifdef __APPLE__
   AddString(ao, "audiooutput.audiodevice", 545, "Default", SPIN_CONTROL_TEXT);
@@ -472,7 +473,6 @@ void CGUISettings::Initialize()
 #elif defined(_WIN32)
   AddString(ao, "audiooutput.audiodevice", 545, "Default", SPIN_CONTROL_TEXT);
 #endif
-  AddBool(ao, "audiooutput.autoselectaudio", 549, false);
 
   CSettingsCategory* in = AddCategory(4, "input", 14094);
 #if defined(__APPLE__)

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -472,6 +472,7 @@ void CGUISettings::Initialize()
 #elif defined(_WIN32)
   AddString(ao, "audiooutput.audiodevice", 545, "Default", SPIN_CONTROL_TEXT);
 #endif
+  AddBool(ao, "audiooutput.autoselectaudio", 549, false);
 
   CSettingsCategory* in = AddCategory(4, "input", 14094);
 #if defined(__APPLE__)

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -43,6 +43,7 @@ SRCS=AlarmClock.cpp \
      Splash.cpp \
      ssrc.cpp \
      Stopwatch.cpp \
+     StreamUtils.cpp \
      StreamDetails.cpp \
      StringUtils.cpp \
      SystemInfo.cpp \

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -21,6 +21,7 @@
 
 #include <math.h>
 #include "StreamDetails.h"
+#include "StreamUtils.h"
 #include "Variant.h"
 
 void CStreamDetail::Archive(CArchive &ar)
@@ -104,27 +105,6 @@ void CStreamDetailAudio::Serialize(CVariant& value)
   value["channels"] = m_iChannels;
 }
 
-int CStreamDetailAudio::GetCodecPriority() const
-{
-  // technically, truehd, dtshd_ma, and flac are equivalently good (they're all lossless)
-  // however, ffmpeg can't decode dtshd_ma losslessy yet
-  if (m_strCodec == "flac")
-    return 7;
-  if (m_strCodec == "truehd")
-    return 6;
-  if (m_strCodec == "dtshd_ma")
-    return 5;
-  if (m_strCodec == "dtshd_hra")
-    return 4;
-  if (m_strCodec == "eac3")
-    return 3;
-  if (m_strCodec == "dca")
-    return 2;
-  if (m_strCodec == "ac3")
-    return 1;
-  return 0;
-}
-
 bool CStreamDetailAudio::IsWorseThan(CStreamDetail *that)
 {
   if (that->m_eType != CStreamDetail::AUDIO)
@@ -137,8 +117,8 @@ bool CStreamDetailAudio::IsWorseThan(CStreamDetail *that)
   if (m_iChannels > sda->m_iChannels)
     return false;
 
-  // In case of a tie, flac > eac3 > dts > ac3 > all else.
-  return sda->GetCodecPriority() > GetCodecPriority();
+  // In case of a tie, revert to codec priority
+  return StreamUtils::GetCodecPriority(sda->m_strCodec) > StreamUtils::GetCodecPriority(m_strCodec);
 }
 
 CStreamDetailSubtitle::CStreamDetailSubtitle() :
@@ -171,10 +151,10 @@ bool CStreamDetailSubtitle::IsWorseThan(CStreamDetail *that)
   // the preferred subtitle should be the one in the user's language
   if (m_pParent)
   {
-    if (m_pParent->m_strLanguage == m_strLanguage)
+    if (StreamUtils::IsSameLanguage(m_pParent->m_strLanguage, m_strLanguage))
       return false;  // already the best
     else
-      return (m_pParent->m_strLanguage == ((CStreamDetailSubtitle *)that)->m_strLanguage);
+      return StreamUtils::IsSameLanguage(m_pParent->m_strLanguage, ((CStreamDetailSubtitle *)that)->m_strLanguage);
   }
   return false;
 }

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -73,8 +73,6 @@ public:
   int m_iChannels;
   CStdString m_strCodec;
   CStdString m_strLanguage;
-private:
-  int GetCodecPriority() const;
 };
 
 class CStreamDetailSubtitle : public CStreamDetail

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -1,0 +1,80 @@
+/*
+ *      Copyright (C) 2005-2010 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "StreamUtils.h"
+#include "LangInfo.h"
+
+//#include <algorithm>
+
+using namespace std;
+
+int StreamUtils::GetCodecPriority(const CStdString &codec)
+{
+  if (codec == "flac") // Lossless FLAC
+    return 6;
+  if (codec == "dtsma") // DTS-HD Master Audio (aka DTS++)
+    return 5;
+  if (codec == "truehd") // Dolby TrueHD
+    return 4;
+  if (codec == "eac3") // Dolby Digital Plus
+    return 3;
+  if (codec == "dca") // DTS
+    return 2;
+  if (codec == "ac3") // Dolby Digital
+    return 1;
+  return 0;
+}
+
+bool StreamUtils::IsSameLanguage(const CStdString &left, const CStdString &right)
+{
+  /*
+   * If either language code is empty then assume that they are the same. No sensible comparison can
+   * take place.
+   */
+  if(left.IsEmpty() || right.IsEmpty())
+    return true;
+
+  /*
+   * If the language codes are the same length then do a direct comparison.
+   */
+  if (left.length() == right.length())
+    return left == right;
+
+  /*
+   * The ffmpeg stream language is supposed to be an ISO 639-2 code (3 characters long). The language
+   * being compared with may only be a 2 character ISO 639-1 code. Convert both to the 2 character
+   * language code and go from there. If one of the codes is invalid, then an empty language code
+   * will be returned and will ultimately be different to a valid code.
+   *
+   * http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+   * http://en.wikipedia.org/wiki/List_of_ISO_639-2_codes
+   */
+  CStdString convertedLeft(left);
+  CStdString convertedRight(right);
+
+  if(left.length() == 3) // IS639-2 code
+    convertedLeft = g_langInfo.ConvertIso6392ToIso6391(left); // IS639-1 code
+
+  if(right.length() == 3) // IS639-2 code
+    convertedRight = g_langInfo.ConvertIso6392ToIso6391(right); // IS639-1 code
+
+  return convertedLeft == convertedRight;
+}

--- a/xbmc/utils/StreamUtils.h
+++ b/xbmc/utils/StreamUtils.h
@@ -1,0 +1,32 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2010 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "StreamUtils.h"
+
+#include "StdString.h"
+
+class StreamUtils
+{
+public:
+  static int GetCodecPriority(const CStdString &codec);
+  static bool IsSameLanguage(const CStdString &left, const CStdString &right);
+};


### PR DESCRIPTION
I found a trac discussion on adding the option to have the "best" audio track auto-selected (http://trac.xbmc.org/ticket/5773).  It looks like that got dropped, but it is an option I wanted.  So, I grabbed dteirney's last patch, updated it to apply to current master, and added a gui option to turn the auto-selection on/off (defaults to off).  It works well with my videos (m4v files with aac as the first track and ac3 tracks after that, for use on AppleTV2).  Feedback is appreciated.

Thanks,
Joel
