### PR TITLE
Second attempt to unify window closing

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -634,11 +634,11 @@ case TMSG_POWERDOWN:
       }
       break;
 
-    case TMSG_GUI_DIALOG_CLOSE:
+    case TMSG_GUI_WINDOW_CLOSE:
       {
-        CGUIDialog *dialog = (CGUIDialog *)pMsg->lpVoid;
-        if (dialog)
-          dialog->Close(pMsg->dwParam1 > 0);
+        CGUIWindow *window = (CGUIWindow *)pMsg->lpVoid;
+        if (window)
+          window->Close(pMsg->dwParam1 > 0);
       }
       break;
 
@@ -1091,11 +1091,11 @@ void CApplicationMessenger::Show(CGUIDialog *pDialog)
   SendMessage(tMsg, true);
 }
 
-void CApplicationMessenger::Close(CGUIDialog *dialog, bool forceClose,
+void CApplicationMessenger::Close(CGUIWindow *window, bool forceClose,
                                   bool waitResult)
 {
-  ThreadMessage tMsg = {TMSG_GUI_DIALOG_CLOSE, forceClose ? 1 : 0};
-  tMsg.lpVoid = dialog;
+  ThreadMessage tMsg = {TMSG_GUI_WINDOW_CLOSE, forceClose ? 1 : 0};
+  tMsg.lpVoid = window;
   SendMessage(tMsg, waitResult);
 }
 

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -638,7 +638,7 @@ case TMSG_POWERDOWN:
       {
         CGUIWindow *window = (CGUIWindow *)pMsg->lpVoid;
         if (window)
-          window->Close(pMsg->dwParam1 > 0);
+          window->Close(pMsg->dwParam2 & 0x1 ? true : false, pMsg->dwParam1, pMsg->dwParam2 & 0x2 ? true : false);
       }
       break;
 
@@ -1091,10 +1091,10 @@ void CApplicationMessenger::Show(CGUIDialog *pDialog)
   SendMessage(tMsg, true);
 }
 
