### PR TITLE
Replaced string literal "Unknown" with the localized version

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2468,7 +2468,7 @@ void CDVDPlayer::GetSubtitleName(int iStream, CStdString &strStreamName)
   if(s.name.length() > 0)
     strStreamName = s.name;
   else
-    strStreamName = "Unknown";
+    strStreamName = g_localizeStrings.Get(13205); // Unknown
 
   if(s.type == STREAM_NONE)
     strStreamName += "(Invalid)";


### PR DESCRIPTION
CDVDPlayer::GetSubtitleName would produce "Unknown" for an unknown subtitle name regardless of the user's language settings.
