### PR TITLE
Make CThread::SetName private to avoid having to lock it

### DIFF
--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -135,12 +135,11 @@ void CBackgroundInfoLoader::Load(CFileItemList& items)
   m_nActiveThreads = nThreads;
   for (int i=0; i < nThreads; i++)
   {
-    CThread *pThread = new CThread(this);
+    CThread *pThread = new CThread(this, "Background Loader");
     pThread->Create();
 #ifndef _LINUX
     pThread->SetPriority(THREAD_PRIORITY_BELOW_NORMAL);
 #endif
-    pThread->SetName("Background Loader");
     m_workers.push_back(pThread);
   }
 

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -42,6 +42,7 @@ namespace ADDON
 CCriticalSection CAddonStatusHandler::m_critSection;
 
 CAddonStatusHandler::CAddonStatusHandler(const CStdString &addonID, ADDON_STATUS status, CStdString message, bool sameThread)
+  : CThread("CAddonStatusHandler:" + addonID)
 {
   if (!CAddonMgr::Get().GetAddon(addonID, m_addon))
     return;
@@ -57,11 +58,7 @@ CAddonStatusHandler::CAddonStatusHandler(const CStdString &addonID, ADDON_STATUS
   }
   else
   {
-    CStdString ThreadName;
-    ThreadName.Format("Addon Status: %s", m_addon->Name().c_str());
-
     Create(true, THREAD_MINSTACKSIZE);
-    SetName(ThreadName.c_str());
     SetPriority(-15);
   }
 }

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -64,7 +64,7 @@ extern HWND g_hWnd;
 
 CExternalPlayer::CExternalPlayer(IPlayerCallback& callback)
     : IPlayer(callback),
