### PR TITLE
Updated Dutch language files

### DIFF
--- a/addons/skin.confluence/language/Dutch/strings.xml
+++ b/addons/skin.confluence/language/Dutch/strings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
   <!-- Misc labels -->
   <string id="31000">Aanpassen</string>
@@ -7,8 +7,10 @@
   <string id="31003">Energiebeheer</string>
   <string id="31004">Bezig...</string>
   <string id="31005">Info verbergen</string> <!-- slaat niet op .NFO-bestand, wel op oa. plot, acteurs, etc.-->
-
+  
+<string id="31006">Weergave Opties</string>
   <string id="31007">Plugins</string>
+  <string id="31008">Volledig scherm</string>
 
   <string id="31020">Hoofdstuktitel</string>
   <string id="31021">Video - Bestanden</string>
@@ -38,6 +40,9 @@
   <string id="31047">Huidige instelling</string>
   <string id="31048">Visualisatiestijl</string>
   <string id="31049">Eindigt om</string>
+
+  <string id="31050">Sorteren: Oplopend</string>
+  <string id="31051">Sorteren: Aflopend</string>
 
 
   <!-- Playlist Editor labels -->
@@ -84,6 +89,12 @@
   <string id="31130"></string>
   <string id="31131"></string>
 
+  <string id="31132">Liedtekst Add-on</string>
+  <string id="31133">Ondertiteling Add-on</string>
+  <string id="31134">Begin Scherm Videos Submenu</string>
+  <string id="31135">Begin Scherm Music Submenu</string>
+  <string id="31136">Begin Scherm Pictures Submenu</string>
+
   <string id="31140">Muziek-OSD</string>
   <string id="31141">Video-OSD</string>
 
@@ -92,8 +103,8 @@
   <string id="31201">Categorieën</string>
   <string id="31202">Toon cast</string>
   <string id="31203">Kies uw nummer</string>
-  <string id="31204">Sectielinks</string>
-  <string id="31205">Songtekstbron</string>
+  <string id="31204">Sectie links</string>
+  <string id="31205">Liedtekst bron</string>
 
   <!-- Extra labels -->
   <string id="31300">Huidige temperatuur</string> <!--Voldoende ruimte in de layout van het weerscherm om temperatuur voluit te schrijven-->
@@ -128,6 +139,9 @@
   <string id="31329">[B]Timer geconfigureerd![/B] [COLOR=grey2] - Systeem schakelt automatisch uit in[/COLOR]</string>
   <string id="31330">Klik op de knop om af te spelen[CR][CR]Filmtrailer</string>
 
+  <string id="31331">Album Details</string>
+
+  
   <!-- Video and Music OSD Labels  -->
   <string id="31351">Pauze</string>
   <string id="31352">Stop</string>
@@ -154,4 +168,17 @@
   <string id="31408">[B]ADD-ONS CONFIGUREREN[/B][CR][CR]Beheer uw geïnstalleerde Add-ons · Zoek en installeer Add-ons via xbmc.org · Wijzig Add-oninstellingen</string>
 
   <string id="31421">Selecteer uw XBMC-gebruikersprofiel[CR]om in te loggen</string>
+  
+  <!-- Weather plugin -->
+  <string id="31900">Weer Kaarten</string>
+  <string id="31901">36 Uur Voorspelling</string>
+  <string id="31902">Per Uur Voorspelling</string>
+  <string id="31903">Weekend Voorspelling</string>
+  <string id="31904">10 Dagen Voorspelling</string>
+  <string id="31905">Voorspelling</string>
+  <string id="31906">Kaarten en Video</string>
+  <string id="31907">Video voorspelling [COLOR=grey2](Volledig scherm Afspelen)[/COLOR]</string>
+  <string id="31908">Kans Op Neerslag</string>
+  <string id="31909">Weersvoorspelling ophalen...</string>
+  
 </strings>

--- a/addons/skin.confluence/language/English/strings.xml
+++ b/addons/skin.confluence/language/English/strings.xml
@@ -86,7 +86,7 @@
   <string id="31129"></string>  <!-- blanked 2010-11-12 -->
   <string id="31130"></string>  <!-- blanked 2010-11-12 -->
   
-  <string id="31131"></string> <!-- blanked 2010-12-23 -->
+<string id="31131"></string> <!-- blanked 2010-12-23 -->
   <string id="31132">Lyrics Add-on</string>
   <string id="31133">Subtitle Add-on</string>
   <string id="31134">Home Page Videos Submenu</string>

--- a/addons/visualization.milkdrop/resources/language/Dutch/strings.xml
+++ b/addons/visualization.milkdrop/resources/language/Dutch/strings.xml
@@ -10,5 +10,16 @@
     <string id="30006">Gemiddelde tijd tussen ruwe afkappingen</string>
     <string id="30007">Maximale verversingsfrequentie</string>
     <string id="30008">Stereo 3D inschakelen</string>
-    <string id="30009">Presetpakket</string>
+    <string id="30009">Preset pakket</string>
+    <string id="30010">Gebruiker Preset Folder        </string>
+    <string id="30011">Preset Shuffle Mode</string>
+    
+    <string id="30020">WA51 Presets</string>
+    <string id="30021">Winamp Presets</string>
+    <string id="30022">Gebruiker Gedefineerde Preset Folder</string>
+
+    <!-- setting value formats -->
+    <string id="30050">%2.Van sec.</string>
+    <string id="30051">%2.Van %%</string>
+    <string id="30052">%2.Van fps</string>
 </strings>

--- a/addons/visualization.projectm/resources/language/Dutch/strings.xml
+++ b/addons/visualization.projectm/resources/language/Dutch/strings.xml
@@ -10,4 +10,12 @@
     <string id="30006">Smooth-Presetduur</string>
     <string id="30007">Presetduur</string>
     <string id="30008">Beatgevoeligheid</string>
+    <string id="30009">Preset Pakket</string>
+    <string id="30010">Standaard Pakket</string>
+    <string id="30011">Gebruiker Gedefineerde Preset Folder</string>
+    <string id="30012">Gebruiker  Preset Folder</string>
+
+    <!-- setting value formats -->
+    <string id="30050">%2.Van sec.</string>
+    <string id="30051">%2.Van %%</string>
 </strings>

--- a/language/Dutch/strings.xml
+++ b/language/Dutch/strings.xml
@@ -1,10 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <!--Language file translated with Team XBMC Translator-->
-<!--Translator: idioteque-->
-<!--Email: ronaldloggen@gmail.com-->
-<!--Date of translation: 12/28/2010-->
-<!--$Revision$-->
-<!--Based on english strings version 35208-->
 <strings>
   <string id="0">Programma's</string>
   <string id="1">Afbeeldingen</string>
@@ -16,6 +11,7 @@
   <string id="7">Bestandsbeheer</string>
   <string id="8">Weer</string>
   <string id="9">XBMC Media Center</string>
+  
   <string id="11">Maandag</string>
   <string id="12">Dinsdag</string>
   <string id="13">Woensdag</string>
@@ -23,6 +19,7 @@
   <string id="15">Vrijdag</string>
   <string id="16">Zaterdag</string>
   <string id="17">Zondag</string>
+  
   <string id="21">januari</string>
   <string id="22">februari</string>
   <string id="23">maart</string>
@@ -35,6 +32,7 @@
   <string id="30">oktober</string>
   <string id="31">november</string>
   <string id="32">december</string>
+  
   <string id="41">Ma</string>
   <string id="42">Di</string>
   <string id="43">Wo</string>
