### PR TITLE
Added: XBMC remembers the weather location

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1491,7 +1491,7 @@ int CBuiltins::Execute(const CStdString& execString)
   else if (execute.Equals("weather.locationset"))
   {
     int loc = atoi(params[0]);
-    CGUIMessage msg(GUI_MSG_ITEM_SELECT, 0, 0, loc - 1);
+    CGUIMessage msg(GUI_MSG_ITEM_SELECT, 0, 0, loc);
     g_windowManager.SendMessage(msg, WINDOW_WEATHER);
   }
   else if (execute.Equals("weather.locationnext"))

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -255,6 +255,7 @@ void CGUISettings::Initialize()
   // My Weather settings
   AddGroup(2, 8);
   CSettingsCategory* wea = AddCategory(2, "weather", 16000);
+  AddInt(NULL, "weather.currentlocation", 0, 1, 1, 1, 3, SPIN_CONTROL_INT_PLUS, NULL, -1);
   AddString(wea, "weather.areacode1", 14019, "USNY0996 - New York, NY", BUTTON_CONTROL_STANDARD);
   AddString(wea, "weather.areacode2", 14020, "UKXX0085 - London, United Kingdom", BUTTON_CONTROL_STANDARD);
   AddString(wea, "weather.areacode3", 14021, "JAXX0085 - Tokyo, Japan", BUTTON_CONTROL_STANDARD);

--- a/xbmc/utils/Weather.h
+++ b/xbmc/utils/Weather.h
@@ -38,6 +38,8 @@ class TiXmlElement;
 #define WEATHER_LABEL_CURRENT_DEWP 27
 #define WEATHER_LABEL_CURRENT_HUMI 28
 
+#define MAX_LOCATION 3
+
 struct day_forecast
 {
   CStdString m_icon;
@@ -135,8 +137,8 @@ public:
   bool IsFetched();
   void Reset();
 
-  void SetArea(int iArea) { m_iCurWeather = iArea; };
-  int GetArea() const { return m_iCurWeather; };
+  void SetArea(int iLocation);
+  int GetArea() const;
 
   static CStdString GetAreaCode(const CStdString &codeAndCity);
   static CStdString GetAreaCity(const CStdString &codeAndCity);
@@ -149,8 +151,7 @@ protected:
 
 private:
 
-  CStdString m_location[3];
-  unsigned int m_iCurWeather;
+  CStdString m_location[MAX_LOCATION];
 
   CWeatherInfo m_info;
 };

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -57,10 +57,6 @@ using namespace ADDON;
 #define CONTROL_LABELD0GEN            34
 #define CONTROL_IMAGED0IMG            35
 
-#define PARTNER_ID          "1004124588"   //weather.com partner id
-#define PARTNER_KEY   "079f24145f208494"  //weather.com partner key
-
-#define MAX_LOCATION                   3
 #define LOCALIZED_TOKEN_FIRSTID      370
 #define LOCALIZED_TOKEN_LASTID       395
 
@@ -74,7 +70,6 @@ FIXME'S
 CGUIWindowWeather::CGUIWindowWeather(void)
     : CGUIWindow(WINDOW_WEATHER, "MyWeather.xml")
 {
-  m_iCurWeather = 0;
 }
 
 CGUIWindowWeather::~CGUIWindowWeather(void)
@@ -89,7 +84,7 @@ bool CGUIWindowWeather::OnMessage(CGUIMessage& message)
       int iControl = message.GetSenderId();
       if (iControl == CONTROL_BTNREFRESH)
       {
-        Refresh(); // Refresh clicked so do a complete update
+        g_weatherManager.Refresh(); // Refresh clicked so do a complete update
       }
       else if (iControl == CONTROL_SELECTLOCATION)
       {
@@ -143,8 +138,9 @@ bool CGUIWindowWeather::OnMessage(CGUIMessage& message)
     {
       if (message.GetSenderId() == 0) //handle only message from builtin
       {
-        int v = (message.GetParam1() + (int)m_iCurWeather) % MAX_LOCATION;
-        if (v < 0) v+= MAX_LOCATION;
+        // Clamp location between 1 and MAX_LOCATION
+        int v = (g_weatherManager.GetArea() + message.GetParam1() - 1) % MAX_LOCATION + 1;
+        if (v < 1) v += MAX_LOCATION;
         SetLocation(v);
         return true;
       }
@@ -173,7 +169,9 @@ void CGUIWindowWeather::UpdateLocations()
   g_windowManager.SendMessage(msg);
   CGUIMessage msg2(GUI_MSG_LABEL_ADD,GetID(),CONTROL_SELECTLOCATION);
 
-  for (unsigned int i = 0; i < MAX_LOCATION; i++)
+  int iCurWeather = g_weatherManager.GetArea();
+
+  for (unsigned int i = 1; i <= MAX_LOCATION; i++)
   {
     CStdString strLabel = g_weatherManager.GetLocation(i);
     if (strLabel.size() > 1) //got the location string yet?
@@ -190,17 +188,17 @@ void CGUIWindowWeather::UpdateLocations()
     }
     else
     {
-      strLabel.Format("AreaCode %i", i + 1);
+      strLabel.Format("AreaCode %i", i);
 
       msg2.SetLabel(strLabel);
       msg2.SetParam1(i);
       g_windowManager.SendMessage(msg2);
     }
-    if (i==m_iCurWeather)
+    if (i == iCurWeather)
       SET_CONTROL_LABEL(CONTROL_SELECTLOCATION,strLabel);
   }
 
-  CONTROL_SELECT_ITEM(CONTROL_SELECTLOCATION, m_iCurWeather);
+  CONTROL_SELECT_ITEM(CONTROL_SELECTLOCATION, iCurWeather);
 }
 
 void CGUIWindowWeather::UpdateButtons()
