### PR TITLE
Fixed potential overflows plus correct use of the system clock.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2003,7 +2003,7 @@ void CApplication::Render()
   //we don't call g_graphicsContext.Flip() anymore, this saves gpu and cpu usage
   bool flip;
   if (g_advancedSettings.m_guiDirtyRegionNoFlipTimeout >= 0)
-    flip = hasRendered || now - m_lastRenderTime < (unsigned int)g_advancedSettings.m_guiDirtyRegionNoFlipTimeout;
+    flip = hasRendered || (now - m_lastRenderTime) < (unsigned int)g_advancedSettings.m_guiDirtyRegionNoFlipTimeout;
   else
     flip = true;
 
@@ -2548,14 +2548,14 @@ bool CApplication::OnAction(const CAction &action)
 void CApplication::UpdateLCD()
 {
 #ifdef HAS_LCD
-  static long lTickCount = 0;
+  static unsigned int lTickCount = 0;
 
   if (!g_lcd || !g_guiSettings.GetBool("videoscreen.haslcd"))
     return ;
-  long lTimeOut = 1000;
+  unsigned int lTimeOut = 1000;
   if ( m_iPlaySpeed != 1)
     lTimeOut = 0;
-  if ( ((long)XbmcThreads::SystemClockMillis() - lTickCount) >= lTimeOut)
+  if ( (XbmcThreads::SystemClockMillis() - lTickCount) >= lTimeOut)
   {
     if (g_application.NavigationIdleTime() < 5)
       g_lcd->Render(ILCD::LCD_MODE_NAVIGATION);

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -59,14 +59,14 @@ bool CImageLoader::DoWork()
       return false;
 
     m_texture = new CTexture();
-    DWORD start = XbmcThreads::SystemClockMillis();
+    unsigned int start = XbmcThreads::SystemClockMillis();
     if (!m_texture->LoadFromFile(loadPath, min(g_graphicsContext.GetWidth(), 2048), min(g_graphicsContext.GetHeight(), 1080), g_guiSettings.GetBool("pictures.useexifrotation")))
     {
       delete m_texture;
       m_texture = NULL;
     }
     else if (XbmcThreads::SystemClockMillis() - start > 100)
-      CLog::Log(LOGDEBUG, "%s - took %d ms to load %s", __FUNCTION__, XbmcThreads::SystemClockMillis() - start, loadPath.c_str());
+      CLog::Log(LOGDEBUG, "%s - took %u ms to load %s", __FUNCTION__, XbmcThreads::SystemClockMillis() - start, loadPath.c_str());
   }
 
   return true;

--- a/xbmc/cores/AudioRenderers/NullDirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/NullDirectSound.cpp
@@ -189,8 +189,10 @@ void CNullDirectSound::SwitchChannels(int iAudioStream, bool bAudioOnAllSpeakers
 
 void CNullDirectSound::Update()
 {
-  long currentTime = XbmcThreads::SystemClockMillis();
-  long deltaTime = (currentTime - m_lastUpdate);
+  unsigned int currentTime = XbmcThreads::SystemClockMillis();
+  // because of the if clause below it's possible that m_lastUpdate is larger
+  //  than currentTime. We need to handle this.
+  long deltaTime = (currentTime - m_lastUpdate); // the diff shouldn't overflow
 
   if (m_paused)
   {

--- a/xbmc/cores/AudioRenderers/NullDirectSound.h
+++ b/xbmc/cores/AudioRenderers/NullDirectSound.h
@@ -66,7 +66,7 @@ private:
   float m_timePerPacket;
   int m_packetsSent;
   bool m_paused;
-  long m_lastUpdate;
+  unsigned int m_lastUpdate;
 
   void Update();
 };

--- a/xbmc/cores/DummyVideoPlayer.h
+++ b/xbmc/cores/DummyVideoPlayer.h
@@ -81,6 +81,6 @@ private:
 
   bool m_paused;
   __int64 m_clock;
-  DWORD m_lastTime;
+  unsigned int m_lastTime;
   int m_speed;
 };

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -221,7 +221,7 @@ CDVDDemuxFFmpeg::~CDVDDemuxFFmpeg()
 
 bool CDVDDemuxFFmpeg::Aborted()
 {
-  if(m_timeout.isTimePast())
+  if(m_timeout.IsTimePast())
     return true;
 
   return false;
@@ -269,7 +269,7 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput)
   }
 
   // try to abort after 30 seconds
-  m_timeout.set(30000);
+  m_timeout.Set(30000);
 
   if( m_pInput->IsStreamType(DVDSTREAM_TYPE_FFMPEG) )
   {
@@ -458,7 +458,7 @@ bool CDVDDemuxFFmpeg::Open(CDVDInputStream* pInput)
     CLog::Log(LOGDEBUG, "%s - av_find_stream_info finished", __FUNCTION__);
   }
   // reset any timeout
-  m_timeout.setInfinite();
+  m_timeout.SetInfinite();
 
   // if format can be nonblocking, let's use that
   m_pFormatContext->flags |= AVFMT_FLAG_NONBLOCK;
@@ -559,7 +559,7 @@ void CDVDDemuxFFmpeg::Flush()
 
 void CDVDDemuxFFmpeg::Abort()
 {
-  m_timeout.setExpired();
+  m_timeout.SetExpired();
 }
 
 void CDVDDemuxFFmpeg::SetSpeed(int iSpeed)
@@ -646,7 +646,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
     pkt.stream_index = MAX_STREAMS;
 
     // timeout reads after 100ms
-    m_timeout.set(20000);
+    m_timeout.Set(20000);
     int result = 0;
     try
     {
@@ -657,7 +657,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
       e.writelog(__FUNCTION__);
       result = AVERROR(EFAULT);
     }
-    m_timeout.setInfinite();
+    m_timeout.SetInfinite();
 
     if (result == AVERROR(EINTR) || result == AVERROR(EAGAIN))
     {

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -27,6 +27,7 @@
 #include "DllAvUtil.h"
 
 #include "threads/CriticalSection.h"
+#include "threads/SystemClock.h"
 
 class CDVDDemuxFFmpeg;
 
@@ -138,7 +139,7 @@ protected:
   bool     m_bAVI;
   int      m_speed;
   unsigned m_program;
-  DWORD    m_timeout;
+  XbmcThreads::EndTime  m_timeout;
 
   CDVDInputStream* m_pInput;
 };

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -74,7 +74,7 @@ bool CDVDFileInfo::GetFileDuration(const CStdString &path, int& duration)
 
 bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, const CStdString &strTarget, CStreamDetails *pStreamDetails)
 {
-  int nTime = XbmcThreads::SystemClockMillis();
+  unsigned int nTime = XbmcThreads::SystemClockMillis();
   CDVDInputStream *pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, strPath, "");
   if (!pInputStream)
   {
@@ -250,8 +250,8 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, const CStdString &str
       file.Close();
   }
 
