### PR TITLE
Close OSD on a mouse wheel action

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -62,15 +62,19 @@ bool CGUIDialogVideoOSD::OnAction(const CAction &action)
 
 EVENT_RESULT CGUIDialogVideoOSD::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
 {
+  // If the action is a mouse wheel up/down close the OSD so the time bar can be seen
   if (event.m_id == ACTION_MOUSE_WHEEL_UP)
   {
+    Close();
     return g_application.OnAction(CAction(ACTION_ANALOG_SEEK_FORWARD, 0.5f)) ? EVENT_RESULT_HANDLED : EVENT_RESULT_UNHANDLED;
   }
   if (event.m_id == ACTION_MOUSE_WHEEL_DOWN)
   {
+    Close();
     return g_application.OnAction(CAction(ACTION_ANALOG_SEEK_BACK, 0.5f)) ? EVENT_RESULT_HANDLED : EVENT_RESULT_UNHANDLED;
   }
 
+  // Pass any other mouse actions to the parent class
   return CGUIDialog::OnMouseEvent(point, event);
 }
 


### PR DESCRIPTION
When the OSD is active it hides the time bar. It also seems to cause problems with passing mouse wheel actions to the time bar though I haven't worked out exactly what is going on.

Anyhow, this patch addresses both problems by closing the OSD when a mouse wheel action is detected. I'm not sure this is the best solution. Ideally the time bar would be moved somewhere it can be seen even when the OSD is open, and we'd work out exactly where the mouse wheel action messages are going astray.
