### PR TITLE
Fix for issue #10819 - add unknown files to library

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2098,6 +2098,7 @@
   <string id="22022">Show video files in listings</string>
   <string id="22023">DirectX vendor:</string>
   <string id="22024">Direct3D version:</string>
+  <string id="22025">Add unknown files to library</string>
 
   <!-- strings 22030 thru 22060 reserved for karaoke -->
   <string id="22030">Font</string>

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -552,6 +552,7 @@ void CGUISettings::Initialize()
   AddGroup(5, 3);
   CSettingsCategory* vdl = AddCategory(5, "videolibrary", 14022);
   AddBool(NULL, "videolibrary.enabled", 418, true);
+  AddBool(vdl, "videolibrary.addunknown", 22025, true);
   AddBool(vdl, "videolibrary.showunwatchedplots", 20369, true);
   AddBool(NULL, "videolibrary.seasonthumbs", 20382, true);
   AddBool(vdl, "videolibrary.actorthumbs", 20402, true);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -494,18 +494,36 @@ namespace VIDEO
     int retVal = 0;
     if (pURL)
       url = *pURL;
-    else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), info2, url, pDlgProgress)) <= 0)
-      return retVal < 0 ? INFO_CANCELLED : INFO_NOT_FOUND;
+    else
+      retVal = FindVideo(pItem->GetMovieName(bDirNames), info2, url, pDlgProgress);
 
-    if (m_pObserver && !url.strTitle.IsEmpty())
-      m_pObserver->OnSetTitle(url.strTitle);
-
-    long lResult=-1;
-    if (GetDetails(pItem.get(), url, info2, result == CNfoFile::COMBINED_NFO ? &m_nfoReader : NULL, pDlgProgress))
+    long lResult = -1;
+    if (retVal < 0)
+      return INFO_CANCELLED;
+    else if (retVal == 0)
     {
-      if ((lResult = AddVideo(pItem.get(), info2->Content(), bDirNames)) < 0)
-        return INFO_ERROR;
-      GetArtwork(pItem.get(), info2->Content(), false, useLocal);
+      if (g_guiSettings.GetBool("videolibrary.addunknown"))
+      {
+        CVideoInfoTag* pVideoInfoTag = pItem->GetVideoInfoTag();
+        pVideoInfoTag->m_strTitle = pItem->GetMovieName(bDirNames);
+        if (AddVideo(pItem.get(), CONTENT_TVSHOWS, bDirNames) < 0)
+          return INFO_ERROR;
+        GetArtwork(pItem.get(), CONTENT_TVSHOWS);
+      }
+      else
+        return INFO_NOT_FOUND;
+    }
+    else
+    {
+      if (m_pObserver && !url.strTitle.IsEmpty())
+        m_pObserver->OnSetTitle(url.strTitle);
+
+      if (GetDetails(pItem.get(), url, info2, result == CNfoFile::COMBINED_NFO ? &m_nfoReader : NULL, pDlgProgress))
+      {
+        if ((lResult = AddVideo(pItem.get(), info2->Content(), bDirNames)) < 0)
+          return INFO_ERROR;
+        GetArtwork(pItem.get(), info2->Content(), false, useLocal);
+      }
     }
     if (fetchEpisodes)
     {
@@ -555,7 +573,7 @@ namespace VIDEO
     if (pURL)
       url = *pURL;
     else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), info2, url, pDlgProgress)) <= 0)
-      return retVal < 0 ? INFO_CANCELLED : INFO_NOT_FOUND;
+      return retVal < 0 ? INFO_CANCELLED : AddVideoByFilename(pItem.get(), CONTENT_MOVIES, bDirNames);
 
     if (m_pObserver && !url.strTitle.IsEmpty())
       m_pObserver->OnSetTitle(url.strTitle);
@@ -607,7 +625,7 @@ namespace VIDEO
     if (pURL)
       url = *pURL;
     else if ((retVal = FindVideo(pItem->GetMovieName(bDirNames), info2, url, pDlgProgress)) <= 0)
-      return retVal < 0 ? INFO_CANCELLED : INFO_NOT_FOUND;
+      return retVal < 0 ? INFO_CANCELLED : AddVideoByFilename(pItem.get(), CONTENT_MUSICVIDEOS, bDirNames);
 
     if (m_pObserver && !url.strTitle.IsEmpty())
       m_pObserver->OnSetTitle(url.strTitle);
@@ -1129,6 +1147,47 @@ namespace VIDEO
     return lResult;
   }
 