-void CApplicationMessenger::Close(CGUIWindow *window, bool forceClose,
-                                  bool waitResult)
+void CApplicationMessenger::Close(CGUIWindow *window, bool forceClose, bool waitResult /*= true*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)
 {
-  ThreadMessage tMsg = {TMSG_GUI_WINDOW_CLOSE, forceClose ? 1 : 0};
+  ThreadMessage tMsg = {TMSG_GUI_WINDOW_CLOSE, nextWindowID};
+  tMsg.dwParam2 = (DWORD)(forceClose ? 0x01 : 0 | enableSound ? 0x02 : 0);
   tMsg.lpVoid = window;
   SendMessage(tMsg, waitResult);
 }

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -622,7 +622,7 @@ case TMSG_POWERDOWN:
       {
         CGUIDialog *pDialog = (CGUIDialog *)pMsg->lpVoid;
         if (pDialog)
-          pDialog->DoModal_Internal((int)pMsg->dwParam1, pMsg->strParam);
+          pDialog->DoModal((int)pMsg->dwParam1, pMsg->strParam);
       }
       break;
 
@@ -630,7 +630,7 @@ case TMSG_POWERDOWN:
       {
         CGUIDialog *pDialog = (CGUIDialog *)pMsg->lpVoid;
         if (pDialog)
-          pDialog->Show_Internal();
+          pDialog->Show();
       }
       break;
 
@@ -638,7 +638,7 @@ case TMSG_POWERDOWN:
       {
         CGUIDialog *dialog = (CGUIDialog *)pMsg->lpVoid;
         if (dialog)
-          dialog->Close_Internal(pMsg->dwParam1 > 0);
+          dialog->Close(pMsg->dwParam1 > 0);
       }
       break;
 

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -186,7 +186,7 @@ public:
 
   void DoModal(CGUIDialog *pDialog, int iWindowID, const CStdString &param = "");
   void Show(CGUIDialog *pDialog);
-  void Close(CGUIWindow *window, bool forceClose, bool waitResult=true);
+  void Close(CGUIWindow *window, bool forceClose, bool waitResult = true, int nextWindowID = 0, bool enableSound = true);
   void ActivateWindow(int windowID, const std::vector<CStdString> &params, bool swappingWindows);
   void SendAction(const CAction &action, int windowID = WINDOW_INVALID, bool waitResult=true);
   std::vector<CStdString> GetInfoLabels(const std::vector<CStdString> &properties);

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -33,6 +33,7 @@
 class CFileItem;
 class CFileItemList;
 class CGUIDialog;
+class CGUIWindow;
 
 // defines here
 #define TMSG_DIALOG_DOMODAL       100
@@ -83,7 +84,7 @@ class CGUIDialog;
 #define TMSG_GUI_SHOW                 601
 #define TMSG_GUI_ACTIVATE_WINDOW      604
 #define TMSG_GUI_PYTHON_DIALOG        605
-#define TMSG_GUI_DIALOG_CLOSE         606
+#define TMSG_GUI_WINDOW_CLOSE         606
 #define TMSG_GUI_ACTION               607
 #define TMSG_GUI_INFOLABEL            608
 #define TMSG_GUI_INFOBOOL             609
@@ -185,7 +186,7 @@ public:
 
   void DoModal(CGUIDialog *pDialog, int iWindowID, const CStdString &param = "");
   void Show(CGUIDialog *pDialog);
-  void Close(CGUIDialog *pDialog, bool forceClose, bool waitResult=true);
+  void Close(CGUIWindow *window, bool forceClose, bool waitResult=true);
   void ActivateWindow(int windowID, const std::vector<CStdString> &params, bool swappingWindows);
   void SendAction(const CAction &action, int windowID = WINDOW_INVALID, bool waitResult=true);
   std::vector<CStdString> GetInfoLabels(const std::vector<CStdString> &properties);

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -1036,7 +1036,7 @@ void CGUIDialogAddonSettings::DoProcess(unsigned int currentTime, CDirtyRegionLi
     }
   }
   CGUIDialogBoxBase::DoProcess(currentTime, dirtyregions);
-  if (alphaFaded && m_bRunning) // dialog may close
+  if (alphaFaded && m_active) // dialog may close
   {
     control->SetFocus(false);
     if (control->GetControlType() == CGUIControl::GUICONTROL_BUTTON)

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -39,7 +39,7 @@ void CGUIDialogBusy::Show_Internal()
   m_bRunning = true;
   m_bModal = true;
   m_bLastVisible = true;
-  m_dialogClosing = false;
+  m_closing = false;
   g_windowManager.RouteToWindow(this);
 
   // active this window...

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -36,7 +36,7 @@ CGUIDialogBusy::~CGUIDialogBusy(void)
 void CGUIDialogBusy::Show_Internal()
 {
   m_bCanceled = false;
-  m_bRunning = true;
+  m_active = true;
   m_bModal = true;
   m_bLastVisible = true;
   m_closing = false;

--- a/xbmc/dialogs/GUIDialogKeyboard.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboard.cpp
@@ -657,12 +657,12 @@ int CGUIDialogKeyboard::ShowAndVerifyPassword(CStdString& strPassword, const CSt
   }
 }
 
-void CGUIDialogKeyboard::Close(bool forceClose)
+void CGUIDialogKeyboard::OnDeinitWindow(int nextWindowID)
 {
+  // call base class
+  CGUIDialog::OnDeinitWindow(nextWindowID);
   // reset the heading (we don't always have this)
   m_strHeading = "";
-  // call base class
-  CGUIDialog::Close(forceClose);
 }
 
 void CGUIDialogKeyboard::MoveCursor(int iAmount)

--- a/xbmc/dialogs/GUIDialogKeyboard.h
+++ b/xbmc/dialogs/GUIDialogKeyboard.h
@@ -48,13 +48,11 @@ public:
   static bool ShowAndVerifyNewPassword(CStdString& newPassword, const CVariant &heading, bool allowEmpty);
   static int ShowAndVerifyPassword(CStdString& strPassword, const CStdString& strHeading, int iRetries);
   static bool ShowAndGetFilter(CStdString& aTextString, bool searching);
-
-  virtual void Close(bool forceClose = false);
-
 protected:
   virtual void OnInitWindow();
   virtual bool OnAction(const CAction &action);
   virtual bool OnMessage(CGUIMessage& message);
+  virtual void OnDeinitWindow(int nextWindowID);
   void SetControlLabel(int id, const CStdString &label);
   void OnShift();
   void MoveCursor(int iAmount);

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -72,7 +72,7 @@ void CGUIDialogProgress::StartModal()
   // a thread message though IMO)
   m_bRunning = true;
   m_bModal = true;
-  m_dialogClosing = false;
+  m_closing = false;
   g_windowManager.RouteToWindow(this);
 
   // active this window...

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -63,14 +63,14 @@ void CGUIDialogProgress::StartModal()
 {
   CSingleLock lock(g_graphicsContext);
 
-  CLog::Log(LOGDEBUG, "DialogProgress::StartModal called %s", m_bRunning ? "(already running)!" : "");
+  CLog::Log(LOGDEBUG, "DialogProgress::StartModal called %s", m_active ? "(already running)!" : "");
   m_bCanceled = false;
 
   // set running before it's routed, else the auto-show code
   // could show it as well if we are in a different thread from
   // the main rendering thread (this should really be handled via
   // a thread message though IMO)
-  m_bRunning = true;
+  m_active = true;
   m_bModal = true;
   m_closing = false;
   g_windowManager.RouteToWindow(this);
@@ -82,7 +82,7 @@ void CGUIDialogProgress::StartModal()
 
   lock.Leave();
 
-  while (m_bRunning && IsAnimating(ANIM_TYPE_WINDOW_OPEN))
+  while (m_active && IsAnimating(ANIM_TYPE_WINDOW_OPEN))
   {
     Progress();
     // we should have rendered at least once by now - if we haven't, then
@@ -96,7 +96,7 @@ void CGUIDialogProgress::StartModal()
 
 void CGUIDialogProgress::Progress()
 {
-  if (m_bRunning)
+  if (m_active)
   {
     g_windowManager.ProcessRenderLoop();
   }
@@ -104,7 +104,7 @@ void CGUIDialogProgress::Progress()
 
 void CGUIDialogProgress::ProgressKeys()
 {
-  if (m_bRunning)
+  if (m_active)
   {
     g_application.FrameMove(true);
   }
@@ -191,7 +191,7 @@ void CGUIDialogProgress::SetProgressAdvance(int nSteps/*=1*/)
 
 bool CGUIDialogProgress::Abort()
 {
-  return m_bRunning ? m_bCanceled : false;
+  return m_active ? m_bCanceled : false;
 }
 
 void CGUIDialogProgress::ShowProgressBar(bool bOnOff)

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -238,18 +238,6 @@ void CGUIDialog::Show_Internal()
 //  m_bRunning = true;
 }
 
