### PR TITLE
Dynamic evaluation of the processor flags passed to libpostproc.

### DIFF
--- a/lib/DllPostProc.h
+++ b/lib/DllPostProc.h
@@ -55,6 +55,25 @@ extern "C" {
 #endif
 }
 
+#include "utils/CPUInfo.h"
+
+inline int PPCPUFlags()
+{
+  unsigned int cpuFeatures = g_cpuInfo.GetCPUFeatures();
+  int flags = 0;
+
+  if (cpuFeatures & CPU_FEATURE_MMX)
+    flags |= PP_CPU_CAPS_MMX;
+  if (cpuFeatures & CPU_FEATURE_MMX2)
+    flags |= PP_CPU_CAPS_MMX2;
+  if (cpuFeatures & CPU_FEATURE_3DNOW)
+    flags |= PP_CPU_CAPS_3DNOW;
+  if (cpuFeatures & CPU_FEATURE_ALTIVEC)
+    flags |= PP_CPU_CAPS_ALTIVEC;
+
+  return flags;
+}
+
 class DllPostProcInterface
 {
 public:

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
@@ -78,7 +78,7 @@ bool CDVDVideoPPFFmpeg::CheckInit(int iWidth, int iHeight)
       Dispose();
     }
 
-    m_pContext = m_dll.pp_get_context(m_pSource->iWidth, m_pSource->iHeight, PP_CPU_CAPS_MMX | PP_CPU_CAPS_MMX2 | PP_FORMAT_420);
+    m_pContext = m_dll.pp_get_context(m_pSource->iWidth, m_pSource->iHeight, PPCPUFlags() | PP_FORMAT_420);
 
     m_iInitWidth = m_pSource->iWidth;
     m_iInitHeight = m_pSource->iHeight;


### PR DESCRIPTION
Similar to the work done for swscale: read the cpu flags instead of hardcoding the available extensions.
Benefits 3DNow and Altivec users, as any optimization in libpostproc for them were never turned on.