@@ -42,6 +40,7 @@
   <string id="45">Vr</string>
   <string id="46">Za</string>
   <string id="47">Zo</string>
+  
   <string id="51">jan</string>
   <string id="52">feb</string>
   <string id="53">mrt</string>
@@ -54,6 +53,7 @@
   <string id="60">okt</string>
   <string id="61">nov</string>
   <string id="62">dec</string>
+  
   <string id="71">N</string>
   <string id="72">NNO</string>
   <string id="73">NO</string>
@@ -70,6 +70,7 @@
   <string id="84">WNW</string>
   <string id="85">NW</string>
   <string id="86">NNW</string>
+  
   <string id="87">variabele</string>
   <string id="98">Layout: Automatisch</string>
   <string id="99">Layout: Autom. groot</string>
@@ -100,7 +101,7 @@
   <string id="124">Deze bestanden verplaatsen?</string>
   <string id="125">Deze bestanden verwijderen? Dit kan niet meer ongedaan worden gemaakt!</string>
   <string id="126">Status</string>
-  <string id="127">items</string>
+  <string id="127">Items</string>
   <string id="128">Algemeen</string>
   <string id="129">Voorstelling</string>
   <string id="130">Systeeminformatie</string>
@@ -140,18 +141,16 @@
   <string id="164">Geen schijf</string>
   <string id="165">Schijf aanwezig</string>
   <string id="166">Skin</string>
-  <string id="167">
-  </string>
-  <string id="168">
-  </string>
+  
   <string id="169">Resolutie</string>
   <string id="170">Verversingsfrequentie scherm aanpassen aan video</string>
-  <string id="171">
-  </string>
+ 
   <string id="172">Releasedatum:</string>
   <string id="173">Geef 4:3 video's weer als</string>
+  
   <string id="175">Stemmingen</string>
   <string id="176">Stijlen</string>
+  
   <string id="179">Tracklist</string>
   <string id="180">Tijdsduur</string>
   <string id="181">Selecteer album</string>
@@ -173,8 +172,10 @@
   <string id="197">%s raadplegen voor informatie</string>
   <string id="198">Filmgegevens ophalen</string>
   <string id="199">Webinterface</string>
+  
   <string id="202">Slagzin</string>
   <string id="203">Plot</string>
+  
   <string id="205">Stemmen:</string>
   <string id="206">Acteurs</string>
   <string id="207">Plot</string>
@@ -192,6 +193,7 @@
   <string id="221">Netwerk is niet verbonden</string>
   <string id="222">Annuleren</string>
   <string id="224">Snelheid</string>
+  <string id="225">Verticale verschuiving</string>
   <string id="226">Testbeeld...</string>
   <string id="227">Bij muziek CD's namen van nummers via internet opzoeken</string>
   <string id="228">Afspeellijst willekeurig afspelen</string>
@@ -212,6 +214,7 @@
   <string id="243">Verversingsfrequentie</string>
   <string id="244">Volledig scherm</string>
   <string id="245">Formaat: (%i,%i)-&gt;(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1)</string>
+  
   <string id="247">Scripts</string>
   <string id="248">Taal</string>
   <string id="249">Muziek</string>
@@ -250,8 +253,7 @@
   <string id="282">%i items gevonden</string>
   <string id="283">Zoekresultaten</string>
   <string id="284">Niets gevonden</string>
-  <string id="286">
-  </string>
+
   <string id="287">Ondertiteling</string>
   <string id="288">Lettertype</string>
   <string id="289">- Formaat</string>
@@ -271,16 +273,7 @@
   <string id="304">Taal</string>
   <string id="305">Ingeschakeld</string>
   <string id="306">Non-Interleaved</string>
-  <string id="307">
-  </string>
-  <string id="308">
-  </string>
-  <string id="309">
-  </string>
-  <string id="310">
-  </string>
-  <string id="311">
-  </string>
+  
   <string id="312">(0=auto)</string>
   <string id="313">Bibliotheek opschonen</string>
   <string id="314">Voorbereiden...</string>
@@ -361,7 +354,7 @@
   <string id="392">Gem.</string>
   <string id="393">Max.</string>
   <string id="394">Mist</string>
-  <string id="395">Heiig</string>
+  <string id="395">Nevel</string>
   <string id="396">Locatie selecteren</string>
   <string id="397">Vernieuwingstijd</string>
   <string id="398">Eenheid temperatuur</string>
@@ -373,10 +366,7 @@
   <string id="404">Wind</string>
   <string id="405">Dauwpunt</string>
   <string id="406">Vochtigheid</string>
-  <string id="407">
-  </string>
-  <string id="408">
-  </string>
+  
   <string id="409">Standaard</string>
   <string id="410">Weersverwachting opzoeken</string>
   <string id="411">Weersverwachting ophalen voor</string>
@@ -390,6 +380,7 @@
   <string id="419">Max</string>
   <string id="420">HDMI</string>
   <string id="422">Albuminformatie wissen</string>
+  
   <string id="423">CDDB-informatie wissen</string>
   <string id="424">Selecteer</string>
   <string id="425">Geen albuminformatie gevonden.</string>
@@ -402,6 +393,7 @@
   <string id="432">Speelfilm uit bibliotheek verwijderen</string>
   <string id="433">'%s' zeker verwijderen?</string>
   <string id="434">Uit het %s met %i %s</string>
+  
   <string id="437">Verwisselbare schijf</string>
   <string id="438">Bestand openen</string>
   <string id="439">Buffer</string>
@@ -439,12 +431,13 @@
   <string id="474">Uit</string>
   <string id="475">Alleen geluid</string>
   <string id="476">Geluid en video</string>
-  <string id="477">Playlist kon niet worden geladen</string>
+  <string id="477">Afspeellijst kon niet worden geladen</string>
   <string id="478">On Screen Display</string>
   <string id="479">Skin en taal</string>
   <string id="480">Uiterlijk</string>
   <string id="481">Geluidsinstellingen</string>
   <string id="482">Over XBMC</string>
+  
   <string id="485">Album verwijderen</string>
   <string id="486">Herhalen</string>
   <string id="487">Nummer herhalen</string>
@@ -472,11 +465,11 @@
   <string id="513">Beginscherm</string>
   <string id="514">Handmatige instellingen</string>
   <string id="515">Genre</string>
+  
   <string id="517">Laatst afgespeelde albums</string>
   <string id="518">Starten</string>
   <string id="519">Starten in..</string>
-  <string id="520">
-  </string>
+  
   <string id="521">Compilaties</string>
   <string id="522">Snelkoppeling verwijderen</string>
   <string id="523">Media veranderen</string>
@@ -505,6 +498,7 @@
   <string id="546">Doorgifte Geluidsuitvoerapparaat</string>
   <string id="547">Geen biografie beschikbaar voor artiest</string>
   <string id="548">Downmix multikanaals audio naar stereo</string>
+  
   <string id="550">Sorteer: %s</string>
   <string id="551">Naam</string>
   <string id="552">Datum</string>
@@ -531,6 +525,8 @@
   <string id="573">Pad</string>
   <string id="574">Land</string>
   <string id="575">Bezig</string>
+  <string id="576">Keren afgespeeld</string>
+  
   <string id="580">Sorteerrichting</string>
   <string id="581">Sorteren op</string>
   <string id="582">Layout</string>
@@ -549,12 +545,14 @@
   <string id="595">Herhalen: Uit</string>
   <string id="596">Herhalen: 1</string>
   <string id="597">Herhalen: Alles</string>