-void CGUIDialog::Close(bool forceClose /* = false */)
-{
-  if (!g_application.IsCurrentThread())
-  {
-    // make sure graphics lock is not held
-    CSingleExit leaveIt(g_graphicsContext);
-    g_application.getApplicationMessenger().Close(this, forceClose);
-  }
-  else
-    Close_Internal(forceClose);
-}
-
 void CGUIDialog::DoModal(int iWindowID /*= WINDOW_INVALID */, const CStdString &param)
 {
   if (!g_application.IsCurrentThread())

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -247,17 +247,31 @@ void CGUIDialog::Close(bool forceClose /* = false */)
     g_application.getApplicationMessenger().Close(this, forceClose);
   }
   else
-    g_application.getApplicationMessenger().Close(this, forceClose);
+    Close_Internal(forceClose);
 }
 
 void CGUIDialog::DoModal(int iWindowID /*= WINDOW_INVALID */, const CStdString &param)
 {
-  g_application.getApplicationMessenger().DoModal(this, iWindowID, param);
+  if (!g_application.IsCurrentThread())
+  {
+    // make sure graphics lock is not held
+    CSingleExit leaveIt(g_graphicsContext);
+    g_application.getApplicationMessenger().DoModal(this, iWindowID, param);
+  }
+  else
+    DoModal_Internal(iWindowID, param);
 }
 
 void CGUIDialog::Show()
 {
-  g_application.getApplicationMessenger().Show(this);
+  if (!g_application.IsCurrentThread())
+  {
+    // make sure graphics lock is not held
+    CSingleExit leaveIt(g_graphicsContext);
+    g_application.getApplicationMessenger().Show(this);
+  }
+  else
+    Show_Internal();
 }
 
 void CGUIDialog::FrameMove()

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -34,7 +34,6 @@ CGUIDialog::CGUIDialog(int id, const CStdString &xmlFile)
   m_bModal = true;
   m_bRunning = false;
   m_wasRunning = false;
-  m_dialogClosing = false;
   m_renderOrder = 1;
   m_autoClosing = false;
   m_enableSound = true;
@@ -98,7 +97,7 @@ bool CGUIDialog::OnMessage(CGUIMessage& message)
       {
         g_windowManager.RemoveDialog(GetID());
         m_bRunning = false;
-        m_dialogClosing = false;
+        m_closing = false;
         m_autoClosing = false;
       }
       return true;
@@ -148,16 +147,16 @@ void CGUIDialog::Close_Internal(bool forceClose /*= false*/)
   if (!m_bRunning) return;
 
   //  Play the window specific deinit sound
