### PR TITLE
Add Unique Identifier to Profiles in profiles.xml

### DIFF
--- a/xbmc/settings/GUIDialogProfileSettings.cpp
+++ b/xbmc/settings/GUIDialogProfileSettings.cpp
@@ -322,7 +322,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
       }*/
 
       // check for old profile settings
-      CProfile profile;
+      CProfile profile(dialog->m_strDirectory,dialog->m_strName,g_settings.GetNextProfileId());
       g_settings.AddProfile(profile);
       bool bExists = CFile::Exists(URIUtils::AddFileToFolder("special://masterprofile/",
                                                           dialog->m_strDirectory+"/guisettings.xml"));

--- a/xbmc/settings/Profile.cpp
+++ b/xbmc/settings/Profile.cpp
@@ -45,8 +45,9 @@ void CProfile::CLock::Validate()
     code = "-";
 }
 
-CProfile::CProfile(const CStdString &directory, const CStdString &name)
+CProfile::CProfile(const CStdString &directory, const CStdString &name, const int id)
 {
+  m_id = id;
   m_directory = directory;
   m_name = name;
   m_bDatabases = true;
@@ -69,8 +70,11 @@ void CProfile::setDate()
     setDate(strDate+" - "+strTime);
 }
 
-void CProfile::Load(const TiXmlNode *node)
+void CProfile::Load(const TiXmlNode *node, int nextIdProfile)
 {
+  if (!XMLUtils::GetInt(node, "id", m_id))
+    m_id = nextIdProfile; 
+
   XMLUtils::GetString(node, "name", m_name);
   XMLUtils::GetPath(node, "directory", m_directory);
   XMLUtils::GetPath(node, "thumbnail", m_thumb);
@@ -101,6 +105,7 @@ void CProfile::Save(TiXmlNode *root) const
   TiXmlElement profileNode("profile");
   TiXmlNode *node = root->InsertEndChild(profileNode);
 
+  XMLUtils::SetInt(node, "id", m_id);
   XMLUtils::SetString(node, "name", m_name);
   XMLUtils::SetPath(node, "directory", m_directory);
   XMLUtils::SetPath(node, "thumbnail", m_thumb);

--- a/xbmc/settings/Profile.h
+++ b/xbmc/settings/Profile.h
@@ -49,13 +49,14 @@ public:
     bool programs;
   };
 
-  CProfile(const CStdString &directory = "", const CStdString &name = "");
+  CProfile(const CStdString &directory = "", const CStdString &name = "", const int id = -1);
   ~CProfile(void);
   
-  void Load(const TiXmlNode *node);
+  void Load(const TiXmlNode *node, int nextIdProfile);
   void Save(TiXmlNode *root) const;
 
   const CStdString& getDate() const { return m_date;}
+  const int getId() const { return m_id; }
   const CStdString& getName() const { return m_name;}
   const CStdString& getDirectory() const { return m_directory;}
   const CStdString& getThumb() const { return m_thumb;}
@@ -89,6 +90,7 @@ public:
 
 private:
   CStdString m_directory;
+  int m_id;
   CStdString m_name;
   CStdString m_date;
   CStdString m_thumb;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -137,6 +137,7 @@ void CSettings::Initialize()
   m_usingLoginScreen = false;
   m_lastUsedProfile = 0;
   m_currentProfile = 0;
+  m_nextIdProfile = 0;
 
   m_activeKeyboardMapping = "default";
 }
@@ -1023,6 +1024,7 @@ void CSettings::LoadProfiles(const CStdString& profilesFile)
       {
         XMLUtils::GetUInt(rootElement, "lastloaded", m_lastUsedProfile);
         XMLUtils::GetBoolean(rootElement, "useloginscreen", m_usingLoginScreen);
+        XMLUtils::GetInt(rootElement, "nextIdProfile", m_nextIdProfile);
 
         TiXmlElement* pProfile = rootElement->FirstChildElement("profile");
         
@@ -1032,7 +1034,11 @@ void CSettings::LoadProfiles(const CStdString& profilesFile)
         while (pProfile)
         {
           CProfile profile(defaultDir);
-          profile.Load(pProfile);
+          profile.Load(pProfile,GetNextProfileId());
+
+          //data integrity check - covers off migration from old profiles.xml and bad data coming in
+          m_nextIdProfile = max(m_nextIdProfile, profile.getId() + 1); 
+
           m_vecProfiles.push_back(profile);
           pProfile = pProfile->NextSiblingElement("profile");
         }
@@ -1046,7 +1052,8 @@ void CSettings::LoadProfiles(const CStdString& profilesFile)
 
   if (m_vecProfiles.empty())
   { // add the master user
-    CProfile profile("special://masterprofile/", "Master user");
+    CProfile profile("special://masterprofile/", "Master user",0);
+    m_nextIdProfile++;
     m_vecProfiles.push_back(profile);
   }
 
@@ -1070,6 +1077,7 @@ bool CSettings::SaveProfiles(const CStdString& profilesFile) const
   if (!pRoot) return false;
   XMLUtils::SetInt(pRoot,"lastloaded", m_currentProfile);
   XMLUtils::SetBoolean(pRoot,"useloginscreen",m_usingLoginScreen);
+  XMLUtils::SetInt(pRoot,"nextIdProfile",m_nextIdProfile);      
   for (unsigned int i = 0; i < m_vecProfiles.size(); ++i)
     m_vecProfiles[i].Save(pRoot);
 
@@ -1857,6 +1865,11 @@ const CProfile &CSettings::GetCurrentProfile() const
   return emptyProfile;
 }
 
