### PR TITLE
Attempt to unify WindowClose animation trigerring

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -638,7 +638,7 @@ case TMSG_POWERDOWN:
       {
         CGUIDialog *dialog = (CGUIDialog *)pMsg->lpVoid;
         if (dialog)
-          dialog->Close_Internal(pMsg->dwParam1 > 0);
+          g_windowManager.DeinitWindow(dialog, 0, false, dialog->SoundEnabled());
       }
       break;
 

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -648,6 +648,14 @@ case TMSG_POWERDOWN:
       }
       break;
 
+    case TMSG_GUI_DEINIT:
+      {
+        CGUIWindow *pWindow = (CGUIWindow *)pMsg->lpVoid;
+        if (pWindow)
+          g_windowManager.DeinitWindow(pWindow, pMsg->dwParam1, pMsg->dwParam2 & 0x1 ? true : false, pMsg->dwParam2 & 0x2 ? true : false);
+      }
+      break;
+
     case TMSG_GUI_PYTHON_DIALOG:
       {
         if (pMsg->lpVoid)
@@ -1103,6 +1111,13 @@ void CApplicationMessenger::ActivateWindow(int windowID, const vector<CStdString
 {
   ThreadMessage tMsg = {TMSG_GUI_ACTIVATE_WINDOW, windowID, swappingWindows ? 1 : 0};
   tMsg.params = params;
+  SendMessage(tMsg, true);
+}
+
+void CApplicationMessenger::DeinitWindow(CGUIWindow *pWindow, int nextWindowID /*= 0*/, bool blockContext /*= true*/, bool enableSound /*= true*/)
+{
+  ThreadMessage tMsg = {TMSG_GUI_DEINIT, nextWindowID, (DWORD)blockContext | (DWORD)enableSound << 1};
+  tMsg.lpVoid = pWindow;
   SendMessage(tMsg, true);
 }
 

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -32,6 +32,7 @@
 class CFileItem;
 class CFileItemList;
 class CGUIDialog;
+class CGUIWindow;
 
 // defines here
 #define TMSG_DIALOG_DOMODAL       100
@@ -80,6 +81,7 @@ class CGUIDialog;
 
 #define TMSG_GUI_DO_MODAL             600
 #define TMSG_GUI_SHOW                 601
+#define TMSG_GUI_DEINIT               602
 #define TMSG_GUI_ACTIVATE_WINDOW      604
 #define TMSG_GUI_PYTHON_DIALOG        605
 #define TMSG_GUI_DIALOG_CLOSE         606
@@ -186,6 +188,7 @@ public:
   void Show(CGUIDialog *pDialog);
   void Close(CGUIDialog *pDialog, bool forceClose, bool waitResult=true);
   void ActivateWindow(int windowID, const std::vector<CStdString> &params, bool swappingWindows);
+  void DeinitWindow(CGUIWindow *pWindow, int nextWindowID = 0, bool blockContext = true, bool enableSound = true);
   void SendAction(const CAction &action, int windowID = WINDOW_INVALID, bool waitResult=true);
   std::vector<CStdString> GetInfoLabels(const std::vector<CStdString> &properties);
   std::vector<bool> GetInfoBooleans(const std::vector<CStdString> &properties);

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -72,7 +72,7 @@ void CGUIDialogProgress::StartModal()
   // a thread message though IMO)
   m_bRunning = true;
   m_bModal = true;
-  m_dialogClosing = false;
+  m_bClosing = false;
   g_windowManager.RouteToWindow(this);
 
   // active this window...

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -142,33 +142,6 @@ void CGUIDialog::UpdateVisibility()
   }
 }
 