-  if(!m_dialogClosing && m_enableSound)
+  if(!m_closing && m_enableSound)
     g_audioManager.PlayWindowSound(GetID(), SOUND_DEINIT);
 
   // don't close if we should be animating
   if (!forceClose && HasAnimation(ANIM_TYPE_WINDOW_CLOSE))
   {
-    if (!m_dialogClosing && !IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
+    if (!m_closing && !IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
     {
       QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
-      m_dialogClosing = true;
+      m_closing = true;
     }
     return;
   }
@@ -175,7 +174,7 @@ void CGUIDialog::DoModal_Internal(int iWindowID /*= WINDOW_INVALID */, const CSt
   if (!g_windowManager.Initialized())
     return; // don't do anything
 
-  m_dialogClosing = false;
+  m_closing = false;
   m_bModal = true;
   // set running before it's added to the window manager, else the auto-show code
   // could show it as well if we are in a different thread from
@@ -212,7 +211,7 @@ void CGUIDialog::Show_Internal()
   //maybe we should have a critical section per window instead??
   CSingleLock lock(g_graphicsContext);
 
-  if (m_bRunning && !m_dialogClosing && !IsAnimating(ANIM_TYPE_WINDOW_CLOSE)) return;
+  if (m_bRunning && !m_closing && !IsAnimating(ANIM_TYPE_WINDOW_CLOSE)) return;
 
   if (!g_windowManager.Initialized())
     return; // don't do anything
@@ -224,7 +223,7 @@ void CGUIDialog::Show_Internal()
   // the main rendering thread (this should really be handled via
   // a thread message though IMO)
   m_bRunning = true;
-  m_dialogClosing = false;
+  m_closing = false;
   g_windowManager.AddModeless(this);
 
   //  Play the window specific init sound
@@ -264,7 +263,7 @@ void CGUIDialog::Show()
 
 void CGUIDialog::FrameMove()
 {
-  if (m_autoClosing && m_showStartTime + m_showDuration < CTimeUtils::GetFrameTime() && !m_dialogClosing)
+  if (m_autoClosing && m_showStartTime + m_showDuration < CTimeUtils::GetFrameTime() && !m_closing)
     Close();
   CGUIWindow::FrameMove();
 }
@@ -275,21 +274,6 @@ void CGUIDialog::Render()
     return;
 
   CGUIWindow::Render();
-  // Check to see if we should close at this point
-  // We check after the controls have finished rendering, as we may have to close due to
-  // the controls rendering after the window has finished it's animation
-  // we call the base class instead of this class so that we can find the change
-  if (m_dialogClosing && !CGUIWindow::IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
-  {
-    Close(true);
-  }
-}
-
-bool CGUIDialog::IsAnimating(ANIMATION_TYPE animType)
-{
-  if (animType == ANIM_TYPE_WINDOW_CLOSE)
-    return m_dialogClosing;
-  return CGUIWindow::IsAnimating(animType);
 }
 
 void CGUIDialog::SetDefaults()

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -138,33 +138,6 @@ void CGUIDialog::UpdateVisibility()
   }
 }
 
-void CGUIDialog::Close_Internal(bool forceClose /*= false*/)
-{
-  //Lock graphic context here as it is sometimes called from non rendering threads
-  //maybe we should have a critical section per window instead??
-  CSingleLock lock(g_graphicsContext);
-
-  if (!m_bRunning) return;
-
-  //  Play the window specific deinit sound
-  if(!m_closing && m_enableSound)
-    g_audioManager.PlayWindowSound(GetID(), SOUND_DEINIT);
-
-  // don't close if we should be animating
-  if (!forceClose && HasAnimation(ANIM_TYPE_WINDOW_CLOSE))
-  {
-    if (!m_closing && !IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
-    {
-      QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
-      m_closing = true;
-    }
-    return;
-  }
-
-  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
-  OnMessage(msg);
-}
-
 void CGUIDialog::DoModal_Internal(int iWindowID /*= WINDOW_INVALID */, const CStdString &param /* = "" */)
 {
   //Lock graphic context here as it is sometimes called from non rendering threads

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -157,10 +157,6 @@ void CGUIDialog::DoModal_Internal(int iWindowID /*= WINDOW_INVALID */, const CSt
   m_active = true;
   g_windowManager.RouteToWindow(this);
 
-  //  Play the window specific init sound
-  if (m_enableSound)
-    g_audioManager.PlayWindowSound(GetID(), SOUND_INIT);
-
   // active this window...
   CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0, WINDOW_INVALID, iWindowID);
   msg.SetStringParam(param);
@@ -197,10 +193,6 @@ void CGUIDialog::Show_Internal()
   m_active = true;
   m_closing = false;
   g_windowManager.AddModeless(this);
-
-  //  Play the window specific init sound
-  if (m_enableSound)
-    g_audioManager.PlayWindowSound(GetID(), SOUND_INIT);
 
   // active this window...
   CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0);

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -55,6 +55,7 @@ public:
 
   void SetAutoClose(unsigned int timeoutMs);
   void SetSound(bool OnOff) { m_enableSound = OnOff; };
+  virtual bool IsSoundEnabled() const { return m_enableSound; };
 
 protected:
   virtual void SetDefaults();

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -49,7 +49,6 @@ public:
   void DoModal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
   void Show(); // modeless
 
-  virtual void Close(bool forceClose = false);
   virtual bool IsDialogRunning() const { return m_bRunning; };
   virtual bool IsDialog() const { return true;};
   virtual bool IsModalDialog() const { return m_bModal; };
@@ -66,7 +65,7 @@ protected:
 
   virtual void DoModal_Internal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
   virtual void Show_Internal(); // modeless
-  void Close_Internal(bool forceClose = false);
+  virtual void Close_Internal(bool forceClose = false);
 
   bool m_bRunning;
   bool m_wasRunning; ///< \brief true if we were running during the last DoProcess()

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -49,7 +49,7 @@ public:
   void DoModal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
   void Show(); // modeless
 
-  virtual bool IsDialogRunning() const { return m_bRunning; };
+  virtual bool IsDialogRunning() const { return m_active; };
   virtual bool IsDialog() const { return true;};
   virtual bool IsModalDialog() const { return m_bModal; };
 
@@ -64,8 +64,8 @@ protected:
 
   virtual void DoModal_Internal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
   virtual void Show_Internal(); // modeless
+  virtual void OnDeinitWindow(int nextWindowID);
 
-  bool m_bRunning;
   bool m_wasRunning; ///< \brief true if we were running during the last DoProcess()
   bool m_bModal;
   bool m_autoClosing;

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -53,8 +53,6 @@ public:
   virtual bool IsDialog() const { return true;};
   virtual bool IsModalDialog() const { return m_bModal; };
 
-  virtual bool IsAnimating(ANIMATION_TYPE animType);
-
   void SetAutoClose(unsigned int timeoutMs);
   void SetSound(bool OnOff) { m_enableSound = OnOff; };
 
@@ -70,7 +68,6 @@ protected:
   bool m_bRunning;
   bool m_wasRunning; ///< \brief true if we were running during the last DoProcess()
   bool m_bModal;
-  bool m_dialogClosing;
   bool m_autoClosing;
   bool m_enableSound;
   unsigned int m_showStartTime;

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -64,7 +64,6 @@ protected:
 
   virtual void DoModal_Internal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
   virtual void Show_Internal(); // modeless
-  virtual void Close_Internal(bool forceClose = false);
 
   bool m_bRunning;
   bool m_wasRunning; ///< \brief true if we were running during the last DoProcess()

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -64,7 +64,6 @@ protected:
   virtual void OnWindowLoaded();
   virtual void UpdateVisibility();
 
-  friend class CApplicationMessenger;
   virtual void DoModal_Internal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
   virtual void Show_Internal(); // modeless
   void Close_Internal(bool forceClose = false);

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -446,6 +446,10 @@ EVENT_RESULT CGUIWindow::OnMouseEvent(const CPoint &point, const CMouseEvent &ev
 /// calling the base method.
 void CGUIWindow::OnInitWindow()
 {
+  //  Play the window specific init sound
+  if (IsSoundEnabled())
+    g_audioManager.PlayWindowSound(GetID(), SOUND_INIT);
+
   // set our rendered state
   m_hasRendered = false;
   m_closing = false;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -39,6 +39,7 @@
 #include "utils/TimeUtils.h"
 #include "input/ButtonTranslator.h"
 #include "utils/XMLUtils.h"
+#include "Application.h"
 
 #ifdef HAS_PERFORMANCE_SAMPLE
 #include "utils/PerformanceSample.h"
@@ -314,9 +315,21 @@ void CGUIWindow::DoRender()
   if (CGUIControlProfiler::IsRunning()) CGUIControlProfiler::Instance().EndFrame();
 }
 
-void CGUIWindow::Close(bool forceClose)
+void CGUIWindow::Close_Internal(bool forceClose)
 {
   CLog::Log(LOGERROR,"%s - should never be called on the base class!", __FUNCTION__);
+}
+
+void CGUIWindow::Close(bool forceClose /* = false */)
+{
+  if (!g_application.IsCurrentThread())
+  {
+    // make sure graphics lock is not held
+    CSingleExit leaveIt(g_graphicsContext);
+    g_application.getApplicationMessenger().Close(this, forceClose);
+  }
+  else
+    Close_Internal(forceClose);
 }
 
 bool CGUIWindow::OnAction(const CAction &action)

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -60,6 +60,7 @@ CGUIWindow::CGUIWindow(int id, const CStdString &xmlFile)
   m_windowLoaded = false;
   m_loadOnDemand = true;
   m_closing = false;
+  m_active = false;
   m_renderOrder = 0;
   m_dynamicResourceAlloc = true;
   m_previousWindow = WINDOW_INVALID;
@@ -331,7 +332,6 @@ void CGUIWindow::Render()
 void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)
 {
   CSingleLock lock(g_graphicsContext);
-  if (!g_windowManager.IsWindowActive(GetID(), false)) return;
   forceClose |= (nextWindowID == WINDOW_FULLSCREEN_VIDEO);
   if (forceClose)
   {
@@ -339,7 +339,7 @@ void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*
     OnMessage(msg);
     m_closing = false;
   }
-  else if (!m_closing)
+  else if (m_active && !m_closing)
   {
     if (enableSound && IsSoundEnabled())
       g_audioManager.PlayWindowSound(GetID(), SOUND_DEINIT);
@@ -449,6 +449,7 @@ void CGUIWindow::OnInitWindow()
   // set our rendered state
   m_hasRendered = false;
   m_closing = false;
+  m_active = true;
   ResetAnimations();  // we need to reset our animations as those windows that don't dynamically allocate
                       // need their anims reset. An alternative solution is turning off all non-dynamic
                       // allocation (which in some respects may be nicer, but it kills hdd spindown and the like)
@@ -481,6 +482,7 @@ void CGUIWindow::OnDeinitWindow(int nextWindowID)
   }
 
   SaveControlStates();
+  m_active = false;
 }
 
 bool CGUIWindow::OnMessage(CGUIMessage& message)

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -39,6 +39,7 @@
 #include "utils/TimeUtils.h"
 #include "input/ButtonTranslator.h"
 #include "utils/XMLUtils.h"
+#include "GUIAudioManager.h"
 #include "Application.h"
 
 #ifdef HAS_PERFORMANCE_SAMPLE
@@ -327,21 +328,38 @@ void CGUIWindow::Render()
     Close(true);
 }
 
-void CGUIWindow::Close_Internal(bool forceClose)
+void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)
 {
-  CLog::Log(LOGERROR,"%s - should never be called on the base class!", __FUNCTION__);
+  CSingleLock lock(g_graphicsContext);
+  if (!g_windowManager.IsWindowActive(GetID(), false)) return;
+  forceClose |= (nextWindowID == WINDOW_FULLSCREEN_VIDEO);
+  if (forceClose)
+  {
+    CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
+    OnMessage(msg);
+    m_closing = false;
+  }
+  else if (!m_closing)
+  {
+    if (enableSound && IsSoundEnabled())
+      g_audioManager.PlayWindowSound(GetID(), SOUND_DEINIT);
+    
+    // Perform the window out effect
+    QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
+    m_closing = true;
+  }
 }
 