-  int nTotalTime = XbmcThreads::SystemClockMillis() - nTime;
-  CLog::Log(LOGDEBUG,"%s - measured %d ms to extract thumb from file <%s> ", __FUNCTION__, nTotalTime, strPath.c_str());
+  unsigned int nTotalTime = XbmcThreads::SystemClockMillis() - nTime;
+  CLog::Log(LOGDEBUG,"%s - measured %u ms to extract thumb from file <%s> ", __FUNCTION__, nTotalTime, strPath.c_str());
   return bOk;
 }
 

--- a/xbmc/cores/dvdplayer/DVDMessage.cpp
+++ b/xbmc/cores/dvdplayer/DVDMessage.cpp
@@ -47,12 +47,12 @@ void CDVDMsgGeneralSynchronize::Wait(volatile bool *abort, DWORD source)
 
   AtomicIncrement(&m_objects);
 
-  DWORD timeout = XbmcThreads::SystemClockMillis() + m_timeout;
+  XbmcThreads::EndTime timeout(m_timeout);
 
   if (abort)
-    while( m_objects < GetNrOfReferences() && timeout > XbmcThreads::SystemClockMillis() && !(*abort)) Sleep(1);
+    while( m_objects < GetNrOfReferences() && !timeout.isTimePast() && !(*abort)) Sleep(1);
   else