-void CGUIDialog::Close_Internal(bool forceClose /*= false*/)
-{
-  //Lock graphic context here as it is sometimes called from non rendering threads
-  //maybe we should have a critical section per window instead??
-  CSingleLock lock(g_graphicsContext);
-
-  if (!m_bRunning) return;
-
-  //  Play the window specific deinit sound
-  if(!m_bClosing && m_enableSound)
-    g_audioManager.PlayWindowSound(GetID(), SOUND_DEINIT);
-
-  // don't close if we should be animating
-  if (!forceClose && HasAnimation(ANIM_TYPE_WINDOW_CLOSE))
-  {
-    if (!m_bClosing && !IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
-    {
-      QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
-      m_bClosing = true;
-    }
-    return;
-  }
-
-  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
-  OnMessage(msg);
-}
-
 void CGUIDialog::DoModal_Internal(int iWindowID /*= WINDOW_INVALID */, const CStdString &param /* = "" */)
 {
   //Lock graphic context here as it is sometimes called from non rendering threads

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -54,14 +54,13 @@ public:
   virtual bool IsDialog() const { return true;};
   virtual bool IsModalDialog() const { return m_bModal; };
 
-  virtual bool IsAnimating(ANIMATION_TYPE animType);
-
   void SetAutoClose(unsigned int timeoutMs);
   void SetSound(bool OnOff) { m_enableSound = OnOff; };
 
 protected:
   virtual void SetDefaults();
   virtual void OnWindowLoaded();
+  virtual void OnWindowDeinited();
   virtual void UpdateVisibility();
 
   friend class CApplicationMessenger;
@@ -72,7 +71,6 @@ protected:
   bool m_bRunning;
   bool m_wasRunning; ///< \brief true if we were running during the last DoProcess()
   bool m_bModal;
-  bool m_dialogClosing;
   bool m_autoClosing;
   bool m_enableSound;
   unsigned int m_showStartTime;

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -56,6 +56,7 @@ public:
 
   void SetAutoClose(unsigned int timeoutMs);
   void SetSound(bool OnOff) { m_enableSound = OnOff; };
+  bool SoundEnabled() { return m_enableSound; };
 
 protected:
   virtual void SetDefaults();
@@ -66,7 +67,6 @@ protected:
   friend class CApplicationMessenger;
   void DoModal_Internal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
   void Show_Internal(); // modeless
-  void Close_Internal(bool forceClose = false);
 
   bool m_bRunning;
   bool m_wasRunning; ///< \brief true if we were running during the last DoProcess()

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -432,23 +432,6 @@ void CGUIWindow::OnDeinitWindow(int nextWindowID)
     RunUnloadActions();
   }
 
-  if (nextWindowID != WINDOW_FULLSCREEN_VIDEO)
-  {
-    // Dialog animations are handled in Close() rather than here
-    if (HasAnimation(ANIM_TYPE_WINDOW_CLOSE) && !IsDialog() && IsActive())
-    {
-      // Perform the window out effect
-      QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
-      while (IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
-      {
-        // TODO This shouldn't be handled like this
-        // The processing should be done from WindowManager and deinit
-        // should probably be called from there.
-        g_windowManager.Process(CTimeUtils::GetFrameTime());
-        g_windowManager.ProcessRenderLoop(true);
-      }
-    }
-  }
   SaveControlStates();
 }
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -64,6 +64,7 @@ CGUIWindow::CGUIWindow(int id, const CStdString &xmlFile)
   m_manualRunActions = false;
   m_exclusiveMouseControl = 0;
   m_clearBackground = 0xff000000; // opaque black -> always clear
+  m_bClosing = false;
 }
 
 CGUIWindow::~CGUIWindow(void)
@@ -310,6 +311,17 @@ void CGUIWindow::DoRender()
   if (CGUIControlProfiler::IsRunning()) CGUIControlProfiler::Instance().EndFrame();
 }
 
