### PR TITLE
changed: allow any threaded directory requests to be canceled by abandoni

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3127,6 +3127,11 @@ bool CApplication::Cleanup()
 
     CAddonMgr::Get().DeInit();
 
+#if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
+    CLog::Log(LOGNOTICE, "closing down remote control service");
+    g_RemoteControl.Disconnect();
+#endif
+
     CLog::Log(LOGNOTICE, "unload sections");
 
 #ifdef HAS_PERFORMANCE_SAMPLE

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -20,13 +20,57 @@
  */
 
 #include "GUIDialogBusy.h"
+#include "guilib/GUIWindowManager.h"
 
 CGUIDialogBusy::CGUIDialogBusy(void)
 : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml")
 {
   m_loadOnDemand = false;
+  m_bModal = true;
 }
 
 CGUIDialogBusy::~CGUIDialogBusy(void)
 {
+}
+
+void CGUIDialogBusy::Show_Internal()
+{
+  m_bCanceled = false;
+  m_bRunning = true;
+  m_bModal = true;
+  m_bLastVisible = true;
+  m_dialogClosing = false;
+  g_windowManager.RouteToWindow(this);
+
+  // active this window...
+  CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0);
+  OnMessage(msg);
+}
+
+void CGUIDialogBusy::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions)
+{
+  bool visible = g_windowManager.GetTopMostModalDialogID() == WINDOW_DIALOG_BUSY;
+  if(!visible && m_bLastVisible)
+    dirtyregions.push_back(m_renderRegion);
+  m_bLastVisible = visible;
+  CGUIDialog::DoProcess(currentTime, dirtyregions);
+}
+
+void CGUIDialogBusy::Render()
+{
+  if(!m_bLastVisible)
+    return;
+  CGUIDialog::Render();
+}
+
+bool CGUIDialogBusy::OnAction(const CAction &action)
+{
+  if(action.GetID() == ACTION_NAV_BACK 
+  || action.GetID() == ACTION_PREVIOUS_MENU)
+  {
+    m_bCanceled = true;
+    return true;
+  }
+  else
+    return CGUIDialog::OnAction(action);
 }

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -29,4 +29,13 @@ class CGUIDialogBusy: public CGUIDialog
 public:
   CGUIDialogBusy(void);
   virtual ~CGUIDialogBusy(void);
+  virtual bool OnAction(const CAction &action);
+  virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
+  virtual void Render();
+
+  bool IsCanceled() { return m_bCanceled; }
+protected:
+  virtual void Show_Internal(); // modeless'ish
+  bool m_bCanceled;
+  bool m_bLastVisible;
 };

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -65,8 +65,8 @@ protected:
   virtual void UpdateVisibility();
 
   friend class CApplicationMessenger;
-  void DoModal_Internal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
-  void Show_Internal(); // modeless
+  virtual void DoModal_Internal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
+  virtual void Show_Internal(); // modeless
   void Close_Internal(bool forceClose = false);
 
   bool m_bRunning;


### PR DESCRIPTION
This allows any directory request to be aborted while the busy dialog is up. 

The busy dialog will be be modal in a sense to it will swallow events as if it was a true blocking modal. But it will not block whoever made it modal. It will only respond to back or previous menu actions.
- If any new modal dialog shows up after the busy dialog shows it will go away. 
- If the original modal dialog shows up again, the busy dialog is shown again.
