### PR TITLE
Wifi improvements

### DIFF
--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -89,6 +89,46 @@ bool in_ether (const char *bufp, unsigned char *addr)
   return true;
 }
 
+int NetworkAccessPoint::getQuality() const
+{
+  // Cisco dBm lookup table (partially nonlinear)
+  // Source: "Converting Signal Strength Percentage to dBm Values, 2002"
+  int quality;
+  if (m_dBm >= -10) quality = 100;
+  else if (m_dBm >= -20) quality = 85 + (m_dBm + 20);
+  else if (m_dBm >= -30) quality = 77 + (m_dBm + 30);
+  else if (m_dBm >= -60) quality = 48 + (m_dBm + 60);
+  else if (m_dBm >= -98) quality = 13 + (m_dBm + 98);
+  else if (m_dBm >= -112) quality = 1 + (m_dBm + 112);
+  else quality = 0;
+  return quality;
+}
+
+int NetworkAccessPoint::FreqToChannel(float frequency)
+{
+  int IEEE80211Freq[] = {2412, 2417, 2422, 2427, 2432,
+                         2437, 2442, 2447, 2452, 2457,
+                         2462, 2467, 2472, 2484,
+                         5180, 5200, 5210, 5220, 5240, 5250,
+                         5260, 5280, 5290, 5300, 5320,
+                         5745, 5760, 5765, 5785, 5800, 5805, 5825};
+  int IEEE80211Ch[] =   {   1,    2,    3,    4,    5,
+                            6,    7,    8,    9,   10,
+                           11,   12,   13,   14,
+                           36,   40,   42,   44,   48,   50,
+                           52,   56,   58,   60,   64,
+                          149,  152,  153,  157,  160,  161,  165};
+  // Round frequency to the nearest MHz
+  int mod_chan = (int)(frequency / 1000000 + 0.5f);
+  for (unsigned int i = 0; i < sizeof(IEEE80211Freq) / sizeof(int); ++i)
+  {
+    if (IEEE80211Freq[i] == mod_chan)
+      return IEEE80211Ch[i];
+  }
+  return 0; // unknown
+}
+
+
 CNetwork::CNetwork()
 {
   CApplicationMessenger::Get().NetworkMessage(SERVICES_UP, 0);

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -32,21 +32,41 @@ enum NetworkAssignment { NETWORK_DASH = 0, NETWORK_DHCP = 1, NETWORK_STATIC = 2,
 class NetworkAccessPoint
 {
 public:
-   NetworkAccessPoint(CStdString& essId, int quality, EncMode encryption)
+   NetworkAccessPoint(const CStdString &essId, const CStdString &macAddress, int signalStrength, EncMode encryption, int channel = 0)
    {
-      m_essId = essId;
-      m_quality = quality;
+      m_essId          = essId;
+      m_macAddress     = macAddress;
+      m_dBm            = signalStrength;
       m_encryptionMode = encryption;
+      m_channel        = channel;
    }
 
-   CStdString getEssId() { return m_essId; }
-   int getQuality() { return m_quality; }
-   EncMode getEncryptionMode() { return m_encryptionMode; }
+   const CStdString &getEssId() const { return m_essId; }
+   const CStdString &getMacAddress() const { return m_macAddress; }
+   int getSignalStrength() const { return m_dBm; }
+   EncMode getEncryptionMode() const { return m_encryptionMode; }
+   int getChannel() const { return m_channel; }
+
+   /*!
+    \brief  Returns the quality, normalized as a percentage, of the network access point
+    \return The quality as an integer between 0 and 100
+    */
+   int getQuality() const;
+
+   /*!
+    \brief  Translates a 802.11a+g frequency into the corresponding channel
+    \param  frequency  The frequency of the channel in units of Hz
+    \return The channel as an integer between 1 and 14 (802.11b+g) or
+            between 36 and 165 (802.11a), or 0 if unknown.
+    */
+   static int FreqToChannel(float frequency);
 
 private:
-   CStdString   m_essId;
-   int          m_quality;
-   EncMode      m_encryptionMode;
+   CStdString  m_essId;
+   CStdString  m_macAddress;
+   int         m_dBm;
+   EncMode     m_encryptionMode;
+   int         m_channel;
 };
 
 class CNetworkInterface

--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -655,7 +655,7 @@ std::vector<NetworkAccessPoint> CNetworkInterfaceLinux::GetAccessPoints(void)
       return result;
 
 #if defined(TARGET_LINUX)
-   // Query the wireless extentsions version number. It will help us when we
+   // Query the wireless extension's version number. It will help us when we
    // parse the resulting events
    struct iwreq iwr;
    char rangebuffer[sizeof(iw_range) * 2];    /* Large enough */
@@ -680,14 +680,18 @@ std::vector<NetworkAccessPoint> CNetworkInterfaceLinux::GetAccessPoints(void)
    iwr.ifr_name[IFNAMSIZ - 1] = 0;
    if (ioctl(m_network->GetSocket(), SIOCSIWSCAN, &iwr) < 0)
    {
-      CLog::Log(LOGWARNING, "Cannot initiate wireless scan: ioctl[SIOCSIWSCAN]: %s", strerror(errno));
+      // Triggering scanning is a privileged operation (root only)
+      if (errno == EPERM)
+         CLog::Log(LOGWARNING, "Cannot initiate wireless scan: ioctl[SIOCSIWSCAN]: %s. Try running as root", strerror(errno));
+      else
+         CLog::Log(LOGWARNING, "Cannot initiate wireless scan: ioctl[SIOCSIWSCAN]: %s", strerror(errno));
       return result;
    }
 
    // Get the results of the scanning. Three scenarios:
    //    1. There's not enough room in the result buffer (E2BIG)
    //    2. The scanning is not complete (EAGAIN) and we need to try again. We cap this with 15 seconds.
-   //    3. Were'e good.
+   //    3. We're good.
    int duration = 0; // ms
    unsigned char* res_buf = NULL;
    int res_buf_len = IW_SCAN_MAX_DATA;
@@ -732,25 +736,29 @@ std::vector<NetworkAccessPoint> CNetworkInterfaceLinux::GetAccessPoints(void)
       }
    }
 