+void CGUIWindow::Render()
+{
+  CGUIControlGroup::Render();
+  // Check to see if we should close at this point
+  // We check after the controls have finished rendering, as we may have to close due to
+  // the controls rendering after the window has finished it's animation
+  // we call the base class instead of this class so that we can find the change
+  if (m_bClosing && !CGUIControlGroup::IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
+    OnWindowDeinited();
+}
+
 void CGUIWindow::Close(bool forceClose)
 {
   CLog::Log(LOGERROR,"%s - should never be called on the base class!", __FUNCTION__);
@@ -401,6 +413,7 @@ void CGUIWindow::OnInitWindow()
 {
   // set our rendered state
   m_hasRendered = false;
+  m_bClosing = false;
   ResetAnimations();  // we need to reset our animations as those windows that don't dynamically allocate
                       // need their anims reset. An alternative solution is turning off all non-dynamic
                       // allocation (which in some respects may be nicer, but it kills hdd spindown and the like)
@@ -427,12 +440,20 @@ void CGUIWindow::OnInitWindow()
 // Override this function and call the base class before doing any dynamic memory freeing
 void CGUIWindow::OnDeinitWindow(int nextWindowID)
 {
+  m_bClosing = true;
   if (!m_manualRunActions)
   {
     RunUnloadActions();
   }
 
   SaveControlStates();
+}
+
+void CGUIWindow::OnWindowDeinited()
+{
+  // now free the window
+  if (m_dynamicResourceAlloc) FreeResources();
+  m_bClosing = false;
 }
 
 bool CGUIWindow::OnMessage(CGUIMessage& message)
@@ -452,8 +473,6 @@ bool CGUIWindow::OnMessage(CGUIMessage& message)
     {
       CLog::Log(LOGDEBUG, "------ Window Deinit (%s) ------", GetProperty("xmlfile").c_str());
       OnDeinitWindow(message.GetParam1());
-      // now free the window
-      if (m_dynamicResourceAlloc) FreeResources();
       return true;
     }
     break;
@@ -658,6 +677,8 @@ bool CGUIWindow::IsAnimating(ANIMATION_TYPE animType)
 {
   if (!m_animationsEnabled)
     return false;
+  if (animType == ANIM_TYPE_WINDOW_CLOSE)
+    return m_bClosing;
   return CGUIControlGroup::IsAnimating(animType);
 }
 

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -95,6 +95,7 @@ public:
    \sa FrameMove
    */
   virtual void DoRender();
+  virtual void Render();
   
   /*! \brief Main update function, called every frame prior to rendering
    Any window that requires updating on a frame by frame basis (such as to maintain
@@ -219,6 +220,7 @@ protected:
   virtual void OnWindowLoaded();
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);
+  virtual void OnWindowDeinited();
   EVENT_RESULT OnMouseAction(const CAction &action);
   virtual bool Animate(unsigned int currentTime);
   virtual bool CheckAnimation(ANIMATION_TYPE animType);
@@ -256,6 +258,7 @@ protected:
   bool m_windowLoaded;  // true if the window's xml file has been loaded
   bool m_loadOnDemand;  // true if the window should be loaded only as needed
   bool m_isDialog;      // true if we have a dialog, false otherwise.
+  bool m_bClosing;      // true if window is closing
   bool m_dynamicResourceAlloc;
   CGUIInfoColor m_clearBackground; // colour to clear the window
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -332,6 +332,9 @@ void CGUIWindowManager::DeinitWindow(CGUIWindow* window, int nextWindowID /*= 0*
   if (nextWindowID != WINDOW_FULLSCREEN_VIDEO && window->HasAnimation(ANIM_TYPE_WINDOW_CLOSE))
     window->QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
 
+  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0, nextWindowID);
+  window->OnMessage(msg);
+
   if (blockContext)
   {
     while (window->IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
@@ -340,9 +343,6 @@ void CGUIWindowManager::DeinitWindow(CGUIWindow* window, int nextWindowID /*= 0*
       ProcessRenderLoop(true);
     }
   }
-
-  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0, nextWindowID);
-  window->OnMessage(msg);
 }
 
 void CGUIWindowManager::ChangeActiveWindow(int newWindow, const CStdString& strPath)

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -303,9 +303,7 @@ void CGUIWindowManager::PreviousWindow()
   HideOverlay(pNewWindow->GetOverlayState());
 
   // deinitialize our window
-  g_audioManager.PlayWindowSound(pCurrentWindow->GetID(), SOUND_DEINIT);
-  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
-  pCurrentWindow->OnMessage(msg);
+  DeinitWindow(pCurrentWindow);
 
   g_infoManager.SetNextWindow(WINDOW_INVALID);
   g_infoManager.SetPreviousWindow(currentWindow);
@@ -321,6 +319,30 @@ void CGUIWindowManager::PreviousWindow()
 
   g_infoManager.SetPreviousWindow(WINDOW_INVALID);
   return;
+}
+
+void CGUIWindowManager::DeinitWindow(CGUIWindow* window, int nextWindowID /*= 0*/, bool blockContext /*= true*/, bool enableSound /*= true*/)
+{
+  if (!window || !window->IsActive())
+    return;
+
+  if (enableSound)
+    g_audioManager.PlayWindowSound(window->GetID(), SOUND_DEINIT);
+
+  if (nextWindowID != WINDOW_FULLSCREEN_VIDEO && window->HasAnimation(ANIM_TYPE_WINDOW_CLOSE))
+    window->QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
+
+  if (blockContext)
+  {
+    while (window->IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
+    {
+      Process(CTimeUtils::GetFrameTime());
+      ProcessRenderLoop(true);
+    }
+  }
+
+  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0, nextWindowID);
+  window->OnMessage(msg);
 }
 
 void CGUIWindowManager::ChangeActiveWindow(int newWindow, const CStdString& strPath)
@@ -412,9 +434,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<CStd
   if (pWindow)
   {
     //  Play the window specific deinit sound
-    g_audioManager.PlayWindowSound(pWindow->GetID(), SOUND_DEINIT);
-    CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0, iWindowID);
-    pWindow->OnMessage(msg);
+    DeinitWindow(pWindow, iWindowID);
   }
   g_infoManager.SetNextWindow(WINDOW_INVALID);
 
@@ -655,8 +675,7 @@ void CGUIWindowManager::DeInitialize()
     if (IsWindowActive(it->first))
     {
       pWindow->DisableAnimations();
-      CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
-      pWindow->OnMessage(msg);
+      DeinitWindow(pWindow, 0, true, false);
     }
     pWindow->ResetControlStates();
     pWindow->FreeResources(true);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -323,6 +323,18 @@ void CGUIWindowManager::PreviousWindow()
 
 void CGUIWindowManager::DeinitWindow(CGUIWindow* window, int nextWindowID /*= 0*/, bool blockContext /*= true*/, bool enableSound /*= true*/)
 {
+  if (!g_application.IsCurrentThread())
+  {
+    // make sure graphics lock is not held
+    CSingleExit leaveIt(g_graphicsContext);
+    g_application.getApplicationMessenger().DeinitWindow(window, nextWindowID, blockContext, enableSound);
+  }
+  else
+    DeinitWindow_Internal(window, nextWindowID, blockContext, enableSound);
+}
+
+void CGUIWindowManager::DeinitWindow_Internal(CGUIWindow* window, int nextWindowID /*= 0*/, bool blockContext /*= true*/, bool enableSound /*= true*/)
+{
   if (!window || !window->IsActive())
     return;
 

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -139,6 +139,7 @@ private:
 
   friend class CApplicationMessenger;
   void ActivateWindow_Internal(int windowID, const std::vector<CStdString> &params, bool swappingWindows);
+  void DeinitWindow_Internal(CGUIWindow* window, int nextWindowID = 0, bool needRenderLoop = true, bool enableSound = true);
 
   typedef std::map<int, CGUIWindow *> WindowMap;
   WindowMap m_mapWindows;

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -60,6 +60,7 @@ public:
   void ChangeActiveWindow(int iNewID, const CStdString &strPath = "");
   void ActivateWindow(int iWindowID, const std::vector<CStdString>& params, bool swappingWindows = false);
   void PreviousWindow();
+  void DeinitWindow(CGUIWindow* window, int nextWindowID = 0, bool needRenderLoop = true, bool enableSound = true);
 
   void CloseDialogs(bool forceClose = false);
 

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.cpp
@@ -78,9 +78,7 @@ void CGUIPythonWindowDialog::Show_Internal(bool show /* = true */)
   }
   else // hide
   {
-    CGUIMessage msg(GUI_MSG_WINDOW_DEINIT,0,0);
-    OnMessage(msg);
-
+    g_windowManager.DeinitWindow(this);
     g_windowManager.RemoveDialog(GetID());
     m_bRunning = false;
   }

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.cpp
@@ -78,8 +78,14 @@ void CGUIPythonWindowDialog::Show_Internal(bool show /* = true */)
   }
   else // hide
   {
-    g_windowManager.DeinitWindow(this);
-    g_windowManager.RemoveDialog(GetID());
-    m_bRunning = false;
+    g_windowManager.DeinitWindow(this, 0, false);
   }