-void CGUIWindow::Close(bool forceClose /* = false */)
+void CGUIWindow::Close(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)
 {
   if (!g_application.IsCurrentThread())
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(g_graphicsContext);
-    g_application.getApplicationMessenger().Close(this, forceClose);
+    g_application.getApplicationMessenger().Close(this, forceClose, true, nextWindowID, enableSound);
   }
   else
-    Close_Internal(forceClose);
+    Close_Internal(forceClose, nextWindowID, enableSound);
 }
 
 bool CGUIWindow::OnAction(const CAction &action)
@@ -462,22 +480,6 @@ void CGUIWindow::OnDeinitWindow(int nextWindowID)
     RunUnloadActions();
   }
 
-  if (nextWindowID != WINDOW_FULLSCREEN_VIDEO)
-  {
-    // Dialog animations are handled in Close() rather than here
-    if (HasAnimation(ANIM_TYPE_WINDOW_CLOSE) && !IsDialog() && IsActive())
-    {
-      // Perform the window out effect
-      QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
-      while (IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
-      {
-        // TODO This shouldn't be handled like this
-        // The processing should be done from WindowManager and deinit
-        // should probably be called from there.
-        g_windowManager.ProcessRenderLoop(true);
-      }
-    }
-  }
   SaveControlStates();
 }
 

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -105,8 +105,7 @@ public:
    */
   virtual void FrameMove() {};
 