-    while( m_objects < GetNrOfReferences() && timeout > XbmcThreads::SystemClockMillis() ) Sleep(1);
+    while( m_objects < GetNrOfReferences() && !timeout.isTimePast() ) Sleep(1);
 }
 
 /**

--- a/xbmc/cores/dvdplayer/DVDMessage.cpp
+++ b/xbmc/cores/dvdplayer/DVDMessage.cpp
@@ -50,9 +50,9 @@ void CDVDMsgGeneralSynchronize::Wait(volatile bool *abort, DWORD source)
   XbmcThreads::EndTime timeout(m_timeout);
 
   if (abort)
-    while( m_objects < GetNrOfReferences() && !timeout.isTimePast() && !(*abort)) Sleep(1);
+    while( m_objects < GetNrOfReferences() && !timeout.IsTimePast() && !(*abort)) Sleep(1);
   else
-    while( m_objects < GetNrOfReferences() && !timeout.isTimePast() ) Sleep(1);
+    while( m_objects < GetNrOfReferences() && !timeout.IsTimePast() ) Sleep(1);
 }
 
 /**

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1089,7 +1089,7 @@ void CDVDPlayer::Process()
         {
           if (m_dvd.iDVDStillTime > 0)
           {
-            if (XbmcThreads::SystemClockMillis() >= (m_dvd.iDVDStillStartTime + m_dvd.iDVDStillTime))
+            if ((XbmcThreads::SystemClockMillis() - m_dvd.iDVDStillStartTime) >= m_dvd.iDVDStillTime)
             {
               m_dvd.iDVDStillTime = 0;
               m_dvd.iDVDStillStartTime = 0;

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -357,8 +357,8 @@ protected:
     }
 
     int state;                // current dvdstate
-    DWORD iDVDStillTime;      // total time in ticks we should display the still before continuing
-    DWORD iDVDStillStartTime; // time in ticks when we started the still
+    unsigned int iDVDStillTime;      // total time in ticks we should display the still before continuing
+    unsigned int iDVDStillStartTime; // time in ticks when we started the still
     int iSelectedSPUStream;   // mpeg stream id, or -1 if disabled
     int iSelectedAudioStream; // mpeg stream id, or -1 if disabled
   } m_dvd;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -495,7 +495,7 @@ void PAPlayer::ToFFRW(int iSpeed)
 void PAPlayer::UpdateCacheLevel()
 {
   //check cachelevel every .5 seconds
-  if (m_LastCacheLevelCheck + 500 < XbmcThreads::SystemClockMillis())
+  if ((XbmcThreads::SystemClockMillis() - m_LastCacheLevelCheck) > 500)
   {
     ICodec* codec = m_decoder[m_currentDecoder].GetCodec();
     if (codec)
@@ -888,9 +888,9 @@ void PAPlayer::HandleSeeking()
 {
   if (m_SeekTime != -1)
   {
-    DWORD time = XbmcThreads::SystemClockMillis();
+    unsigned int time = XbmcThreads::SystemClockMillis();
     m_timeOffset = m_decoder[m_currentDecoder].Seek(m_SeekTime);
-    CLog::Log(LOGDEBUG, "Seek to time %f took %i ms", 0.001f * m_SeekTime, XbmcThreads::SystemClockMillis() - time);
+    CLog::Log(LOGDEBUG, "Seek to time %f took %i ms", 0.001f * m_SeekTime, (int)(XbmcThreads::SystemClockMillis() - time));
     FlushStreams();
     m_SeekTime = -1;
   }

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -44,7 +44,7 @@ CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const CStdString& strHeader, con
   if(dwDelay == 0)
     OpenDialog();    
   else
-    endTime.set((unsigned int)dwDelay);
+    m_endtime.Set((unsigned int)dwDelay);
 
   Create(true);
 }
@@ -133,7 +133,7 @@ void CGUIDialogCache::Process()
         {
           bSentCancel = true;
         }
-        else if( !m_pDlg->IsDialogRunning() && endTime.isTimePast() 
+        else if( !m_pDlg->IsDialogRunning() && m_endtime.IsTimePast() 
               && !g_windowManager.IsWindowActive(WINDOW_DIALOG_YES_NO) )
           OpenDialog();
       }

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -29,7 +29,7 @@
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
 
-CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const CStdString& strHeader, const CStdString& strMsg)
+CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const CStdString& strHeader, const CStdString& strMsg) 
 {
   m_pDlg = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
 
@@ -44,7 +44,7 @@ CGUIDialogCache::CGUIDialogCache(DWORD dwDelay, const CStdString& strHeader, con
   if(dwDelay == 0)
     OpenDialog();    
   else
-    m_dwTimeStamp = XbmcThreads::SystemClockMillis() + dwDelay;
+    endTime.set((unsigned int)dwDelay);
 
   Create(true);
 }
@@ -133,7 +133,7 @@ void CGUIDialogCache::Process()
         {
           bSentCancel = true;
         }
-        else if( !m_pDlg->IsDialogRunning() && XbmcThreads::SystemClockMillis() > m_dwTimeStamp 
+        else if( !m_pDlg->IsDialogRunning() && endTime.isTimePast() 
               && !g_windowManager.IsWindowActive(WINDOW_DIALOG_YES_NO) )
           OpenDialog();
       }

--- a/xbmc/dialogs/GUIDialogCache.h
+++ b/xbmc/dialogs/GUIDialogCache.h
@@ -23,6 +23,7 @@
 
 #include "filesystem/File.h"
 #include "threads/Thread.h"
+#include "threads/SystemClock.h"
 
 class CGUIDialogProgress;
 
@@ -47,8 +48,7 @@ protected:
 
   void OpenDialog();
 
-  DWORD m_dwTimeStamp;
-  DWORD m_dwDelay;
+  XbmcThreads::EndTime endTime;
   CGUIDialogProgress* m_pDlg;
   CStdString m_strLinePrev;
   CStdString m_strLinePrev2;

--- a/xbmc/dialogs/GUIDialogCache.h
+++ b/xbmc/dialogs/GUIDialogCache.h
@@ -48,7 +48,7 @@ protected:
 
   void OpenDialog();
 
-  XbmcThreads::EndTime endTime;
+  XbmcThreads::EndTime m_endtime;
   CGUIDialogProgress* m_pDlg;
   CStdString m_strLinePrev;
   CStdString m_strLinePrev2;

--- a/xbmc/filesystem/CacheCircular.cpp
+++ b/xbmc/filesystem/CacheCircular.cpp
@@ -178,8 +178,8 @@ int64_t CCacheCircular::WaitForData(unsigned int minumum, unsigned int millis)
   if(minumum > m_size - m_size_back)
     minumum = m_size - m_size_back;
 
-  XbmcThreads::EndTime endTime(millis);
-  while (!IsEndOfInput() && avail < minumum && !endTime.isTimePast() )
+  XbmcThreads::EndTime endtime(millis);
+  while (!IsEndOfInput() && avail < minumum && !endtime.IsTimePast() )
   {
     lock.Leave();
     m_written.WaitMSec(50); // may miss the deadline. shouldn't be a problem.

--- a/xbmc/filesystem/CacheCircular.cpp
+++ b/xbmc/filesystem/CacheCircular.cpp
@@ -178,8 +178,8 @@ int64_t CCacheCircular::WaitForData(unsigned int minumum, unsigned int millis)
   if(minumum > m_size - m_size_back)
     minumum = m_size - m_size_back;
 
-  unsigned int time = XbmcThreads::SystemClockMillis() + millis;
-  while (!IsEndOfInput() && avail < minumum && XbmcThreads::SystemClockMillis() < time )
+  XbmcThreads::EndTime endTime(millis);
+  while (!IsEndOfInput() && avail < minumum && !endTime.isTimePast() )
   {
     lock.Leave();
     m_written.WaitMSec(50); // may miss the deadline. shouldn't be a problem.

--- a/xbmc/filesystem/CacheMemBuffer.cpp
+++ b/xbmc/filesystem/CacheMemBuffer.cpp
@@ -137,8 +137,8 @@ int64_t CacheMemBuffer::WaitForData(unsigned int iMinAvail, unsigned int millis)
   if (millis == 0 || IsEndOfInput())
     return m_buffer.getMaxReadSize();
 
-  unsigned int time = XbmcThreads::SystemClockMillis() + millis;
-  while (!IsEndOfInput() && (unsigned int) m_buffer.getMaxReadSize() < iMinAvail && XbmcThreads::SystemClockMillis() < time )
+  XbmcThreads::EndTime endTime(millis);
+  while (!IsEndOfInput() && (unsigned int) m_buffer.getMaxReadSize() < iMinAvail && !endTime.isTimePast() )
     m_written.WaitMSec(50); // may miss the deadline. shouldn't be a problem.
 
   return m_buffer.getMaxReadSize();

--- a/xbmc/filesystem/CacheMemBuffer.cpp
+++ b/xbmc/filesystem/CacheMemBuffer.cpp
@@ -138,7 +138,7 @@ int64_t CacheMemBuffer::WaitForData(unsigned int iMinAvail, unsigned int millis)
     return m_buffer.getMaxReadSize();
 
   XbmcThreads::EndTime endTime(millis);
-  while (!IsEndOfInput() && (unsigned int) m_buffer.getMaxReadSize() < iMinAvail && !endTime.isTimePast() )
+  while (!IsEndOfInput() && (unsigned int) m_buffer.getMaxReadSize() < iMinAvail && !endTime.IsTimePast() )
     m_written.WaitMSec(50); // may miss the deadline. shouldn't be a problem.
 
   return m_buffer.getMaxReadSize();

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -187,7 +187,7 @@ int64_t CSimpleFileCache::WaitForData(unsigned int iMinAvail, unsigned int iMill
 
   XbmcThreads::EndTime endTime(iMillis);
   unsigned int millisLeft;
-  while ( !IsEndOfInput() && (millisLeft = endTime.millisLeft()) > 0 )
+  while ( !IsEndOfInput() && (millisLeft = endTime.MillisLeft()) > 0 )
   {
     int64_t iAvail = GetAvailableRead();
     if (iAvail >= iMinAvail)

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -185,16 +185,16 @@ int64_t CSimpleFileCache::WaitForData(unsigned int iMinAvail, unsigned int iMill
   if( iMillis == 0 || IsEndOfInput() )
     return GetAvailableRead();
 
-  unsigned int timeout = XbmcThreads::SystemClockMillis() + iMillis;
-  unsigned int time;
-  while ( !IsEndOfInput() && (time = XbmcThreads::SystemClockMillis()) < timeout )
+  XbmcThreads::EndTime endTime(iMillis);
+  unsigned int millisLeft;
+  while ( !IsEndOfInput() && (millisLeft = endTime.millisLeft()) > 0 )
   {
     int64_t iAvail = GetAvailableRead();
     if (iAvail >= iMinAvail)
       return iAvail;
 
     // busy look (sleep max 1 sec each round)
-    if (!m_hDataAvailEvent->WaitMSec((timeout - time)>1000?(timeout - time):1000 ))
+    if (!m_hDataAvailEvent->WaitMSec(millisLeft>1000?millisLeft:1000 ))
       return CACHE_RC_ERROR;
   }
 

--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -93,7 +93,7 @@ void DllLibCurlGlobal::CheckIdle()
   VEC_CURLSESSIONS::iterator it = m_sessions.begin();
   while(it != m_sessions.end())
   {
-    if( !it->m_busy && it->m_idletimestamp + idletime < XbmcThreads::SystemClockMillis())
+    if( !it->m_busy && (XbmcThreads::SystemClockMillis() - it->m_idletimestamp) > idletime )
     {
       CLog::Log(LOGINFO, "%s - Closing session to %s://%s (easy=%p, multi=%p)\n", __FUNCTION__, it->m_protocol.c_str(), it->m_hostname.c_str(), (void*)it->m_easy, (void*)it->m_multi);
 
@@ -113,7 +113,7 @@ void DllLibCurlGlobal::CheckIdle()
   }
 
   /* check if we should unload the dll */
