### PR TITLE
[change] - check if directory exists before trying to create it

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -235,7 +235,7 @@ bool CDirectory::Create(const CStdString& strPath)
     CStdString realPath = Translate(strPath);
     auto_ptr<IDirectory> pDirectory(CFactoryDirectory::Create(realPath));
     if (pDirectory.get())
-      if(pDirectory->Create(realPath.c_str()))
+      if(pDirectory->Exists(realPath.c_str()) || pDirectory->Create(realPath.c_str()))
         return true;
   }
 #ifndef _LINUX


### PR DESCRIPTION
Please let this in. The 100000000 lines in the xbmc.log according to creating of directorys failed because they already exist makes me go crazy!.

I do this as a pr - because this solution wasn't treated as good by some devs. But i don't want these sensless errors in the logs all the time ...
