### PR TITLE
Tidy up mouse interaction with screen saver

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -378,12 +378,6 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
       g_Keyboard.ProcessKeyUp();
       break;
     case XBMC_MOUSEBUTTONDOWN:
-      g_Mouse.HandleEvent(newEvent);
-      // Only mousewheel actions should be processed at this point. Other
-      // mouse button actions are processed when the button is released.
-      if (g_Mouse.GetAction() == ACTION_MOUSE_WHEEL_UP || g_Mouse.GetAction() == ACTION_MOUSE_WHEEL_DOWN)
-        g_application.ProcessMouse();          
-      break;
     case XBMC_MOUSEBUTTONUP:
     case XBMC_MOUSEMOTION:
       g_Mouse.HandleEvent(newEvent);
@@ -2745,14 +2739,16 @@ bool CApplication::ProcessMouse()
   if (!g_Mouse.IsActive() || !m_AppFocused)
     return false;
 
+  // Get the mouse command ID
+  uint32_t mousecommand = g_Mouse.GetAction();
+  if (mousecommand == ACTION_NOOP)
+    return true;
+
   // Reset the screensaver and idle timers
   m_idleTimer.StartZero();
   ResetScreenSaver();
   if (WakeUpScreenSaverAndDPMS())
     return true;
-
-  // Get the mouse command ID
-  uint32_t mousecommand = g_Mouse.GetAction();
 
   // Retrieve the corresponding action
   int iWin;

--- a/xbmc/input/MouseStat.cpp
+++ b/xbmc/input/MouseStat.cpp
@@ -24,6 +24,197 @@
 #include "windowing/WindowingFactory.h"
 #include "utils/TimeUtils.h"
 