-  // Close should never be called on this base class (only on derivatives) - its here so that window-manager can use a general close
-  void Close(bool forceClose = false);
+  void Close(bool forceClose = false, int nextWindowID = 0, bool enableSound = true);
 
   // OnAction() is called by our window manager.  We should process any messages
   // that should be handled at the window level in the derived classes, and any
@@ -226,7 +225,7 @@ protected:
   virtual void OnWindowLoaded();
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);
-  virtual void Close_Internal(bool forceClose = false);
+  void Close_Internal(bool forceClose = false, int nextWindowID = 0, bool enableSound = true);
   EVENT_RESULT OnMouseAction(const CAction &action);
   virtual bool Animate(unsigned int currentTime);
   virtual bool CheckAnimation(ANIMATION_TYPE animType);

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -105,7 +105,7 @@ public:
   virtual void FrameMove() {};
 
   // Close should never be called on this base class (only on derivatives) - its here so that window-manager can use a general close
-  virtual void Close(bool forceClose = false);
+  void Close(bool forceClose = false);
 
   // OnAction() is called by our window manager.  We should process any messages
   // that should be handled at the window level in the derived classes, and any
@@ -224,6 +224,7 @@ protected:
   virtual void OnWindowLoaded();
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);
+  virtual void Close_Internal(bool forceClose = false);
   EVENT_RESULT OnMouseAction(const CAction &action);
   virtual bool Animate(unsigned int currentTime);
   virtual bool CheckAnimation(ANIMATION_TYPE animType);

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -137,6 +137,7 @@ public:
   virtual bool IsModalDialog() const { return false; };
   virtual bool IsMediaWindow() const { return false; };
   virtual bool HasListItems() const { return false; };
+  virtual bool IsSoundEnabled() const { return true; };
   virtual CFileItemPtr GetCurrentListItem(int offset = 0) { return CFileItemPtr(); };
   virtual int GetViewContainerID() const { return 0; };
   virtual bool IsActive() const;

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -97,6 +97,7 @@ public:
    \sa FrameMove
    */
   virtual void DoRender();
