### PR TITLE
[change] Introduce XbmcThreads::InversePredicate as a helper for threadin

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1882,8 +1882,7 @@ bool CApplication::WaitFrame(unsigned int timeout)
   CSingleLock lock(m_frameMutex);
   //wait until event is set, but modify remaining time
 
-  NotFrameCount nfc(this);
-  TightConditionVariable<NotFrameCount&> cv(m_frameCond, nfc);
+  TightConditionVariable<InversePredicate<int&> > cv(m_frameCond, InversePredicate<int&>(m_frameCount));
   cv.wait(lock,timeout);
   done = m_frameCount == 0;
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -388,15 +388,6 @@ protected:
   std::map<std::string, std::map<int, float> > m_lastAxisMap;
 #endif
 
-  class NotFrameCount
-  {
-    CApplication* ths;
-  public:
-    inline NotFrameCount(CApplication* o) : ths(o) {}
-    inline bool operator!() { return !(ths->m_frameCount); }
-  };
-
-  friend class NotFrameCount;
 };
 
 extern CApplication g_application;

--- a/xbmc/threads/Helpers.h
+++ b/xbmc/threads/Helpers.h
@@ -34,5 +34,22 @@ namespace XbmcThreads
     inline NonCopyable() {}
   };
 
+  /**
+   * This will create a new predicate from an old predicate P with 
+   *  inverse truth value. This predicate is safe to use in a 
+   *  TightConditionVariable<P>
+   */
+  template <class P> class InversePredicate
+  {
+    P predicate;
+
+  public:
+    inline InversePredicate(P predicate_) : predicate(predicate_) {}
+    inline InversePredicate(const InversePredicate<P>& other) : predicate(other.predicate) {}
+    inline InversePredicate<P>& operator=(InversePredicate<P>& other) { predicate = other.predicate; }
+
+    inline bool operator!() const { return !(!predicate); }
+  };
+
 }
 


### PR DESCRIPTION
[change] Introduce XbmcThreads::InversePredicate as a helper for threading mechanisms that deal with predicates.

This is a slight modification that makes the code more readable and provides for a general mechanism to use condition variables in a more straightforward manner. This currently effects CSharedSection and CApplication. With respect to the use of TightConditionVariable, they should be cleaner now.

I wont leave this out there too long - it's a fairly minor change. If someone has a problem with it please let me know.
