### PR TITLE
Change the volume increment/decrement so it's always 1

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2508,9 +2508,9 @@ bool CApplication::OnAction(const CAction &action)
         speed /= 50; //50 fps
 
       if (action.GetID() == ACTION_VOLUME_UP)
-        volume += (int)((float)fabs(action.GetAmount()) * action.GetAmount() * speed);
+        volume += (int) speed;
       else
-        volume -= (int)((float)fabs(action.GetAmount()) * action.GetAmount() * speed);
+        volume -= (int) speed;
 
       SetVolume(volume, false);
     }


### PR DESCRIPTION
The handler for ACTION_VOLUME_UP/DOWN changes the volume by the value in action.GetAmount() squared. However this value is only ever 1 unless the volume action has been mapped to the mouse wheel, in which case it's a random number related to the position of the mouse. The patch removes the unnecessary reference to action.GetAmount() and allows the mouse wheel to be used for controlling the volume.