+  virtual void Render();
   
   /*! \brief Main update function, called every frame prior to rendering
    Any window that requires updating on a frame by frame basis (such as to maintain
@@ -263,6 +264,7 @@ protected:
   bool m_loadOnDemand;  // true if the window should be loaded only as needed
   bool m_isDialog;      // true if we have a dialog, false otherwise.
   bool m_dynamicResourceAlloc;
+  bool m_closing;
   CGUIInfoColor m_clearBackground; // colour to clear the window
 
   int m_renderOrder;      // for render order of dialogs

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -265,6 +265,7 @@ protected:
   bool m_isDialog;      // true if we have a dialog, false otherwise.
   bool m_dynamicResourceAlloc;
   bool m_closing;
+  bool m_active;        // true if window is active or dialog is running
   CGUIInfoColor m_clearBackground; // colour to clear the window
 
   int m_renderOrder;      // for render order of dialogs

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -312,7 +312,6 @@ void CGUIWindowManager::PreviousWindow()
 
   // ok, initialize the new window
   CLog::Log(LOGDEBUG,"CGUIWindowManager::PreviousWindow: Activate new");
-  g_audioManager.PlayWindowSound(pNewWindow->GetID(), SOUND_INIT);
   CGUIMessage msg2(GUI_MSG_WINDOW_INIT, 0, 0, WINDOW_INVALID, GetActiveWindow());
   pNewWindow->OnMessage(msg2);
 
@@ -425,7 +424,6 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<CStd
   AddToWindowHistory(iWindowID);
 
   g_infoManager.SetPreviousWindow(currentWindow);
-  g_audioManager.PlayWindowSound(pNewWindow->GetID(), SOUND_INIT);
   // Send the init message
   CGUIMessage msg(GUI_MSG_WINDOW_INIT, 0, 0, currentWindow, iWindowID);
   msg.SetStringParams(params);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -302,9 +302,7 @@ void CGUIWindowManager::PreviousWindow()
   HideOverlay(pNewWindow->GetOverlayState());
 
   // deinitialize our window
-  g_audioManager.PlayWindowSound(pCurrentWindow->GetID(), SOUND_DEINIT);
-  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
-  pCurrentWindow->OnMessage(msg);
+  CloseWindowSync(pCurrentWindow);
 
   g_infoManager.SetNextWindow(WINDOW_INVALID);
   g_infoManager.SetPreviousWindow(currentWindow);
@@ -415,12 +413,7 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const vector<CStd
   int currentWindow = GetActiveWindow();
   CGUIWindow *pWindow = GetWindow(currentWindow);
   if (pWindow)
-  {
-    //  Play the window specific deinit sound
-    g_audioManager.PlayWindowSound(pWindow->GetID(), SOUND_DEINIT);
-    CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0, iWindowID);
-    pWindow->OnMessage(msg);
-  }
+    CloseWindowSync(pWindow, iWindowID);
   g_infoManager.SetNextWindow(WINDOW_INVALID);
 
   // Add window to the history list (we must do this before we activate it,
@@ -656,8 +649,7 @@ void CGUIWindowManager::DeInitialize()
     if (IsWindowActive(it->first))
     {
       pWindow->DisableAnimations();
-      CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
-      pWindow->OnMessage(msg);
+      pWindow->Close(true);
     }
     pWindow->ResetControlStates();
     pWindow->FreeResources(true);
@@ -962,6 +954,13 @@ void CGUIWindowManager::ClearWindowHistory()
 {
   while (m_windowHistory.size())
     m_windowHistory.pop();
+}
+
+void CGUIWindowManager::CloseWindowSync(CGUIWindow *window, int nextWindowID /*= 0*/)
+{
+  window->Close(false, nextWindowID);
+  while (window->IsAnimating(ANIM_TYPE_WINDOW_CLOSE))
+    g_windowManager.ProcessRenderLoop(true);
 }
 
 #ifdef _DEBUG

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -138,6 +138,7 @@ private:
   void HideOverlay(CGUIWindow::OVERLAY_STATE state);
   void AddToWindowHistory(int newWindowID);
   void ClearWindowHistory();
+  void CloseWindowSync(CGUIWindow *window, int nextWindowID = 0);
   CGUIWindow *GetTopMostDialog() const;
 
   friend class CApplicationMessenger;

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.cpp
@@ -27,7 +27,6 @@
 CGUIPythonWindowDialog::CGUIPythonWindowDialog(int id)
 :CGUIPythonWindow(id)
 {
-  m_bRunning = false;
   m_loadOnDemand = false;
 }
 
@@ -66,14 +65,15 @@ void CGUIPythonWindowDialog::Show_Internal(bool show /* = true */)
     // active this dialog...
     CGUIMessage msg(GUI_MSG_WINDOW_INIT,0,0);
     OnMessage(msg);
-    m_bRunning = true;
+    m_active = true;
   }
   else // hide
-  {
-    CGUIMessage msg(GUI_MSG_WINDOW_DEINIT,0,0);
-    OnMessage(msg);
+    Close();
+}
 