+  
   <string id="600">Cd kopiëren</string>
   <string id="601">Middelmatig</string>
   <string id="602">Standaard</string>
   <string id="603">Extreem</string>
   <string id="604">Constante bitsnelheid</string>
   <string id="605">Kopiëren...</string>
+  
   <string id="607">Naar:</string>
   <string id="608">Kopiëren van CD of nummer mislukt</string>
   <string id="609">CDDA-doelmap is niet ingegeven.</string>
@@ -562,6 +560,7 @@
   <string id="611">Voer nummer in</string>
   <string id="612">Bits/Sample</string>
   <string id="613">Sample frequentie</string>
+  
   <string id="620">Muziek CD's</string>
   <string id="621">Encoder</string>
   <string id="622">Kwaliteit</string>
@@ -599,26 +598,30 @@
   <string id="657">Map openen</string>
   <string id="658">Muziekinformatie</string>
   <string id="659">Niet-lineair uitrekken</string>
+  
   <string id="660">Volumeversterking</string>
   <string id="661">Exporteerlocatie kiezen</string>
   <string id="662">Dit bestand is niet langer beschikbaar.</string>
   <string id="663">Wilt u het verwijderen uit de bibliotheek?</string>
   <string id="664">Naar script zoeken</string>
   <string id="665">Compressieniveau</string>
+  
   <string id="700">Bibliotheek opschonen</string>
   <string id="701">Oude nummers uit bibliotheek verwijderen</string>
   <string id="702">Deze locatie is al eerder gescand</string>
   <string id="705">Netwerk</string>
   <string id="706">- Host</string>
+  
   <string id="708">HTTP-proxy gebruiken</string>
+  
   <string id="711">Internet Protocol (IP)</string>
   <string id="712">Ongeldig poortnummer. Waarde moet tussen 1 en 65535 liggen.</string>
   <string id="713">HTTP proxy</string>
+  
   <string id="715">Toewijzing</string>
   <string id="716">Automatisch (DHCP)</string>
   <string id="717">Handmatig (Statisch)</string>
-  <string id="718">
-  </string>
+
   <string id="719">- IP-adres</string>
   <string id="720">- Netmask</string>
   <string id="721">- Standaard Gateway</string>
@@ -629,10 +632,9 @@
   <string id="726">Veranderingen niet opgeslagen. Doorgaan zonder op te slaan?</string>
   <string id="727">Webserver</string>
   <string id="728">FTP-server</string>
-  <string id="729">
-  </string>
+  
   <string id="730">- Poort</string>
-  <string id="731">- Host</string>
+
   <string id="732">Opslaan en toepassen</string>
   <string id="733">- Wachtwoord</string>
   <string id="734">Geen wachtwoord</string>
@@ -653,10 +655,12 @@
   <string id="749">Spiegel afbeelding</string>
   <string id="750">Weet u het zeker?</string>
   <string id="751">Snelkoppeling verwijderen</string>
+  
   <string id="754">Programmalink toevoegen</string>
   <string id="755">Programmalink wijzigen</string>
   <string id="756">Programmanaam wijzigen</string>
   <string id="757">Zoekdiepte instellen</string>
+  
   <string id="759">Layout: Groot</string>
   <string id="760">Geel</string>
   <string id="761">Wit</string>
@@ -664,11 +668,12 @@
   <string id="763">Lichtgroen</string>
   <string id="764">Lichtgeel</string>
   <string id="765">Cyaan</string>
-  <string id="766">Reserved</string>
-  <string id="767">Reserved</string>
+  <string id="766">Lichtgrijs</string>
+  <string id="767">Grijs</string>
+  <!-- strings 768 and 769 reserved for more subtitle colors -->
+
   <string id="770">Fout %i: gedeelde map niet beschikbaar</string>
-  <string id="771">
-  </string>
+
   <string id="772">Geluidshardware</string>
   <string id="773">Zoeken</string>
   <string id="774">Map schermbeveiliging door diavoorstelling</string>
@@ -687,6 +692,7 @@
   <string id="787">Verbinding uitgeschakeld</string>
   <string id="788">Verbinding succesvol uitgeschakeld.</string>
   <string id="789">Naam draadloos netwerk (ESSID)</string>
+  
   <string id="791">Gebeurtenissen op afstand activeren</string>
   <string id="792">Poort voor gebeurtenissen op afstand</string>
   <string id="793">Poortbereik voor gebeurtenissen op afstand</string>
@@ -695,14 +701,20 @@
   <string id="796">Doorgaande herhalingsvertraging (ms)</string>
   <string id="797">Maximaal aantal gebruikers</string>
   <string id="798">Internettoegang</string>
+  
   <string id="850">Ongeldig poortnummer ingevoerd</string>
   <string id="851">Geldig poortbereik is 1-65535</string>
   <string id="852">Geldig poortbereik is 1024-65535</string>
+  
+
+  <string id="998">Muziek Toevoegen...</string>
+  <string id="999">Videos Toevoegen...</string>
   <string id="1000">- Test schermbeveiliging</string>
   <string id="1001">Verbinding mislukt</string>
   <string id="1002">XBMC kon niet verbinden met de netwerklocatie.</string>
   <string id="1003">Dit kan veroorzaakt worden doordat het netwerk niet verbonden is.</string>
   <string id="1004">Wilt u het toch toevoegen?</string>
+  
   <string id="1006">IP-adres</string>
   <string id="1007">Netwerklocatie toevoegen</string>
   <string id="1008">Protocol</string>
@@ -749,12 +761,15 @@
   <string id="1049">Script instellingen</string>
   <string id="1050">Singles</string>
   <string id="1051">Voer URL in</string>
+  
   <string id="1200">SMB-client</string>
   <string id="1202">Werkgroep</string>
   <string id="1203">Standaardgebruikersnaam</string>
   <string id="1204">Standaardwachtwoord</string>
+  
   <string id="1207">WINS-server</string>
   <string id="1208">Laad SMB gedeeld netwerk</string>
+  
   <string id="1210">Verwijder</string>
   <string id="1211">Muziek</string>
   <string id="1212">Video</string>
@@ -779,22 +794,21 @@
   <string id="1233">Programma's, video en muziek</string>
   <string id="1234">Programma's, afbeeldingen en muziek</string>
   <string id="1235">Programma's, afbeeldingen en video's</string>
-  <string id="1245">
-  </string>
-  <string id="1246">
-  </string>
-  <string id="1247">
-  </string>
+  
   <string id="1250">Systeem detecteren</string>
   <string id="1251">Aangesloten systemen automatisch detecteren</string>
-  <string id="1252">Nickname</string>
+  <string id="1252">Bijnaam</string>
+
   <string id="1254">Vragen om verbinding te maken</string>
   <string id="1255">FTP-gebruikersnaam en -wachtwoord verzenden</string>
   <string id="1256">Pinginterval in sec.</string>
   <string id="1257">Verbinding maken met de gevonden systeem?</string>
+
   <string id="1260">Zeroconf publishing</string>
+
   <string id="1300">Aangepaste geluidskaart</string>
   <string id="1301">Aangepast Passthrough apparaat</string>
+
   <string id="1396">Stuifsneeuw</string>
   <string id="1397">en</string>
   <string id="1398">Vrieskou</string>
@@ -817,21 +831,25 @@
   <string id="1415">Motregen</string>
   <string id="1416">Mistig</string>
   <string id="1417">Korrels</string>
-  <string id="1418">T-Storms</string>
+  <string id="1418">Onweer</string>
   <string id="1419">Onweersbuien</string>
   <string id="1420">Matig</string>
