### PR TITLE
DXVA2 video processor based renderer

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderFlags.h
+++ b/xbmc/cores/VideoRenderers/RenderFlags.h
@@ -45,6 +45,26 @@
 #define CONF_FLAGS_YUV_FULLRANGE 0x08
 #define CONF_FLAGS_FULLSCREEN    0x10
 
+/* defines color primaries */
+#define CONF_FLAGS_COLPRI_MASK(a) ((a) & 0xe0)
+#define CONF_FLAGS_COLPRI_BT709   0x20
+#define CONF_FLAGS_COLPRI_BT470M  0x40
+#define CONF_FLAGS_COLPRI_BT470BG 0x60
+#define CONF_FLAGS_COLPRI_170M    0x80
+#define CONF_FLAGS_COLPRI_240M    0xa0
+
+/* defines chroma subsampling sample location */
+#define CONF_FLAGS_CHROMA_MASK(a) ((a) & 0x0300)
+#define CONF_FLAGS_CHROMA_LEFT    0x0100
+#define CONF_FLAGS_CHROMA_CENTER  0x0200
+#define CONF_FLAGS_CHROMA_TOPLEFT 0x0300
+
+/* defines color transfer function */
+#define CONF_FLAGS_TRC_MASK(a) ((a) & 0x0c00)
+#define CONF_FLAGS_TRC_BT709      0x0400
+#define CONF_FLAGS_TRC_GAMMA22    0x0800
+#define CONF_FLAGS_TRC_GAMMA28    0x0c00
+
 #define CONF_FLAGS_FORMAT_MASK(a) ((a) & 0xff000)
 #define CONF_FLAGS_FORMAT_YV12   0x01000
 #define CONF_FLAGS_FORMAT_NV12   0x02000

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -694,6 +694,10 @@ int CXBMCRenderManager::AddVideoPicture(DVDVideoPicture& pic)
   if (!m_pRenderer)
     return -1;
 
+#ifdef HAS_DX
+  m_pRenderer->AddProcessor(&pic);
+#endif
+
   YV12Image image;
   int index = m_pRenderer->GetImage(&image);
 
@@ -713,10 +717,6 @@ int CXBMCRenderManager::AddVideoPicture(DVDVideoPicture& pic)
   {
     CDVDCodecUtils::CopyYUV422PackedPicture(&image, &pic);
   }
-#ifdef HAS_DX
-  else if(pic.format == DVDVideoPicture::FMT_DXVA)
-    m_pRenderer->AddProcessor(pic.proc, pic.proc_id);
-#endif
 #ifdef HAVE_LIBVDPAU
   else if(pic.format == DVDVideoPicture::FMT_VDPAU)
     m_pRenderer->AddProcessor(pic.vdpau);

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -80,6 +80,7 @@ class DllAvCodec;
 class DllSwScale;
 
 namespace DXVA { class CProcessor; }