-      CThread()
+      CThread("CExternalPlayer")
 {
   m_bAbortRequest = false;
   m_bIsPlaying = false;
@@ -135,8 +135,6 @@ bool CExternalPlayer::IsPlaying() const
 
 void CExternalPlayer::Process()
 {
-  SetName("CExternalPlayer");
-
   CStdString mainFile = m_launchFilename;
   CStdString archiveContent = "";
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -293,7 +293,7 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
 
 CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
     : IPlayer(callback),
-      CThread(),
+      CThread("CDVDPlayer"),
       m_CurrentAudio(STREAM_AUDIO),
       m_CurrentVideo(STREAM_VIDEO),
       m_CurrentSubtitle(STREAM_SUBTITLE),
@@ -419,7 +419,6 @@ bool CDVDPlayer::IsPlaying() const
 
 void CDVDPlayer::OnStartup()
 {
-  CThread::SetName("CDVDPlayer");
   m_CurrentVideo.Clear();
   m_CurrentAudio.Clear();
   m_CurrentSubtitle.Clear();

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -146,7 +146,7 @@ public:
 
 
 CDVDPlayerAudio::CDVDPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent)
-: CThread()
+: CThread("CDVDPlayerAudio")
 , m_messageQueue("audio")
 , m_messageParent(parent)
 , m_dvdAudio((bool&)m_bStop)
@@ -515,8 +515,6 @@ int CDVDPlayerAudio::DecodeFrame(DVDAudioFrame &audioframe, bool bDropPacket)
 
 void CDVDPlayerAudio::OnStartup()
 {
-  CThread::SetName("CDVDPlayerAudio");
-
   m_decode.msg = NULL;
   m_decode.Release();
 

--- a/xbmc/cores/dvdplayer/DVDPlayerTeletext.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerTeletext.cpp
@@ -95,7 +95,7 @@ signed int CDVDTeletextTools::deh24(unsigned char *p)
 
 
 CDVDTeletextData::CDVDTeletextData()
-: CThread()
+: CThread("CDVDTeletextData")
 , m_messageQueue("teletext")
 {
   m_speed = DVD_PLAYSPEED_NORMAL;
@@ -231,11 +231,6 @@ void CDVDTeletextData::ResetTeletextCache()
   m_TXTCache.line30                   = "";
   if (m_TXTCache.SubPage == 0xff)
     m_TXTCache.SubPage = 0;
-}
-
-void CDVDTeletextData::OnStartup()
-{
-  CThread::SetName("CDVDTeletextData");
 }
 
 void CDVDTeletextData::Process()

--- a/xbmc/cores/dvdplayer/DVDPlayerTeletext.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerTeletext.h
@@ -49,7 +49,6 @@ public:
   CDVDMessageQueue m_messageQueue;
 
 protected:
-  virtual void OnStartup();
   virtual void OnExit();
   virtual void Process();
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -122,7 +122,7 @@ public:
 CDVDPlayerVideo::CDVDPlayerVideo( CDVDClock* pClock
                                 , CDVDOverlayContainer* pOverlayContainer
                                 , CDVDMessageQueue& parent)
-: CThread()
+: CThread("CDVDPlayerVideo")
 , m_messageQueue("video")
 , m_messageParent(parent)
 {
@@ -271,7 +271,6 @@ void CDVDPlayerVideo::CloseStream(bool bWaitForBuffers)
 
 void CDVDPlayerVideo::OnStartup()
 {
-  CThread::SetName("CDVDPlayerVideo");
   m_iDroppedFrames = 0;
 
   m_crop.x1 = m_crop.x2 = 0.0f;

--- a/xbmc/input/windows/IRServerSuite.cpp
+++ b/xbmc/input/windows/IRServerSuite.cpp
@@ -32,7 +32,7 @@
 
 CRemoteControl g_RemoteControl;
 
-CRemoteControl::CRemoteControl()
+CRemoteControl::CRemoteControl() : CThread("CRemoteControl")
 {
   m_socket = INVALID_SOCKET;
   m_bInitialized = false;
@@ -79,7 +79,6 @@ void CRemoteControl::Initialize()
   if (m_isConnecting || m_bInitialized) return;
   //trying to connect when there is nothing to connect to is kinda slow so kick it off in a thread.
   Create();
-  SetName("CRemoteControl");
 }
 
 void CRemoteControl::Process()

--- a/xbmc/interfaces/DbusServer.cpp
+++ b/xbmc/interfaces/DbusServer.cpp
@@ -270,9 +270,8 @@ void CDbusServer::StartServer(CApplication *parent)
   }
 
   m_bStop = false;
-  m_pThread = new CThread(this);
+  m_pThread = new CThread(this, "DbusServer");
   m_pThread->Create();
-  m_pThread->SetName("DbusServer");
 }
 
 void CDbusServer::StopServer(bool bWait)

--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -60,7 +60,7 @@ extern "C"
   char* dll_getenv(const char* szKey);
 }
 
-XBPyThread::XBPyThread(XBPython *pExecuter, int id)
+XBPyThread::XBPyThread(XBPython *pExecuter, int id) : CThread("XBPyThread")
 {
   CLog::Log(LOGDEBUG,"new python thread created. id=%d", id);
   m_pExecuter   = pExecuter;
@@ -127,11 +127,6 @@ int XBPyThread::setArgv(const std::vector<CStdString> &argv)
     strcpy(m_argv[i], argv[i].c_str());
   }
   return 0;
-}
-
-void XBPyThread::OnStartup()
-{
-  CThread::SetName("Python Thread");
 }
 
 void XBPyThread::Process()

--- a/xbmc/interfaces/python/XBPyThread.h
+++ b/xbmc/interfaces/python/XBPyThread.h
@@ -54,7 +54,6 @@ protected:
 
   void setSource(const CStdString &src);
 
-  virtual void OnStartup();
   virtual void Process();
   virtual void OnExit();
   virtual void OnException();

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -47,7 +47,7 @@ using namespace std;
 /* CEventServer                                                         */
 /************************************************************************/
 CEventServer* CEventServer::m_pInstance = NULL;
-CEventServer::CEventServer()
+CEventServer::CEventServer() : CThread("CEventServer")
 {
   m_pSocket       = NULL;
   m_pPacketBuffer = NULL;
@@ -98,7 +98,6 @@ void CEventServer::StartServer()
   }
 
   CThread::Create();
-  CThread::SetName("EventServer");
 }
 
 void CEventServer::StopServer(bool bWait)

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -65,7 +65,7 @@ CDetectDVDMedia* CDetectDVDMedia::m_pInstance = NULL;
 CStdString CDetectDVDMedia::m_diskLabel = "";
 CStdString CDetectDVDMedia::m_diskPath = "";
 