-  <string id="1421">Very High</string>
+  <string id="1421">Heel hoog</string>
   <string id="1422">Winderig</string>
   <string id="1423">Mist</string>
+  
+   <!-- strings through to 1450 reserved for weather translation -->
+   
   <string id="1450">Schakel beeldscherm uit bij inactiviteit</string>
+  <!-- strings through to 1470 reserved for power-saving -->
+  
   <string id="2050">Speelduur</string>
+  
   <string id="2100">Fout in script! : %s</string>
   <string id="2101">Nieuwere versie vereist - Zie log</string>
-  <string id="2102">
-  </string>
-  <string id="2103">
-  </string>
+
   <string id="4501">Gebruik LCD/VFD</string>
+
   <string id="10000">Beginscherm</string>
   <string id="10001">Programma's</string>
   <string id="10002">Afbeeldingen</string>
@@ -854,15 +872,19 @@
   <string id="10019">Instellingen - Uiterlijk</string>
   <string id="10020">Scripts</string>
   <string id="10021">Webbrowser</string>
+
   <string id="10028">Video/Afspeellijst</string>
   <string id="10034">Instellingen - Profielen</string>
+  
   <string id="10100">Ja/Nee</string>
   <string id="10101">Voortgang</string>
+  
   <string id="10210">Zoeken naar ondertitels...</string>
   <string id="10211">Ondertitels cachen...</string>
   <string id="10212">Bezig met afsluiten</string>
   <string id="10213">Bufferen</string>
   <string id="10214">Bezig met het openen van stream</string>
+  
   <string id="10500">Muziek/Afspeellijst</string>
   <string id="10501">Muziek/Bestanden</string>
   <string id="10502">Muziek/Bibliotheek</string>
@@ -875,11 +897,14 @@
   <string id="10509">Netwerk gaming</string>
   <string id="10510">Extensies</string>
   <string id="10511">Systeeminformatie</string>
+  
   <string id="10516">Muziek - Bibliotheek</string>
   <string id="10517">Muziek - Afspeellijst</string>
+
   <string id="10522">Video's - Afspeellijst</string>
   <string id="10523">Albuminformatie</string>
   <string id="10524">Filminformatie</string>
+
   <string id="12000">Selecteren</string>
   <string id="12001">Muziek/Informatie</string>
   <string id="12002">Bevestiging</string>
@@ -887,32 +912,15 @@
   <string id="12004">Scripts/Informatie</string>
   <string id="12005">Volledig scherm</string>
   <string id="12006">Geluidsvisualisatie</string>
+  
   <string id="12008">Bestanden groeperen</string>
   <string id="12009">Herindexeren</string>
   <string id="12010">Terug naar Muziek</string>
   <string id="12011">Terug naar Video's</string>
-  <string id="12012">
-  </string>
-  <string id="12013">
-  </string>
-  <string id="12014">
-  </string>
-  <string id="12015">
-  </string>
-  <string id="12016">
-  </string>
-  <string id="12017">
-  </string>
-  <string id="12018">
-  </string>
-  <string id="12019">
-  </string>
-  <string id="12020">
-  </string>
+  
   <string id="12021">Starten vanaf begin</string>
   <string id="12022">Hervatten vanaf %s</string>
-  <string id="12023">
-  </string>
+  
   <string id="12310">0</string>
   <string id="12311">1</string>
   <string id="12312">2</string>
@@ -962,34 +970,31 @@
   <string id="12377">Dit zal alle voorgaande opgeslagen waarden resetten</string>
   <string id="12378">Afbeeldingen weergeven gedurende</string>
   <string id="12379">Pan- en zoomeffecten gebruiken</string>
-  <string id="12380">
-  </string>
-  <string id="12381">
-  </string>
-  <string id="12382">
-  </string>
+    
   <string id="12383">12-uursformaat</string>
   <string id="12384">24-uursformaat</string>
   <string id="12385">Dag/Maand</string>
   <string id="12386">Maand/Dag</string>
+  
   <string id="12390">Systeem actief</string>
   <string id="12391">minuten</string>
   <string id="12392">uur</string>
   <string id="12393">dagen</string>
   <string id="12394">Totale activiteit</string>
+  <string id="12395">Battery niveau</string>
+
   <string id="12600">Het weer</string>
+    
   <string id="12900">Schermbeveiliging</string>
   <string id="12901">Volledig scherm On Screen Display</string>
+  
   <string id="13000">Systeem</string>
   <string id="13001">Harde schijf onmiddellijk uitschakelen</string>
   <string id="13002">Alleen beeld</string>
   <string id="13003">- Vertraging</string>
   <string id="13004">- Minimale bestandsduur</string>
   <string id="13005">Computer uitschakelen</string>
-  <string id="13006">
-  </string>
-  <string id="13007">
-  </string>
+  
   <string id="13008">Standaard afsluitmethode</string>
   <string id="13009">XBMC afsluiten</string>
   <string id="13010">Winterslaap (S4)</string>
@@ -998,15 +1003,20 @@
   <string id="13013">Opnieuw opstarten</string>
   <string id="13014">Minimaliseren</string>
   <string id="13015">Actie voor aan/uitknop</string>
+  <string id="13016">Systeem Uitschakelen</string>
+  
   <string id="13020">Er is een andere sessie actief, wellicht SSH?</string>
   <string id="13021">Verwisselbare harde schijf aankoppelen?</string>
   <string id="13022">Apparaat onveilig verwijderd</string>
   <string id="13023">Apparaat succesvol verwijderd</string>
   <string id="13024">Joystick aangesloten</string>
   <string id="13025">Geen joystick aangesloten</string>
+  
   <string id="13050">Lage accuspanning</string>
+  
   <string id="13100">Flikkerfilter</string>
   <string id="13101">Laat keuze aan driver (herstart vereist)</string>
+  
   <string id="13105">Vertical blank sync</string>
   <string id="13106">Uitgeschakeld</string>
   <string id="13107">Ingeschakeld tijdens afspelen</string>
@@ -1025,62 +1035,38 @@
   <string id="13120">Strikte Pixmap-Texture Binding (vereist herstart)</string>
   <string id="13121">VDPAU HQ Upscaling level</string>
   <string id="13122">VDPAU Studio level color conversion</string>
+  
   <string id="13130">Stop doorgifte videosignaal aan andere beeldschermen</string>
   <string id="13131">Uitgeschakeld</string>
   <string id="13132">Stop doorgifte videosignaal</string>
+  
   <string id="13140">Actieve verbindingen gedetecteerd!</string>
   <string id="13141">Als u doorgaat, kunt u XBMC mogelijk niet meer</string>
   <string id="13142">besturen. Weet u zeker dat u de Event Server wilt stoppen?</string>
+  
   <string id="13144">Verander Apple afstandsbediengsmodus?</string>
   <string id="13145">Als u op dit moment de Apple afstandsbediening gebruikt</string>
   <string id="13146">om XBMC te besturen, kan het veranderen van deze instelling</string>
   <string id="13147">de mogelijkheid om het te blijven besturen beïnvloeden. Doorgaan?</string>
-  <string id="13150">
-  </string>
-  <string id="13151">
-  </string>
-  <string id="13152">
-  </string>
-  <string id="13153">
-  </string>
-  <string id="13154">
-  </string>
-  <string id="13155">
-  </string>
-  <string id="13156">
-  </string>
-  <string id="13157">
-  </string>
-  <string id="13158">
-  </string>
+  
   <string id="13159">Subnetmasker</string>
   <string id="13160">Gateway</string>
   <string id="13161">DNS-server</string>
   <string id="13162">Initialiseren mislukt</string>
