### PR TITLE
Added functionality to automatically choose the best audio stream

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -785,6 +785,7 @@
     <ClCompile Include="..\..\xbmc\utils\ssrc.cpp" />
     <ClCompile Include="..\..\xbmc\utils\Stopwatch.cpp" />
     <ClCompile Include="..\..\xbmc\utils\StreamDetails.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\StreamUtils.cpp" />
     <ClCompile Include="..\..\xbmc\utils\StringUtils.cpp" />
     <ClCompile Include="..\..\xbmc\utils\SystemInfo.cpp" />
     <ClCompile Include="..\..\xbmc\utils\TimeUtils.cpp" />
@@ -1627,6 +1628,7 @@
     <ClInclude Include="..\..\xbmc\utils\StdString.h" />
     <ClInclude Include="..\..\xbmc\utils\Stopwatch.h" />
     <ClInclude Include="..\..\xbmc\utils\StreamDetails.h" />
+    <ClInclude Include="..\..\xbmc\utils\StreamUtils.h" />
     <ClInclude Include="..\..\xbmc\utils\StringUtils.h" />
     <ClInclude Include="..\..\xbmc\utils\SystemInfo.h" />
     <ClInclude Include="..\..\xbmc\utils\TimeUtils.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1952,6 +1952,9 @@
     <ClCompile Include="..\..\xbmc\utils\StreamDetails.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\StreamUtils.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\utils\StringUtils.cpp">
       <Filter>utils</Filter>
     </ClCompile>
@@ -4455,6 +4458,9 @@
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\StreamDetails.h">
+      <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\StreamUtils.h">
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\StringUtils.h">

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -102,6 +102,8 @@ typedef struct
   CDemuxStream::EFlags flags;
   int          source;
   int          id;
+  std::string  codec;
+  int          channels;
 } SelectionStream;
 
 class CSelectionStreams

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -44,6 +44,7 @@ SRCS=AlarmClock.cpp \
      ssrc.cpp \
      Stopwatch.cpp \
      StreamDetails.cpp \
+     StreamUtils.cpp \
      StringUtils.cpp \
      SystemInfo.cpp \
      TimeUtils.cpp \

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -21,6 +21,7 @@
 
 #include <math.h>
 #include "StreamDetails.h"
+#include "StreamUtils.h"
 #include "Variant.h"
 
 void CStreamDetail::Archive(CArchive &ar)
@@ -104,27 +105,6 @@ void CStreamDetailAudio::Serialize(CVariant& value)
   value["channels"] = m_iChannels;
 }
 
-int CStreamDetailAudio::GetCodecPriority() const
-{
-  // technically, truehd, dtshd_ma, and flac are equivalently good (they're all lossless)
-  // however, ffmpeg can't decode dtshd_ma losslessy yet
-  if (m_strCodec == "flac")
-    return 7;
-  if (m_strCodec == "truehd")
-    return 6;
-  if (m_strCodec == "dtshd_ma")
-    return 5;
-  if (m_strCodec == "dtshd_hra")
-    return 4;
-  if (m_strCodec == "eac3")
-    return 3;
-  if (m_strCodec == "dca")
-    return 2;
-  if (m_strCodec == "ac3")
-    return 1;
-  return 0;
-}
-
 bool CStreamDetailAudio::IsWorseThan(CStreamDetail *that)
 {
   if (that->m_eType != CStreamDetail::AUDIO)
@@ -137,8 +117,8 @@ bool CStreamDetailAudio::IsWorseThan(CStreamDetail *that)
   if (m_iChannels > sda->m_iChannels)
     return false;
 
-  // In case of a tie, flac > eac3 > dts > ac3 > all else.
-  return sda->GetCodecPriority() > GetCodecPriority();
+  // In case of a tie, revert to codec priority
+  return StreamUtils::GetCodecPriority(sda->m_strCodec) > StreamUtils::GetCodecPriority(m_strCodec);
 }
 
 CStreamDetailSubtitle::CStreamDetailSubtitle() :

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -73,8 +73,6 @@ public:
   int m_iChannels;
   CStdString m_strCodec;
   CStdString m_strLanguage;
-private:
-  int GetCodecPriority() const;
 };
 
 class CStreamDetailSubtitle : public CStreamDetail

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -1,0 +1,45 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "StreamUtils.h"
+
+int StreamUtils::GetCodecPriority(const CStdString &codec)
+{
+  /*
+   * Technically flac, truehd, and dtshd_ma are equivalently good as they're all lossless. However,
+   * ffmpeg can't decode dtshd_ma losslessy yet.
+   */
+  if (codec == "flac") // Lossless FLAC
+    return 7;
+  if (codec == "truehd") // Dolby TrueHD
+    return 6;
+  if (codec == "dtshd_ma") // DTS-HD Master Audio (previously known as DTS++)
+    return 5;
+  if (codec == "dtshd_hra") // DTS-HD High Resolution Audio
+    return 4;
+  if (codec == "eac3") // Dolby Digital Plus
+    return 3;
+  if (codec == "dca") // DTS
+    return 2;
+  if (codec == "ac3") // Dolby Digital
+    return 1;
+  return 0;
+}

--- a/xbmc/utils/StreamUtils.h
+++ b/xbmc/utils/StreamUtils.h
@@ -1,0 +1,31 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "StreamUtils.h"
+
+#include "StdString.h"
+
+class StreamUtils
+{
+public:
+  static int GetCodecPriority(const CStdString &codec);
+};


### PR DESCRIPTION
This code has been around in http://trac.xbmc.org/ticket/5773 for a while now. Are there any changes that need to be made for this to go into master? There was some mention of checking for the capabilities of the client much earlier on, but I think downstream code handles conversion from the chosen audio stream to whatever the client system hardware supports.

This pull request only contains the logic for choosing the best stream. Additional functionality to be able to only automatically choose streams of a given language can be added later.

Similarly code to automatically choose the correct subtitle stream based on a given language can also be added later.
