### PR TITLE
Replace literals with XBMCVK_ symbols

### DIFF
--- a/xbmc/dialogs/GUIDialogKeyboard.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboard.cpp
@@ -139,27 +139,27 @@ bool CGUIDialogKeyboard::OnAction(const CAction &action)
   else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_ASCII)
   { // input from the keyboard (vkey, not ascii)
     uint8_t b = action.GetID() & 0xFF;
-    if (b == XBMCVK_HOME) // home
+    if (b == XBMCVK_HOME)
     {
       MoveCursor(-GetCursorPos());
     }
-    else if (b == XBMCVK_END) // end
+    else if (b == XBMCVK_END)
     {
       MoveCursor(m_strEdit.GetLength() - GetCursorPos());
     }
-    else if (b == XBMCVK_LEFT) // left
+    else if (b == XBMCVK_LEFT)
     {
       MoveCursor( -1);
     }
-    else if (b == XBMCVK_RIGHT) // right
+    else if (b == XBMCVK_RIGHT)
     {
       MoveCursor(1);
     }
-    else if (b == XBMCVK_RETURN || b == XBMCVK_NUMPADENTER) // enter
+    else if (b == XBMCVK_RETURN || b == XBMCVK_NUMPADENTER)
     {
       OnOK();
     }
-    else if (b == XBMCVK_DELETE) // delete
+    else if (b == XBMCVK_DELETE)
     {
       if (GetCursorPos() < m_strEdit.GetLength())
       {
@@ -167,8 +167,8 @@ bool CGUIDialogKeyboard::OnAction(const CAction &action)
         Backspace();
       }
     }
-    else if (b == XBMCVK_BACK) Backspace();    // backspace
-    else if (b == XBMCVK_ESCAPE) Close();        // escape
+    else if (b == XBMCVK_BACK) Backspace();
+    else if (b == XBMCVK_ESCAPE) Close();
   }
   else if (action.GetID() >= KEY_ASCII)
   { // input from the keyboard

--- a/xbmc/dialogs/GUIDialogKeyboard.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboard.cpp
@@ -26,6 +26,7 @@
 #include "GUIDialogOK.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
+#include "input/XBMC_vkeys.h"
 #include "utils/RegExp.h"
 #include "GUIPassword.h"
 #include "utils/md5.h"
@@ -138,27 +139,27 @@ bool CGUIDialogKeyboard::OnAction(const CAction &action)
   else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_ASCII)
   { // input from the keyboard (vkey, not ascii)
     uint8_t b = action.GetID() & 0xFF;
-    if (b == 0x88) // home
+    if (b == XBMCVK_HOME) // home
     {
       MoveCursor(-GetCursorPos());
     }
-    else if (b == 0x89) // end
+    else if (b == XBMCVK_END) // end
     {
       MoveCursor(m_strEdit.GetLength() - GetCursorPos());
     }
-    else if (b == 0x82) // left
+    else if (b == XBMCVK_LEFT) // left
     {
       MoveCursor( -1);
     }
-    else if (b == 0x83) // right
+    else if (b == XBMCVK_RIGHT) // right
     {
       MoveCursor(1);
     }
-    else if (b == 0x0D || b == 0x65) // enter
+    else if (b == XBMCVK_RETURN || b == XBMCVK_NUMPADENTER) // enter
     {
       OnOK();
     }
-    else if (b == 0x87) // delete
+    else if (b == XBMCVK_DELETE) // delete
     {
       if (GetCursorPos() < m_strEdit.GetLength())
       {
@@ -166,8 +167,8 @@ bool CGUIDialogKeyboard::OnAction(const CAction &action)
         Backspace();
       }
     }
-    else if (b == 0x08) Backspace();    // backspace
-    else if (b == 0x1B) Close();        // escape
+    else if (b == XBMCVK_BACK) Backspace();    // backspace
+    else if (b == XBMCVK_ESCAPE) Close();        // escape
   }
   else if (action.GetID() >= KEY_ASCII)
   { // input from the keyboard

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -24,6 +24,7 @@
 #include "utils/md5.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIDialogOK.h"
+#include "input/XBMC_vkeys.h"
 #include "utils/StringUtils.h"
 #include "guilib/LocalizeStrings.h"
 
@@ -70,11 +71,11 @@ bool CGUIDialogNumeric::OnAction(const CAction &action)
   else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_ASCII)
   { // input from the keyboard (vkey, not ascii)
     BYTE b = action.GetID() & 0xFF;
-    if (b == 0x82) OnPrevious();     // left
-    else if (b == 0x83) OnNext();  // right
-    else if (b == 0x0D) OnOK();         // enter
-    else if (b == 0x08) OnBackSpace();    // backspace
-    else if (b == 0x1B) OnCancel();        // escape
+    if (b == XBMCVK_LEFT) OnPrevious();     // left
+    else if (b == XBMCVK_RIGHT) OnNext();  // right
+    else if (b == XBMCVK_RETURN) OnOK();         // enter
+    else if (b == XBMCVK_BACK) OnBackSpace();    // backspace
+    else if (b == XBMCVK_ESCAPE) OnCancel();        // escape
   }
   else if (action.GetID() >= KEY_ASCII) // FIXME make it KEY_UNICODE
   { // input from the keyboard

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -71,11 +71,11 @@ bool CGUIDialogNumeric::OnAction(const CAction &action)
   else if (action.GetID() >= KEY_VKEY && action.GetID() < KEY_ASCII)
   { // input from the keyboard (vkey, not ascii)
     BYTE b = action.GetID() & 0xFF;
-    if (b == XBMCVK_LEFT) OnPrevious();     // left
-    else if (b == XBMCVK_RIGHT) OnNext();  // right
-    else if (b == XBMCVK_RETURN) OnOK();         // enter
-    else if (b == XBMCVK_BACK) OnBackSpace();    // backspace
-    else if (b == XBMCVK_ESCAPE) OnCancel();        // escape
+    if (b == XBMCVK_LEFT) OnPrevious();
+    else if (b == XBMCVK_RIGHT) OnNext();
+    else if (b == XBMCVK_RETURN || b == XBMCVK_NUMPADENTER) OnOK();
+    else if (b == XBMCVK_BACK) OnBackSpace();
+    else if (b == XBMCVK_ESCAPE) OnCancel();
   }
   else if (action.GetID() >= KEY_ASCII) // FIXME make it KEY_UNICODE
   { // input from the keyboard

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -24,6 +24,7 @@
 #include "utils/CharsetConverter.h"
 #include "dialogs/GUIDialogKeyboard.h"
 #include "dialogs/GUIDialogNumeric.h"
+#include "input/XBMC_vkeys.h"
 #include "LocalizeStrings.h"
 #include "XBDateTime.h"
 #include "utils/md5.h"
@@ -138,31 +139,31 @@ bool CGUIEditControl::OnAction(const CAction &action)
   {
     // input from the keyboard (vkey, not ascii)
     BYTE b = action.GetID() & 0xFF;
-    if (b == 0x88) // home
+    if (b == XBMCVK_HOME) // home
     {
       m_cursorPos = 0;
       UpdateText(false);
       return true;
     }
-    else if (b == 0x89) // end
+    else if (b == XBMCVK_END) // end
     {
       m_cursorPos = m_text2.length();
       UpdateText(false);
       return true;
     }
-    if (b == 0x82 && m_cursorPos > 0)
+    if (b == XBMCVK_LEFT && m_cursorPos > 0)
     { // left
       m_cursorPos--;
       UpdateText(false);
       return true;
     }
-    if (b == 0x83 && m_cursorPos < m_text2.length())
+    if (b == XBMCVK_RIGHT && m_cursorPos < m_text2.length())
     { // right
       m_cursorPos++;
       UpdateText(false);
       return true;
     }
-    if (b == 0x87)
+    if (b == XBMCVK_DELETE)
     {
       if (m_cursorPos < m_text2.length())
       { // delete
@@ -172,7 +173,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
         return true;
       }
     }
-    if (b == 0x8)
+    if (b == XBMCVK_BACK)
     {
       if (m_cursorPos > 0)
       { // backspace

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -139,26 +139,26 @@ bool CGUIEditControl::OnAction(const CAction &action)
   {
     // input from the keyboard (vkey, not ascii)
     BYTE b = action.GetID() & 0xFF;
-    if (b == XBMCVK_HOME) // home
+    if (b == XBMCVK_HOME)
     {
       m_cursorPos = 0;
       UpdateText(false);
       return true;
     }
-    else if (b == XBMCVK_END) // end
+    else if (b == XBMCVK_END)
     {
       m_cursorPos = m_text2.length();
       UpdateText(false);
       return true;
     }
     if (b == XBMCVK_LEFT && m_cursorPos > 0)
-    { // left
+    {
       m_cursorPos--;
       UpdateText(false);
       return true;
     }
     if (b == XBMCVK_RIGHT && m_cursorPos < m_text2.length())
-    { // right
+    {
       m_cursorPos++;
       UpdateText(false);
       return true;
@@ -166,7 +166,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
     if (b == XBMCVK_DELETE)
     {
       if (m_cursorPos < m_text2.length())
-      { // delete
+      {
         if (!ClearMD5())
           m_text2.erase(m_cursorPos, 1);
         UpdateText();
@@ -176,7 +176,7 @@ bool CGUIEditControl::OnAction(const CAction &action)
     if (b == XBMCVK_BACK)
     {
       if (m_cursorPos > 0)
-      { // backspace
+      {
         if (!ClearMD5())
           m_text2.erase(--m_cursorPos, 1);
         UpdateText();

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -52,7 +52,6 @@
 
 static XBMCKey VK_keymap[XBMCK_LAST];
 static HKL hLayoutUS = NULL;
-static XBMCKey Arrows_keymap[4];
 
 static GUID USB_HID_GUID = { 0x4D1E55B2, 0xF16F, 0x11CF, { 0x88, 0xCB, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30 } };
 
@@ -228,11 +227,6 @@ void DIB_InitOSKeymap()
     VK_keymap[VK_LAUNCH_APP1]         = XBMCK_LAUNCH_APP1;
     VK_keymap[VK_LAUNCH_APP2]         = XBMCK_LAUNCH_APP2;
   }
-
-  Arrows_keymap[3] = (XBMCKey)0x25;
-  Arrows_keymap[2] = (XBMCKey)0x26;
-  Arrows_keymap[1] = (XBMCKey)0x27;
-  Arrows_keymap[0] = (XBMCKey)0x28;
 }
 
 static int XBMC_MapVirtualKey(int scancode, int vkey)


### PR DESCRIPTION
This is just housekeeping. It replaces literal values for the vkey codes by the symbols defined in XBMC_vkeys.h.