-  <string id="13163">
-  </string>
-  <string id="13164">
-  </string>
-  <string id="13165">
-  </string>
-  <string id="13166">
-  </string>
-  <string id="13167">
-  </string>
-  <string id="13168">
-  </string>
-  <string id="13169">
-  </string>
+  
   <string id="13170">Nooit</string>
   <string id="13171">Direct</string>
   <string id="13172">Na %i sec.</string>
   <string id="13173">HDD installatiedatum:</string>
   <string id="13174">HDD Power Cycle teller:</string>
+  
   <string id="13200">Profielen</string>
   <string id="13201">Profiel '%s' verwijderen?</string>
+  
   <string id="13204">Laatst gebruikt profiel:</string>
   <string id="13205">Onbekend</string>
   <string id="13206">Overschrijven</string>
+  
   <string id="13208">Alarmklok</string>
   <string id="13209">Alarmklokinterval (in minuten)</string>
   <string id="13210">Gestart, alarm over %im</string>
@@ -1088,13 +1074,16 @@
   <string id="13212">Gestopt met nog %im%is te gaan</string>
   <string id="13213">%2.0fm</string>
   <string id="13214">%2.0fs</string>
+  
   <string id="13249">Naar ondertitels zoeken in RAR-archieven</string>
   <string id="13250">Ondertitels zoeken</string>
   <string id="13251">Item verplaatsen</string>
   <string id="13252">Item hierheen verplaatsen</string>
   <string id="13253">Verplaatsen annuleren</string>
+  
   <string id="13270">Hardware:</string>
   <string id="13271">Belasting:</string>
+  
   <string id="13274">XBMC is verbonden, maar geen DNS beschikbaar.</string>
   <string id="13275">Harde schijf</string>
   <string id="13276">DVD-ROM</string>
@@ -1103,29 +1092,20 @@
   <string id="13279">Netwerk</string>
   <string id="13280">Video</string>
   <string id="13281">Hardware</string>
+
   <string id="13283">Besturingssysteem:</string>
   <string id="13284">Kloksnelheid:</string>
-  <string id="13285">
-  </string>
+
   <string id="13286">Video-encoder:</string>
   <string id="13287">Schermresolutie:</string>
-  <string id="13288">
-  </string>
-  <string id="13289">
-  </string>
-  <string id="13290">
-  </string>
-  <string id="13291">
-  </string>
+
   <string id="13292">A/V-kabel:</string>
-  <string id="13293">
-  </string>
+
   <string id="13294">DVD-regio:</string>
   <string id="13295">Internet:</string>
   <string id="13296">Ja, verbonden met internet</string>
   <string id="13297">Nee, niet verbonden met internet. Controleer uw netwerkinstellingen.</string>
-  <string id="13298">
-  </string>
+
   <string id="13299">- Doeltemperatuur</string>
   <string id="13300">- Ventilatorsnelheid</string>
   <string id="13301">Automatische ventilatorsnelheid</string>
@@ -1164,10 +1144,7 @@
   <string id="13334">Label aanpassen</string>
   <string id="13335">Maak standaard</string>
   <string id="13336">Verwijder Knop</string>
-  <string id="13338">
-  </string>
-  <string id="13339">
-  </string>
+
   <string id="13340">Onveranderd laten</string>
   <string id="13341">Groen</string>
   <string id="13342">Oranje</string>
@@ -1190,6 +1167,7 @@
   <string id="13359">Afbeelding artiest instellen</string>
   <string id="13360">Miniaturen automatisch aanmaken</string>
   <string id="13361">Stem inschakelen</string>
+  
   <string id="13375">Apparaat inschakelen</string>
   <string id="13376">Volume</string>
   <string id="13377">Standaard weergavemodus</string>
@@ -1218,7 +1196,7 @@
   <string id="13400">Nummers van hetzelfde album in elkaar laten overvloeien</string>
   <string id="13401">Zoeken naar %s</string>
   <string id="13402">Trackpositie weergeven</string>
-  <string id="13403">Default leegmaken</string>
+  <string id="13403">Standaard leegmaken</string>
   <string id="13404">Hervatten</string>
   <string id="13405">Miniaturen</string>
   <string id="13406">Afbeeldingsinformatie</string>
@@ -1227,6 +1205,7 @@
   <string id="13409">Top 250</string>
   <string id="13410">Op Last.FM beluisteren</string>
   <string id="13411">Minimale ventilatorsnelheid</string>
+  <string id="13412">Afspelen vanaf hier</string>
   <string id="13413">Download</string>
   <string id="13414">Artiesten weergeven die alleen op verzamel CD's voorkomen</string>
   <string id="13415">Rendermethode</string>
@@ -1246,6 +1225,8 @@
   <string id="13429">Hardwareversnelling inschakelen (VDADecoder)</string>
   <string id="13430">Hardwareversnelling inschakelen (OpenMax)</string>
   <string id="13431">Pixelshaders</string>
+  <string id="13432">Hardware acceleratie toestaan (VideoToolbox)</string>
+  
   <string id="13500">A/V-synchronisatiemethode</string>
   <string id="13501">Audiosignaal</string>
   <string id="13502">Videosignaal (Drop/Dupe audio)</string>
@@ -1257,15 +1238,25 @@
   <string id="13508">Hoog</string>
   <string id="13509">Echt hoog (traag!)</string>
   <string id="13510">Synchroniseer video met beeldschermfrequentie</string>
+  
+  <string id="13550">Pauzeren gedurende wijzigen verversing snelheid</string>
+  <string id="13551">Uit</string>
+  <string id="13552">%.1f Seconde</string>
+  <string id="13553">%.1f Seconden</string>
+
   <string id="13600">Type Apple afstandsbediening</string>
+  
   <string id="13602">Gebruik afstandsbediening om XBMC zelf op te staren</string>
   <string id="13603">Ondertitel eerder/later starten</string>
+  
   <string id="13610">Uitgeschakeld</string>
   <string id="13611">Standaard</string>
   <string id="13612">Universele afstandsbediening</string>
   <string id="13613">Multi Remote (Harmony)</string>
+   
   <string id="13620">Apple afstandsbedieningsfout</string>
   <string id="13621">Apple afstandsbedieningsondersteuning kan niet worden geactiveerd.</string>
+  
   <string id="14000">Groeperen</string>
   <string id="14001">Groeperen: Uit</string>
   <string id="14003">Afspeellijst downloaden...</string>
@@ -1273,6 +1264,7 @@
   <string id="14005">Streamlijst verwerken...</string>
   <string id="14006">Streamlijst downloaden mislukt</string>
   <string id="14007">Afspeellijst downloaden mislukt</string>
+  
   <string id="14009">Spellocatie</string>
   <string id="14010">Automatisch overschakelen naar miniaturen als</string>
   <string id="14011">Automatisch overschakelen naar miniaturen</string>
@@ -1299,11 +1291,12 @@
   <string id="14034">DVD-buffer</string>
   <string id="14035">- Lokaal netwerk</string>
   <string id="14036">Servers</string>
+
   <string id="14038">Netwerkinstellingen gewijzigd</string>
   <string id="14039">XBMC moet herstarten om de netwerkinstellingen</string>
   <string id="14040">te wijzigen. Wilt u nu herstarten?</string>