+struct DVDVideoPicture;
 
 struct DRAWRECT
 {
@@ -196,7 +197,7 @@ public:
   virtual bool         Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags);
   virtual int          GetImage(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
   virtual void         ReleaseImage(int source, bool preserve = false);
-  virtual void         AddProcessor(DXVA::CProcessor* processor, int64_t id);
+  virtual void         AddProcessor(DVDVideoPicture* picture);
   virtual void         FlipPage(int source);
   virtual unsigned int PreInit();
   virtual void         UnInit();
@@ -241,6 +242,7 @@ protected:
   bool                 m_bConfigured;
   SVideoBuffer        *m_VideoBuffers[NUM_BUFFERS];
   RenderMethod         m_renderMethod;
+  DXVA::CProcessor*    m_processor;
 
   // software scale libraries (fallback if required pixel shaders version is not available)
   DllAvUtil           *m_dllAvUtil;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -85,6 +85,9 @@ struct DVDVideoPicture
   unsigned int iFrameType         : 4; // see defines above // 1->I, 2->P, 3->B, 0->Undef
   unsigned int color_matrix       : 4;
   unsigned int color_range        : 1; // 1 indicate if we have a full range of color
+  unsigned int chroma_position;
+  unsigned int color_primaries;
+  unsigned int color_transfer;
   int iGroupId;
 
   int8_t* qscale_table; // Quantization parameters, primarily used by filters

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -602,6 +602,10 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(DVDVideoPicture* pDvdVideoPicture)
   if(m_pCodecContext->pix_fmt == PIX_FMT_YUVJ420P)
     pDvdVideoPicture->color_range = 1;
 
+  pDvdVideoPicture->chroma_position = m_pCodecContext->chroma_sample_location;
+  pDvdVideoPicture->color_primaries = m_pCodecContext->color_primaries;
+  pDvdVideoPicture->color_transfer = m_pCodecContext->color_trc;
+
   pDvdVideoPicture->qscale_table = m_pFrame->qscale_table;
   pDvdVideoPicture->qscale_stride = m_pFrame->qstride;
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecLibMpeg2.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecLibMpeg2.cpp
@@ -428,6 +428,9 @@ int CDVDVideoCodecLibMpeg2::Decode(BYTE* pData, int iSize, double dts, double pt
             // make sure we send the color coeficients with the image
             pBuffer->color_matrix = m_pInfo->sequence->matrix_coefficients;
             pBuffer->color_range = 0; // mpeg2 always have th 16->235/229 color range
+            pBuffer->chroma_position = 1; // mpeg2 chroma positioning always left
+            pBuffer->color_primaries = m_pInfo->sequence->colour_primaries;
+            pBuffer->color_transfer = m_pInfo->sequence->transfer_characteristics;
 
             TagUnion u;
             u.tag.l = m_pInfo->display_picture->tag;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -106,10 +106,13 @@ public:
   CProcessor();
  ~CProcessor();
 
+  bool           Open(UINT width, UINT height, unsigned int flags);
   bool           Open(const DXVA2_VideoDesc& dsc);
+  bool           CreateSurfaces();
   void           Close();
   void           HoldSurface(IDirect3DSurface9* surface);
   REFERENCE_TIME Add(IDirect3DSurface9* source);
+  bool           ProcessPicture(DVDVideoPicture* picture);
   bool           Render(const RECT& dst, IDirect3DSurface9* target, const REFERENCE_TIME time);
   int            Size() { return m_size; }
 
@@ -117,6 +120,9 @@ public:
   virtual void OnDestroyDevice() { CSingleLock lock(m_section); Close(); }
   virtual void OnLostDevice()    { CSingleLock lock(m_section); Close(); }
   virtual void OnResetDevice()   { CSingleLock lock(m_section); Close(); }
+
+protected:
+  bool           Open(UINT width, UINT height, unsigned int flags, D3DFORMAT format);
 
   IDirectXVideoProcessorService* m_service;
   IDirectXVideoProcessor*        m_process;
@@ -132,13 +138,15 @@ public:
   REFERENCE_TIME   m_time;
   unsigned         m_size;
 
+  unsigned         m_index;
   typedef std::deque<DXVA2_VideoSample> SSamples;
   SSamples          m_sample;
 
   CCriticalSection  m_section;
 
-protected:
   std::vector<IDirect3DSurface9*> m_heldsurfaces;
+  LPDIRECT3DSURFACE9* m_surfaces;
+  unsigned            m_surfaces_count;
 };
 
 };

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -913,6 +913,9 @@ int CDVDPlayerVideo::OutputPicture(DVDVideoPicture* pPicture, double pts)
    || m_output.framerate != m_fFrameRate
    || m_output.color_format != (unsigned int)pPicture->format
    || ( m_output.color_matrix != pPicture->color_matrix && pPicture->color_matrix != 0 ) // don't reconfigure on unspecified
