### PR TITLE
[change] - a mouseclick does only break the screensaver - not execute the

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -377,11 +377,13 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
     case XBMC_KEYUP:
       g_Keyboard.ProcessKeyUp();
       break;
-    case XBMC_MOUSEBUTTONDOWN:
     case XBMC_MOUSEBUTTONUP:
     case XBMC_MOUSEMOTION:
       g_Mouse.HandleEvent(newEvent);
       g_application.ProcessMouse();
+      break;
+    case XBMC_MOUSEBUTTONDOWN:
+      g_Mouse.HandleEvent(newEvent);    
       break;
     case XBMC_VIDEORESIZE:
       if (!g_application.m_bInitializing &&

--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -93,7 +93,7 @@ CMouseStat::CButtonState::BUTTON_ACTION CMouseStat::CButtonState::Update(unsigne
       m_state = STATE_RELEASED;
       return Update(time, x, y, down);
     }
-    if (down)
+    if (!down)
     {
       m_state = STATE_IN_DOUBLE_IGNORE;
       return MB_DOUBLE_CLICK;


### PR DESCRIPTION
A mouseclick should only break the screensaver and not execute the action.
At the moment the mouse button down has broken the screensaver and the mouse button up has executed the action. This commit should fix it. It was mainly unlovely on touch devices...
