### PR TITLE
Winxp condition variable fix

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -732,6 +732,7 @@
     <ClCompile Include="..\..\xbmc\threads\Event.cpp" />
     <ClCompile Include="..\..\xbmc\threads\LockFree.cpp" />
     <ClCompile Include="..\..\xbmc\threads\platform\Implementation.cpp" />
+    <ClCompile Include="..\..\xbmc\threads\platform\win\FairMonitor.cpp" />
     <ClCompile Include="..\..\xbmc\threads\SystemClock.cpp" />
     <ClCompile Include="..\..\xbmc\threads\Thread.cpp" />
     <ClCompile Include="..\..\xbmc\ThumbLoader.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2482,6 +2482,9 @@
     <ClCompile Include="..\..\xbmc\threads\SystemClock.cpp">
       <Filter>threads</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\threads\platform\win\FairMonitor.cpp">
+      <Filter>threads\platform\win</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">

--- a/xbmc/threads/platform/win/FairMonitor.cpp
+++ b/xbmc/threads/platform/win/FairMonitor.cpp
@@ -30,6 +30,9 @@ MERCHANTABILITY ARE HEREBY DISCLAIMED.
 // Thomas Becker Dec 2000: Created
 // Thomas Becker Oct 2006: More error checking in Wait() and EndSynchronized()
 //
+// Jim Carroll Jul 2011: Use include <windows>
+// Jim Carroll Jul 2011: The "Wait" call never cleaned up correctly if it timed
+//  out.
 
 #include<Windows.h>
 #include"assert.h"