-    g_windowManager.RemoveDialog(GetID());
-    m_bRunning = false;
-  }
+void CGUIPythonWindowDialog::OnDeinitWindow(int nextWindowID)
+{
+  g_windowManager.RemoveDialog(GetID());
+  CGUIWindow::OnDeinitWindow(nextWindowID);
+  g_windowManager.Delete(GetID());
 }

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.h
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.h
@@ -31,14 +31,12 @@ public:
   CGUIPythonWindowDialog(int id);
   virtual ~CGUIPythonWindowDialog(void);
   virtual bool    OnMessage(CGUIMessage& message);
-  virtual bool    IsDialogRunning() const { return m_bRunning; }
+  virtual bool    IsDialogRunning() const { return m_active; }
   virtual bool    IsDialog() const { return true;};
   virtual bool    IsModalDialog() const { return true; };
 
 protected:
   friend class CApplicationMessenger;
   void Show_Internal(bool show = true);
-
-private:
-  bool             m_bRunning;
+  virtual void OnDeinitWindow(int nextWindowID = 0);
 };

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.cpp
@@ -27,7 +27,6 @@
 CGUIPythonWindowXMLDialog::CGUIPythonWindowXMLDialog(int id, CStdString strXML, CStdString strFallBackPath)
 : CGUIPythonWindowXML(id,strXML,strFallBackPath)
 {
-  m_bRunning = false;
   m_loadOnDemand = false;
 }
 
@@ -56,14 +55,15 @@ void CGUIPythonWindowXMLDialog::Show_Internal(bool show /* = true */)
     // active this dialog...
     CGUIMessage msg(GUI_MSG_WINDOW_INIT,0,0);
     OnMessage(msg);
-    m_bRunning = true;
+    m_active = true;
   }
   else // hide
-  {
-    CGUIMessage msg(GUI_MSG_WINDOW_DEINIT,0,0);
-    OnMessage(msg);
+    Close();
+}
 
-    g_windowManager.RemoveDialog(GetID());
-    m_bRunning = false;
-  }
+void CGUIPythonWindowXMLDialog::OnDeinitWindow(int nextWindowID)
+{
+  g_windowManager.RemoveDialog(GetID());
+  CGUIWindow::OnDeinitWindow(nextWindowID);
+  g_windowManager.Delete(GetID());
 }

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.h
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.h
@@ -31,14 +31,13 @@ class CGUIPythonWindowXMLDialog : public CGUIPythonWindowXML
     CGUIPythonWindowXMLDialog(int id, CStdString strXML, CStdString strFallBackPath);
     virtual ~CGUIPythonWindowXMLDialog(void);
     virtual bool    OnMessage(CGUIMessage &message);
-    virtual bool    IsDialogRunning() const { return m_bRunning; }
+    virtual bool    IsDialogRunning() const { return m_active; }
     virtual bool    IsDialog() const { return true;};
     virtual bool    IsModalDialog() const { return true; };
     virtual bool    IsMediaWindow() const { return false; };
   protected:
     friend class CApplicationMessenger;
     void Show_Internal(bool show = true);
-  private:
-    bool             m_bRunning;
+    virtual void OnDeinitWindow(int nextWindowID = 0);
 };
 

--- a/xbmc/interfaces/python/xbmcmodule/window.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/window.cpp
@@ -383,7 +383,7 @@ namespace PYXBMC
       ++it;
     }
 
-    if (self->bIsPythonWindow)
+    if (self->bIsPythonWindow && !self->pWindow->IsDialog())
       g_windowManager.Delete(self->pWindow->GetID());
 
     lock.Leave();

--- a/xbmc/music/dialogs/GUIDialogMusicScan.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicScan.cpp
@@ -69,7 +69,7 @@ bool CGUIDialogMusicScan::OnMessage(CGUIMessage& message)
 
 void CGUIDialogMusicScan::FrameMove()
 {
-  if (m_bRunning)
+  if (m_active)
     UpdateState();
 
   CGUIDialog::FrameMove();

--- a/xbmc/video/dialogs/GUIDialogVideoScan.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoScan.cpp
@@ -72,7 +72,7 @@ bool CGUIDialogVideoScan::OnMessage(CGUIMessage& message)
 
 void CGUIDialogVideoScan::FrameMove()
 {
-  if (m_bRunning)
+  if (m_active)
     UpdateState();
 
   CGUIDialog::FrameMove();


### PR DESCRIPTION
This set of commits moves some bool members from CGUIDialog to CGUIWindow and use unified CGUIWindow::Close method to trigger window (and dialog) close actions (queue WindowClose animation and optionally play deinit sound). Deinit message is sent when animation is finished.

As a bonus it fixes not working python dialogs WindowClose animations.

Going further this road may allow merging CGUIWindow and CGUIDialog into 1 class (if this is desired).

I'm not sure if this is right direction so before detailed code review - some "idea review" would be appreciated.