+}
+
+void CGUIPythonWindowDialog::OnWindowDeinited()
+{
+  g_windowManager.RemoveDialog(GetID());
+  m_bRunning = false;
+  CGUIWindow::OnWindowDeinited();
+  g_windowManager.Delete(GetID());
 }

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.h
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.h
@@ -39,7 +39,7 @@ public:
 protected:
   friend class CApplicationMessenger;
   void Show_Internal(bool show = true);
-
+  virtual void OnWindowDeinited();
 private:
   bool             m_bRunning;
 };

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.cpp
@@ -68,8 +68,14 @@ void CGUIPythonWindowXMLDialog::Show_Internal(bool show /* = true */)
   }
   else // hide
   {
-    g_windowManager.DeinitWindow(this);
-    g_windowManager.RemoveDialog(GetID());
-    m_bRunning = false;
+    g_windowManager.DeinitWindow(this, 0, false);
   }
+}
+
+void CGUIPythonWindowXMLDialog::OnWindowDeinited()
+{
+  g_windowManager.RemoveDialog(GetID());
+  m_bRunning = false;
+  CGUIWindow::OnWindowDeinited();
+  g_windowManager.Delete(GetID());
 }

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.cpp
@@ -68,9 +68,7 @@ void CGUIPythonWindowXMLDialog::Show_Internal(bool show /* = true */)
   }
   else // hide
   {
-    CGUIMessage msg(GUI_MSG_WINDOW_DEINIT,0,0);
-    OnMessage(msg);
-
+    g_windowManager.DeinitWindow(this);
     g_windowManager.RemoveDialog(GetID());
     m_bRunning = false;
   }

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.h
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.h
@@ -39,6 +39,7 @@ class CGUIPythonWindowXMLDialog : public CGUIPythonWindowXML
   protected:
     friend class CApplicationMessenger;
     void Show_Internal(bool show = true);
