### PR TITLE
Display subtitle language

### DIFF
--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -110,6 +110,7 @@ public:
   virtual int  GetSubtitle()          { return -1; }
   virtual void GetSubtitleName(int iStream, CStdString &strStreamName){};
   virtual void GetSubtitleLanguage(int iStream, CStdString &strStreamLang){};
+  virtual void GetSubtitleFilename(int iStream, CStdString &strStreamFilename){};
   virtual void SetSubtitle(int iStream){};
   virtual bool GetSubtitleVisible(){ return false;};
   virtual void SetSubtitleVisible(bool bVisible){};

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2488,13 +2488,16 @@ void CDVDPlayer::GetSubtitleLanguage(int iStream, CStdString &strStreamLang)
       CStdString strStreamFilename = URIUtils::GetFileName(s.filename).substr(strBase.length() + 1);
       int iPos = strStreamFilename.ReverseFind(".");
       if (iPos > 0)
+      {
         strStreamFilename = strStreamFilename.Left(iPos);
-      
-      if (strStreamFilename.length() > 0)
-        if (!g_LangCodeExpander.Lookup(strStreamLang, strStreamFilename))
-          strStreamLang = strStreamFilename;
+        if (strStreamFilename.length() > 0)
+        {
+          if (!g_LangCodeExpander.Lookup(strStreamLang, strStreamFilename))
+            strStreamLang = strStreamFilename;
+        }
+      }
     }
-    else
+    if (!strStreamLang.length() > 0)
       strStreamLang = g_localizeStrings.Get(13205); // Unknown
   }
 }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2478,7 +2478,33 @@ void CDVDPlayer::GetSubtitleLanguage(int iStream, CStdString &strStreamLang)
 {
   SelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, iStream);
   if (!g_LangCodeExpander.Lookup(strStreamLang, s.language))
-    strStreamLang = g_localizeStrings.Get(13205); // Unknown
+  {
+    if (s.filename.length() > 0)
+    {
+      // attempt to extract a language or description from the filename
+      CStdString strBase = URIUtils::GetFileName(m_filename);
+      URIUtils::RemoveExtension(strBase);
+      
+      CStdString strStreamFilename = URIUtils::GetFileName(s.filename).substr(strBase.length() + 1);
+      int iPos = strStreamFilename.ReverseFind(".");
+      if (iPos > 0)
+        strStreamFilename = strStreamFilename.Left(iPos);
+      
+      if (strStreamFilename.length() > 0)
+        if (!g_LangCodeExpander.Lookup(strStreamLang, strStreamFilename))
+          strStreamLang = strStreamFilename;
+    }
+    else
+      strStreamLang = g_localizeStrings.Get(13205); // Unknown
+  }
+}
+
+void CDVDPlayer::GetSubtitleFilename(int iStream, CStdString &strStreamFilename)
+{
+  strStreamFilename = "";
+  SelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, iStream);
+  if (s.filename.length() > 0)
+    strStreamFilename = s.filename;
 }
 
 void CDVDPlayer::SetSubtitle(int iStream)

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -178,6 +178,7 @@ public:
   virtual int GetSubtitle();
   virtual void GetSubtitleName(int iStream, CStdString &strStreamName);
   virtual void GetSubtitleLanguage(int iStream, CStdString &strStreamLang);
+  virtual void GetSubtitleFilename(int iStream, CStdString &strStreamFilename);
   virtual void SetSubtitle(int iStream);
   virtual bool GetSubtitleVisible();
   virtual void SetSubtitleVisible(bool bVisible);

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -195,8 +195,7 @@ void CGUIDialogAudioSubtitleSettings::AddSubtitleStreams(unsigned int id)
     {
       CStdString strFilename;
       g_application.m_pPlayer->GetSubtitleFilename(i, strFilename);
-      strFilename = URIUtils::GetFileName(strFilename);
-      if (strName != strFilename)
+      if (strName != URIUtils::GetFileName(strFilename))
         strName.Format("%s [%s]", strName.c_str(), strLanguage.c_str());
       else
         strName.Format("%s [%s]", strLanguage.c_str(), strName.c_str());

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -192,7 +192,15 @@ void CGUIDialogAudioSubtitleSettings::AddSubtitleStreams(unsigned int id)
     g_application.m_pPlayer->GetSubtitleLanguage(i, strLanguage);
 
     if (strName != strLanguage)
-      strName.Format("%s [%s]", strName.c_str(), strLanguage.c_str());
+    {
+      CStdString strFilename;
+      g_application.m_pPlayer->GetSubtitleFilename(i, strFilename);
+      strFilename = URIUtils::GetFileName(strFilename);
+      if (strName != strFilename)
+        strName.Format("%s [%s]", strName.c_str(), strLanguage.c_str());
+      else
+        strName.Format("%s [%s]", strLanguage.c_str(), strName.c_str());
+    }
 
     strItem.Format("%s (%i/%i)", strName.c_str(), i + 1, (int)setting.max + 1);
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -49,6 +49,7 @@
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
+#include "utils/URIUtils.h"
 #include "XBDateTime.h"
 #include "input/ButtonTranslator.h"
 
@@ -263,8 +264,16 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
       {
         g_application.m_pPlayer->GetSubtitleName(g_application.m_pPlayer->GetSubtitle(),sub);
         g_application.m_pPlayer->GetSubtitleLanguage(g_application.m_pPlayer->GetSubtitle(),lang);
+        
         if (sub != lang)
-          sub.Format("%s [%s]", sub.c_str(), lang.c_str());
+        {
+          CStdString filename;
+          g_application.m_pPlayer->GetSubtitleFilename(g_application.m_pPlayer->GetSubtitle(),filename);
+          if (sub != URIUtils::GetFileName(filename))
+            sub.Format("%s [%s]", sub.c_str(), lang.c_str());
+          else
+            sub.Format("%s [%s]", lang.c_str(), sub.c_str());
+        }
       }
       else
         sub = g_localizeStrings.Get(1223);
@@ -316,7 +325,14 @@ bool CGUIWindowFullScreen::OnAction(const CAction &action)
         g_application.m_pPlayer->GetSubtitleName(g_settings.m_currentVideoSettings.m_SubtitleStream,sub);
         g_application.m_pPlayer->GetSubtitleLanguage(g_settings.m_currentVideoSettings.m_SubtitleStream,lang);
         if (sub != lang)
-          sub.Format("%s [%s]", sub.c_str(), lang.c_str());
+        {
+          CStdString filename;
+          g_application.m_pPlayer->GetSubtitleFilename(g_settings.m_currentVideoSettings.m_SubtitleStream,filename);
+          if (sub != URIUtils::GetFileName(filename))
+            sub.Format("%s [%s]", sub.c_str(), lang.c_str());
+          else
+            sub.Format("%s [%s]", lang.c_str(), sub.c_str());
+        }
       }
       else
         sub = g_localizeStrings.Get(1223);


### PR DESCRIPTION
This addresses the remainder of [#11715](http://trac.xbmc.org/ticket/11715).

When a subtitle language can't be determined normally, an attempt is made to extract it from the filename. For example:

a.quite.long.filename.for.this.example.English.srt > English [a.quite.long.filename.for.this.example.English.srt]
a.quite.long.filename.for.this.example.Director's Commentary.srt > Director's Commentary [a.quite.long.filename.for.this.example.Director's Commentary.srt]
a.quite.long.filename.for.this.example.srt > Unknown [a.quite.long.filename.for.this.example.srt]