+  INFO_RET CVideoInfoScanner::AddVideoByFilename(CFileItem *pItem, const CONTENT_TYPE &content, bool videoFolder, int idShow)
+  {
+    if (g_guiSettings.GetBool("videolibrary.addunknown"))
+    {
+      CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding unknown item to %s:%s", TranslateContent(content).c_str(), pItem->m_strPath.c_str());
+      CVideoInfoTag* pVideoInfoTag = pItem->GetVideoInfoTag();
+      pVideoInfoTag->m_strTitle = pItem->GetMovieName(videoFolder);
+
+      if (AddVideo(pItem, content, videoFolder, idShow) < 0)
+        return INFO_ERROR;
+      else
+      {
+        GetArtwork(pItem, content);
+        return INFO_ADDED;
+      }
+    }
+    return INFO_NOT_FOUND;
+  }
+
+  INFO_RET CVideoInfoScanner::AddEpisodeByFilename(CFileItem *pItem, int idShow, int iSeason, int iEpisode, CStdString strAirDate)
+  {
+    if (g_guiSettings.GetBool("videolibrary.addunknown"))
+    {
+      CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding unknown episode: season %i ep %i : %s", iSeason, iEpisode, pItem->m_strPath.c_str());
+      CVideoInfoTag* pVideoInfoTag = pItem->GetVideoInfoTag();
+      pVideoInfoTag->m_strTitle = pItem->GetMovieName(false);
+      pVideoInfoTag->m_iSeason = iSeason;
+      pVideoInfoTag->m_iEpisode = iEpisode;
+      pVideoInfoTag->m_strFirstAired = strAirDate;
+
+      if (AddVideo(pItem, CONTENT_TVSHOWS, false, idShow) < 0)
+        return INFO_ERROR;
+      else
+      {
+        GetArtwork(pItem, CONTENT_TVSHOWS);
+        return INFO_ADDED;
+      }
+    }
+    return INFO_NOT_FOUND;
+  }
+
   void CVideoInfoScanner::GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir, bool useLocal, CGUIDialogProgress* pDialog /* == NULL */)
   {
     CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
@@ -1274,9 +1333,10 @@ namespace VIDEO
 
       if (episodes.empty())
       {
-        CLog::Log(LOGERROR, "VideoInfoScanner: Asked to lookup episode %s"
-                            " online, but we have no episode guide. Check your tvshow.nfo and make"
-                            " sure the <episodeguide> tag is in place.", file->strPath.c_str());
+        if (AddEpisodeByFilename(&item, idShow, file->iSeason, file->iEpisode, file->cDate.GetAsLocalizedDate().c_str()) < 0 )
+          CLog::Log(LOGERROR, "VideoInfoScanner: Asked to lookup episode %s"
+                              " online, but we have no episode guide. Check your tvshow.nfo and make"
+                              " sure the <episodeguide> tag is in place.", file->strPath.c_str());
         continue;
       }
 
@@ -1354,9 +1414,15 @@ namespace VIDEO
         CFileItem item;
         item.m_strPath = file->strPath;
         if (!imdb.GetEpisodeDetails(guide->cScraperUrl, *item.GetVideoInfoTag(), pDlgProgress))
-          return INFO_NOT_FOUND; // TODO: should we just skip to the next episode?
-        item.GetVideoInfoTag()->m_iSeason = guide->key.first;
-        item.GetVideoInfoTag()->m_iEpisode = guide->key.second;
+        {
+          AddEpisodeByFilename(&item, idShow, guide->key.first, guide->key.second, file->cDate.GetAsLocalizedDate().c_str());
+          continue;
+        }
+        else
+        {
+          item.GetVideoInfoTag()->m_iSeason = guide->key.first;
+          item.GetVideoInfoTag()->m_iEpisode = guide->key.second;
+        }
         if (m_pObserver)
         {
           CStdString strTitle;
@@ -1369,9 +1435,10 @@ namespace VIDEO
       }
       else
       {
-        CLog::Log(LOGDEBUG,"%s - no match for show: '%s', season: %d, episode: %d, airdate: '%s', title: '%s'",
-                  __FUNCTION__, strShowTitle.c_str(), file->iSeason, file->iEpisode,
-                  file->cDate.GetAsLocalizedDate().c_str(), file->strTitle.c_str());
+        if ( AddEpisodeByFilename(&item, idShow, file->iSeason, file->iEpisode, file->cDate.GetAsLocalizedDate().c_str()) < 0 )
+          CLog::Log(LOGDEBUG,"%s - no match for show: '%s', season: %d, episode: %d, airdate: '%s', title: '%s'",
+                    __FUNCTION__, strShowTitle.c_str(), file->iSeason, file->iEpisode,
+                    file->cDate.GetAsLocalizedDate().c_str(), file->strTitle.c_str());
       }
     }
     if (g_guiSettings.GetBool("videolibrary.seasonthumbs"))

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -112,6 +112,9 @@ namespace VIDEO
      */
     bool RetrieveVideoInfo(CFileItemList& items, bool bDirNames, CONTENT_TYPE content, bool useLocal = true, CScraperUrl *pURL = NULL, bool fetchEpisodes = true, CGUIDialogProgress* pDlgProgress = NULL);
 
+    INFO_RET AddVideoByFilename(CFileItem *pItem, const CONTENT_TYPE &content, bool videoFolder = false, int idShow = -1);
+    INFO_RET AddEpisodeByFilename(CFileItem *pItem, int idShow, int iSeason, int iEpisode, CStdString strAirDate);
+
     static void ApplyThumbToFolder(const CStdString &folder, const CStdString &imdbThumb);
     static bool DownloadFailed(CGUIDialogProgress* pDlgProgress);
     CNfoFile::NFOResult CheckForNFOFile(CFileItem* pItem, bool bGrabAny, ADDON::ScraperPtr& scraper, CScraperUrl& scrUrl);


### PR DESCRIPTION
This patch adds an option to add unknown files to the library.

Movies and music video are added by filename.
TV show episodes are added by filename plus any scanned season/episode data
