### PR TITLE
[fix] valgrind identified uninitialize memory usage.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -112,6 +112,7 @@ CVDPAU::CVDPAU()
 
   tmpBrightness  = 0;
   tmpContrast    = 0;
+  tmpDeint       = 0;
   max_references = 0;
 
   for (int i = 0; i < NUM_OUTPUT_SURFACES; i++)

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -23,7 +23,7 @@
 #include "guilib/GUIWindowManager.h"
 
 CGUIDialogBusy::CGUIDialogBusy(void)
-: CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml")
+  : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml"), m_bLastVisible(false)
 {
   m_loadOnDemand = false;
   m_bModal = true;

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -27,6 +27,7 @@ CGUILabel::CGUILabel(float posX, float posY, float width, float height, const CL
     : m_textLayout(labelInfo.font, overflow == OVER_FLOW_WRAP, height)
     , m_scrollInfo(50, 0, labelInfo.scrollSpeed, labelInfo.scrollSuffix)
     , m_maxRect(posX, posY, posX + width, posY + height)
+    , m_color(COLOR_UNKNOWN)
 {
   m_selected = false;
   m_overflowType = overflow;

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -84,7 +84,8 @@ public:
   enum COLOR { COLOR_TEXT = 0,
                COLOR_SELECTED,
                COLOR_FOCUSED,
-               COLOR_DISABLED };
+               COLOR_DISABLED, 
+               COLOR_UNKNOWN };
   
   /*! \brief allowed overflow handling techniques for labels, as defined by the skin
    */

--- a/xbmc/settings/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/GUIDialogContentSettings.cpp
@@ -41,7 +41,7 @@ using namespace std;
 using namespace ADDON;
 
 CGUIDialogContentSettings::CGUIDialogContentSettings(void)
-    : CGUIDialogSettings(WINDOW_DIALOG_CONTENT_SETTINGS, "DialogContentSettings.xml")
+  : CGUIDialogSettings(WINDOW_DIALOG_CONTENT_SETTINGS, "DialogContentSettings.xml"), m_origContent(CONTENT_NONE)
 {
   m_bNeedSave = false;
   m_content = CONTENT_NONE;

--- a/xbmc/threads/Lockables.h
+++ b/xbmc/threads/Lockables.h
@@ -89,8 +89,6 @@ namespace XbmcThreads
         lock();
     }
 
-    inline unsigned int getCount() { return count; }
-
     /**
      * Some implementations (see pthreads) require access to the underlying 
      *  CCriticalSection, which is also implementation specific. This 

--- a/xbmc/utils/LCD.cpp
+++ b/xbmc/utils/LCD.cpp
@@ -388,6 +388,8 @@ void ILCD::Initialize()
   lcdPath = g_settings.GetUserDataItem("LCD.xml");
   LoadSkin(lcdPath);
   m_eCurrentCharset = CUSTOM_CHARSET_DEFAULT;
+  m_disableOnPlay = DISABLE_ON_PLAY_NONE;
+  m_eCurrentCharset = CUSTOM_CHARSET_DEFAULT;
 
   // Big number blocks, used for screensaver clock
   // Note, the big block isn't here, it's in the LCD's ROM

--- a/xbmc/utils/LCD.h
+++ b/xbmc/utils/LCD.h
@@ -31,6 +31,9 @@ class TiXmlNode;
 
 class ILCD : public CThread
 {
+private:
+  enum DISABLE_ON_PLAY { DISABLE_ON_PLAY_NONE = 0, DISABLE_ON_PLAY_VIDEO = 1, DISABLE_ON_PLAY_MUSIC = 2 };
+
 public:
   enum LCD_MODE {
                         LCD_MODE_GENERAL = 0,
@@ -63,13 +66,15 @@ public:
   void LoadSkin(const CStdString &xmlFile);
   void Reset();
   void Render(LCD_MODE mode);
+  ILCD() : m_disableOnPlay(DISABLE_ON_PLAY_NONE), 
+           m_eCurrentCharset(CUSTOM_CHARSET_DEFAULT) {}
 protected:
   virtual void Process() = 0;
   void StringToLCDCharSet(CStdString& strText);
   unsigned char GetLCDCharsetCharacter( UINT _nCharacter, int _nCharset=-1);
   void LoadMode(TiXmlNode *node, LCD_MODE mode);
+
 private:
-  enum DISABLE_ON_PLAY { DISABLE_ON_PLAY_NONE = 0, DISABLE_ON_PLAY_VIDEO = 1, DISABLE_ON_PLAY_MUSIC = 2 };
   int m_disableOnPlay;
 
   std::vector<CGUIInfoLabel> m_lcdMode[LCD_MODE_MAX];


### PR DESCRIPTION
Valgrind identified uninitialized memory usage.

While trying to track down an overrun problem I ran across these. I cleaned them up just to get the valgrind messages to stop but they should probably be fixed. Since I'm not sure what some of these SHOULD be initialized to, I'm putting this out there as a PR rather than just merging.
