### PR TITLE
Refactor the Windows Shaders destruction

### DIFF
--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -94,11 +94,6 @@ CWinShader::~CWinShader()
     m_vb.Release();
 }
 
-void CWinShader::Release()
-{
-  delete this;
-}
-
 bool CWinShader::CreateVertexBuffer(DWORD FVF, unsigned int vertCount, unsigned int vertSize, unsigned int primitivesCount)
 {
   if (!m_vb.Create(vertCount * vertSize, D3DUSAGE_WRITEONLY, FVF, g_Windowing.DefaultD3DPool()))

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -194,8 +194,6 @@ bool CWinShader::Execute()
 
 bool CYUV2RGBShader::Create(unsigned int sourceWidth, unsigned int sourceHeight, BufferFormat fmt)
 {
-  ReleaseInternal();
-
   CWinShader::CreateVertexBuffer(D3DFVF_XYZRHW | D3DFVF_TEX3, 4, sizeof(CUSTOMVERTEX), 2);
 
   m_sourceWidth = sourceWidth;
@@ -395,8 +393,6 @@ bool CYUV2RGBShader::UploadToGPU(YUVBuffer* YUVbuf)
 
 bool CConvolutionShader::Create(ESCALINGMETHOD method)
 {
-  ReleaseInternal();
-
   CStdString effectString;
   switch(method)
   {

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -26,11 +26,6 @@
 #include "../../guilib/Geometry.h"
 #include "../WinRenderer.h"
 
-/*
-class CBaseVideoFilter
-{
-};
-*/
 
 class CYUV2RGBMatrix
 {

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -46,6 +46,7 @@ class CWinShader
 {
 protected:
   CWinShader() {}
+  virtual ~CWinShader();
 
 public:
   void Release(); // for user code only, like the SAFE_RELEASE() construct
@@ -54,7 +55,6 @@ protected:
   virtual bool CreateVertexBuffer(DWORD FVF, unsigned int vertCount, unsigned int vertSize, unsigned int primitivesCount);
   virtual bool LockVertexBuffer(void **data);
   virtual bool UnlockVertexBuffer();
-  virtual void ReleaseInternal();
   virtual bool LoadEffect(CStdString filename, DefinesMap* defines);
   virtual bool Execute();
 
@@ -78,6 +78,7 @@ public:
                       float brightness,
                       unsigned int flags,
                       YUVBuffer* YUVbuf);
+  virtual ~CYUV2RGBShader();
 
 protected:
   virtual void PrepareParameters(CRect sourceRect,
@@ -86,7 +87,6 @@ protected:
                                  float brightness,
                                  unsigned int flags);
   virtual void SetShaderParameters(YUVBuffer* YUVbuf);
-  virtual void ReleaseInternal();
   virtual bool UploadToGPU(YUVBuffer* YUVbuf);
 
 private:
@@ -113,6 +113,7 @@ public:
                                unsigned int sourceWidth, unsigned int sourceHeight,
                                CRect sourceRect,
                                CRect destRect);
+  virtual ~CConvolutionShader();
 
 protected:
   virtual bool KernelTexFormat();
@@ -121,7 +122,6 @@ protected:
                                CRect sourceRect,
                                CRect destRect);
   virtual void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps, int texStepsCount);
-  virtual void ReleaseInternal();
 
 private:
   CD3DTexture   m_HQKernelTexture;

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -47,11 +47,6 @@ class CWinShader
 protected:
   CWinShader() {}
   virtual ~CWinShader();
-
-public:
-  void Release(); // for user code only, like the SAFE_RELEASE() construct
-
-protected:
   virtual bool CreateVertexBuffer(DWORD FVF, unsigned int vertCount, unsigned int vertSize, unsigned int primitivesCount);
   virtual bool LockVertexBuffer(void **data);
   virtual bool UnlockVertexBuffer();

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -144,18 +144,16 @@ void CWinRenderer::SelectRenderMethod()
         // Try the pixel shaders support
         if (m_deviceCaps.PixelShaderVersion >= D3DPS_VERSION(2, 0))
         {
-          CTestShader* shader = new CTestShader;
-          if (shader->Create())
+          CTestShader shader;
+          if (shader.Create())
           {
             m_renderMethod = RENDER_PS;
-            shader->Release();
             break;
           }
           else
           {
             CLog::Log(LOGNOTICE, "D3D: unable to load test shader - D3D installation is most likely incomplete");
             CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, "DirectX", g_localizeStrings.Get(2101));
-            shader->Release();
           }
         }
         else
@@ -357,8 +355,8 @@ void CWinRenderer::UnInit()
   if (m_IntermediateTarget.Get())
     m_IntermediateTarget.Release();
 
-  SAFE_RELEASE(m_colorShader);
-  SAFE_RELEASE(m_scalerShader);
+  SAFE_DELETE(m_colorShader);
+  SAFE_DELETE(m_scalerShader);
   
   m_bConfigured = false;
   m_bFilterInitialized = false;
@@ -471,14 +469,14 @@ void CWinRenderer::SelectPSVideoFilter()
 
 void CWinRenderer::UpdatePSVideoFilter()
 {
-  SAFE_RELEASE(m_scalerShader);
+  SAFE_DELETE(m_scalerShader);
 
   if (m_bUseHQScaler)
   {
     m_scalerShader = new CConvolutionShader();
     if (!m_scalerShader->Create(m_scalingMethod))
     {
-      SAFE_RELEASE(m_scalerShader);
+      SAFE_DELETE(m_scalerShader);
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, "Video Renderering", "Failed to init video scaler, falling back to bilinear scaling.");
       m_bUseHQScaler = false;
     }
@@ -489,11 +487,11 @@ void CWinRenderer::UpdatePSVideoFilter()
 
   if (m_bUseHQScaler && !CreateIntermediateRenderTarget())
   {
-    SAFE_RELEASE(m_scalerShader);
+    SAFE_DELETE(m_scalerShader);
     m_bUseHQScaler = false;
   }
 
-  SAFE_RELEASE(m_colorShader);
+  SAFE_DELETE(m_colorShader);
 
   BufferFormat format = BufferFormatFromFlags(m_flags);
 
@@ -504,8 +502,8 @@ void CWinRenderer::UpdatePSVideoFilter()
     {
       // Try again after disabling the HQ scaler and freeing its resources
       m_IntermediateTarget.Release();
-      SAFE_RELEASE(m_scalerShader);
-      SAFE_RELEASE(m_colorShader);
+      SAFE_DELETE(m_scalerShader);
+      SAFE_DELETE(m_colorShader);
       m_bUseHQScaler = false;
     }
   }
@@ -514,7 +512,7 @@ void CWinRenderer::UpdatePSVideoFilter()
   {
     m_colorShader = new CYUV2RGBShader();
     if (!m_colorShader->Create(m_sourceWidth, m_sourceHeight, format))
-      SAFE_RELEASE(m_colorShader);
+      SAFE_DELETE(m_colorShader);
     // we're in big trouble - should fallback on D3D accelerated or sw method
   }
 }


### PR DESCRIPTION
Simplify the destruction/release of resources by the objects wrapping the D3D shaders.

Use the standard delete() operator to release resources of the base and derived classes instead of a custom mechanism that's more complicated and error prone. I don't know what I was thinking when I did the initial implementation...
- a couple cosmetic changes.

The changes are rather trivial but I'm getting back in the game and would rather not do something stupid :)
