### PR TITLE
More post-processing options: different post processing modes per video

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1538,6 +1538,10 @@
   <string id="16324">Software Blend</string>
   
   <string id="16400">Post-processing</string>
+  <string id="16401">Post-processing Mode</string>
+  <string id="16402">Default</string>
+  <string id="16403">Aggressive</string>
+  <string id="16404">Auto (slow CPU)</string>
 
   <string id="17500">Display sleep timeout</string>
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -623,8 +623,26 @@ void CDVDPlayerVideo::Process()
             {
               if (!sPostProcessType.empty())
                 sPostProcessType += ",";
-              // This is what mplayer uses for its "high-quality filter combination"
-              sPostProcessType += g_advancedSettings.m_videoPPFFmpegPostProc;
+
+              switch (g_settings.m_currentVideoSettings.m_PostProcessingMode)
+              {
+              case VS_PPMODE_DEFAULT:
+                {
+                  // this is the one that will be overwritten by settings in Advancedsettings.xml
+                  sPostProcessType += g_advancedSettings.m_videoPPFFmpegPostProcDefault;
+                }
+                break;
+              case VS_PPMODE_AGGRESSIVE:
+                {
+                  sPostProcessType += g_advancedSettings.m_videoPPFFmpegPostProcAggressive;
+                }
+                break;
+              case VS_PPMODE_SLOW_CPU:
+                {
+                  sPostProcessType += g_advancedSettings.m_videoPPFFmpegPostProcAutoQuality;
+                }
+                break;
+              }
             }
 
             if (!sPostProcessType.empty())

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -82,7 +82,9 @@ void CAdvancedSettings::Initialize()
   m_videoPercentSeekBackwardBig = -10;
   m_videoBlackBarColour = 0;
   m_videoPPFFmpegDeint = "linblenddeint";
-  m_videoPPFFmpegPostProc = "ha:128:7,va,dr";
+  m_videoPPFFmpegPostProcDefault = "ha,va,dr"; // ha:32:39,va,dr
+  m_videoPPFFmpegPostProcAggressive = "ha:128:7,va,dr";
+  m_videoPPFFmpegPostProcAutoQuality = "hb:a,vb:a,dr:a"; // ":a"=automatically switch the subfilter off if the CPU is too slow
   m_videoDefaultPlayer = "dvdplayer";
   m_videoDefaultDVDPlayer = "dvdplayer";
   m_videoIgnoreSecondsAtStart = 3*60;
@@ -449,7 +451,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
 
     XMLUtils::GetString(pElement,"cleandatetime", m_videoCleanDateTimeRegExp);
     XMLUtils::GetString(pElement,"ppffmpegdeinterlacing",m_videoPPFFmpegDeint);
-    XMLUtils::GetString(pElement,"ppffmpegpostprocessing",m_videoPPFFmpegPostProc);
+    XMLUtils::GetString(pElement,"ppffmpegpostprocessing",m_videoPPFFmpegPostProcDefault);
     XMLUtils::GetBoolean(pElement,"vdpauscaling",m_videoVDPAUScaling);
     XMLUtils::GetFloat(pElement, "nonlinearstretchratio", m_videoNonLinStretchRatio, 0.01f, 1.0f);
     XMLUtils::GetBoolean(pElement,"enablehighqualityhwscalers", m_videoEnableHighQualityHwScalers);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -100,7 +100,9 @@ class CAdvancedSettings
     int m_videoPercentSeekForwardBig;
     int m_videoPercentSeekBackwardBig;
     CStdString m_videoPPFFmpegDeint;
-    CStdString m_videoPPFFmpegPostProc;
+    CStdString m_videoPPFFmpegPostProcDefault;
+    CStdString m_videoPPFFmpegPostProcAggressive;
+    CStdString m_videoPPFFmpegPostProcAutoQuality;
     bool m_musicUseTimeSeeking;
     int m_musicTimeSeekForward;
     int m_musicTimeSeekBackward;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -711,6 +711,9 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
     GetFloat(pElement, "volumeamplification", m_defaultVideoSettings.m_VolumeAmplification, VOLUME_DRC_MINIMUM * 0.01f, VOLUME_DRC_MINIMUM * 0.01f, VOLUME_DRC_MAXIMUM * 0.01f);
     GetFloat(pElement, "noisereduction", m_defaultVideoSettings.m_NoiseReduction, 0.0f, 0.0f, 1.0f);
     XMLUtils::GetBoolean(pElement, "postprocess", m_defaultVideoSettings.m_PostProcess);
