### PR TITLE
Identify the process taking the focus from XBMC

### DIFF
--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -1361,6 +1361,65 @@ bool CWIN32Util::GetCrystalHDLibraryPath(CStdString &strPath)
     return false;
 }
 
+// Retrieve the filename of the process that currently has the focus.
+// Typically this will be some process using the system tray grabbing
+// the focus and causing XBMC to minimise. Logging the offending
+// process name can help the user fix the problem.
+bool CWIN32Util::GetFocussedProcess(CStdString &strProcessFile)
+{
+  strProcessFile = "";
+
+  // Get the window that has the focus
+  HWND hfocus = GetForegroundWindow();
+  if (!hfocus)
+    return false;
+
+  // Get the process ID from the window handle
+  DWORD pid = 0;
+  GetWindowThreadProcessId(hfocus, &pid);
+
+  // Use OpenProcess to get the process handle from the process ID
+  HANDLE hproc = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, 0, pid);
+  if (!hproc)
+    return false;
+
+  // Load QueryFullProcessImageName dynamically because it isn't available
+  // in all versions of Windows.
+  char procfile[MAX_PATH+1];
+  DWORD procfilelen = MAX_PATH;
+
+  HINSTANCE hkernel32 = LoadLibrary("kernel32.dll");
+  if (hkernel32)
+  {
+    DWORD (WINAPI *pQueryFullProcessImageNameA)(HANDLE,DWORD,LPTSTR,PDWORD);
+    pQueryFullProcessImageNameA = (DWORD (WINAPI *)(HANDLE,DWORD,LPTSTR,PDWORD)) GetProcAddress(hkernel32, "QueryFullProcessImageNameA");
+    if (pQueryFullProcessImageNameA)
+      if (pQueryFullProcessImageNameA(hproc, 0, procfile, &procfilelen))
+        strProcessFile = procfile;
+    FreeLibrary(hkernel32);
+  }
+
+  // If QueryFullProcessImageName failed fall back to GetModuleFileNameEx.
+  // Note this does not work across x86-x64 boundaries.
+  if (strProcessFile == "")
+  {
+    HINSTANCE hpsapi = LoadLibrary("psapi.dll");
+    if (hpsapi)
+    {
+      DWORD (WINAPI *pGetModuleFileNameExA)(HANDLE,HMODULE,LPTSTR,DWORD); 
+      pGetModuleFileNameExA = (DWORD (WINAPI*)(HANDLE,HMODULE,LPTSTR,DWORD)) GetProcAddress(hpsapi, "GetModuleFileNameExA");
+      if (pGetModuleFileNameExA)
+        if (pGetModuleFileNameExA(hproc, NULL, procfile, MAX_PATH))
+          strProcessFile = procfile;
+      FreeLibrary(hpsapi);
+    }
+  }
+
+  CloseHandle(hproc);
+
+  return true;
+}
+
 void CWinIdleTimer::StartZero()
 {
   SetThreadExecutionState(ES_SYSTEM_REQUIRED);

--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -79,6 +79,8 @@ public:
 
   static bool GetCrystalHDLibraryPath(CStdString &strPath);
   
+  static bool GetFocussedProcess(CStdString &strProcessFile);
+
 private:
 #if _MSC_VER > 1400
   static DEVINST GetDrivesDevInstByDiskNumber(long DiskNumber);

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -424,6 +424,12 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     case WM_KILLFOCUS:
       g_application.m_AppFocused = uMsg == WM_SETFOCUS;
       g_Windowing.NotifyAppFocusChange(g_application.m_AppFocused);
+      if (uMsg == WM_KILLFOCUS)
+      {
+        CStdString procfile;
+        if (CWIN32Util::GetFocussedProcess(procfile))
+          CLog::Log(LOGDEBUG, __FUNCTION__": Focus switched to process %s", procfile.c_str());
+      }
       break;
     case WM_SYSKEYDOWN:
       switch (wParam)


### PR DESCRIPTION
Apps stealing the focus and minimising XBMC is a regular problem with Windows users. This patch identifies which process has the focus when the WM_KILLFOCUS message is sent to XBMC.