-   size_t len = iwr.u.data.length;
-   char* pos = (char *) res_buf;
-   char* end = (char *) res_buf + len;
-   char* custom;
-   struct iw_event iwe_buf, *iwe = &iwe_buf;
+   size_t len = iwr.u.data.length;           // total length of the wireless events from the scan results
+   unsigned char* pos = res_buf;             // pointer to the current event (about 10 per wireless network)
+   unsigned char* end = res_buf + len;       // marks the end of the scan results
+   unsigned char* custom;                    // pointer to the event payload
+   struct iw_event iwe_buf, *iwe = &iwe_buf; // buffer to hold individual events
 
    CStdString essId;
-   int quality = 0;
+   CStdString macAddress;
+   int signalLevel = 0;
    EncMode encryption = ENC_NONE;
-   bool first = true;
+   int channel = 0;
 
    while (pos + IW_EV_LCP_LEN <= end)
    {
       /* Event data may be unaligned, so make a local, aligned copy
        * before processing. */
+
+      // copy event prefix (size of event minus IOCTL fixed payload)
       memcpy(&iwe_buf, pos, IW_EV_LCP_LEN);
       if (iwe->len <= IW_EV_LCP_LEN)
          break;
 
+      // if the payload is nontrivial (i.e. > 16 octets) assume it comes after a pointer
       custom = pos + IW_EV_POINT_LEN;
       if (range->we_version_compiled > 18 &&
           (iwe->cmd == SIOCGIWESSID ||
@@ -758,29 +766,48 @@ std::vector<NetworkAccessPoint> CNetworkInterfaceLinux::GetAccessPoints(void)
            iwe->cmd == IWEVGENIE ||
            iwe->cmd == IWEVCUSTOM))
       {
-         /* Wireless extentsions v19 removed the pointer from struct iw_point */
-         char *dpos = (char *) &iwe_buf.u.data.length;
-         int dlen = dpos - (char *) &iwe_buf;
-         memcpy(dpos, pos + IW_EV_LCP_LEN, sizeof(struct iw_event) - dlen);
+         /* Wireless extensions v19 removed the pointer from struct iw_point */
+         char *data_pos = (char *) &iwe_buf.u.data.length;
+         int data_len = data_pos - (char *) &iwe_buf;
+         memcpy(data_pos, pos + IW_EV_LCP_LEN, sizeof(struct iw_event) - data_len);
       }
       else
       {
+         // copy the rest of the event and point custom toward the payload offset
          memcpy(&iwe_buf, pos, sizeof(struct iw_event));
          custom += IW_EV_POINT_OFF;
       }
 
+      // Interpret the payload based on event type. Each access point generates ~12 different events
       switch (iwe->cmd)
       {
+         // Get access point MAC addresses
          case SIOCGIWAP:
-            if (first)
-               first = false;
-            else
-            {
-               result.push_back(NetworkAccessPoint(essId, quality, encryption));
-               encryption = ENC_NONE;
-            }
+         {
+            // This event marks a new access point, so push back the old information
+            if (!macAddress.IsEmpty())
+               result.push_back(NetworkAccessPoint(essId, macAddress, signalLevel, encryption, channel));
+            unsigned char* mac = (unsigned char*)iwe->u.ap_addr.sa_data;
+            // macAddress is big-endian, write in byte chunks
+            macAddress.Format("%02x-%02x-%02x-%02x-%02x-%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+            // Reset the remaining fields
+            essId = "";
+            encryption = ENC_NONE;
+            signalLevel = 0;
+            channel = 0;
             break;
+         }
 
+         // Get operation mode
+         case SIOCGIWMODE:
+         {
+            // Ignore Ad-Hoc networks (1 is the magic number for this)
+            if (iwe->u.mode == 1)
+               macAddress = "";
+            break;
+         }
+
+         // Get ESSID
          case SIOCGIWESSID:
          {
             char essid[IW_ESSID_MAX_SIZE+1];
@@ -793,21 +820,42 @@ std::vector<NetworkAccessPoint> CNetworkInterfaceLinux::GetAccessPoints(void)
             break;
          }
 
+         // Quality part of statistics
          case IWEVQUAL:
-             quality = iwe->u.qual.qual;
-             break;
+         {
+            // u.qual.qual is scaled to a vendor-specific RSSI_Max, so use u.qual.level
+            signalLevel = iwe->u.qual.level - 0x100; // and remember we use 8-bit arithmetic
+            break;
+         }
 
+         // Get channel/frequency (Hz)
+         // This gets called twice per network, what's the difference between the two?
+         case SIOCGIWFREQ:
+         {
+            float freq = ((float)iwe->u.freq.m) * pow(10, iwe->u.freq.e);
+            if (freq > 1000)
+               channel = NetworkAccessPoint::FreqToChannel(freq);
+            else
+               channel = (int)freq; // Some drivers report channel instead of frequency
+            break;
+         }
+
+         // Get encoding token & mode
          case SIOCGIWENCODE:
-             if (!(iwe->u.data.flags & IW_ENCODE_DISABLED) && encryption == ENC_NONE)
-                encryption = ENC_WEP;
-             break;
+         {
+            if (!(iwe->u.data.flags & IW_ENCODE_DISABLED) && encryption == ENC_NONE)
+               encryption = ENC_WEP;
+            break;
+         }
 
+         // Generic IEEE 802.11 information element (IE) for WPA, RSN, WMM, ...
          case IWEVGENIE:
          {
             int offset = 0;
-            while (offset <= iwe_buf.u.data.length)
+            // Loop on each IE, each IE is minimum 2 bytes
+            while (offset <= (iwe_buf.u.data.length - 2))
             {
-               switch ((unsigned char)custom[offset])
+               switch (custom[offset])
                {
                   case 0xdd: /* WPA1 */
                      if (encryption != ENC_WPA2)
@@ -816,7 +864,7 @@ std::vector<NetworkAccessPoint> CNetworkInterfaceLinux::GetAccessPoints(void)
                   case 0x30: /* WPA2 */
                      encryption = ENC_WPA2;
                }
-
+               // Skip over this IE to the next one in the list
                offset += custom[offset+1] + 2;
             }
          }
@@ -825,8 +873,8 @@ std::vector<NetworkAccessPoint> CNetworkInterfaceLinux::GetAccessPoints(void)
       pos += iwe->len;
    }
 
-   if (!first)
-      result.push_back(NetworkAccessPoint(essId, quality, encryption));
+   if (!macAddress.IsEmpty())
+      result.push_back(NetworkAccessPoint(essId, macAddress, signalLevel, encryption, channel));
 
    free(res_buf);
    res_buf = NULL;

--- a/xbmc/network/windows/NetworkWin32.cpp
+++ b/xbmc/network/windows/NetworkWin32.cpp
@@ -115,7 +115,7 @@ CStdString CNetworkInterfaceWin32::GetCurrentWirelessEssId(void)
       PWLAN_INTERFACE_INFO_LIST ppInterfaceList;
       if(WlanEnumInterfaces(hClientHdl,NULL, &ppInterfaceList ) == ERROR_SUCCESS)
       {
-        for(int i=0; i<ppInterfaceList->dwNumberOfItems;i++)
+        for(unsigned int i=0; i<ppInterfaceList->dwNumberOfItems;i++)
         {
           GUID guid = ppInterfaceList->InterfaceInfo[i].InterfaceGuid;
           WCHAR wcguid[64];
@@ -388,7 +388,7 @@ void CNetworkInterfaceWin32::GetSettings(NetworkAssignment& assignment, CStdStri
       PWLAN_INTERFACE_INFO_LIST ppInterfaceList;
       if(WlanEnumInterfaces(hClientHdl,NULL, &ppInterfaceList ) == ERROR_SUCCESS)
       {
-        for(int i=0; i<ppInterfaceList->dwNumberOfItems;i++)
+        for(unsigned int i=0; i<ppInterfaceList->dwNumberOfItems;i++)
         {
           GUID guid = ppInterfaceList->InterfaceInfo[i].InterfaceGuid;
           WCHAR wcguid[64];

--- a/xbmc/network/windows/NetworkWin32.cpp
+++ b/xbmc/network/windows/NetworkWin32.cpp
@@ -29,7 +29,7 @@
 
 // undefine if you want to build without the wlan stuff
 // might be needed for VS2003
-//#define HAS_WIN32_WLAN_API
+#define HAS_WIN32_WLAN_API
 
 #ifdef HAS_WIN32_WLAN_API
 #include "Wlanapi.h"
@@ -318,8 +318,85 @@ bool CNetworkInterfaceWin32::GetHostMacAddress(unsigned long host, CStdString& m
 std::vector<NetworkAccessPoint> CNetworkInterfaceWin32::GetAccessPoints(void)
 {
    std::vector<NetworkAccessPoint> result;
+#ifdef HAS_WIN32_WLAN_API
+  if (!IsWireless())
+    return result;
 
-   return result;
+  // According to Mozilla: "We could be executing on either Windows XP or Windows
+  // Vista, so use the lower version of the client WLAN API. It seems that the
+  // negotiated version is the Vista version irrespective of what we pass!"
+  // http://dxr.mozilla.org/mozilla-central/source/netwerk/wifi/nsWifiScannerWin.cpp#l51
+  static const int xpWlanClientVersion = 1;
+  DWORD negotiated_version;
+  DWORD dwResult;
+  HANDLE wlan_handle = NULL;
+
+  // Get the handle to the WLAN API
+  dwResult = WlanOpenHandle(xpWlanClientVersion, NULL, &negotiated_version, &wlan_handle);
+  if (dwResult != ERROR_SUCCESS || !wlan_handle)
+  {
+    CLog::Log(LOGERROR, "Could not load the client WLAN API");
+    return result;
+  }
+
+  // Get the list of interfaces (WlanEnumInterfaces allocates interface_list)
+  WLAN_INTERFACE_INFO_LIST *interface_list = NULL;
+  dwResult = WlanEnumInterfaces(wlan_handle, NULL, &interface_list);
+  if (dwResult != ERROR_SUCCESS || !interface_list)
+  {
+    WlanCloseHandle(wlan_handle, NULL);
+    CLog::Log(LOGERROR, "Failed to get the list of interfaces");
+    return result;
+  }
+
+  for (unsigned int i = 0; i < interface_list->dwNumberOfItems; ++i)
+  {
+    GUID guid = interface_list->InterfaceInfo[i].InterfaceGuid;
+    WCHAR wcguid[64];
+    StringFromGUID2(guid, (LPOLESTR)&wcguid, 64);
+    CStdStringW strGuid = wcguid;
+    CStdStringW strAdaptername = m_adapter.AdapterName;
+    if (strGuid == strAdaptername)
+    {
+      WLAN_BSS_LIST *bss_list;
+      HRESULT rv = WlanGetNetworkBssList(wlan_handle,
+                                         &interface_list->InterfaceInfo[i].InterfaceGuid,
+                                         NULL,               // Get all SSIDs
+                                         dot11_BSS_type_any, // unused
+                                         false,              // bSecurityEnabled - unused
+                                         NULL,               // reserved
+                                         &bss_list);
+      if (rv != ERROR_SUCCESS || !bss_list)
+        break;
+      for (unsigned int j = 0; j < bss_list->dwNumberOfItems; ++j)
+      {
+        const WLAN_BSS_ENTRY bss_entry = bss_list->wlanBssEntries[j];
+        // Add the access point info to the list of results
+        CStdString essId((char*)bss_entry.dot11Ssid.ucSSID, (unsigned int)bss_entry.dot11Ssid.uSSIDLength);
+        CStdString macAddress;
+        // macAddress is big-endian, write in byte chunks
+        macAddress.Format("%02x-%02x-%02x-%02x-%02x-%02x",
+          bss_entry.dot11Bssid[0], bss_entry.dot11Bssid[1], bss_entry.dot11Bssid[2],
+          bss_entry.dot11Bssid[3], bss_entry.dot11Bssid[4], bss_entry.dot11Bssid[5]);
+        int signalLevel = bss_entry.lRssi;
+        EncMode encryption = ENC_NONE; // TODO
+        int channel = NetworkAccessPoint::FreqToChannel((float)bss_entry.ulChCenterFrequency * 1000);
+        result.push_back(NetworkAccessPoint(essId, macAddress, signalLevel, encryption, channel));
+      }
+      WlanFreeMemory(bss_list);
+      break;
+    }
+  }
+
+  // Free the interface list
+  WlanFreeMemory(interface_list);
+
+  // Close the handle
+  WlanCloseHandle(wlan_handle, NULL);
+
+#endif
+
+  return result;
 }
 
 void CNetworkInterfaceWin32::GetSettings(NetworkAssignment& assignment, CStdString& ipAddress, CStdString& networkMask, CStdString& defaultGateway, CStdString& essId, CStdString& key, EncMode& encryptionMode)


### PR DESCRIPTION
Contains the following 3 modifications:
- Class NetworkAccessPoint has been augmented to include macAddress and channel
- CNetworkInterfaceLinux::GetAccessPoints() adds these two new fields, and includes general readability fixups
- CNetworkInterfaceWin32::GetAccessPoints() has been implemented

topfs2 has made some progress on a network abstraction layer (https://github.com/topfs2/xbmc/tree/network_abstraction). This will probably obsolesce these changes, but in the meantime, it can't hurt to have better wifi support :)