+   || ( m_output.chroma_position != pPicture->chroma_position && pPicture->chroma_position != 0 )
+   || ( m_output.color_primaries != pPicture->color_primaries && pPicture->color_primaries != 0 )
+   || ( m_output.color_transfer != pPicture->color_transfer && pPicture->color_transfer != 0 )
    || m_output.color_range != pPicture->color_range)
   {
     CLog::Log(LOGNOTICE, " fps: %f, pwidth: %i, pheight: %i, dwidth: %i, dheight: %i",
@@ -941,6 +944,51 @@ int CDVDPlayerVideo::OutputPicture(DVDVideoPicture* pPicture, double pts)
           flags |= CONF_FLAGS_YUVCOEF_BT709;
         else
           flags |= CONF_FLAGS_YUVCOEF_BT601;
+        break;
+    }
+
+    switch(pPicture->chroma_position)
+    {
+      case 1:
+        flags |= CONF_FLAGS_CHROMA_LEFT;
+        break;
+      case 2:
+        flags |= CONF_FLAGS_CHROMA_CENTER;
+        break;
+      case 3:
+        flags |= CONF_FLAGS_CHROMA_TOPLEFT;
+        break;
+    }
+
+    switch(pPicture->color_primaries)
+    {
+      case 1:
+        flags |= CONF_FLAGS_COLPRI_BT709;
+        break;
+      case 4:
+        flags |= CONF_FLAGS_COLPRI_BT470M;
+        break;
+      case 5:
+        flags |= CONF_FLAGS_COLPRI_BT470BG;
+        break;
+      case 6:
+        flags |= CONF_FLAGS_COLPRI_170M;
+        break;
+      case 7:
+        flags |= CONF_FLAGS_COLPRI_240M;
+        break;
+    }
+
+    switch(pPicture->color_transfer)
+    {
+      case 1:
+        flags |= CONF_FLAGS_TRC_BT709;
+        break;
+      case 4:
+        flags |= CONF_FLAGS_TRC_GAMMA22;
+        break;
+      case 5:
+        flags |= CONF_FLAGS_TRC_GAMMA28;
         break;
     }
 
@@ -1005,6 +1053,9 @@ int CDVDPlayerVideo::OutputPicture(DVDVideoPicture* pPicture, double pts)
     m_output.framerate = m_fFrameRate;
     m_output.color_format = pPicture->format;
     m_output.color_matrix = pPicture->color_matrix;
+    m_output.chroma_position = pPicture->chroma_position;
+    m_output.color_primaries = pPicture->color_primaries;
+    m_output.color_transfer = pPicture->color_transfer;
     m_output.color_range = pPicture->color_range;
   }
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -152,6 +152,9 @@ protected:
     unsigned int color_format;
     unsigned int color_matrix : 4;
     unsigned int color_range  : 1;
+    unsigned int chroma_position;
+    unsigned int color_primaries;
+    unsigned int color_transfer;
     double       framerate;
     bool         inited;
   } m_output; //holds currently configured output

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -570,6 +570,8 @@ void CGUISettings::Initialize()
   renderers.insert(make_pair(13416, RENDER_METHOD_AUTO));
 
 #ifdef HAS_DX
+  if (g_sysinfo.IsVistaOrHigher())
+    renderers.insert(make_pair(16319, RENDER_METHOD_DXVA));
   renderers.insert(make_pair(13431, RENDER_METHOD_D3D_PS));
   renderers.insert(make_pair(13419, RENDER_METHOD_SOFTWARE));
 #endif

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -35,6 +35,7 @@ class TiXmlElement;
 #define RENDER_METHOD_GLSL      2
 #define RENDER_METHOD_SOFTWARE  3
 #define RENDER_METHOD_D3D_PS    4
+#define RENDER_METHOD_DXVA      5
 #define RENDER_OVERLAYS         99   // to retain compatibility
 
 // Scaling options.


### PR DESCRIPTION
This is mainly isidrogar's work. I just turned it into a renderer option trying not to compromise existing functionality and providing fallback to pixel shader rendering when DXVA2 is not available.

Benefits of DXVA2 rendering is that users can leverage the capabilities of their video hardware and video output will be similar to other players using Windows EVR renderer: all post-processing options like deinterlacing, color correction, noise filtering, sharpening, etc. will take place for videos played within XBMC.

This patch does not yet implement DXVA deinterlacing. By the time, only DXVA2 hardware scaling is supported for this renderer, but pixel shader based HQ scaling is possible and will be added in the future.