-  <string id="14041">
-  </string>
+  <string id="14041">Bandbreedte internet verbinding limiteren</string>
+  
   <string id="14043">- Uitschakelen tijdens gebruik</string>
   <string id="14044">%i minuten</string>
   <string id="14045">%i sec.</string>
@@ -1315,6 +1308,7 @@
   <string id="14051">Tijdnotatie</string>
   <string id="14052">Datumnotatie</string>
   <string id="14053">GUI-filters</string>
+  
   <string id="14055">Scannen op de achtergrond inschakelen</string>
   <string id="14056">Scan annuleren</string>
   <string id="14057">Niet mogelijk tijdens scannen naar media-info</string>
@@ -1332,6 +1326,7 @@
   <string id="14069">Instellingen nu toepassen?</string>
   <string id="14070">Instellingen toepassen</string>
   <string id="14071">Hernoemen en verwijderen van bestanden toestaan</string>
+  
   <string id="14074">Tijdzone</string>
   <string id="14075">Automatische zomer-/wintertijd</string>
   <string id="14076">Aan favorieten toevoegen</string>
@@ -1354,21 +1349,27 @@
   <string id="14093">Beveiliging</string>
   <string id="14094">Invoerapparaten</string>
   <string id="14095">Energiebeheer</string>
+  
   <string id="15015">Verwijder</string>
   <string id="15016">Spellen</string>
+  
   <string id="15019">Voeg toe</string>
+  
   <string id="15052">Wachtwoord</string>
+  
   <string id="15100">Bibliotheek</string>
   <string id="15101">Database</string>
   <string id="15102">* Alle albums</string>
   <string id="15103">* Alle artiesten</string>
   <string id="15104">* Alle nummers</string>
   <string id="15105">* Alle genres</string>
+  
   <string id="15107">Bufferen...</string>
   <string id="15108">Navigatiegeluiden</string>
   <string id="15109">Standaarduiterijk</string>
   <string id="15111">- Thema</string>
   <string id="15112">Standaard thema</string>
+  
   <string id="15200">Last.FM</string>
   <string id="15201">Afgespeelde nummers op Last.FM bijhouden</string>
   <string id="15202">Last.FM-gebruikersnaam</string>
@@ -1391,6 +1392,7 @@
   <string id="15219">Libre.fm-wachtwoord</string>
   <string id="15220">Libre.fm</string>
   <string id="15221">Nummers bijhouden</string>
+  
   <string id="15250">Last.FM-radio aan Last.FM toevoegen</string>
   <string id="15251">Verbinding maken met Last.FM...</string>
   <string id="15252">Station selecteren...</string>
@@ -1427,7 +1429,7 @@
   <string id="15283">Onlangs door %name% afgespeelde nummers</string>
   <string id="15284">Beluister de aanbevelingen van %name% op Last.FM-radio</string>
   <string id="15285">Top tags van %name%</string>
-  <string id="15286">Beluister %name%'s Last.FM afspeellijst radio</string>
+  
   <string id="15287">Wilt u dit nummer toevoegen aan uw favoriete nummers?</string>
   <string id="15288">Wilt u dit nummer verbannen?</string>
   <string id="15289">Toegevoegd aan favoriete nummers: %s</string>
@@ -1440,16 +1442,21 @@
   <string id="15296">Ban opheffen</string>
   <string id="15297">Wilt u dit nummer verwijderen uit uw favoriete nummers?</string>
   <string id="15298">Wilt u de ban op dit nummer opheffen?</string>
+  
   <string id="15300">Pad niet gevonden of ongeldig</string>
   <string id="15301">Kan niet verbinden met netwerkserver</string>
   <string id="15302">Geen servers gevonden</string>
   <string id="15303">Werkgroep niet gevonden</string>
+  
   <string id="15310">Openen multi-pad favoriet</string>
   <string id="15311">Pad:</string>
+  
   <string id="16000">Algemeen</string>
+  
   <string id="16002">Zoeken op CDDB</string>
   <string id="16003">Speler</string>
   <string id="16004">Media van disk afspelen</string>
+  
   <string id="16008">Geef een nieuwe titel</string>
   <string id="16009">Geef naam van de film</string>
   <string id="16010">Geef profielnaam</string>
@@ -1468,7 +1475,7 @@
   <string id="16023">Interlaced handling</string>
   <string id="16024">Annuleren...</string>
   <string id="16025">Geef de artiest op</string>
-  <string id="16026">Playlist afspelen afgebroken</string>
+  <string id="16026">Afspeellijst afspelen afgebroken</string>
   <string id="16027">Eén of meer item kan niet worden afgespeeld.</string>
   <string id="16028">Voer waarde in</string>
   <string id="16029">Controleer het logbestand voor details.</string>
@@ -1478,22 +1485,14 @@
   <string id="16033">Kan database niet openen.</string>
   <string id="16034">Kan geen nummers uit database verkrijgen.</string>
   <string id="16035">Feestmix afspeellijst</string>
+  
   <string id="16100">Alle video's</string>
   <string id="16101">Niet bekeken</string>
   <string id="16102">Bekeken</string>
   <string id="16103">Als bekeken markeren</string>
   <string id="16104">Als niet-bekeken markeren</string>
   <string id="16105">Titel aanpassen</string>
-  <string id="16106">
-  </string>
-  <string id="16107">
-  </string>
-  <string id="16108">
-  </string>
-  <string id="16109">
-  </string>
-  <string id="16110">
-  </string>
+
   <string id="16200">Actie is afgebroken</string>
   <string id="16201">Kopiëren mislukt</string>
   <string id="16202">Tenminste 1 bestand is niet gekopieerd</string>
@@ -1501,6 +1500,7 @@
   <string id="16204">Tenminste 1 bestand is niet verplaatst</string>
   <string id="16205">Verwijderen mislukt</string>
   <string id="16206">Tenminste 1 bestand is niet verwijderd</string>
+  
   <string id="16300">Videoschalingsmethode</string>
   <string id="16301">Nearest neighbour</string>
   <string id="16302">Bilinear</string>
@@ -1521,21 +1521,24 @@
   <string id="16317">Temporal (Half)</string>
   <string id="16318">Temporal/Spatial (Half)</string>
   <string id="16319">DXVA</string>
+  
   <string id="16400">Kwaliteitsverbetering video</string>
-  <string id="16401">Uitgeschakeld</string>
-  <string id="16402">Ingeschakeld voor SD beelden</string>
-  <string id="16403">Altijd ingeschakeld</string>
+   
   <string id="17500">Uitschakeltijd beeldscherm</string>
+  
   <string id="19000">Kanaal wijzigen</string>
+  
   <string id="20000">Opgeslagen muziek map...</string>
   <string id="20001">Andere DVD-speler gebruiken</string>
   <string id="20002">- Locatie van de DVD-speler</string>
   <string id="20003">Trainersmap</string>
   <string id="20004">Screenshotmap</string>
-  <string id="20006">Playlistmap</string>
+  
+  <string id="20006">Afspeellijstmap</string>
   <string id="20007">Opnames</string>
   <string id="20008">Screenshots</string>
   <string id="20009">XBMC gebruiken</string>
+  
   <string id="20011">Muziekafspeellijsten</string>
   <string id="20012">Videoafspeellijsten</string>
   <string id="20013">Wilt u het spel starten?</string>
@@ -1545,12 +1548,16 @@
   <string id="20017">Lokale afbeelding</string>
   <string id="20018">Geen afbeelding</string>
   <string id="20019">Miniatuur kiezen</string>
