### PR TITLE
release all refs to graphics context when entering modal dialogs

### DIFF
--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -252,6 +252,8 @@ void CGUIDialog::Close(bool forceClose /* = false */)
 
 void CGUIDialog::DoModal(int iWindowID /*= WINDOW_INVALID */, const CStdString &param)
 {
+  // make sure we hold no lock to graphics context
+  CSingleExit exit(g_graphicsContext);
   g_application.getApplicationMessenger().DoModal(this, iWindowID, param);
 }
 


### PR DESCRIPTION
If DoModal was called from application thread, it had still locked the graphics context.