@@ -209,7 +207,7 @@ void CGUIWindowWeather::UpdateButtons()
 
   SET_CONTROL_LABEL(CONTROL_BTNREFRESH, 184);   //Refresh
 
-  SET_CONTROL_LABEL(WEATHER_LABEL_LOCATION, g_weatherManager.GetLocation(m_iCurWeather));
+  SET_CONTROL_LABEL(WEATHER_LABEL_LOCATION, g_weatherManager.GetLocation(g_weatherManager.GetArea()));
   SET_CONTROL_LABEL(CONTROL_LABELUPDATED, g_weatherManager.GetLastUpdateTime());
 
   SET_CONTROL_LABEL(WEATHER_LABEL_CURRENT_COND, g_weatherManager.GetInfo(WEATHER_LABEL_CURRENT_COND));
@@ -257,35 +255,35 @@ void CGUIWindowWeather::FrameMove()
   CGUIWindow::FrameMove();
 }
 
+/*!
+ \brief Sets the location to the specified index and refreshes the weather
+ \param loc the location index (in the range [1..MAXLOCATION])
+ */
 void CGUIWindowWeather::SetLocation(int loc)
 {
-  if (loc < 0 || loc >= MAX_LOCATION)
+  if (loc < 1 || loc > MAX_LOCATION)
     return;
-
-  m_iCurWeather = loc;
-  CStdString strLabel=g_weatherManager.GetLocation(m_iCurWeather);
-  int iPos = strLabel.ReverseFind(", ");
-  if (iPos)
-    strLabel = strLabel.substr(0,iPos);
-
-  SET_CONTROL_LABEL(CONTROL_SELECTLOCATION,strLabel);
-  Refresh();
-}
-
-//Do a complete download, parse and update
-void CGUIWindowWeather::Refresh()
-{
-  g_weatherManager.SetArea(m_iCurWeather);
+  // Avoid a settings write if old location == new location
+  if (g_weatherManager.GetArea() != loc)
+  {
+    g_weatherManager.SetArea(loc);
+    CStdString strLabel = g_weatherManager.GetLocation(loc);
+    int iPos = strLabel.ReverseFind(", ");
+    if (iPos)
+      strLabel = strLabel.substr(0, iPos);
+    SET_CONTROL_LABEL(CONTROL_SELECTLOCATION, strLabel);
+  }
   g_weatherManager.Refresh();
 }
 
 void CGUIWindowWeather::SetProperties()
 {
   // Current weather
-  SetProperty("Location", g_weatherManager.GetLocation(m_iCurWeather));
-  SetProperty("LocationIndex", int(m_iCurWeather + 1));
+  int iCurWeather = g_weatherManager.GetArea();
+  SetProperty("Location", g_weatherManager.GetLocation(iCurWeather));
+  SetProperty("LocationIndex", iCurWeather);
   CStdString strSetting;
-  strSetting.Format("weather.areacode%i", m_iCurWeather + 1);
+  strSetting.Format("weather.areacode%i", iCurWeather);
   SetProperty("AreaCode", CWeather::GetAreaCode(g_guiSettings.GetString(strSetting)));
   SetProperty("Updated", g_weatherManager.GetLastUpdateTime());
   SetProperty("Current.ConditionIcon", g_weatherManager.GetInfo(WEATHER_IMAGE_CURRENT_ICON));
@@ -343,7 +341,7 @@ void CGUIWindowWeather::CallScript()
 
     // get the current locations area code
     CStdString strSetting;
-    strSetting.Format("weather.areacode%i", m_iCurWeather + 1);
+    strSetting.Format("weather.areacode%i", g_weatherManager.GetArea());
     argv.push_back(CWeather::GetAreaCode(g_guiSettings.GetString(strSetting)));
 
     // call our script, passing the areacode

--- a/xbmc/windows/GUIWindowWeather.h
+++ b/xbmc/windows/GUIWindowWeather.h
@@ -41,8 +41,5 @@ protected:
   void CallScript();
   void SetLocation(int loc);
 
-  void Refresh();
-
-  unsigned int m_iCurWeather;
   CStopWatch m_scriptTimer;
 };


### PR DESCRIPTION
Currently CGUIWindowWeather and CWeather both have their own instance of m_iCurWeather. This patch makes CGUIWindowWeather depend on CWeather for the current location. CWeather in turn stores this value in the settings, so that it persists across application restarts.

Area codes are 1-indexed in the settings file and the code has been updated to refer to locations as 1-3 instead of 0-2 for consistency. Pretty much all the +1's and -1's outside of CWeather::GetLocation() have been removed.

Pieh suggested just letting CApplication::Stop save the location, and I disagree - location changes happen relatively infrequenty, simply refreshing no longer triggers a save, and hitting the power button won't "ctrl+z" your location switch

Tested on Win32. Replaces https://github.com/xbmc/xbmc/pull/229.
