### PR TITLE
[yafrcf] Yet Another Race Condition Fix

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -73,7 +73,7 @@ CDelayedMessage::CDelayedMessage(ThreadMessage& msg, unsigned int delay)
   m_msg.dwMessage  = msg.dwMessage;
   m_msg.dwParam1   = msg.dwParam1;
   m_msg.dwParam2   = msg.dwParam2;
-  m_msg.hWaitEvent = msg.hWaitEvent;
+  m_msg.waitEvent  = msg.waitEvent;
   m_msg.lpVoid     = msg.lpVoid;
   m_msg.strParam   = msg.strParam;
   m_msg.params     = msg.params;
@@ -102,8 +102,8 @@ void CApplicationMessenger::Cleanup()
   {
     ThreadMessage* pMsg = m_vecMessages.front();
 
-    if (pMsg->hWaitEvent)
-      pMsg->hWaitEvent->Set();
+    if (pMsg->waitEvent)
+      pMsg->waitEvent->Set();
 
     delete pMsg;
     m_vecMessages.pop();
@@ -113,8 +113,8 @@ void CApplicationMessenger::Cleanup()
   {
     ThreadMessage* pMsg = m_vecWindowMessages.front();
 
-    if (pMsg->hWaitEvent)
-      pMsg->hWaitEvent->Set();
+    if (pMsg->waitEvent)
+      pMsg->waitEvent->Set();
 
     delete pMsg;
     m_vecWindowMessages.pop();
@@ -123,12 +123,16 @@ void CApplicationMessenger::Cleanup()
 
 void CApplicationMessenger::SendMessage(ThreadMessage& message, bool wait)
 {
-  message.hWaitEvent = NULL;
+  message.waitEvent.reset();
+  boost::shared_ptr<CEvent> waitEvent;
   if (wait)
   { // check that we're not being called from our application thread, else we'll be waiting
     // forever!
     if (!g_application.IsCurrentThread())
-      message.hWaitEvent = new CEvent(true);
+    {
+      message.waitEvent.reset(new CEvent(true));
+      waitEvent = message.waitEvent;
+    }
     else
     {
       //OutputDebugString("Attempting to wait on a SendMessage() from our application thread will cause lockup!\n");
@@ -142,11 +146,8 @@ void CApplicationMessenger::SendMessage(ThreadMessage& message, bool wait)
 
   if (g_application.m_bStop)
   {
-    if (message.hWaitEvent)
-    {
-      delete message.hWaitEvent;
-      message.hWaitEvent = NULL;
-    }
+    if (message.waitEvent)
+      message.waitEvent.reset();
     return;
   }
 
@@ -154,7 +155,7 @@ void CApplicationMessenger::SendMessage(ThreadMessage& message, bool wait)
   msg->dwMessage = message.dwMessage;
   msg->dwParam1 = message.dwParam1;
   msg->dwParam2 = message.dwParam2;
-  msg->hWaitEvent = message.hWaitEvent;
+  msg->waitEvent = message.waitEvent;
   msg->lpVoid = message.lpVoid;
   msg->strParam = message.strParam;
   msg->params = message.params;
@@ -163,14 +164,18 @@ void CApplicationMessenger::SendMessage(ThreadMessage& message, bool wait)
     m_vecWindowMessages.push(msg);
   else
     m_vecMessages.push(msg);
-  lock.Leave();
-
-  if (message.hWaitEvent)
-  { // ensure the thread doesn't hold the graphics lock
+  lock.Leave();  // this releases the lock on the vec of messages and
+                 //   allows the ProcessMessage to execute and therefore
+                 //   delete the message itself. Therefore any accesss
+                 //   of the message itself after this point consittutes
+                 //   a race condition (yarc - "yet another race condition")
+                 //
+  if (waitEvent) // ... it just so happens we have a spare reference to the
+                 //  waitEvent ... just for such contingencies :)
+  { 
+    // ensure the thread doesn't hold the graphics lock
     CSingleExit exit(g_graphicsContext);
-    message.hWaitEvent->Wait();
-    delete message.hWaitEvent;
-    message.hWaitEvent = NULL;
+    waitEvent->Wait();
   }
 }
 
@@ -186,11 +191,13 @@ void CApplicationMessenger::ProcessMessages()
 
     //Leave here as the message might make another
     //thread call processmessages or sendmessage
-    lock.Leave();
+
+    boost::shared_ptr<CEvent> waitEvent = pMsg->waitEvent; 
+    lock.Leave(); // <- see the large comment in SendMessage ^
 
     ProcessMessage(pMsg);
-    if (pMsg->hWaitEvent)
-      pMsg->hWaitEvent->Set();
+    if (waitEvent)
+      waitEvent->Set();
     delete pMsg;
 
     lock.Enter();
@@ -744,11 +751,13 @@ void CApplicationMessenger::ProcessWindowMessages()
     m_vecWindowMessages.pop();
 
     // leave here in case we make more thread messages from this one
-    lock.Leave();
+
+    boost::shared_ptr<CEvent> waitEvent = pMsg->waitEvent;
+    lock.Leave(); // <- see the large comment in SendMessage ^
 
     ProcessMessage(pMsg);
-    if (pMsg->hWaitEvent)
-      pMsg->hWaitEvent->Set();
+    if (waitEvent)
+      waitEvent->Set();
     delete pMsg;
 
     lock.Enter();

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -101,7 +101,7 @@ typedef struct
   DWORD dwParam2;
   CStdString strParam;
   std::vector<CStdString> params;
-  CEvent* hWaitEvent;
+  boost::shared_ptr<CEvent> waitEvent;
   LPVOID lpVoid;
 }
 ThreadMessage;


### PR DESCRIPTION
This fixes the race condition between SendMessage and ProcessMessages/ProcessWindowsMessages. 

To the best of my knowledge this is was also the issue with vrdfan's 32bit ripping problem. I managed to reproduce it on a single processor 32 bit linux box myself and this addresses the issue - though it's possible I didn't reproduce the same issue.

As far as I can tell this is the last known remaining issue caused by, or uncovered by, the threading refactor.