-  <string id="20022">
-  </string>
+
+  <!-- string id 20022 will always be set to an empty string (LocalizeStrings.cpp)-->
+  <string id="20022"></string>
   <string id="20023">Conflict</string>
   <string id="20024">Scan nieuwe</string>
   <string id="20025">Scan alles</string>
   <string id="20026">Regio</string>
+  
+  <!-- string id's 20027 thru 20034 are reserved for temperature strings (LocalizeStrings.cpp)-->
+
   <string id="20037">Samenvatting</string>
   <string id="20038">Muzieksectie vergrendelen</string>
   <string id="20039">Videosectie vergrendelen</string>
@@ -1570,6 +1577,7 @@
   <string id="20053">Ontgrendelde modus verlaten</string>
   <string id="20054">Ontgrendelde modus inschakelen</string>
   <string id="20055">Allmusic.com-miniatuur</string>
+  
   <string id="20057">Miniatuur verwijderen</string>
   <string id="20058">Profiel toevoegen...</string>
   <string id="20059">Info opvragen voor alle albums</string>
@@ -1699,10 +1707,7 @@
   <string id="20184">Foto's draaien op basis van EXIF-informatie</string>
   <string id="20185">Posterstijl voor tv-series gebruiken</string>
   <string id="20186">Even geduld...</string>
-  <string id="20187">
-  </string>
-  <string id="20188">
-  </string>
+  
   <string id="20189">Plot en bespreking automatisch scrollen</string>
   <string id="20190">Handmatig</string>
   <string id="20191">Foutregistratie inschakelen</string>
@@ -1714,6 +1719,9 @@
   <string id="20197">Muziekbibliotheek importeren...</string>
   <string id="20198">Geen artiest gevonden!</string>
   <string id="20199">Downloaden van artiestinformatie mislukt</string>
