### PR TITLE
Dvdclockfix

### DIFF
--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -96,21 +96,17 @@ double CDVDClock::GetClock(bool interpolated /*= true*/)
   return SystemToPlaying(g_VideoReferenceClock.GetTime(interpolated));
 }
 
-double CDVDClock::DistanceToPts(double pts, double& absolute, bool interpolated /*= true*/)
+double CDVDClock::GetClock(double& absolute, bool interpolated /*= true*/)
 {
   int64_t current = g_VideoReferenceClock.GetTime(interpolated);
-
-  double clock;
-  {
-    CSharedLock lock(m_critSection);
-    clock = SystemToPlaying(current);
-  }
   {
     CSingleLock lock(m_systemsection);
+    CheckSystemClock();
     absolute = SystemToAbsolute(current);
   }
 
-  return pts - clock;
+  CSharedLock lock(m_critSection);
+  return SystemToPlaying(current);
 }
 
 void CDVDClock::SetSpeed(int iSpeed)

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -96,6 +96,23 @@ double CDVDClock::GetClock(bool interpolated /*= true*/)
   return SystemToPlaying(g_VideoReferenceClock.GetTime(interpolated));
 }
 
+double CDVDClock::DistanceToPts(double pts, double& absolute, bool interpolated /*= true*/)
+{
+  int64_t current = g_VideoReferenceClock.GetTime(interpolated);
+
+  double clock;
+  {
+    CSharedLock lock(m_critSection);
+    clock = SystemToPlaying(current);
+  }
+  {
+    CSingleLock lock(m_systemsection);
+    absolute = SystemToAbsolute(current);
+  }
+
+  return pts - clock;
+}
+
 void CDVDClock::SetSpeed(int iSpeed)
 {
   // this will sometimes be a little bit of due to rounding errors, ie clock might jump abit when changing speed

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -58,7 +58,6 @@ double CDVDClock::GetAbsoluteClock(bool interpolated /*= true*/)
 
   int64_t current;
   current = g_VideoReferenceClock.GetTime(interpolated);
-  current -= m_systemOffset;
 
 #if _DEBUG
   if (interpolated) //only compare interpolated time, clock might go backwards otherwise
@@ -70,7 +69,7 @@ double CDVDClock::GetAbsoluteClock(bool interpolated /*= true*/)
   }
 #endif
 
-  return DVD_TIME_BASE * (double)current / m_systemFrequency;
+  return SystemToAbsolute(current);
 }
 
 double CDVDClock::WaitAbsoluteClock(double target)
@@ -223,5 +222,10 @@ void CDVDClock::CheckSystemClock()
 
   if(!m_systemOffset)
     m_systemOffset = g_VideoReferenceClock.GetTime();
+}
+
+double CDVDClock::SystemToAbsolute(int64_t system)
+{
+  return DVD_TIME_BASE * (double)(system - m_systemOffset) / m_systemFrequency;
 }
 

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -93,24 +93,7 @@ double CDVDClock::WaitAbsoluteClock(double target)
 double CDVDClock::GetClock(bool interpolated /*= true*/)
 {
   CSharedLock lock(m_critSection);
-  int64_t current;
-
-  if (m_bReset)
-  {
-    m_startClock = g_VideoReferenceClock.GetTime(interpolated);
-    m_systemUsed = m_systemFrequency;
-    m_pauseClock = 0;
-    m_iDisc = 0;
-    m_bReset = false;
-  }
-
-  if (m_pauseClock)
-    current = m_pauseClock;
-  else
-    current = g_VideoReferenceClock.GetTime(interpolated);
-
-  current -= m_startClock;
-  return DVD_TIME_BASE * (double)current / m_systemUsed + m_iDisc;
+  return SystemToPlaying(g_VideoReferenceClock.GetTime(interpolated));
 }
 
 void CDVDClock::SetSpeed(int iSpeed)