+CMouseStat::CMouseStat()
+{
+  m_pointerState = MOUSE_STATE_NORMAL;
+  SetEnabled();
+  m_speedX = m_speedY = 0;
+  m_maxX = m_maxY = 0;
+  memset(&m_mouseState, 0, sizeof(m_mouseState));
+  m_Action = ACTION_NOOP;
+}
+
+CMouseStat::~CMouseStat()
+{
+}
+
+void CMouseStat::Initialize()
+{
+  // Set the default resolution (PAL)
+  SetResolution(720, 576, 1, 1);
+}
+
+void CMouseStat::HandleEvent(XBMC_Event& newEvent)
+{
+  // Save the mouse position and the size of the last move
+  int dx = newEvent.motion.x - m_mouseState.x;
+  int dy = newEvent.motion.y - m_mouseState.y;
+  
+  m_mouseState.dx = dx;
+  m_mouseState.dy = dy;
+  m_mouseState.x  = std::max(0, std::min(m_maxX, m_mouseState.x + dx));
+  m_mouseState.y  = std::max(0, std::min(m_maxY, m_mouseState.y + dy));
+
+  // Fill in the public members
+  if (newEvent.button.type == XBMC_MOUSEBUTTONDOWN)
+  {
+    if (newEvent.button.button == XBMC_BUTTON_LEFT) m_mouseState.button[MOUSE_LEFT_BUTTON] = true;
+    if (newEvent.button.button == XBMC_BUTTON_RIGHT) m_mouseState.button[MOUSE_RIGHT_BUTTON] = true;
+    if (newEvent.button.button == XBMC_BUTTON_MIDDLE) m_mouseState.button[MOUSE_MIDDLE_BUTTON] = true;
+    if (newEvent.button.button == XBMC_BUTTON_X1) m_mouseState.button[MOUSE_EXTRA_BUTTON1] = true;
+    if (newEvent.button.button == XBMC_BUTTON_X2) m_mouseState.button[MOUSE_EXTRA_BUTTON2] = true;
+    if (newEvent.button.button == XBMC_BUTTON_WHEELUP) m_mouseState.dz = 1;
+    if (newEvent.button.button == XBMC_BUTTON_WHEELDOWN) m_mouseState.dz = -1;
+  }
+  else if (newEvent.button.type == XBMC_MOUSEBUTTONUP)
+  {
+    if (newEvent.button.button == XBMC_BUTTON_LEFT) m_mouseState.button[MOUSE_LEFT_BUTTON] = false;
+    if (newEvent.button.button == XBMC_BUTTON_RIGHT) m_mouseState.button[MOUSE_RIGHT_BUTTON] = false;
+    if (newEvent.button.button == XBMC_BUTTON_MIDDLE) m_mouseState.button[MOUSE_MIDDLE_BUTTON] = false;
+    if (newEvent.button.button == XBMC_BUTTON_X1) m_mouseState.button[MOUSE_EXTRA_BUTTON1] = false;
+    if (newEvent.button.button == XBMC_BUTTON_X2) m_mouseState.button[MOUSE_EXTRA_BUTTON2] = false;
+    if (newEvent.button.button == XBMC_BUTTON_WHEELUP) m_mouseState.dz = 0;
+    if (newEvent.button.button == XBMC_BUTTON_WHEELDOWN) m_mouseState.dz = 0;
+  }
+
+  // Now check the current message and the previous state to find out if
+  // this is a click, doubleclick, drag etc
+  uint32_t now = CTimeUtils::GetFrameTime();
+  bool bNothingDown = true;
+  
+  for (int i = 0; i < 5; i++)
+  {
+    bClick[i] = false;
+    bDoubleClick[i] = false;
+    bHold[i] = 0;
+
+    // CButtonState::Update does the hard work of checking the button state
+    // and spotting drags, doubleclicks etc
+    CButtonState::BUTTON_ACTION action = m_buttonState[i].Update(now, m_mouseState.x, m_mouseState.y, m_mouseState.button[i]);
+    switch (action)
+    {
+    case CButtonState::MB_SHORT_CLICK:
+    case CButtonState::MB_LONG_CLICK:
+      bClick[i] = true;
+      bNothingDown = false;
+      break;
+    case CButtonState::MB_DOUBLE_CLICK:
+      bDoubleClick[i] = true;
+      bNothingDown = false;
+      break;
+    case CButtonState::MB_DRAG_START:
+    case CButtonState::MB_DRAG:
+    case CButtonState::MB_DRAG_END:
+      bHold[i] = action - CButtonState::MB_DRAG_START + 1;
+      bNothingDown = false;
+      break;
+    default:
+      break;
+    }
+  }
+
+  // Now work out what action ID to send to XBMC.
+  // The bClick array is set true if CButtonState::Update spots a click
+  // i.e. a button down followed by a button up.
+  if (bClick[MOUSE_LEFT_BUTTON])
+    m_Action = ACTION_MOUSE_LEFT_CLICK;
+  else if (bClick[MOUSE_RIGHT_BUTTON])
+    m_Action = ACTION_MOUSE_RIGHT_CLICK;
+  else if (bClick[MOUSE_MIDDLE_BUTTON])
+    m_Action = ACTION_MOUSE_MIDDLE_CLICK;
+
+  // The bDoubleClick array is set true if CButtonState::Update spots a
+  // button down within double_click_time (500ms) of the last click
+  else if (bDoubleClick[MOUSE_LEFT_BUTTON])
+    m_Action = ACTION_MOUSE_DOUBLE_CLICK;
+
+  // The bHold array is set true if CButtonState::Update spots a mouse drag
+  else if (bHold[MOUSE_LEFT_BUTTON])
+    m_Action = ACTION_MOUSE_DRAG;
+
+  // dz is +1 on wheel up and -1 on wheel down
+  else if (m_mouseState.dz > 0)
+    m_Action = ACTION_MOUSE_WHEEL_UP;
+  else if (m_mouseState.dz < 0)
+    m_Action = ACTION_MOUSE_WHEEL_DOWN;
+
+  // Finally check for a mouse move (that isn't a drag)
+  else if (newEvent.type == XBMC_MOUSEMOTION)
+    m_Action = ACTION_MOUSE_MOVE;
+
+  // ignore any other mouse messages
+  else
+    m_Action = ACTION_NOOP;
+
+  // Activate the mouse pointer
+  if (MovedPastThreshold() || m_mouseState.dz)
+    SetActive();
+  else if (bNothingDown)
+    SetState(MOUSE_STATE_NORMAL);
+  else
+    SetActive();
+}
+
+void CMouseStat::SetResolution(int maxX, int maxY, float speedX, float speedY)
+{
+  m_maxX = maxX;
+  m_maxY = maxY;
+
+  // speed is currently unused
+  m_speedX = speedX;
+  m_speedY = speedY;
+}
+
+void CMouseStat::SetActive(bool active /*=true*/)
+{
+  m_lastActiveTime = CTimeUtils::GetFrameTime();
+  m_mouseState.active = active;
+  // we show the OS mouse if:
+  // 1. The mouse is active (it has been moved) AND
+  // 2. The XBMC mouse is disabled in settings AND
+  // 3. XBMC is not in fullscreen.
+  g_Windowing.ShowOSMouse(m_mouseState.active && !IsEnabled() && !g_Windowing.IsFullScreen());
+}
+
+// IsActive - returns true if we have been active in the last MOUSE_ACTIVE_LENGTH period
+bool CMouseStat::IsActive()
+{
+  if (m_mouseState.active && (CTimeUtils::GetFrameTime() - m_lastActiveTime > MOUSE_ACTIVE_LENGTH))
+    SetActive(false);
+  return (m_mouseState.active && IsEnabled());
+}
+
+void CMouseStat::SetEnabled(bool enabled)
+{
+  m_mouseEnabled = enabled;
+  SetActive(enabled);
+}
+
+// IsEnabled - returns true if mouse is enabled
+bool CMouseStat::IsEnabled() const
+{
+  return m_mouseEnabled;
+}
+
+bool CMouseStat::MovedPastThreshold() const
+{
+  return (m_mouseState.dx * m_mouseState.dx + m_mouseState.dy * m_mouseState.dy >= MOUSE_MINIMUM_MOVEMENT * MOUSE_MINIMUM_MOVEMENT);
+}
+
+uint32_t CMouseStat::GetAction() const
+{
+  return m_Action;
+}
+
+int CMouseStat::GetHold(int ButtonID) const
+{
+  switch (ButtonID)
+  { case MOUSE_LEFT_BUTTON:
+      return bHold[MOUSE_LEFT_BUTTON];
+  }
+  return false;
+}
+
 CMouseStat::CButtonState::CButtonState()
 {
   m_state = STATE_RELEASED;
@@ -105,199 +296,5 @@ CMouseStat::CButtonState::BUTTON_ACTION CMouseStat::CButtonState::Update(unsigne
   }
 
   return MB_NONE;
-}
-
-CMouseStat::CMouseStat()
-{
-  m_pointerState = MOUSE_STATE_NORMAL;
-  SetEnabled();
-  m_speedX = m_speedY = 0;
-  m_maxX = m_maxY = 0;
-  memset(&m_mouseState, 0, sizeof(m_mouseState));
-  m_LastMessage = 0;
-}
-
-CMouseStat::~CMouseStat()
-{
-}
-
-void CMouseStat::Initialize()
-{
-  // Set the default resolution (PAL)
-  SetResolution(720, 576, 1, 1);
-  
-}
-
-void CMouseStat::HandleEvent(XBMC_Event& newEvent)
-{
-  m_LastMessage = newEvent.type;
-
-  int dx = newEvent.motion.x - m_mouseState.x;
-  int dy = newEvent.motion.y - m_mouseState.y;
-  
-  m_mouseState.dx = dx;
-  m_mouseState.dy = dy;
-  m_mouseState.x  = std::max(0, std::min(m_maxX, m_mouseState.x + dx));
-  m_mouseState.y  = std::max(0, std::min(m_maxY, m_mouseState.y + dy));
-
-  // Fill in the public members
-  if (newEvent.button.type == XBMC_MOUSEBUTTONDOWN)
-  {
-    if (newEvent.button.button == XBMC_BUTTON_LEFT) m_mouseState.button[MOUSE_LEFT_BUTTON] = true;
-    if (newEvent.button.button == XBMC_BUTTON_RIGHT) m_mouseState.button[MOUSE_RIGHT_BUTTON] = true;
-    if (newEvent.button.button == XBMC_BUTTON_MIDDLE) m_mouseState.button[MOUSE_MIDDLE_BUTTON] = true;
-    if (newEvent.button.button == XBMC_BUTTON_X1) m_mouseState.button[MOUSE_EXTRA_BUTTON1] = true;
-    if (newEvent.button.button == XBMC_BUTTON_X2) m_mouseState.button[MOUSE_EXTRA_BUTTON2] = true;
-    if (newEvent.button.button == XBMC_BUTTON_WHEELUP) m_mouseState.dz = 1;
-    if (newEvent.button.button == XBMC_BUTTON_WHEELDOWN) m_mouseState.dz = -1;
-  }
-  else if (newEvent.button.type == XBMC_MOUSEBUTTONUP)
-  {
-    if (newEvent.button.button == XBMC_BUTTON_LEFT) m_mouseState.button[MOUSE_LEFT_BUTTON] = false;
-    if (newEvent.button.button == XBMC_BUTTON_RIGHT) m_mouseState.button[MOUSE_RIGHT_BUTTON] = false;
-    if (newEvent.button.button == XBMC_BUTTON_MIDDLE) m_mouseState.button[MOUSE_MIDDLE_BUTTON] = false;
-    if (newEvent.button.button == XBMC_BUTTON_X1) m_mouseState.button[MOUSE_EXTRA_BUTTON1] = false;
-    if (newEvent.button.button == XBMC_BUTTON_X2) m_mouseState.button[MOUSE_EXTRA_BUTTON2] = false;
-    if (newEvent.button.button == XBMC_BUTTON_WHEELUP) m_mouseState.dz = 0;
-    if (newEvent.button.button == XBMC_BUTTON_WHEELDOWN) m_mouseState.dz = 0;
-  }
-  UpdateInternal();
-}
-
-void CMouseStat::UpdateInternal()
-{
-  uint32_t now = CTimeUtils::GetFrameTime();
-  // update our state from the mouse device
-  if (MovedPastThreshold() || m_mouseState.dz)
-    SetActive();
-
-  // Perform the click mapping (for single, long single, and double click detection)
-  bool bNothingDown = true;
-  
-  for (int i = 0; i < 5; i++)
-  {
-    bClick[i] = false;
-    bDoubleClick[i] = false;
-    bHold[i] = 0;
-
-    CButtonState::BUTTON_ACTION action = m_buttonState[i].Update(now, m_mouseState.x, m_mouseState.y, m_mouseState.button[i]);
-    switch (action)
-    {
-    case CButtonState::MB_SHORT_CLICK:
-    case CButtonState::MB_LONG_CLICK:
-      bClick[i] = true;
-      bNothingDown = false;
-      break;
-    case CButtonState::MB_DOUBLE_CLICK:
-      bDoubleClick[i] = true;
-      bNothingDown = false;
-      break;
-    case CButtonState::MB_DRAG_START:
-    case CButtonState::MB_DRAG:
-    case CButtonState::MB_DRAG_END:
-      bHold[i] = action - CButtonState::MB_DRAG_START + 1;
-      bNothingDown = false;
-      break;
-    default:
-      break;
-    }
-  }
-
-  if (bNothingDown)
-    SetState(MOUSE_STATE_NORMAL);
-  else
-    SetActive();
-}
-
-
-void CMouseStat::SetResolution(int maxX, int maxY, float speedX, float speedY)
-{
-  m_maxX = maxX;
-  m_maxY = maxY;
-
-  // speed is currently unused
-  m_speedX = speedX;
-  m_speedY = speedY;
-}
-
-void CMouseStat::SetActive(bool active /*=true*/)
-{
-  m_lastActiveTime = CTimeUtils::GetFrameTime();
-  m_mouseState.active = active;
-  // we show the OS mouse if:
-  // 1. The mouse is active (it has been moved) AND
-  // 2. The XBMC mouse is disabled in settings AND
-  // 3. XBMC is not in fullscreen.
-  g_Windowing.ShowOSMouse(m_mouseState.active && !IsEnabled() && !g_Windowing.IsFullScreen());
-}
-
-// IsActive - returns true if we have been active in the last MOUSE_ACTIVE_LENGTH period
-bool CMouseStat::IsActive()
-{
-  if (m_mouseState.active && (CTimeUtils::GetFrameTime() - m_lastActiveTime > MOUSE_ACTIVE_LENGTH))
-    SetActive(false);
-  return (m_mouseState.active && IsEnabled());
-}
-
-void CMouseStat::SetEnabled(bool enabled)
-{
-  m_mouseEnabled = enabled;
-  SetActive(enabled);
-}
-
-// IsEnabled - returns true if mouse is enabled
-bool CMouseStat::IsEnabled() const
-{
-  return m_mouseEnabled;
-}
-
-bool CMouseStat::MovedPastThreshold() const
-{
-  return (m_mouseState.dx * m_mouseState.dx + m_mouseState.dy * m_mouseState.dy >= MOUSE_MINIMUM_MOVEMENT * MOUSE_MINIMUM_MOVEMENT);
-}
-
-uint32_t CMouseStat::GetAction() const
-{
-  int actionID;
-
-  // Check the button state array
-  if (bClick[MOUSE_LEFT_BUTTON])
-    actionID = ACTION_MOUSE_LEFT_CLICK;
-  else if (bClick[MOUSE_RIGHT_BUTTON])
-    actionID = ACTION_MOUSE_RIGHT_CLICK;
-  else if (bClick[MOUSE_MIDDLE_BUTTON])
-    actionID = ACTION_MOUSE_MIDDLE_CLICK;
-  else if (bDoubleClick[MOUSE_LEFT_BUTTON])
-    actionID = ACTION_MOUSE_DOUBLE_CLICK;
-  else if (bHold[MOUSE_LEFT_BUTTON])
-    actionID = ACTION_MOUSE_DRAG;
-
-  // If nothing is set in the button state array check if it's a wheel action
-  else if (m_mouseState.dz > 0)
-    actionID = ACTION_MOUSE_WHEEL_UP;
-  else if (m_mouseState.dz < 0)
-    actionID = ACTION_MOUSE_WHEEL_DOWN;
-
-  // If it's not a button or wheel, check if the last mouse message was a move
-  else if (m_LastMessage == XBMC_MOUSEMOTION)
-    actionID = ACTION_MOUSE_MOVE;
-
-  // Not a button, wheel or move.
-  // Note that button down actions end up here because clicks are actioned
-  // the button up not the button down.
-  else
-    actionID = ACTION_NOOP;
-
-
-  return actionID;
-}
-
-int CMouseStat::GetHold(int ButtonID) const
-{
-  switch (ButtonID)
-  { case MOUSE_LEFT_BUTTON:
-      return bHold[MOUSE_LEFT_BUTTON];
-  }
-  return false;
 }
 