+  
+  <!-- string id's 20200 thru 20211 are reserved for speedstrings (LocalizeStrings.cpp)-->
+
   <string id="20250">Feesten maar! (video's)</string>
   <string id="20251">Drankjes mixen (video's)</string>
   <string id="20252">Glazen vullen (video's)</string>
@@ -1722,44 +1730,33 @@
   <string id="20255">Eerste login, profiel bijwerken</string>
   <string id="20256">HTS tvheadend client</string>
   <string id="20257">VDR streamdev client</string>
+ <string id="20258">MythTV client</string>
+  <string id="20259">Network Filesystem (NFS)</string>
+  <string id="20260">Secure Shell (SSH/SFTP)</string>
+  
   <string id="20300">Webservermap (HTTP)</string>
   <string id="20301">Webservermap (HTTPS)</string>
   <string id="20302">Kan niet schrijven naar map:</string>
   <string id="20303">Overslaan en verdergaan?</string>
   <string id="20304">RSS-feed</string>
-  <string id="20306">
-  </string>
+  
   <string id="20307">Secundaire DNS</string>
   <string id="20308">DHCP-server:</string>
   <string id="20309">Nieuwe map</string>
   <string id="20310">LCD dimmen tijdens afspelen</string>
   <string id="20311">Onbekend of onboard (beveiligd)</string>
   <string id="20312">LCD dimmen tijdens pauze</string>
-  <string id="20313">
-  </string>
+
   <string id="20314">Video - Bibliotheek</string>
-  <string id="20315">
-  </string>
+
   <string id="20316">Sorteer: ID</string>
-  <string id="20317">
-  </string>
-  <string id="20318">
-  </string>
-  <string id="20319">
-  </string>
-  <string id="20320">
-  </string>
-  <string id="20321">
-  </string>
-  <string id="20322">
-  </string>
-  <string id="20323">
-  </string>
+
   <string id="20324">Afspelen deel...</string>
   <string id="20325">Kalibratie opnieuw instellen</string>
   <string id="20326">Dit zet de kalibratiewaarden voor %s</string>
   <string id="20327">terug naar de standaardwaarden.</string>
   <string id="20328">een locatie om naar te kopiëren</string>
+
   <string id="20330">Gebruik mapnamen bij zoeken</string>
   <string id="20331">Bestand</string>
   <string id="20332">Ook in bestands- of mapnamen zoeken?</string>
@@ -1834,6 +1831,7 @@
   <string id="20401">Muziekvideo afspelen</string>
   <string id="20402">Afbeeldingen van acteurs automatisch downloaden</string>
   <string id="20403">Acteursafbeelding instellen</string>
+  
   <string id="20405">Afl. uit favorieten verwijderen</string>
   <string id="20406">Afl. aan favorieten toevoegen</string>
   <string id="20407">Scraperinstellingen</string>
@@ -1848,6 +1846,7 @@
   <string id="20416">Eerst uitgez.</string>
   <string id="20417">Schrijver</string>
   <string id="20418">Bestands- en mapnamen opschonen</string>
+  
   <string id="20420">Nooit</string>
   <string id="20421">Alleen indien één seizoen</string>
   <string id="20422">Altijd</string>
@@ -1882,7 +1881,13 @@
   <string id="20451">Landen</string>
   <string id="20452">Aflevering</string>
   <string id="20453">Afleveringen</string>
+  <string id="20454">Luisteraar</string>
+  <string id="20455">Luisteraars</string>
+  <string id="20456">Kies movieset fanart</string>
+    <!-- up to 21329 is reserved for the video db !! !-->
+
   <string id="21330">Verborgen bestanden en mappen weergeven</string>
+  
   <string id="21331">TuxBox-client</string>
   <string id="21332">WAARSCHUWING: TuxBox is aan het opnemen.</string>
   <string id="21333">De stream wordt gestopt!</string>
@@ -1890,12 +1895,16 @@
   <string id="21335">Weet u zeker dat u de stream wil starten?</string>
   <string id="21336">Verbinden met: %s</string>
   <string id="21337">TuxBox-apparaat</string>
+    <!-- up to 21355 is reserved for the TuxBox Client!! !-->
+    
   <string id="21359">Gedeelde media toevoegen...</string>
   <string id="21360">UPnP-server inschakelen</string>
+  
   <string id="21364">Gedeelde media wijzigen</string>
   <string id="21365">Gedeelde media verwijderen</string>
   <string id="21366">Map voor ondertitels...</string>
   <string id="21367">Video - alternatieve ondertitelmap</string>
+  
   <string id="21369">Muis inschakelen</string>
   <string id="21370">Navigatiegeluiden afspelen tijdens afspelen van media</string>
   <string id="21371">Miniatuur</string>
@@ -1981,6 +1990,7 @@
   <string id="21451">Internetverbinding vereist.</string>
   <string id="21452">Add-ons installeren</string>
   <string id="21453">Rootbestandsysteem</string>
+  
   <string id="21800">Bestandsnaam</string>
   <string id="21801">Pad</string>
   <string id="21802">Bestandsgrootte</string>
@@ -1990,6 +2000,7 @@
   <string id="21806">Opmerking</string>
   <string id="21807">Kleur/zwart-wit</string>
   <string id="21808">JPEG-proces</string>
+  
   <string id="21820">Datum/tijd</string>
   <string id="21821">Omschrijving</string>
   <string id="21822">Cameramerk</string>
@@ -2014,6 +2025,7 @@
   <string id="21841">GPS-breedtegraad</string>
   <string id="21842">GPS-hoogte</string>
   <string id="21843">Oriëntatie</string>
+  
   <string id="21860">Overige categorieën</string>
   <string id="21861">Sleutelwoorden</string>
   <string id="21862">Titel</string>
@@ -2055,6 +2067,9 @@
   <string id="21898">Periode:</string>
   <string id="21899">Platenlabel</string>
   <string id="21900">Geboren/Opgericht</string>
+  
+  <!-- strings 21900 thru 21999 reserved for slideshow info -->
+
   <string id="22000">Bibliotheek bijwerken bij het opstarten</string>
   <string id="22001">Voortgang verbergen bij bibliotheek bijwerken</string>
   <string id="22002">- DNS-suffix</string>
@@ -2080,6 +2095,8 @@
   <string id="22022">Toon videobestanden in lijst met afbeeldingen</string>
   <string id="22023">DirectX-leverancier:</string>
   <string id="22024">Direct3D-versie</string>
+  
+  <!-- strings 22030 thru 22060 reserved for karaoke -->
   <string id="22030">Lettertype</string>
   <string id="22031">- Grootte</string>
   <string id="22032">- Kleuren</string>
@@ -2094,24 +2111,32 @@
   <string id="22041">wit/rood</string>
   <string id="22042">wit/blauw</string>
   <string id="22043">zwart/wit</string>
+  
   <string id="22079">Standaardactie bij selecteren</string>
   <string id="22080">Kiezen</string>
   <string id="22081">Informatie tonen</string>
   <string id="22082">Meer...</string>
   <string id="22083">Alles afspelen</string>
+  
   <string id="23049">Teletekst niet beschikbaar</string>
   <string id="23050">Teletekst activeren</string>
   <string id="23051">Stuk %i</string>
   <string id="23052">%i bytes bufferen</string>
   <string id="23053">Instellingen ontbreken</string>
   <string id="23054">Instellingen verkeerd</string>
+  
+  <!-- strings 23100 thru 23150 reserved for external player -->
   <string id="23100">Externe speler actief</string>
   <string id="23101">Klik op OK om de speler te beëindigen</string>
+  
   <string id="23104">Klik op OK als afspelen beëindigd is</string>
+  
+  <!-- strings 24000 thru 24299 reserved for the Add-ons framework -->
   <string id="24000">Add-on</string>
   <string id="24001">Add-ons</string>
-  <string id="24002">Add-onopties</string>
-  <string id="24003">Add-oninformatie</string>
+  <string id="24002">Add-on opties</string>
+  <string id="24003">Add-on informatie</string>
+  
   <string id="24005">Mediabronnen</string>
   <string id="24007">Filminformatie</string>
   <string id="24008">Schermbeveiliging</string>
@@ -2124,6 +2149,8 @@
   <string id="24015">Muziekvideoinformatie</string>
   <string id="24016">Albuminformatie</string>
   <string id="24017">Artiestinformatie</string>
+  <string id="24018">Processen</string>
+  
   <string id="24020">Configureren</string>
   <string id="24021">Uitschakelen</string>
   <string id="24022">Inschakelen</string>
@@ -2144,6 +2171,9 @@
   <string id="24041">Add-ons installeren mbv zipbestand</string>
   <string id="24042">Downloaden van %i%%</string>
   <string id="24043">Beschikbare updates</string>
+  <string id="24044">Niet voldaan aan afhankelijkheden</string>
+  <string id="24045">Add-on heeft niet de juiste structuur</string>
+  
   <string id="24050">Beschikbare add-ons</string>
   <string id="24051">Versie:</string>
   <string id="24052">Disclaimer</string>
@@ -2169,25 +2199,22 @@
   <string id="24080">Nogmaals proberen te verbinden?</string>
   <string id="24089">Add-on aan het herstarten</string>
   <string id="24090">Add-onmanager vastzetten</string>
-  <string id="24091">
-  </string>
-  <string id="24092">
-  </string>
-  <string id="24093">
-  </string>
-  <string id="24094">
-  </string>
-  <string id="24095">Uitgeschakelde systeem add-on</string>
+  
   <string id="24096">Add-on is gemarkeerd als niet werkend in het repository.</string>
   <string id="24097">Wilt u de add-on uitschakelen?</string>
   <string id="24098">Defect</string>
   <string id="24099">Wilt u deze skin gebruiken?</string>
   <string id="25000">Mededelingen</string>
+
+  <!-- strings 29800 thru 29998 reserved strings used only in the default Project Mayhem III skin and not c++ code -->
   <string id="29800">Bibliotheekmodus</string>
   <string id="29801">QWERTY-indeling toetsenbord</string>
   <string id="29802">Passthrough audio in gebruik</string>
-  <string id="29999">
-  </string>
+
+  <!-- strings 30000 thru 30999 reserved for plugins and plugin settings -->
+  <!-- strings 31000 thru 31999 reserved for skins -->
+  <!-- strings 32000 thru 32999 reserved for scripts -->
+  <!-- strings 33000 thru 33999 reserved for common strings used in addons -->
   <string id="33001">Trailerkwaliteit</string>
   <string id="33002">Stream</string>
   <string id="33003">Downloaden</string>
@@ -2260,12 +2287,20 @@
   <string id="33081">Dit bestand bestaat uit meerdere delen, selecteer het deel dat u wilt afspelen.</string>
   <string id="33082">Pad naar script</string>
   <string id="33083">Stel aangepaste scriptknop in</string>
+  
+  <string id="33100">Starten mislukt</string>
+  <string id="33101">Webserver</string>
+  <string id="33102">Event Server</string>
+  <string id="33103">Remote communication server</string>
+  
+  <!-- translators: no need to add these to your language files -->
   <string id="34000">Lame</string>
   <string id="34001">Vorbis</string>
   <string id="34002">Wav</string>
   <string id="34003">DXVA2</string>
   <string id="34004">VAAPI</string>
   <string id="34005">FLAC</string>
+  
   <string id="34100">Aantal geluidskanalen</string>
   <string id="34101">2.0</string>
   <string id="34102">2.1</string>
@@ -2277,4 +2312,6 @@
   <string id="34108">5.1</string>
   <string id="34109">7.0</string>
   <string id="34110">7.1</string>
+    <!-- 34112-34200 reserved for future use -->
+    
 </strings>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1015,6 +1015,7 @@
 
   <string id="13100">Flicker filter</string>
   <string id="13101">Let driver choose (requires restart)</string>
+  
   <string id="13105">Vertical blank sync</string>
   <string id="13106">Disabled</string>
   <string id="13107">Enabled during video playback</string>
@@ -1062,9 +1063,11 @@
 
   <string id="13200">Profiles</string>
   <string id="13201">Delete profile '%s'?</string>
+  
   <string id="13204">Last loaded profile:</string>
   <string id="13205">Unknown</string>
   <string id="13206">Overwrite</string>
+  
   <string id="13208">Alarm clock</string>
   <string id="13209">Alarm clock interval (in minutes)</string>
   <string id="13210">Started, alarm in %im</string>
@@ -1165,6 +1168,7 @@
   <string id="13359">Set artist thumb</string>
   <string id="13360">Automatically generate thumbnails</string>
   <string id="13361">Enable voice</string>
+  
   <string id="13375">Enable device</string>
   <string id="13376">Volume</string>
   <string id="13377">Default view mode</string>


### PR DESCRIPTION
I updated the Dutch language files of XBMC to match the English language files.
Work done:
- Deleted entries in Dutch that weren't present in the English file (anymore).
- Added Dutch entries that weren't there but English file they were.
- Changed some Dutch words/sentences.
- Match the English and Dutch files according to the line numbers
  (all non sequencial "string id" have an empty line between them for beter reading)

Hopefully this helps to make XBMC even better.

Greetings,
Machine-Sanctum