-  if(g_curlReferences == 1 && XbmcThreads::SystemClockMillis() > g_curlTimeout + idletime)
+  if(g_curlReferences == 1 && XbmcThreads::SystemClockMillis() - g_curlTimeout > idletime)
     Unload();
 }
 

--- a/xbmc/filesystem/HDHomeRun.cpp
+++ b/xbmc/filesystem/HDHomeRun.cpp
@@ -256,7 +256,7 @@ unsigned int CFileHomeRun::Read(void* lpBuf, int64_t uiBufSize)
       return (unsigned int)datasize;
     }
 
-    if(timestamp.isTimePast())
+    if(timestamp.IsTimePast())
       return 0;
 
     Sleep(64);

--- a/xbmc/filesystem/HDHomeRun.cpp
+++ b/xbmc/filesystem/HDHomeRun.cpp
@@ -245,7 +245,7 @@ unsigned int CFileHomeRun::Read(void* lpBuf, int64_t uiBufSize)
   // neither of the players can be forced to
   // continue even if read return 0 as can happen
   // on live streams.
-  unsigned int timestamp = XbmcThreads::SystemClockMillis() + 5000;
+  XbmcThreads::EndTime timestamp(5000);
   while(1)
   {
     datasize = (size_t) uiBufSize;
@@ -256,7 +256,7 @@ unsigned int CFileHomeRun::Read(void* lpBuf, int64_t uiBufSize)
       return (unsigned int)datasize;
     }
 