--- a/xbmc/input/MouseStat.h
+++ b/xbmc/input/MouseStat.h
@@ -158,6 +158,7 @@ private:
   bool m_mouseEnabled;
   CButtonState m_buttonState[5];
 
+  unsigned char m_LastMessage;
   int m_maxX;
   int m_maxY;
   float m_speedX;

--- a/xbmc/input/MouseStat.h
+++ b/xbmc/input/MouseStat.h
@@ -150,15 +150,12 @@ private:
    */
   bool MovedPastThreshold() const;
 
-  void UpdateInternal();
- 
   // state of the mouse
   MOUSE_STATE m_pointerState;
   MouseState m_mouseState;
   bool m_mouseEnabled;
   CButtonState m_buttonState[5];
 
-  unsigned char m_LastMessage;
   int m_maxX;
   int m_maxY;
   float m_speedX;
@@ -170,6 +167,8 @@ private:
   bool bClick[5];
   bool bDoubleClick[5];
   int  bHold[5];
+
+  uint32_t m_Action;
 };
 
 extern CMouseStat g_Mouse;


### PR DESCRIPTION
The aim is to stop a mouse click doing anything (except deactivate the screensaver) when the screen saver is active. Previous commits have done this, but this change hopefully makes things a bit tidier. The key change is to make CMouseStat remember the last mouse message so that CMouseStat::GetAction() can tell a button down message from a mouse move message.