@@ -227,5 +210,26 @@ void CDVDClock::CheckSystemClock()
 double CDVDClock::SystemToAbsolute(int64_t system)
 {
   return DVD_TIME_BASE * (double)(system - m_systemOffset) / m_systemFrequency;
+}
+
+double CDVDClock::SystemToPlaying(int64_t system)
+{
+  int64_t current;
+
+  if (m_bReset)
+  {
+    m_startClock = system;
+    m_systemUsed = m_systemFrequency;
+    m_pauseClock = 0;
+    m_iDisc = 0;
+    m_bReset = false;
+  }
+  
+  if (m_pauseClock)
+    current = m_pauseClock;
+  else
+    current = system;
+
+  return DVD_TIME_BASE * (double)(current - m_startClock) / m_systemUsed + m_iDisc;
 }
 

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -68,7 +68,8 @@ public:
   static bool IsMasterClock()                    { return m_ismasterclock;          }
 
 protected:
-  static void CheckSystemClock();
+  static void   CheckSystemClock();
+  static double SystemToAbsolute(int64_t system);
 
   CSharedSection m_critSection;
   int64_t m_systemUsed;

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -43,6 +43,7 @@ public:
   ~CDVDClock();
 
   double GetClock(bool interpolated = true);
+  double DistanceToPts(double pts, double& absolute, bool interpolated = true);
 
   void Discontinuity(double currentPts = 0LL);
 

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -70,6 +70,7 @@ public:
 protected:
   static void   CheckSystemClock();
   static double SystemToAbsolute(int64_t system);
+  double        SystemToPlaying(int64_t system);
 
   CSharedSection m_critSection;
   int64_t m_systemUsed;

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -43,7 +43,7 @@ public:
   ~CDVDClock();
 
   double GetClock(bool interpolated = true);
-  double DistanceToPts(double pts, double& absolute, bool interpolated = true);
+  double GetClock(double& absolute, bool interpolated = true);
 
   void Discontinuity(double currentPts = 0LL);
 

--- a/xbmc/cores/dvdplayer/DVDClock.h
+++ b/xbmc/cores/dvdplayer/DVDClock.h
@@ -68,6 +68,8 @@ public:
   static bool IsMasterClock()                    { return m_ismasterclock;          }
 
 protected:
+  static void CheckSystemClock();
+
   CSharedSection m_critSection;
   int64_t m_systemUsed;
   int64_t m_startClock;

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1099,8 +1099,7 @@ int CDVDPlayerVideo::OutputPicture(DVDVideoPicture* pPicture, double pts)
   // calculate the time we need to delay this picture before displaying
   double iSleepTime, iClockSleep, iFrameSleep, iCurrentClock, iFrameDuration;
 
-  iCurrentClock = m_pClock->GetAbsoluteClock(false); // snapshot current clock
-  iClockSleep = pts - m_pClock->GetClock(false);  //sleep calculated by pts to clock comparison
+  iClockSleep = m_pClock->DistanceToPts(pts, iCurrentClock, false); //sleep calculated by pts to clock comparison
   iFrameSleep = m_FlipTimeStamp - iCurrentClock; // sleep calculated by duration of frame
   iFrameDuration = pPicture->iDuration;
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1097,9 +1097,10 @@ int CDVDPlayerVideo::OutputPicture(DVDVideoPicture* pPicture, double pts)
   pts += m_iVideoDelay;
 
   // calculate the time we need to delay this picture before displaying
-  double iSleepTime, iClockSleep, iFrameSleep, iCurrentClock, iFrameDuration;
+  double iSleepTime, iClockSleep, iFrameSleep, iPlayingClock, iCurrentClock, iFrameDuration;
 
-  iClockSleep = m_pClock->DistanceToPts(pts, iCurrentClock, false); //sleep calculated by pts to clock comparison
+  iPlayingClock = m_pClock->GetClock(iCurrentClock, false); // snapshot current clock
+  iClockSleep = pts - iPlayingClock; //sleep calculated by pts to clock comparison
   iFrameSleep = m_FlipTimeStamp - iCurrentClock; // sleep calculated by duration of frame
   iFrameDuration = pPicture->iDuration;
 


### PR DESCRIPTION
This fixes a problem in CDVDPlayerVideo::OutputPicture() where two different clock samples are used to convert a pts into a presenttime, if sync playback to display is used, it's possible that g_VideoReferenceClock jumps forward a whole vblank tick, causing the presenttime to be wrong.