-    if(XbmcThreads::SystemClockMillis() > timestamp)
+    if(timestamp.isTimePast())
       return 0;
 
     Sleep(64);

--- a/xbmc/filesystem/HTSPDirectory.cpp
+++ b/xbmc/filesystem/HTSPDirectory.cpp
@@ -52,7 +52,7 @@ struct SSession
   std::string            password;
   CHTSPDirectorySession* session;
   int                    refs;
-  DWORD                  last;
+  unsigned int           last;
 };
 
 struct STimedOut
@@ -63,10 +63,10 @@ struct STimedOut
   }
   bool operator()(SSession& data)
   {
-    return data.refs == 0 && data.last + m_idle < m_time;
+    return data.refs == 0 && (m_time - data.last) > m_idle;
   }
-  DWORD m_idle;
-  DWORD m_time;
+  unsigned int m_idle;
+  unsigned int m_time;
 };
 
 typedef std::vector<SSession> SSessions;

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -56,14 +56,14 @@ bool CMultiPathDirectory::GetDirectory(const CStdString& strPath, CFileItemList 
   if (!GetPaths(strPath, vecPaths))
     return false;
 
-  unsigned int progressTime = XbmcThreads::SystemClockMillis() + 3000L;   // 3 seconds before showing progress bar
+  XbmcThreads::EndTime progressTime(3000); // 3 seconds before showing progress bar
   CGUIDialogProgress* dlgProgress = NULL;
 
   unsigned int iFailures = 0;
   for (unsigned int i = 0; i < vecPaths.size(); ++i)
   {
     // show the progress dialog if we have passed our time limit
-    if (XbmcThreads::SystemClockMillis() > progressTime && !dlgProgress)
+    if (progressTime.isTimePast() && !dlgProgress)
     {
       dlgProgress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
       if (dlgProgress)

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -63,7 +63,7 @@ bool CMultiPathDirectory::GetDirectory(const CStdString& strPath, CFileItemList 
   for (unsigned int i = 0; i < vecPaths.size(); ++i)
   {
     // show the progress dialog if we have passed our time limit
-    if (progressTime.isTimePast() && !dlgProgress)
+    if (progressTime.IsTimePast() && !dlgProgress)
     {
       dlgProgress = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
       if (dlgProgress)

--- a/xbmc/filesystem/MythFile.cpp
+++ b/xbmc/filesystem/MythFile.cpp
@@ -547,7 +547,7 @@ bool CMythFile::UpdateItem(CFileItem& item)
 
 int CMythFile::GetTotalTime()
 {
-  if(m_recorder && m_timestamp + 5000 < XbmcThreads::SystemClockMillis())
+  if(m_recorder && (XbmcThreads::SystemClockMillis() - m_timestamp) > 5000 )
   {
     m_timestamp = XbmcThreads::SystemClockMillis();
     if(m_program)

--- a/xbmc/filesystem/MythSession.cpp
+++ b/xbmc/filesystem/MythSession.cpp
@@ -60,7 +60,7 @@ void CMythSession::CheckIdle()
   for (it = m_sessions.begin(); it != m_sessions.end(); )
   {
     CMythSession* session = *it;
-    if (session->m_timestamp + (MYTH_IDLE_TIMEOUT * 1000) < XbmcThreads::SystemClockMillis())
+    if ((XbmcThreads::SystemClockMillis() - session->m_timestamp) > (MYTH_IDLE_TIMEOUT * 1000) )
     {
       CLog::Log(LOGINFO, "%s - closing idle connection to MythTV backend: %s", __FUNCTION__, session->m_hostname.c_str());
       delete session;

--- a/xbmc/filesystem/SAPDirectory.cpp
+++ b/xbmc/filesystem/SAPDirectory.cpp
@@ -17,6 +17,7 @@
 * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
+#include "threads/SystemClock.h"
 #include "system.h" // WIN32INCLUDES - not sure why this is needed
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
@@ -340,6 +341,7 @@ bool CSAPSessions::ParseAnnounce(char* data, int len)
       }
 
       // should be improved in the case of sdp
+      it->timeout = XbmcThreads::SystemClockMillis() + 60*60*1000;
       return true;
     }
   }
@@ -366,6 +368,7 @@ bool CSAPSessions::ParseAnnounce(char* data, int len)
   session.payload_type   = header.payload_type;
   session.payload_origin = desc.origin;
   session.payload.assign(data, len);
+  session.timeout = XbmcThreads::SystemClockMillis() + 60*60*1000;
   m_sessions.push_back(session);
 
   CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);

--- a/xbmc/filesystem/SAPDirectory.cpp
+++ b/xbmc/filesystem/SAPDirectory.cpp
@@ -17,7 +17,6 @@
 * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
-#include "threads/SystemClock.h"
 #include "system.h" // WIN32INCLUDES - not sure why this is needed
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
@@ -341,7 +340,6 @@ bool CSAPSessions::ParseAnnounce(char* data, int len)
       }
 
       // should be improved in the case of sdp
-      it->timeout = XbmcThreads::SystemClockMillis() + 60*60*1000;
       return true;
     }
   }
@@ -368,7 +366,6 @@ bool CSAPSessions::ParseAnnounce(char* data, int len)
   session.payload_type   = header.payload_type;
   session.payload_origin = desc.origin;
   session.payload.assign(data, len);
-  session.timeout = XbmcThreads::SystemClockMillis() + 60*60*1000;
   m_sessions.push_back(session);
 
   CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_PATH);

--- a/xbmc/filesystem/SAPDirectory.h
+++ b/xbmc/filesystem/SAPDirectory.h
@@ -117,7 +117,6 @@ protected:
   {
     std::string  origin;
     int          msgid;
-    unsigned int timeout;
     std::string  payload_origin;
     std::string  payload_type;
     std::string  payload;

--- a/xbmc/filesystem/SAPDirectory.h
+++ b/xbmc/filesystem/SAPDirectory.h
@@ -117,6 +117,7 @@ protected:
   {
     std::string  origin;
     int          msgid;
+    unsigned int timeout;
     std::string  payload_origin;
     std::string  payload_type;
     std::string  payload;

--- a/xbmc/input/linux/LIRC.cpp
+++ b/xbmc/input/linux/LIRC.cpp
@@ -125,9 +125,9 @@ void CRemoteControl::setDeviceName(const CStdString& value)
 void CRemoteControl::Initialize()
 {
   struct sockaddr_un addr;
-  int now = XbmcThreads::SystemClockMillis();
+  unsigned int now = XbmcThreads::SystemClockMillis();
 
-  if (!m_used || now < m_lastInitAttempt + m_initRetryPeriod)
+  if (!m_used || (now - m_lastInitAttempt) < m_initRetryPeriod)
     return;
   
   m_lastInitAttempt = now;

--- a/xbmc/input/windows/IRServerSuite.cpp
+++ b/xbmc/input/windows/IRServerSuite.cpp
@@ -84,8 +84,8 @@ void CRemoteControl::Initialize()
 
 void CRemoteControl::Process()
 {
-  DWORD iMsRetryDelay = 5000;
-  DWORD time = XbmcThreads::SystemClockMillis() - iMsRetryDelay;
+  unsigned int iMsRetryDelay = 5000;
+  unsigned int time = XbmcThreads::SystemClockMillis() - iMsRetryDelay;
   // try to connect 60 times @ a 5 second interval (5 minutes)
   // multiple tries because irss service might be up and running a little later then xbmc on boot.
   while (!m_bStop && m_iAttempt <= 60)

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -2063,7 +2063,7 @@ CStdString CXbmcHttp::GetCloseTag()
 CKey CXbmcHttp::GetKey()
 {
   if (repeatKeyRate!=0)
-    if (XbmcThreads::SystemClockMillis() >= MarkTime + repeatKeyRate)
+    if ((XbmcThreads::SystemClockMillis() - MarkTime) >=  repeatKeyRate)
     {
       MarkTime=XbmcThreads::SystemClockMillis();
       key=lastKey;

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -490,7 +490,7 @@ void XBPython::Process()
       else ++it;
     }
 
-    if(m_iDllScriptCounter == 0 && m_endtime + 10000 < XbmcThreads::SystemClockMillis())
+    if(m_iDllScriptCounter == 0 && (XbmcThreads::SystemClockMillis() - m_endtime) > 10000 )
       Finalize();
   }
 }

--- a/xbmc/linux/XLCDproc.cpp
+++ b/xbmc/linux/XLCDproc.cpp
@@ -58,7 +58,7 @@ void XLCDproc::Initialize()
 
   // don't try to initialize too often
   int now = XbmcThreads::SystemClockMillis();
-  if (now < m_lastInitAttempt + m_initRetryInterval)
+  if ((now - m_lastInitAttempt) < m_initRetryInterval)
     return;
   m_lastInitAttempt = now;
 

--- a/xbmc/music/karaoke/karaokelyricsmanager.h
+++ b/xbmc/music/karaoke/karaokelyricsmanager.h
@@ -66,7 +66,7 @@ class CKaraokeLyricsManager
     bool        m_karaokeSongPlayed;
 
     //! Stores the last time the song was still played
-    DWORD       m_lastPlayedTime;
+    unsigned int m_lastPlayedTime;
 };
 
 

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -1069,7 +1069,7 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
     items.m_strPath = parent_id;
     if (!items.Load()) {
         // cache anything that takes more than a second to retrieve
-      unsigned int time = XbmcThreads::SystemClockMillis() + 1000;
+      unsigned int time = XbmcThreads::SystemClockMillis();
 
         if (parent_id.StartsWith("virtualpath://upnproot")) {
             CFileItemPtr item;
@@ -1090,7 +1090,7 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
             CDirectory::GetDirectory((const char*)parent_id, items);
         }
 
-        if (items.CacheToDiscAlways() || (items.CacheToDiscIfSlow() && time < XbmcThreads::SystemClockMillis())) {
+        if (items.CacheToDiscAlways() || (items.CacheToDiscIfSlow() && (XbmcThreads::SystemClockMillis() - time) > 1000 )) {
             items.Save();
         }
     }

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -810,10 +810,10 @@ void CRenderSystemDX::SetCameraPosition(const CPoint &camera, int screenWidth, i
 
 bool CRenderSystemDX::TestRender()
 {
-  static DWORD lastTime = 0;
+  static unsigned int lastTime = 0;
   static float delta = 0;
 
-  DWORD thisTime = XbmcThreads::SystemClockMillis();
+  unsigned int thisTime = XbmcThreads::SystemClockMillis();
 
   if(thisTime - lastTime > 10)
   {

--- a/xbmc/threads/Condition.h
+++ b/xbmc/threads/Condition.h
@@ -62,7 +62,7 @@ namespace XbmcThreads
         {
           EndTime endTime((unsigned int)milliseconds);
           for (bool notdone = true; notdone && ret == true;
-               ret = (notdone = (!predicate)) ? ((milliseconds = endTime.millisLeft()) != 0) : true)
+               ret = (notdone = (!predicate)) ? ((milliseconds = endTime.MillisLeft()) != 0) : true)
             cond.wait(lock,milliseconds);
         }
       }

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -49,17 +49,17 @@ namespace XbmcThreads
     inline EndTime() : startTime(0), totalWaitTime(0) {}
     inline EndTime(unsigned int millisecondsIntoTheFuture) : startTime(SystemClockMillis()), totalWaitTime(millisecondsIntoTheFuture) {}
 
-    inline void set(unsigned int millisecondsIntoTheFuture) { startTime = SystemClockMillis(); totalWaitTime = millisecondsIntoTheFuture; }
+    inline void Set(unsigned int millisecondsIntoTheFuture) { startTime = SystemClockMillis(); totalWaitTime = millisecondsIntoTheFuture; }
 
-    inline bool isTimePast() { return totalWaitTime == 0 ? true : (SystemClockMillis() - startTime) >= totalWaitTime; }
+    inline bool IsTimePast() { return totalWaitTime == 0 ? true : (SystemClockMillis() - startTime) >= totalWaitTime; }
 
-    inline unsigned int millisLeft()
+    inline unsigned int MillisLeft()
     {
       unsigned int timeWaitedAlready = (SystemClockMillis() - startTime);
       return (timeWaitedAlready >= totalWaitTime) ? 0 : (totalWaitTime - timeWaitedAlready);
     }
 
-    inline void setExpired() { totalWaitTime = 0; }
-    inline void setInfinite() { totalWaitTime = std::numeric_limits<unsigned int>::max(); }
+    inline void SetExpired() { totalWaitTime = 0; }
+    inline void SetInfinite() { totalWaitTime = std::numeric_limits<unsigned int>::max(); }
   };
 }

--- a/xbmc/utils/AsyncFileCopy.cpp
+++ b/xbmc/utils/AsyncFileCopy.cpp
@@ -63,7 +63,7 @@ bool CAsyncFileCopy::Copy(const CStdString &from, const CStdString &to, const CS
     if (!m_running)
       break;
     // start the dialog up as needed
-    if (dlg && !dlg->IsDialogRunning() && XbmcThreads::SystemClockMillis() > time + 500) // wait 0.5 seconds before starting dialog
+    if (dlg && !dlg->IsDialogRunning() && (XbmcThreads::SystemClockMillis() - time) > 500) // wait 0.5 seconds before starting dialog
     {
       dlg->SetHeading(heading);
       dlg->SetLine(0, url1.GetWithoutUserDetails());

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3013,7 +3013,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMusicVideo(auto_ptr<Dataset> &pDS)
   CVideoInfoTag details;
   details.Reset();
 
-  DWORD time = XbmcThreads::SystemClockMillis();
+  unsigned int time = XbmcThreads::SystemClockMillis();
   int idMovie = pDS->fv(0).get_asInt();
 
   GetDetailsFromDB(pDS, VIDEODB_ID_MUSICVIDEO_MIN, VIDEODB_ID_MUSICVIDEO_MAX, DbMusicVideoOffsets, details);
@@ -5856,7 +5856,7 @@ bool CVideoDatabase::GetMusicVideosByWhere(const CStdString &baseDir, const CStd
 {
   try
   {
-    DWORD time = XbmcThreads::SystemClockMillis();
+    unsigned int time = XbmcThreads::SystemClockMillis();
     movieTime = 0;
     castTime = 0;
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -633,7 +633,7 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
       return false;
 
     // took over a second, and not normally cached, so cache it
-    if (time + 1000 < XbmcThreads::SystemClockMillis() && items.CacheToDiscIfSlow())
+    if ((XbmcThreads::SystemClockMillis() - time) > 1000  && items.CacheToDiscIfSlow())
       items.Save(GetID());
 
     // if these items should replace the current listing, then pop it off the top


### PR DESCRIPTION
In reviewing the use of the XbmcThread::SystemClockMillis call (the call formerly known as CTimeUtils::GetTimeMS) there were many places where the return value was used incorrectly.

1) The type of the return value should match since it's possible for the value returned from the clock to wrap and overflows wont be handled correctly.

2) Because of the fact that this could wrap the user SHOULD NOT compare absolute values returned from the call. For example:

   BAD:
            unsigned int endTime = XbmcThreads::SystemClockMillis() + endDurationMillis;
            ...
            if (endTime > XbmcThreads::SystemClockMillis()) ...

  GOOD:
            unsigned int startTime = XbmcThreads::SystemClockMillis();
            ...
            if ((XbmcThreads::SystemClockMillis() - startTime) > endDurationMillis ) ...

The former is subject to problems when the clock wraps, the latter is not. If you cannot see the difference between these two then please ask before using it.