+    int postProcessingMode;
+    GetInteger(pElement, "postprocessingmode", postProcessingMode, VS_PPMODE_DEFAULT, VS_PPMODE_DEFAULT, VS_PPMODE_SLOW_CPU);
+    m_defaultVideoSettings.m_PostProcessingMode = (EPOSTPROCESSINGMODE)postProcessingMode;
     GetFloat(pElement, "sharpness", m_defaultVideoSettings.m_Sharpness, 0.0f, -1.0f, 1.0f);
     XMLUtils::GetBoolean(pElement, "outputtoallspeakers", m_defaultVideoSettings.m_OutputToAllSpeakers);
     XMLUtils::GetBoolean(pElement, "showsubtitles", m_defaultVideoSettings.m_SubtitleOn);
@@ -878,6 +881,7 @@ bool CSettings::SaveSettings(const CStdString& strSettingsFile, CGUISettings *lo
   XMLUtils::SetInt(pNode, "scalingmethod", m_defaultVideoSettings.m_ScalingMethod);
   XMLUtils::SetFloat(pNode, "noisereduction", m_defaultVideoSettings.m_NoiseReduction);
   XMLUtils::SetBoolean(pNode, "postprocess", m_defaultVideoSettings.m_PostProcess);
+  XMLUtils::SetInt(pNode, "postprocessingmode", m_defaultVideoSettings.m_PostProcessingMode);
   XMLUtils::SetFloat(pNode, "sharpness", m_defaultVideoSettings.m_Sharpness);
   XMLUtils::SetInt(pNode, "viewmode", m_defaultVideoSettings.m_ViewMode);
   XMLUtils::SetFloat(pNode, "zoomamount", m_defaultVideoSettings.m_CustomZoomAmount);

--- a/xbmc/settings/VideoSettings.cpp
+++ b/xbmc/settings/VideoSettings.cpp
@@ -50,6 +50,7 @@ CVideoSettings::CVideoSettings()
   m_Sharpness = 0.0f;
   m_NoiseReduction = 0;
   m_PostProcess = false;
+  m_PostProcessingMode = VS_PPMODE_DEFAULT;
   m_VolumeAmplification = 0;
   m_AudioDelay = 0.0f;
   m_OutputToAllSpeakers = false;
@@ -82,6 +83,7 @@ bool CVideoSettings::operator!=(const CVideoSettings &right) const
   if (m_Sharpness != right.m_Sharpness) return true;
   if (m_NoiseReduction != right.m_NoiseReduction) return true;
   if (m_PostProcess != right.m_PostProcess) return true;
+  if (m_PostProcessingMode != right.m_PostProcessingMode) return true;
   if (m_VolumeAmplification != right.m_VolumeAmplification) return true;
   if (m_AudioDelay != right.m_AudioDelay) return true;
   if (m_OutputToAllSpeakers != right.m_OutputToAllSpeakers) return true;

--- a/xbmc/settings/VideoSettings.h
+++ b/xbmc/settings/VideoSettings.h
@@ -92,6 +92,13 @@ enum ESCALINGMETHOD
   VS_SCALINGMETHOD_SPLINE36
 };
 