-CDetectDVDMedia::CDetectDVDMedia()
+CDetectDVDMedia::CDetectDVDMedia() : CThread("CDetectDVDMedia")
 {
   m_bAutorun = false;
   m_bStop = false;
@@ -87,7 +87,6 @@ void CDetectDVDMedia::OnStartup()
 
 void CDetectDVDMedia::Process()
 {
-  SetName("CDetectDVDMedia");
 // for apple - currently disable this check since cdio will return null if no media is loaded
 #ifndef __APPLE__
   //Before entering loop make sure we actually have a CDrom drive

--- a/xbmc/storage/DetectDVDType.h
+++ b/xbmc/storage/DetectDVDType.h
@@ -36,6 +36,7 @@
 #include "threads/CriticalSection.h"
 
 #include "threads/Thread.h"
+#include "utils/StdString.h"
 
 namespace MEDIA_DETECT
 {

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -123,8 +123,9 @@ DWORD WINAPI CThread::staticThread(LPVOID* data)
     return 1;
   }
 
-  if (pThread->m_ThreadName.IsEmpty())
-    pThread->SetName(pThread->GetTypeName().c_str());
+  if (pThread->m_ThreadName.empty())
+    pThread->m_ThreadName = pThread->GetTypeName();
+  pThread->SetDebugCallStackName(pThread->m_ThreadName.c_str());
 
   CLog::Log(LOGDEBUG,"Thread %s start, auto delete: %d", pThread->m_ThreadName.c_str(), pThread->IsAutoDelete());
 
@@ -377,10 +378,8 @@ int CThread::GetNormalPriority(void)
 }
 
 
-void CThread::SetName( LPCTSTR szThreadName )
+void CThread::SetDebugCallStackName( const char *name )
 {
-  m_ThreadName = szThreadName;
-
 #ifdef _WIN32
   const unsigned int MS_VC_EXCEPTION = 0x406d1388;
   struct THREADNAME_INFO
@@ -392,7 +391,7 @@ void CThread::SetName( LPCTSTR szThreadName )
   } info;
 
   info.dwType = 0x1000;
-  info.szName = szThreadName;
+  info.szName = name;
   info.dwThreadID = m_ThreadId;
   info.dwFlags = 0;
 
@@ -408,14 +407,14 @@ void CThread::SetName( LPCTSTR szThreadName )
 
 // Get the thread name using the implementation dependant typeid() class
 // and attempt to clean it.
-CStdString CThread::GetTypeName(void)
+std::string CThread::GetTypeName(void)
 {
-  CStdString name = typeid(*this).name();
+  std::string name = typeid(*this).name();
  
 #if defined(_MSC_VER)
   // Visual Studio 2010 returns the name as "class CThread" etc
   if (name.substr(0, 6) == "class ")
-    name = name.Right(name.length() - 6);
+    name = name.substr(6, name.length() - 6);
 #elif defined(__GNUC__) && !defined(__clang__)
   // gcc provides __cxa_demangle to demangle the name
   char* demangled = NULL;

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -30,12 +30,12 @@
 #pragma once
 #endif // _MSC_VER > 1000
 
+#include <string>
 #include "system.h" // for HANDLE
 #ifdef _LINUX
 #include "PlatformInclude.h"
 #endif
 #include "Event.h"
-#include "utils/StdString.h"
 
 class IRunnable
 {
@@ -65,7 +65,6 @@ public:
   int GetMinPriority(void);
   int GetMaxPriority(void);
   int GetNormalPriority(void);
-  void SetName( LPCTSTR szThreadName );
   HANDLE ThreadHandle();
   operator HANDLE();
   operator HANDLE() const;
@@ -109,7 +108,10 @@ protected:
   }
 
 private:
-  CStdString GetTypeName(void);
+  /*! \brief set the threadname for the debugger/callstack, implementation dependent.
+   */
+  void SetDebugCallStackName( const char *threadName );
+  std::string GetTypeName(void);
 
 private:
   ThreadIdentifier ThreadId() const;
@@ -123,7 +125,7 @@ private:
   unsigned __int64 m_iLastTime;
   float m_fLastUsage;
 
-  CStdString m_ThreadName;
+  std::string m_ThreadName;
 
 #ifdef _LINUX
   static void term_handler (int signum);

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -32,7 +32,7 @@ bool CJob::ShouldCancel(unsigned int progress, unsigned int total) const
   return false;
 }
 
-CJobWorker::CJobWorker(CJobManager *manager)
+CJobWorker::CJobWorker(CJobManager *manager) : CThread("Jobworker")
 {
   m_jobManager = manager;
   Create(true); // start work immediately, and kill ourselves when we're done
@@ -51,7 +51,6 @@ CJobWorker::~CJobWorker()
 void CJobWorker::Process()
 {
   SetPriority( GetMinPriority() );
-  SetName("Jobworker");
   while (true)
   {
     // request an item from our manager (this call is blocking)


### PR DESCRIPTION
Pretty self-explanatory.  Before we had subclasses of CThread calling SetName() from outside the thread.  This would ofcourse cause issues of writing to m_ThreadName while the thread was reading from it.

There doesn't seem any need for this to be set other than at construction time, and given we already have support for setting the name via the constructor we mayaswell use it.

I also took the liberty of renaming CThread::SetName() to what it actually does - it's actually only on win32 that it does anything of substance (namely set the thread name for the callstack in the debugger).

This needs checking on win32 that the debugger callstack actually has the correct names still (I don't see why not, but it's not tested)
