### PR TITLE
Restore -d command line argument

### DIFF
--- a/xbmc/settings/AppParamParser.cpp
+++ b/xbmc/settings/AppParamParser.cpp
@@ -91,7 +91,7 @@ void CAppParamParser::DisplayHelp()
 {
   printf("Usage: xbmc [OPTION]... [FILE]...\n\n");
   printf("Arguments:\n");
-  printf("  -d <n>\t\t\tdelay <n> seconds before starting\n");
+  printf("  -d <n>\t\tdelay <n> seconds before starting\n");
   printf("  -fs\t\t\tRuns XBMC in full screen\n");
   printf("  --standalone\t\tXBMC runs in a stand alone environment without a window \n");
   printf("\t\t\tmanager and supporting applications. For example, that\n");

--- a/xbmc/settings/AppParamParser.cpp
+++ b/xbmc/settings/AppParamParser.cpp
@@ -26,13 +26,13 @@
 #include "FileItem.h"
 #include "Application.h"
 #include "utils/log.h"
-#ifdef _WIN32
+#ifdef TARGET_WINDOWS
 #include "WIN32Util.h"
 #endif
 #ifdef HAS_LIRC
 #include "input/linux/LIRC.h"
 #endif
-#ifndef _WIN32
+#ifndef TARGET_WINDOWS
 #include "linux/XTimeUtils.h"
 #endif
 

--- a/xbmc/settings/AppParamParser.cpp
+++ b/xbmc/settings/AppParamParser.cpp
@@ -32,6 +32,9 @@
 #ifdef HAS_LIRC
 #include "input/linux/LIRC.h"
 #endif
+#ifndef _WIN32
+#include "linux/XTimeUtils.h"
+#endif
 
 CAppParamParser::CAppParamParser()
 {
@@ -62,7 +65,6 @@ void CAppParamParser::Parse(const char* argv[], int nArgs)
       else if (strnicmp(argv[i], "-n", 2) == 0 || strnicmp(argv[i], "--nolirc", 8) == 0)
          g_RemoteControl.setUsed(false);
 #endif
-#ifdef _WIN32
       if (stricmp(argv[i], "-d") == 0)
       {
         if (i + 1 < nArgs)
@@ -73,7 +75,6 @@ void CAppParamParser::Parse(const char* argv[], int nArgs)
         }
         i++;
       }
-#endif
     }
   }
   PlayPlaylist();
@@ -90,9 +91,7 @@ void CAppParamParser::DisplayHelp()
 {
   printf("Usage: xbmc [OPTION]... [FILE]...\n\n");
   printf("Arguments:\n");
-#ifdef _WIN32
   printf("  -d <n>\t\t\tdelay <n> seconds before starting\n");
-#endif
   printf("  -fs\t\t\tRuns XBMC in full screen\n");
   printf("  --standalone\t\tXBMC runs in a stand alone environment without a window \n");
   printf("\t\t\tmanager and supporting applications. For example, that\n");

--- a/xbmc/settings/AppParamParser.cpp
+++ b/xbmc/settings/AppParamParser.cpp
@@ -62,6 +62,18 @@ void CAppParamParser::Parse(const char* argv[], int nArgs)
       else if (strnicmp(argv[i], "-n", 2) == 0 || strnicmp(argv[i], "--nolirc", 8) == 0)
          g_RemoteControl.setUsed(false);
 #endif
+#ifdef _WIN32
+      if (stricmp(argv[i], "-d") == 0)
+      {
+        if (i + 1 < nArgs)
+        {
+          int sleeptime = atoi(argv[i + 1]);
+          if (sleeptime > 0 && sleeptime < 360)
+            Sleep(sleeptime*1000);
+        }
+        i++;
+      }
+#endif
     }
   }
   PlayPlaylist();
@@ -78,6 +90,9 @@ void CAppParamParser::DisplayHelp()
 {
   printf("Usage: xbmc [OPTION]... [FILE]...\n\n");
   printf("Arguments:\n");
+#ifdef _WIN32
+  printf("  -d <n>\t\t\tdelay <n> seconds before starting\n");
+#endif
   printf("  -fs\t\t\tRuns XBMC in full screen\n");
   printf("  --standalone\t\tXBMC runs in a stand alone environment without a window \n");
   printf("\t\t\tmanager and supporting applications. For example, that\n");


### PR DESCRIPTION
Restore the "-d <n>" argument that got misplaced during the CAppParamParser change
