### PR TITLE
Valgrind uninitialized mem find fix

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -112,6 +112,7 @@ CVDPAU::CVDPAU()
 
   tmpBrightness  = 0;
   tmpContrast    = 0;
+  tmpDeint       = 0;
   max_references = 0;
 
   for (int i = 0; i < NUM_OUTPUT_SURFACES; i++)

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -23,7 +23,7 @@
 #include "guilib/GUIWindowManager.h"
 
 CGUIDialogBusy::CGUIDialogBusy(void)
-: CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml")
+  : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml"), m_bLastVisible(false)
 {
   m_loadOnDemand = false;
   m_bModal = true;

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -27,6 +27,7 @@ CGUILabel::CGUILabel(float posX, float posY, float width, float height, const CL
     : m_textLayout(labelInfo.font, overflow == OVER_FLOW_WRAP, height)
     , m_scrollInfo(50, 0, labelInfo.scrollSpeed, labelInfo.scrollSuffix)
     , m_maxRect(posX, posY, posX + width, posY + height)
+    , m_color(COLOR_UNKNOWN)
 {
   m_selected = false;
   m_overflowType = overflow;

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -84,7 +84,8 @@ public:
   enum COLOR { COLOR_TEXT = 0,
                COLOR_SELECTED,
                COLOR_FOCUSED,
-               COLOR_DISABLED };
+               COLOR_DISABLED, 
+               COLOR_UNKNOWN };
   
   /*! \brief allowed overflow handling techniques for labels, as defined by the skin
    */

--- a/xbmc/settings/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/GUIDialogContentSettings.cpp
@@ -41,7 +41,7 @@ using namespace std;
 using namespace ADDON;
 
 CGUIDialogContentSettings::CGUIDialogContentSettings(void)
-    : CGUIDialogSettings(WINDOW_DIALOG_CONTENT_SETTINGS, "DialogContentSettings.xml")
+  : CGUIDialogSettings(WINDOW_DIALOG_CONTENT_SETTINGS, "DialogContentSettings.xml"), m_origContent(CONTENT_NONE)
 {
   m_bNeedSave = false;
   m_content = CONTENT_NONE;

--- a/xbmc/threads/Helpers.h
+++ b/xbmc/threads/Helpers.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include <assert.h>
-
 namespace XbmcThreads
 {
   /**
@@ -38,14 +36,3 @@ namespace XbmcThreads
 
 }
 
-/*#ifdef NDEBUG
-#define XBMC_ASSERT_TRUE(expression) assert( expression )
-#define XBMC_ASSERT_NOTEQUALS(compareTo,expression) assert( compareTo != expression )
-#define XBMC_ASSERT_EQUALS(compareTo,expression) assert( compareTo == expression )
-#define XBMC_ASSERT_ZERO(expression) assert( 0 == expression )
-#else*/
-#define XBMC_ASSERT_TRUE(expression) expression
-#define XBMC_ASSERT_NOTEQUALS(compareTo,expression) expression
-#define XBMC_ASSERT_EQUALS(compareTo,expression) expression
-#define XBMC_ASSERT_ZERO(expression) expression
-//#endif

--- a/xbmc/threads/Lockables.h
+++ b/xbmc/threads/Lockables.h
@@ -89,8 +89,6 @@ namespace XbmcThreads
         lock();
     }
 
-    inline unsigned int getCount() { return count; }
-
     /**
      * Some implementations (see pthreads) require access to the underlying 
      *  CCriticalSection, which is also implementation specific. This 

--- a/xbmc/threads/platform/pthreads/Condition.h
+++ b/xbmc/threads/platform/pthreads/Condition.h
@@ -40,21 +40,20 @@ namespace XbmcThreads
   private:
     pthread_cond_t cond;
 
-
   public:
     inline ConditionVariable() 
     { 
-      XBMC_ASSERT_ZERO(pthread_cond_init(&cond,NULL)); 
+      pthread_cond_init(&cond,NULL); 
     }
 
     inline ~ConditionVariable() 
     { 
-      XBMC_ASSERT_ZERO(pthread_cond_destroy(&cond)); 
+      pthread_cond_destroy(&cond);
     }
 
     inline void wait(CCriticalSection& lock) 
     { 
-      XBMC_ASSERT_ZERO(pthread_cond_wait(&cond,&lock.get_underlying().mutex));
+      pthread_cond_wait(&cond,&lock.get_underlying().mutex);
     }
 
     inline bool wait(CCriticalSection& lock, unsigned long milliseconds) 
@@ -62,13 +61,12 @@ namespace XbmcThreads
       struct timeval tv;
       struct timespec ts;
 
-      XBMC_ASSERT_ZERO(gettimeofday(&tv,NULL));
+      gettimeofday(&tv,NULL);
 
       milliseconds += tv.tv_usec / 1000; // move the usecs onto milliseconds
       ts.tv_sec = tv.tv_sec + (time_t)(milliseconds/1000);
       ts.tv_nsec = (long)((milliseconds % (unsigned long)1000) * (unsigned long)1000000);
       int pthread_cond_timedwait_result = pthread_cond_timedwait(&cond,&lock.get_underlying().mutex,&ts);
-      assert (pthread_cond_timedwait_result == 0 || pthread_cond_timedwait_result == ETIMEDOUT);
       return !pthread_cond_timedwait_result;
     }
 
@@ -77,12 +75,12 @@ namespace XbmcThreads
 
     inline void notifyAll() 
     { 
-      XBMC_ASSERT_ZERO(pthread_cond_broadcast(&cond));
+      pthread_cond_broadcast(&cond);
     }
 
     inline void notify() 
     { 
-      XBMC_ASSERT_ZERO(pthread_cond_signal(&cond)); 
+      pthread_cond_signal(&cond);
     }
   };
 

--- a/xbmc/threads/platform/pthreads/CriticalSection.h
+++ b/xbmc/threads/platform/pthreads/CriticalSection.h
@@ -43,32 +43,15 @@ namespace XbmcThreads
       // needs acces to 'mutex'
       friend class XbmcThreads::ConditionVariable;
     public:
-      inline RecursiveMutex()
-      {
-        XBMC_ASSERT_ZERO(pthread_mutex_init(&mutex,getRecusiveAttr()));
-      }
+      inline RecursiveMutex() { pthread_mutex_init(&mutex,getRecusiveAttr()); }
       
-      inline ~RecursiveMutex()
-      {
-        XBMC_ASSERT_ZERO(pthread_mutex_destroy(&mutex));
-      }
+      inline ~RecursiveMutex() { pthread_mutex_destroy(&mutex); }
 
-      inline void lock()
-      {
-        XBMC_ASSERT_ZERO(pthread_mutex_lock(&mutex));
-      }
+      inline void lock() { pthread_mutex_lock(&mutex); }
 
-      inline void unlock()
-      {
-        XBMC_ASSERT_ZERO(pthread_mutex_unlock(&mutex));
-      }
+      inline void unlock() { pthread_mutex_unlock(&mutex); }
         
-      inline bool try_lock()
-      {
-        int pthread_mutex_trylock_result = pthread_mutex_trylock(&mutex);
-        assert(pthread_mutex_trylock_result == 0 || pthread_mutex_trylock_result == EBUSY);
-        return !pthread_mutex_trylock_result;
-      }
+      inline bool try_lock() { return (pthread_mutex_trylock(&mutex) == 0); }
     };
   }
 }

--- a/xbmc/threads/platform/pthreads/Implementation.cpp
+++ b/xbmc/threads/platform/pthreads/Implementation.cpp
@@ -37,8 +37,8 @@ namespace XbmcThreads
       static bool alreadyCalled = false; // initialized to 0 in the data segment prior to startup init code running
       if (!alreadyCalled)
       {
-        XBMC_ASSERT_ZERO(pthread_mutexattr_init(&recursiveAttr));
-        XBMC_ASSERT_ZERO(pthread_mutexattr_settype(&recursiveAttr,PTHREAD_MUTEX_RECURSIVE));
+        pthread_mutexattr_init(&recursiveAttr);
+        pthread_mutexattr_settype(&recursiveAttr,PTHREAD_MUTEX_RECURSIVE);
         alreadyCalled = true;
       }
       return true; // note, we never call destroy.

--- a/xbmc/threads/platform/pthreads/ThreadLocal.h
+++ b/xbmc/threads/platform/pthreads/ThreadLocal.h
@@ -23,8 +23,6 @@
 
 #include <pthread.h>
 
-#include "threads/Helpers.h"
-
 namespace XbmcThreads
 {
   /**
@@ -35,25 +33,13 @@ namespace XbmcThreads
   {
     pthread_key_t key;
   public:
-    inline ThreadLocal()
-    { 
-      XBMC_ASSERT_ZERO(pthread_key_create(&key,NULL));
-    }
+    inline ThreadLocal() { pthread_key_create(&key,NULL); }
 
-    inline ~ThreadLocal()
-    {
-      XBMC_ASSERT_ZERO(pthread_key_delete(key));
-    }
+    inline ~ThreadLocal() { pthread_key_delete(key); }
 
-    inline void set(T* val) 
-    { 
-      XBMC_ASSERT_ZERO(pthread_setspecific(key,(void*)val));
-    }
+    inline void set(T* val) { pthread_setspecific(key,(void*)val); }
 
-    inline T* get() 
-    {
-      return (T*)pthread_getspecific(key);
-    }
+    inline T* get() { return (T*)pthread_getspecific(key); }
   };
 }
 

--- a/xbmc/threads/platform/win/ThreadLocal.h
+++ b/xbmc/threads/platform/win/ThreadLocal.h
@@ -33,11 +33,11 @@ namespace XbmcThreads
   {
     DWORD key;
   public:
-    inline ThreadLocal() {  XBMC_ASSERT_NOTEQUALS(TLS_OUT_OF_INDEXES,TlsAlloc()); }
+    inline ThreadLocal() { key = TlsAlloc(); }
 
-    inline ~ThreadLocal() { XBMC_ASSERT_TRUE(TlsFree(key));  }
+    inline ~ThreadLocal() { TlsFree(key);  }
 
-    inline void set(T* val) {  XBMC_ASSERT_TRUE(TlsSetValue(key,(LPVOID)val));  }
+    inline void set(T* val) {  TlsSetValue(key,(LPVOID)val);  }
 
     inline T* get() { return (T*)TlsGetValue(key); }
   };

--- a/xbmc/utils/LCD.cpp
+++ b/xbmc/utils/LCD.cpp
@@ -388,6 +388,8 @@ void ILCD::Initialize()
   lcdPath = g_settings.GetUserDataItem("LCD.xml");
   LoadSkin(lcdPath);
   m_eCurrentCharset = CUSTOM_CHARSET_DEFAULT;
+  m_disableOnPlay = DISABLE_ON_PLAY_NONE;
+  m_eCurrentCharset = CUSTOM_CHARSET_DEFAULT;
 
   // Big number blocks, used for screensaver clock
   // Note, the big block isn't here, it's in the LCD's ROM

--- a/xbmc/utils/LCD.h
+++ b/xbmc/utils/LCD.h
@@ -31,6 +31,9 @@ class TiXmlNode;
 
 class ILCD : public CThread
 {
+private:
+  enum DISABLE_ON_PLAY { DISABLE_ON_PLAY_NONE = 0, DISABLE_ON_PLAY_VIDEO = 1, DISABLE_ON_PLAY_MUSIC = 2 };
+
 public:
   enum LCD_MODE {
                         LCD_MODE_GENERAL = 0,
@@ -63,13 +66,15 @@ public:
   void LoadSkin(const CStdString &xmlFile);
   void Reset();
   void Render(LCD_MODE mode);
+  ILCD() : m_disableOnPlay(DISABLE_ON_PLAY_NONE), 
+           m_eCurrentCharset(CUSTOM_CHARSET_DEFAULT) {}
 protected:
   virtual void Process() = 0;
   void StringToLCDCharSet(CStdString& strText);
   unsigned char GetLCDCharsetCharacter( UINT _nCharacter, int _nCharset=-1);
   void LoadMode(TiXmlNode *node, LCD_MODE mode);
+
 private:
-  enum DISABLE_ON_PLAY { DISABLE_ON_PLAY_NONE = 0, DISABLE_ON_PLAY_VIDEO = 1, DISABLE_ON_PLAY_MUSIC = 2 };
   int m_disableOnPlay;
 
   std::vector<CGUIInfoLabel> m_lcdMode[LCD_MODE_MAX];

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -94,8 +94,11 @@ void CGUIWindowHome::Announce(EAnnouncementFlag flag, const char *sender, const 
 
 void CGUIWindowHome::AddRecentlyAddedJobs(int flag)
 {
-  if (flag != 0)
-    CJobManager::GetInstance().AddJob(new CRecentlyAddedJob(flag), NULL);
+  for (int i = 0; i < 10; i++)
+  {
+    if (flag != 0)
+      CJobManager::GetInstance().AddJob(new CRecentlyAddedJob(flag), NULL);
+  }
   m_updateRA = 0;
 }
 


### PR DESCRIPTION
Valgrind identified uninitialize memory usage.

While trying to track down an overrun problem I ran across these. I cleaned them up just to get the valgrind messages to stop but they should probably be fixed. Since I'm not sure what some of these SHOULD be initialized to, I'm putting this out there as a PR rather than just merging.
