### PR TITLE
Fix for ticket #11683

### DIFF
--- a/xbmc/interfaces/python/xbmcmodule/winxml.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/winxml.cpp
@@ -262,7 +262,7 @@ namespace PYXBMC
     PyXBMCGUIUnlock();
 
     Py_INCREF(Py_None);
-    return Py_BuildValue((char*)"l", listPos);
+    return Py_BuildValue((char*)"i", listPos);
   }
 
   // getListItem() method


### PR DESCRIPTION
Fixed: xbmcgui.WindowXML.getCurrentListPosition() returns 4294967295 instead of -1 ([#11683](http://trac.xbmc.org/ticket/11683))