+enum EPOSTPROCESSINGMODE
+{
+  VS_PPMODE_DEFAULT=0,
+  VS_PPMODE_AGGRESSIVE,
+  VS_PPMODE_SLOW_CPU
+};
+
 class CVideoSettings
 {
 public:
@@ -120,6 +127,7 @@ public:
   float m_Gamma;
   float m_NoiseReduction;
   bool m_PostProcess;
+  EPOSTPROCESSINGMODE m_PostProcessingMode;
   float m_Sharpness;
   float m_AudioDelay;
   int m_ResumeTime;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -721,7 +721,7 @@ private:
    */
   bool LookupByFolders(const CStdString &path, bool shows = false);
 
-  virtual int GetMinVersion() const { return 56; };
+  virtual int GetMinVersion() const { return 57; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -67,6 +67,7 @@ CGUIDialogVideoSettings::~CGUIDialogVideoSettings(void)
 #define VIDEO_SETTINGS_POSTPROCESS        22
 #define VIDEO_SETTINGS_VERTICAL_SHIFT     23
 #define VIDEO_SETTINGS_DEINTERLACEMODE    24
+#define VIDEO_SETTINGS_POSTPROCESS_MODE   25
 
 void CGUIDialogVideoSettings::CreateSettings()
 {
@@ -164,7 +165,12 @@ void CGUIDialogVideoSettings::CreateSettings()
   AddSlider(VIDEO_SETTINGS_VERTICAL_SHIFT, 225, &g_settings.m_currentVideoSettings.m_CustomVerticalShift, -2.0f, 0.01f, 2.0f, FormatFloat);
   AddSlider(VIDEO_SETTINGS_PIXEL_RATIO, 217, &g_settings.m_currentVideoSettings.m_CustomPixelRatio, 0.5f, 0.01f, 2.0f, FormatFloat);
   AddBool(VIDEO_SETTINGS_POSTPROCESS, 16400, &g_settings.m_currentVideoSettings.m_PostProcess);
-
+  {
+    const int entries[] = {16402, 16403, 16404};
+    AddSpin(VIDEO_SETTINGS_POSTPROCESS_MODE, 16401, (int*)&g_settings.m_currentVideoSettings.m_PostProcessingMode, 3, entries);
+    EnableSettings(VIDEO_SETTINGS_POSTPROCESS_MODE, g_settings.m_currentVideoSettings.m_PostProcess);
+    UpdateSetting(VIDEO_SETTINGS_POSTPROCESS_MODE);
+  }
 #ifdef HAS_VIDEO_PLAYBACK
   if (g_renderManager.Supports(RENDERFEATURE_BRIGHTNESS))
     AddSlider(VIDEO_SETTINGS_BRIGHTNESS, 464, &g_settings.m_currentVideoSettings.m_Brightness, 0, 1, 100, FormatInteger);
@@ -240,6 +246,11 @@ void CGUIDialogVideoSettings::OnSettingChanged(SettingInfo &setting)
   else if (setting.id == VIDEO_SETTINGS_DEINTERLACEMODE)
   {
     EnableSettings(VIDEO_SETTINGS_INTERLACEMETHOD, g_settings.m_currentVideoSettings.m_DeinterlaceMode != VS_DEINTERLACEMODE_OFF);
+  }
+  else if (setting.id == VIDEO_SETTINGS_POSTPROCESS)
+  {
+    EnableSettings(VIDEO_SETTINGS_POSTPROCESS_MODE, g_settings.m_currentVideoSettings.m_PostProcess);
+    UpdateSetting(VIDEO_SETTINGS_POSTPROCESS_MODE);
   }
 }
 


### PR DESCRIPTION
**2011.Oct.12** Updated for no conflicts with master.

Post-processing all videos with high quality pp filter combination 'ha:128:7,va,dr' makes videos too blurred. Not all videos need so much vertical/horizontal de-blocking. From experience with MPlayer's video filter settings I would suggest the following changes:

Introduce 3 PP Modes that can be switched in the GUI and saved per video:
- Default: 'ha,va,dr' (this is accurate but not too aggressive and it is based on FFMpeg default that is 'hb:a,vb:a,dr:a', only changed horizontal/vertical deblocking to accurate and disabled auto switch-off flag). Because this is the mode that can be overridden in xml, advanced users with own pp settings won't be affected by this change.
- Aggressive: 'ha:128:7,va,dr' (high quality but not suitable for all videos this is FFMpeg high quality pp filter combination 'ha:a:128:7,va:a,dr:a' without the ':a' flag)
- Auto (slow CPU): 'hb:a,vb:a,dr:a' (FFMpeg's default setting that automatically switches the subfilters off if the CPU is too slow)

See: http://trac.xbmc.org/ticket/11556

@elupus: libavfilter was put in place but the currently integrated version does not have a filter named 'mp' so we could use what we have now until ffmpeg will be updated.
