### PR TITLE
Change auto interlace method for VDPAU to use less CPU intensive features

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -607,7 +607,7 @@ void CVDPAU::SetDeinterlacing()
 
   if (method == VS_INTERLACEMETHOD_AUTO)
   {
-    VdpBool enabled[]={1,1,1};
+    VdpBool enabled[]={1,0,0}; // Same features as VS_INTERLACEMETHOD_VDPAU_TEMPORAL
     vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
   }
   else if (method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL


### PR DESCRIPTION
Is this the best way to resolve http://trac.xbmc.org/ticket/10225

I'm using AUTO for interlace method. Playback of some H264 1080i files had significant judder for scenes with a lot of motion. Manually switching the interlace method to Temporal fixed that problem so I've changed the default features for Auto to be the same as Temporal.