@@ -153,11 +156,11 @@ DWORD FairMonitor::Wait(
   std::deque<HANDLE>::const_iterator it_end = m_deqWaitSet.end();
   for ( std::deque<HANDLE>::const_iterator it = m_deqWaitSet.begin(); it < it_end; it++ )
   {
-	  if ((*it) == hWaitEvent)
-	  {
-		  m_deqWaitSet.erase(it);
-		  break;
-	  }
+     if ((*it) == hWaitEvent)
+     {
+        m_deqWaitSet.erase(it);
+        break;
+     }
   }
   ::LeaveCriticalSection(&m_critsecWaitSetProtection);
 

--- a/xbmc/threads/platform/win/FairMonitor.cpp
+++ b/xbmc/threads/platform/win/FairMonitor.cpp
@@ -1,0 +1,283 @@
+/**********************************************************************
+*
+COPYRIGHT (C) 2000 Thomas Becker
+
+PERMISSION NOTICE:
+
+PERMISSION TO USE, COPY, MODIFY, AND DISTRIBUTE THIS SOFTWARE FOR ANY
+PURPOSE AND WITHOUT FEE IS HEREBY GRANTED, PROVIDED THAT ALL COPIES
+ARE ACCOMPANIED BY THE COMPLETE MACHINE-READABLE SOURCE CODE, ALL
+MODIFIED FILES CARRY PROMINENT NOTICES AS TO WHEN AND BY WHOM THEY
+WERE MODIFIED, THE ABOVE COPYRIGHT NOTICE, THIS PERMISSION NOTICE AND
+THE NO-WARRANTY NOTICE BELOW APPEAR IN ALL SOURCE FILES AND IN ALL
+SUPPORTING DOCUMENTATION.
+
+NO-WARRANTY NOTICE:
+
+THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY.
+ALL IMPLIED WARRANTIES OF FITNESS FOR ANY PARTICULAR PURPOSE AND OF
+MERCHANTABILITY ARE HEREBY DISCLAIMED.
+*
+**********************************************************************/
+ 
+//
+// File: FairMonitor.cpp
+//
+// Description: Implementation of class FairMonitor
+//
+// Revision History:
+// 
+// Thomas Becker Dec 2000: Created
+// Thomas Becker Oct 2006: More error checking in Wait() and EndSynchronized()
+//
+
+#include<Windows.h>
+#include"assert.h"
+#include "FairMonitor.h"
+
+///////////////////////////////////////////////////////////////////////
+//
+FairMonitor::FairMonitor() :
+  m_nLockCount(0)
+{
+  // Initialize the critical section that protects access to
+  // the wait set. There is no way to check for errors here.
+  ::InitializeCriticalSection(&m_critsecWaitSetProtection);
+
+  // Initialize the critical section that provides synchronization
+  // to the client. There is no way to check for errors here.
+  ::InitializeCriticalSection(&m_critsecSynchronized);
+}
+
+///////////////////////////////////////////////////////////////////////
+//
+FairMonitor::~FairMonitor()
+{
+  // Uninitialize critical sections. Win32 allows no error checking
+  // here.
+  ::DeleteCriticalSection(&m_critsecWaitSetProtection);
+  ::DeleteCriticalSection(&m_critsecSynchronized);
+
+  // Destroying this thing while threads are waiting is a client
+  // programmer mistake.
+  assert( m_deqWaitSet.empty() );
+}
+
+///////////////////////////////////////////////////////////////////////
+//
+void FairMonitor::BeginSynchronized()
+{ 
+  // Acquire lock. Win32 allows no error checking here.
+  ::EnterCriticalSection(&m_critsecSynchronized); 
+
+  // Record the lock acquisition for proper release in Wait().
+  ++m_nLockCount;
+}
+
+///////////////////////////////////////////////////////////////////////
+//
+BOOL FairMonitor::EndSynchronized()
+{ 
+  if( ! LockHeldByCallingThread() )
+  {
+    ::SetLastError(ERROR_INVALID_FUNCTION); // for the lack of better...
+    return FALSE;
+  }
+
+  // Record the lock release for proper release in Wait().
+  --m_nLockCount;
+
+  // Release lock. Win32 allows no error checking here.
+  ::LeaveCriticalSection(&m_critsecSynchronized); 
+  
+  return TRUE;
+}
+
+///////////////////////////////////////////////////////////////////////
+//
+DWORD FairMonitor::Wait(
+  DWORD dwMillisecondsTimeout/* = INFINITE*/,
+  BOOL bAlertable/* = FALSE */
+  )
+{
+  if( ! LockHeldByCallingThread() )
+  {
+    ::SetLastError(ERROR_INVALID_FUNCTION); // for the lack of better...
+    return WAIT_FAILED;
+  }
+
+  // Enter a new event handle into the wait set.
+  HANDLE hWaitEvent = Push();
+  if( NULL == hWaitEvent )
+    return WAIT_FAILED;
+
+  // Store the current lock count for re-acquisition.
+  int nThisThreadsLockCount = m_nLockCount;
+  m_nLockCount = 0;
+
+  // Release the synchronization lock the appropriate number of times.
+  // Win32 allows no error checking here.
+  for( int i=0; i<nThisThreadsLockCount; ++i)
+    ::LeaveCriticalSection(&m_critsecSynchronized);
+
+  // NOTE: Conceptually, releasing the lock and entering the wait
+  // state is done in one atomic step. Technically, that is not
+  // true here, because we first leave the critical section and
+  // then, in a separate line of code, call WaitForSingleObjectEx.
+  // The reason why this code is correct is that our thread is placed
+  // in the wait set *before* the lock is released. Therefore, if
+  // we get preempted right here and another thread notifies us, then
+  // that notification will *not* be missed: the wait operation below
+  // will find the event signalled.
+  
+  // Wait for the event to become signalled.
+  DWORD dwWaitResult = ::WaitForSingleObjectEx(
+    hWaitEvent,
+    dwMillisecondsTimeout,
+    bAlertable
+    );
+
+  // If the wait failed, store the last error because it will get
+  // overwritten when acquiring the lock.
+  DWORD dwLastError;
+  if( WAIT_FAILED == dwWaitResult )
+    dwLastError = ::GetLastError();
+
+  // Acquire the synchronization lock the appropriate number of times.
+  // Win32 allows no error checking here.
+  for( int j=0; j<nThisThreadsLockCount; ++j)
+    ::EnterCriticalSection(&m_critsecSynchronized);
+
+  // Handle the wait timeout case.
+  ::EnterCriticalSection(&m_critsecWaitSetProtection);
+  std::deque<HANDLE>::const_iterator it_end = m_deqWaitSet.end();
+  for ( std::deque<HANDLE>::const_iterator it = m_deqWaitSet.begin(); it < it_end; it++ )
+  {
+	  if ((*it) == hWaitEvent)
+	  {
+		  m_deqWaitSet.erase(it);
+		  break;
+	  }
+  }
+  ::LeaveCriticalSection(&m_critsecWaitSetProtection);
+
+  // Restore lock count.
+  m_nLockCount = nThisThreadsLockCount;
+
+  // Close event handle
+  if( ! CloseHandle(hWaitEvent) )
+    return WAIT_FAILED;
+
+  if( WAIT_FAILED == dwWaitResult )
+    ::SetLastError(dwLastError);
+
+  return dwWaitResult;
+}
+
+///////////////////////////////////////////////////////////////////////
+//
+BOOL FairMonitor::Notify()
+{
+  // Pop the first handle, if any, off the wait set.
+  HANDLE hWaitEvent = Pop();
+
+  // If there is not thread currently waiting, that's just fine.
+  if(NULL == hWaitEvent)
+    return TRUE;
+
+  // Signal the event.
+  return SetEvent(hWaitEvent);
+}
+
+///////////////////////////////////////////////////////////////////////
+//
+BOOL FairMonitor::NotifyAll()
+{
+  // Signal all events on the deque, then clear it. Win32 allows no
+  // error checking on entering and leaving the critical section.
+  //
+  ::EnterCriticalSection(&m_critsecWaitSetProtection);
+  std::deque<HANDLE>::const_iterator it_run = m_deqWaitSet.begin();
+  std::deque<HANDLE>::const_iterator it_end = m_deqWaitSet.end();
+  for( ; it_run < it_end; ++it_run )
+  {
+    if( ! SetEvent(*it_run) )
+      return FALSE;
+  }
+  m_deqWaitSet.clear();
+  ::LeaveCriticalSection(&m_critsecWaitSetProtection);
+  
+  return TRUE;
+}
+
+///////////////////////////////////////////////////////////////////////
+//
+HANDLE FairMonitor::Push()
+{
+  // Create the new event.
+  HANDLE hWaitEvent = ::CreateEvent(
+    NULL, // no security
+    FALSE, // auto-reset event
+    FALSE, // initially unsignalled
+    NULL // string name
+    );
+  //
+  if( NULL == hWaitEvent ) {
+    return NULL;
+  }
+
+  // Push the handle on the deque.
+  ::EnterCriticalSection(&m_critsecWaitSetProtection);
+  m_deqWaitSet.push_back(hWaitEvent);
+  ::LeaveCriticalSection(&m_critsecWaitSetProtection);
+
+  return hWaitEvent;
+}
+
+///////////////////////////////////////////////////////////////////////
+//
+HANDLE FairMonitor::Pop()
+{
+  // Pop the first handle off the deque.
+  //
+  ::EnterCriticalSection(&m_critsecWaitSetProtection);
+  HANDLE hWaitEvent = NULL; 
+  if( 0 != m_deqWaitSet.size() )
+  {
+    hWaitEvent = m_deqWaitSet.front();
+    m_deqWaitSet.pop_front();
+  }
+  ::LeaveCriticalSection(&m_critsecWaitSetProtection);
+
+  return hWaitEvent;
+}
+
+///////////////////////////////////////////////////////////////////////
+//
+BOOL FairMonitor::LockHeldByCallingThread()
+{
+  BOOL bTryLockResult = ::TryEnterCriticalSection(&m_critsecSynchronized);
+
+  // If we didn't get the lock, someone else has it.
+  //
+  if( ! bTryLockResult )
+  {
+    return FALSE;
+  }
+
+  // If we got the lock, but the lock count is zero, then nobody had it.
+  //
+  if( 0 == m_nLockCount )
+  {
+    assert( bTryLockResult );
+    ::LeaveCriticalSection(&m_critsecSynchronized);
+    return FALSE;
+  }
+
+  // Release lock once. NOTE: we still have it after this release.
+  // Win32 allows no error checking here.
+  assert( bTryLockResult && 0 < m_nLockCount );
+  ::LeaveCriticalSection(&m_critsecSynchronized);
+ 
+  return TRUE;
+}

--- a/xbmc/threads/platform/win/FairMonitor.h
+++ b/xbmc/threads/platform/win/FairMonitor.h
@@ -1,0 +1,182 @@
+/**********************************************************************
+*
+COPYRIGHT (C) 2000 Thomas Becker
+
+PERMISSION NOTICE:
+
+PERMISSION TO USE, COPY, MODIFY, AND DISTRIBUTE THIS SOFTWARE FOR ANY
+PURPOSE AND WITHOUT FEE IS HEREBY GRANTED, PROVIDED THAT ALL COPIES
+ARE ACCOMPANIED BY THE COMPLETE MACHINE-READABLE SOURCE CODE, ALL
+MODIFIED FILES CARRY PROMINENT NOTICES AS TO WHEN AND BY WHOM THEY
+WERE MODIFIED, THE ABOVE COPYRIGHT NOTICE, THIS PERMISSION NOTICE AND
+THE NO-WARRANTY NOTICE BELOW APPEAR IN ALL SOURCE FILES AND IN ALL
+SUPPORTING DOCUMENTATION.
+
+NO-WARRANTY NOTICE:
+
+THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY.
+ALL IMPLIED WARRANTIES OF FITNESS FOR ANY PARTICULAR PURPOSE AND OF
+MERCHANTABILITY ARE HEREBY DISCLAIMED.
+*
+**********************************************************************/
+
+ 
+//
+// File: FairMonitor.h
+//
+// Description: Declaration of class FairMonitor
+//
+// Revision History:
+// 
+// Thomas Becker Dec 2000: Created
+// Thomas Becker Oct 2006: More error checking in Wait() and EndSynchronized()
+//
+
+// Multiple inclusion protection
+//
+#ifndef __FAIR_MONITOR_INCLUDED__
+#define __FAIR_MONITOR_INCLUDED__
+
+#include<Windows.h>
+#include<deque>
+
+///////////////////////////////////////////////////////////////////////
+//
+// The class FairMonitor implements a Java-style monitor in Win32. The
+// monitor guarantees FIFO treatment of waiting threads. The price for
+// this "fairness guarantee" is the use of a significant amount of
+// user-mode code in the Wait(), Notify(), and NotifyAll() functions.
+// See thbecker.net/free_software_utilities/fair_monitor_for_win32/start_page.html
+// for a detailed discussion of monitors and fairness under Win32.
+//
+// Anybody who has used monitors in Java or under pthreads should need
+// no more documentation than this header file.
+//
+class FairMonitor
+{
+public:
+
+  // Public Construction and Destruction
+  // ===================================
+  
+  // Default constructor.
+  FairMonitor();
+
+  // NOTE: If you must derive from this class (which you should not, but I
+  // cannot currently enforce it), then you must make the destructor virtual.
+  ~FairMonitor();
+
+  // Operations
+  // ==========
+  
+  // Acquires the lock once. There is no error checking as the lock is
+  // implemented as a Win32 critical section.
+  void BeginSynchronized();
+
+  // Releases the lock once. As the lock is implemented as a Win32 
+  // critical section, no error checking is possible on the system
+  // call that releases the lock. However, the function does check
+  // whether the calling thread currently holds the lock. If not,
+  // FALSE is returned and the last error is set to 
+  // ERROR_INVALID_FUNCTION (for the lack of better).
+  BOOL EndSynchronized();
+
+  // Waits for a notification. The first argument is the timeout
+  // in milliseconds. The alertable flag must be true if the wait
+  // should complete when a user APC is queued.
+  //
+  // In case of success, the return value is WAIT_OBJECT_0. See
+  // the documentation of the Win32 function WaitForSingleObjectEx()
+  // for an explanation of the other possible return values.
+  //
+  // The function checks whether or not the lock has been acquired by
+  // the calling thread prior to calling this function. If that is not
+  // the case, WAIT_FAILED is returned and the last error is set to 
+  // ERROR_INVALID_FUNCTION (for the lack of better).
+  //
+  // If WAIT_FAILED is returned for a reason other than the one
+  // discussed above, then that indicates an irrecoverably bad
+  // state of the process, usually caused by a bad API call such as 
+  // entering or leaving a destroyed critical section.
+  //
+  // Since the lock is implemented as a Win32 critical section,
+  // no error checking can be performed on the system calls that
+  // aquire or release the lock. 
+  DWORD Wait(
+    DWORD dwMillisecondsTimeout = INFINITE,
+    BOOL bAlertable = FALSE
+    );
+
+  // Notifies one of the waiting threads, if any. In case of success, 
+  // the return value is TRUE. In case of failure, call GetLastError()
+  // to obtain error information.
+  //
+  // NOTE: In most applications, this function will be called while
+  // the lock is held (look at any textbook example code that uses
+  // a monitor). However, it is not technically necessary for the 
+  // calling thread to hold the lock when calling this function.
+  //
+  // The return value FALSE indicates an irrecoverrably bad state
+  // of the process, usually caused by a bad API call such entering or
+  // leaving a destroyed critical section.
+  BOOL Notify();
+
+  // Notifies the waiting threads, if any. In case of success, the 
+  // return value is TRUE. In case of failure, call GetLastError() to 
+  // obtain error information.
+  //
+  // NOTE: In most applications, this function will be called while
+  // the lock is held (look at any textbook example code that uses
+  // a monitor). However, it is not technically necessary for the 
+  // calling thread to hold the lock when calling this function.
+  //
+  // The return value FALSE indicates an irrecoverrably bad state
+  // of the process, usually caused by a bad API call such entering or
+  // leaving a destroyed critical section.
+  BOOL NotifyAll();
+
+private:
+
+  // Private helper functions
+  // ========================
+  
+  // Creates an initially non-signalled auto-reset event and
+  // pushes the handle to the event onto the wait set. The
+  // return value is the event handle. In case of failure,
+  // NULL is returned.
+  HANDLE Push();
+
+  // Pops the first handle off the wait set. Returns NULL if the
+  // wait set was empty.
+  HANDLE Pop();
+
+  // Checks whether the calling thread is holding the lock.
+  BOOL LockHeldByCallingThread();
+
+  // The intended use of the monitor never requires any value copies.
+  // Therefore, the class is non-copyable.
+  FairMonitor(FairMonitor const&);
+  FairMonitor& operator=(FairMonitor const&);
+
+  // Data members
+  // ============
+
+  // STL deque that implements the wait set.
+  std::deque<HANDLE> m_deqWaitSet;
+
+  // Critical section to protect access to wait set.
+  CRITICAL_SECTION m_critsecWaitSetProtection;
+
+  // Critical section for external synchronization.
+  CRITICAL_SECTION m_critsecSynchronized;
+
+  // The monitor must keep track of how many times the lock
+  // has been acquired, because Win32 does not divulge this
+  // information to the client programmer.
+  int m_nLockCount;
+
+};
+
+#endif
+//
+// End multiple inclusion protection

--- a/xbmc/threads/platform/win/FairMonitor.h
+++ b/xbmc/threads/platform/win/FairMonitor.h
@@ -31,6 +31,7 @@ MERCHANTABILITY ARE HEREBY DISCLAIMED.
 // Thomas Becker Dec 2000: Created
 // Thomas Becker Oct 2006: More error checking in Wait() and EndSynchronized()
 //
+// Jim Carroll Jul 2011: Use include <windows>
 
 // Multiple inclusion protection
 //


### PR DESCRIPTION
This fixes the fact that the current master uses windows api's that only exist in Vista or later versions of Windows.

I wanted to get this out there quickly. I plan to dynamically (at run time) select the api that's used based on what's available since the later api is much more efficient. You can hard compile it right now by setting a -DTARGET_VISTAPLUS on your compile (or you can just wait for me to change it).

If you want this in feel free to merge it yourself as I will be unavailable for the next couple of days. I tested it and it works (BUILD FROM SCRATCH!).