+ int CSettings::GetCurrentProfileId() const
+ {
+   return GetCurrentProfile().getId();
+ }
+
 void CSettings::UpdateCurrentProfileDate()
 {
   if (m_currentProfile < m_vecProfiles.size())
@@ -1892,6 +1905,7 @@ int CSettings::GetProfileIndex(const CStdString &name) const
 
 void CSettings::AddProfile(const CProfile &profile)
 {
+  m_nextIdProfile++;
   m_vecProfiles.push_back(profile);
 }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -1035,11 +1035,7 @@ void CSettings::LoadProfiles(const CStdString& profilesFile)
         {
           CProfile profile(defaultDir);
           profile.Load(pProfile,GetNextProfileId());
-
-          //data integrity check - covers off migration from old profiles.xml and bad data coming in
-          m_nextIdProfile = max(m_nextIdProfile, profile.getId() + 1); 
-
-          m_vecProfiles.push_back(profile);
+          AddProfile(profile);
           pProfile = pProfile->NextSiblingElement("profile");
         }
       }
@@ -1053,8 +1049,7 @@ void CSettings::LoadProfiles(const CStdString& profilesFile)
   if (m_vecProfiles.empty())
   { // add the master user
     CProfile profile("special://masterprofile/", "Master user",0);
-    m_nextIdProfile++;
-    m_vecProfiles.push_back(profile);
+    AddProfile(profile);
   }
 
   // check the validity of the previous profile index
@@ -1905,7 +1900,9 @@ int CSettings::GetProfileIndex(const CStdString &name) const
 
 void CSettings::AddProfile(const CProfile &profile)
 {
-  m_nextIdProfile++;
+  //data integrity check - covers off migration from old profiles.xml, incrementing of the m_nextIdProfile,and bad data coming in
+  m_nextIdProfile = max(m_nextIdProfile, profile.getId() + 1); 
+
   m_vecProfiles.push_back(profile);
 }
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -319,6 +319,13 @@ public:
    */
   unsigned int GetCurrentProfileIndex() const { return m_currentProfile; };
 
+  /*! \brief Retrieve the next id to use for a new profile
+   \return the unique <id> to be used when creating a new profile
+   */
+  int GetNextProfileId() const { return m_nextIdProfile; }; // used to get the value of m_nextIdProfile for use in new profile creation
+
+  int GetCurrentProfileId() const;
+
   std::vector<RESOLUTION_INFO> m_ResInfo;
 
   // utility functions for user data folders
@@ -399,6 +406,7 @@ private:
   bool m_usingLoginScreen;
   unsigned int m_lastUsedProfile;
   unsigned int m_currentProfile;
+  int m_nextIdProfile; // for tracking the next available id to give to a new profile to ensure id's are not re-used
 };
 
 extern class CSettings g_settings;


### PR DESCRIPTION
This is background work required to implement trac bug 11747 and anything else looking to store profile related data into the XBMC database. http://trac.xbmc.org/ticket/11747

It includes cases to create a new profiles.xml properly with the ID fields, migrate an existing profiles.xml to add the ID fields, and also have persistence over restarts about which ID to give out next.

It is designed to closely replicated a database auto_increment style of int field, and is required to properly store profile based data into the database (so that we're storing a profileID and not a profile Name)

If we do ever migrate the profiles into the database at a later point in time the methods that interact with the ID field should be fairly easy to migrate.

Please see comments in commits for various code review comments.

Thanks!