+    virtual void OnWindowDeinited();
   private:
     bool             m_bRunning;
 };

--- a/xbmc/interfaces/python/xbmcmodule/window.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/window.cpp
@@ -383,9 +383,6 @@ namespace PYXBMC
       ++it;
     }
 
-    if (self->bIsPythonWindow)
-      g_windowManager.Delete(self->pWindow->GetID());
-
     lock.Leave();
     self->vecControls.clear();
     self->vecControls.~vector();

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -2573,8 +2573,7 @@ void CGUIWindowSettingsCategory::JumpToSection(int windowId, const CStdString &s
       iSection = i;
   if (iSection == -1) return;
 
-  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0, 0, 0);
-  OnMessage(msg);
+  g_windowManager.DeinitWindow(this, 0, true, false);
   m_iSectionBeforeJump=m_iSection;
   m_iControlBeforeJump=m_lastControlID;
   m_iWindowBeforeJump=GetID();
@@ -2589,8 +2588,7 @@ void CGUIWindowSettingsCategory::JumpToSection(int windowId, const CStdString &s
 
 void CGUIWindowSettingsCategory::JumpToPreviousSection()
 {
-  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0, 0, 0);
-  OnMessage(msg);
+  g_windowManager.DeinitWindow(this, 0, true, false);
   m_iSection=m_iSectionBeforeJump;
   m_lastControlID=m_iControlBeforeJump;
   CGUIMessage msg1(GUI_MSG_WINDOW_INIT, 0, 0, WINDOW_INVALID, m_iWindowBeforeJump);


### PR DESCRIPTION
Logic:
- add DeinitWindow method to WindowMenager
- split deiniting into OnDeinitWindow (begin deiniting, queue animation) and OnWindowDeinited (called after animation finished - finalize deinit)
- change CGUIDialog and CGUIPythonWindow(XML)Dialog to use CGUIWindowManager::DeinitWindow

What could be added here is some way of ensuring that OnWindowDeinited will be called. Currently it relies on CGUIWindow::Render to trigger it - with current use it works, but it can be error-prone in future.
