### PR TITLE
Tweens for containers and grouplists

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1032,12 +1032,12 @@ void CGUIBaseContainer::FreeMemory(int keepStart, int keepEnd)
   { // remove before keepStart and after keepEnd
     for (int i = 0; i < keepStart && i < (int)m_items.size(); ++i)
       m_items[i]->FreeMemory();
-    for (int i = keepEnd + 1; i < (int)m_items.size(); ++i)
+    for (int i = std::max(keepEnd + 1, 0); i < (int)m_items.size(); ++i)
       m_items[i]->FreeMemory();
   }
   else
   { // wrapping
-    for (int i = keepEnd + 1; i < keepStart && i < (int)m_items.size(); ++i)
+    for (int i = std::max(keepEnd + 1, 0); i < keepStart && i < (int)m_items.size(); ++i)
       m_items[i]->FreeMemory();
   }
 }

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -37,15 +37,12 @@ using namespace std;
 #define HOLD_TIME_START 100
 #define HOLD_TIME_END   3000
 
-CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, int scrollTime, int preloadItems)
+CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems)
     : CGUIControl(parentID, controlID, posX, posY, width, height)
+    , m_scroller(scroller)
 {
   m_cursor = 0;
   m_offset = 0;
-  m_scrollOffset = 0;
-  m_scrollSpeed = 0;
-  m_scrollLastTime = 0;
-  m_scrollTime = scrollTime ? scrollTime : 1;
   m_lastHoldTime = 0;
   m_itemsPerPage = 10;
   m_pageControl = 0;
@@ -84,7 +81,7 @@ void CGUIBaseContainer::Process(unsigned int currentTime, CDirtyRegionList &dirt
 
   UpdateScrollOffset(currentTime);
 
-  int offset = (int)floorf(m_scrollOffset / m_layout->Size(m_orientation));
+  int offset = (int)floorf(m_scroller.GetValue() / m_layout->Size(m_orientation));
 
   int cacheBefore, cacheAfter;
   GetCacheOffsets(cacheBefore, cacheAfter);
@@ -99,7 +96,7 @@ void CGUIBaseContainer::Process(unsigned int currentTime, CDirtyRegionList &dirt
 
   // we offset our draw position to take into account scrolling and whether or not our focused
   // item is offscreen "above" the list.
-  float drawOffset = (offset - cacheBefore) * m_layout->Size(m_orientation) - m_scrollOffset;
+  float drawOffset = (offset - cacheBefore) * m_layout->Size(m_orientation) - m_scroller.GetValue();
   if (GetOffset() + GetCursor() < offset)
     drawOffset += m_focusedLayout->Size(m_orientation) - m_layout->Size(m_orientation);
   pos += drawOffset;
@@ -187,7 +184,7 @@ void CGUIBaseContainer::Render()
 {
   if (!m_layout || !m_focusedLayout) return;
 
-  int offset = (int)floorf(m_scrollOffset / m_layout->Size(m_orientation));
+  int offset = (int)floorf(m_scroller.GetValue() / m_layout->Size(m_orientation));
 
   int cacheBefore, cacheAfter;
   GetCacheOffsets(cacheBefore, cacheAfter);
@@ -200,7 +197,7 @@ void CGUIBaseContainer::Render()
 
     // we offset our draw position to take into account scrolling and whether or not our focused
     // item is offscreen "above" the list.
-    float drawOffset = (offset - cacheBefore) * m_layout->Size(m_orientation) - m_scrollOffset;
+    float drawOffset = (offset - cacheBefore) * m_layout->Size(m_orientation) - m_scroller.GetValue();
     if (GetOffset() + GetCursor() < offset)
       drawOffset += m_focusedLayout->Size(m_orientation) - m_layout->Size(m_orientation);
     pos += drawOffset;
@@ -597,7 +594,7 @@ CGUIListItemPtr CGUIBaseContainer::GetListItem(int offset, unsigned int flag) co
     return CGUIListItemPtr();
   int item = GetSelectedItem() + offset;
   if (flag & INFOFLAG_LISTITEM_POSITION) // use offset from the first item displayed, taking into account scrolling
-    item = CorrectOffset((int)(m_scrollOffset / m_layout->Size(m_orientation)), offset);
+    item = CorrectOffset((int)(m_scroller.GetValue() / m_layout->Size(m_orientation)), offset);
 
   if (flag & INFOFLAG_LISTITEM_WRAP)
   {
@@ -659,9 +656,9 @@ EVENT_RESULT CGUIBaseContainer::OnMouseEvent(const CPoint &point, const CMouseEv
   }
   else if (event.m_id == ACTION_GESTURE_PAN)
   { // do the drag and validate our offset (corrects for end of scroll)
-    m_scrollOffset -= (m_orientation == HORIZONTAL) ? event.m_offsetX : event.m_offsetY;
+    m_scroller.SetValue(m_scroller.GetValue() - (m_orientation == HORIZONTAL) ? event.m_offsetX : event.m_offsetY);
     float size = (m_layout) ? m_layout->Size(m_orientation) : 10.0f;
-    int offset = (int)MathUtils::round_int(m_scrollOffset / size);
+    int offset = (int)MathUtils::round_int(m_scroller.GetValue() / size);
     m_scrollTimer.Start();
     SetOffset(offset);
     ValidateOffset();
@@ -673,7 +670,7 @@ EVENT_RESULT CGUIBaseContainer::OnMouseEvent(const CPoint &point, const CMouseEv
     SendWindowMessage(msg);
     // and compute the nearest offset from this and scroll there
     float size = (m_layout) ? m_layout->Size(m_orientation) : 10.0f;
-    float offset = m_scrollOffset / size;
+    float offset = m_scroller.GetValue() / size;
     int toOffset = (int)MathUtils::round_int(offset);
     if (toOffset < offset)
       SetOffset(toOffset+1);
@@ -773,7 +770,7 @@ void CGUIBaseContainer::FreeResources(bool immediately)
   { // free any static content
     Reset();
   }
-  m_scrollSpeed = 0;
+  m_scroller.Stop();
 }
 
 void CGUIBaseContainer::UpdateLayout(bool updateAllItems)
@@ -872,7 +869,7 @@ void CGUIBaseContainer::CalculateLayout()
   m_itemsPerPage = (int)((Size() - m_focusedLayout->Size(m_orientation)) / m_layout->Size(m_orientation)) + 1;
 
   // ensure that the scroll offset is a multiple of our size
-  m_scrollOffset = GetOffset() * m_layout->Size(m_orientation);
+  m_scroller.SetValue(GetOffset() * m_layout->Size(m_orientation));
 }
 
 void CGUIBaseContainer::UpdateScrollByLetter()
@@ -913,19 +910,19 @@ void CGUIBaseContainer::ScrollToOffset(int offset)
   float size = (m_layout) ? m_layout->Size(m_orientation) : 10.0f;
   int range = m_itemsPerPage / 4;
   if (range <= 0) range = 1;
-  if (offset * size < m_scrollOffset &&  m_scrollOffset - offset * size > size * range)
+  if (offset * size < m_scroller.GetValue() &&  m_scroller.GetValue() - offset * size > size * range)
   { // scrolling up, and we're jumping more than 0.5 of a screen
-    m_scrollOffset = (offset + range) * size;
+    m_scroller.SetValue((offset + range) * size);
   }
-  if (offset * size > m_scrollOffset && offset * size - m_scrollOffset > size * range)
+  if (offset * size > m_scroller.GetValue() && offset * size - m_scroller.GetValue() > size * range)
   { // scrolling down, and we're jumping more than 0.5 of a screen
-    m_scrollOffset = (offset - range) * size;
+    m_scroller.SetValue((offset - range) * size);
   }
-  m_scrollSpeed = (offset * size - m_scrollOffset) / m_scrollTime;
+  m_scroller.ScrollTo(offset * size);
   if (!m_wasReset)
   {
     SetContainerMoving(offset - GetOffset());
-    if (m_scrollSpeed)
+    if (m_scroller.IsScrolling())
       m_scrollTimer.Start();
     else
       m_scrollTimer.Stop();
@@ -936,22 +933,15 @@ void CGUIBaseContainer::ScrollToOffset(int offset)
 void CGUIBaseContainer::SetContainerMoving(int direction)
 {
   if (direction)
-    g_infoManager.SetContainerMoving(GetID(), direction > 0, m_scrollSpeed != 0);
+    g_infoManager.SetContainerMoving(GetID(), direction > 0, m_scroller.IsScrolling());
 }
 
 void CGUIBaseContainer::UpdateScrollOffset(unsigned int currentTime)
 {
-  if (m_scrollSpeed)
+  if (m_scroller.Update(currentTime))
     MarkDirtyRegion();
-  m_scrollOffset += m_scrollSpeed * (currentTime - m_scrollLastTime);
-  if ((m_scrollSpeed < 0 && m_scrollOffset < GetOffset() * m_layout->Size(m_orientation)) ||
-      (m_scrollSpeed > 0 && m_scrollOffset > GetOffset() * m_layout->Size(m_orientation)))
-  {
-    m_scrollOffset = GetOffset() * m_layout->Size(m_orientation);
-    m_scrollSpeed = 0;
+  else
     m_scrollTimer.Stop();
-  }
-  m_scrollLastTime = currentTime;
 }
 
 int CGUIBaseContainer::CorrectOffset(int offset, int cursor) const
@@ -1084,7 +1074,7 @@ bool CGUIBaseContainer::GetCondition(int condition, int data) const
       return layout ? (layout->GetFocusedItem() == (unsigned int)data) : false;
     }
   case CONTAINER_SCROLLING:
-    return (m_scrollTimer.GetElapsedMilliseconds() > m_scrollTime || m_pageChangeTimer.IsRunning());
+    return (m_scrollTimer.GetElapsedMilliseconds() > m_scroller.GetDuration() || m_pageChangeTimer.IsRunning());
   default:
     return false;
   }
@@ -1167,12 +1157,12 @@ int CGUIBaseContainer::GetCurrentPage() const
 
 void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter)
 {
-  if (m_scrollSpeed > 0)
+  if (m_scroller.IsScrollingDown())
   {
     cacheBefore = 0;
     cacheAfter = m_cacheItems;
   }
-  else if (m_scrollSpeed < 0)
+  else if (m_scroller.IsScrollingUp())
   {
     cacheBefore = m_cacheItems;
     cacheAfter = 0;

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -41,7 +41,7 @@ typedef boost::shared_ptr<CGUIListItem> CGUIListItemPtr;
 class CGUIBaseContainer : public CGUIControl
 {
 public:
-  CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, int scrollTime, int preloadItems);
+  CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
   virtual ~CGUIBaseContainer(void);
 
   virtual bool OnAction(const CAction &action);
@@ -151,9 +151,7 @@ protected:
   void SetContainerMoving(int direction);
   void UpdateScrollOffset(unsigned int currentTime);
 
-  unsigned int m_scrollLastTime;
-  int          m_scrollTime;
-  float        m_scrollOffset;
+  CScroller m_scroller;
 
   VIEW_TYPE m_type;
   CStdString m_label;
@@ -168,8 +166,8 @@ protected:
 
   void UpdateScrollByLetter();
   void GetCacheOffsets(int &cacheBefore, int &cacheAfter);
-  bool ScrollingDown() const { return m_scrollSpeed > 0; };
-  bool ScrollingUp() const { return m_scrollSpeed < 0; };
+  bool ScrollingDown() const { return m_scroller.IsScrollingDown(); };
+  bool ScrollingUp() const { return m_scroller.IsScrollingUp(); };
   void OnNextLetter();
   void OnPrevLetter();
   void OnJumpLetter(char letter);
@@ -194,7 +192,6 @@ private:
   int m_cursor;
   int m_offset;
   int m_cacheItems;
-  float m_scrollSpeed;
   CStopWatch m_scrollTimer;
   CStopWatch m_pageChangeTimer;
 

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1043,8 +1043,11 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   }
   else if (type == CGUIControl::GUICONTROL_GROUPLIST)
   {
+    CScroller scroller;
+    GetScroller(pControlNode, "scrolltime", scroller);
+
     control = new CGUIControlGroupList(
-      parentID, id, posX, posY, width, height, buttonGap, pageControl, orientation, useControlCoords, labelInfo.align, scrollTime);
+      parentID, id, posX, posY, width, height, buttonGap, pageControl, orientation, useControlCoords, labelInfo.align, scroller);
     ((CGUIControlGroup *)control)->SetRenderFocusedLast(renderFocusedLast);
   }
   else if (type == CGUIControl::GUICONTROL_LABEL)

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -452,6 +452,21 @@ bool CGUIControlFactory::GetHitRect(const TiXmlNode *control, CRect &rect)
   return false;
 }
 
+bool CGUIControlFactory::GetScroller(const TiXmlNode *control, const CStdString &scrollerTag, CScroller& scroller)
+{
+  const TiXmlElement* node = control->FirstChildElement(scrollerTag);
+  if (node)
+  {
+    unsigned int scrollTime;
+    if (XMLUtils::GetUInt(control, scrollerTag, scrollTime))
+    {
+      scroller = CScroller(scrollTime, CAnimEffect::GetTweener(node));
+      return true;
+    }
+  }
+  return false;
+}
+
 bool CGUIControlFactory::GetColor(const TiXmlNode *control, const char *strTag, color_t &value)
 {
   const TiXmlElement* node = control->FirstChildElement(strTag);

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1254,7 +1254,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   }
   else if (type == CGUIControl::GUICONTAINER_LIST)
   {
-    control = new CGUIListContainer(parentID, id, posX, posY, width, height, orientation, scrollTime, preloadItems);
+    CScroller scroller;
+    GetScroller(pControlNode, "scrolltime", scroller);
+
+    control = new CGUIListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems);
     ((CGUIListContainer *)control)->LoadLayout(pControlNode);
     ((CGUIListContainer *)control)->LoadContent(pControlNode);
     ((CGUIListContainer *)control)->SetType(viewType, viewLabel);
@@ -1263,7 +1266,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   }
   else if (type == CGUIControl::GUICONTAINER_WRAPLIST)
   {
-    control = new CGUIWrappingListContainer(parentID, id, posX, posY, width, height, orientation, scrollTime, preloadItems, focusPosition);
+    CScroller scroller;
+    GetScroller(pControlNode, "scrolltime", scroller);
+
+    control = new CGUIWrappingListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems, focusPosition);
     ((CGUIWrappingListContainer *)control)->LoadLayout(pControlNode);
     ((CGUIWrappingListContainer *)control)->LoadContent(pControlNode);
     ((CGUIWrappingListContainer *)control)->SetType(viewType, viewLabel);
@@ -1272,7 +1278,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   }
   else if (type == CGUIControl::GUICONTAINER_FIXEDLIST)
   {
-    control = new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation, scrollTime, preloadItems, focusPosition, iMovementRange);
+    CScroller scroller;
+    GetScroller(pControlNode, "scrolltime", scroller);
+
+    control = new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems, focusPosition, iMovementRange);
     ((CGUIFixedListContainer *)control)->LoadLayout(pControlNode);
     ((CGUIFixedListContainer *)control)->LoadContent(pControlNode);
     ((CGUIFixedListContainer *)control)->SetType(viewType, viewLabel);
@@ -1281,7 +1290,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   }
   else if (type == CGUIControl::GUICONTAINER_PANEL)
   {
-    control = new CGUIPanelContainer(parentID, id, posX, posY, width, height, orientation, scrollTime, preloadItems);
+    CScroller scroller;
+    GetScroller(pControlNode, "scrolltime", scroller); 
+
+    control = new CGUIPanelContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems);
     ((CGUIPanelContainer *)control)->LoadLayout(pControlNode);
     ((CGUIPanelContainer *)control)->LoadContent(pControlNode);
     ((CGUIPanelContainer *)control)->SetType(viewType, viewLabel);

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -100,6 +100,7 @@ public:
   static void GetRectFromString(const CStdString &string, CRect &rect);
   static bool GetAction(const TiXmlElement* pElement, CGUIActionDescriptor &action);
   static bool GetHitRect(const TiXmlNode* pRootNode, CRect &rect);
+  static bool GetScroller(const TiXmlNode *pControlNode, const CStdString &scrollerTag, CScroller& scroller);
 private:
   static CStdString GetType(const TiXmlElement *pControlNode);
   bool GetNavigation(const TiXmlElement *node, const char *tag, int &direction, std::vector<CGUIActionDescriptor> &actions);

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -25,19 +25,15 @@
 #include "GUIControlProfiler.h"
 #include "GUIFont.h" // for XBFONT_* definitions
 
-CGUIControlGroupList::CGUIControlGroupList(int parentID, int controlID, float posX, float posY, float width, float height, float itemGap, int pageControl, ORIENTATION orientation, bool useControlPositions, uint32_t alignment, unsigned int scrollTime)
+CGUIControlGroupList::CGUIControlGroupList(int parentID, int controlID, float posX, float posY, float width, float height, float itemGap, int pageControl, ORIENTATION orientation, bool useControlPositions, uint32_t alignment, const CScroller& scroller)
 : CGUIControlGroup(parentID, controlID, posX, posY, width, height)
+, m_scroller(scroller)
 {
   m_itemGap = itemGap;
   m_pageControl = pageControl;
-  m_offset = 0;
   m_totalSize = 10;
   m_orientation = orientation;
   m_alignment = alignment;
-  m_scrollOffset = 0;
-  m_scrollSpeed = 0;
-  m_scrollLastTime = 0;
-  m_scrollTime = scrollTime ? scrollTime : 1;
   m_useControlPositions = useControlPositions;
   ControlType = GUICONTROL_GROUPLIST;
 }
@@ -48,18 +44,8 @@ CGUIControlGroupList::~CGUIControlGroupList(void)
 
 void CGUIControlGroupList::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
-  if (m_scrollSpeed != 0)
-  {
+  if (m_scroller.Update(currentTime))
     MarkDirtyRegion();
-    m_offset += m_scrollSpeed * (currentTime - m_scrollLastTime);
-    if ((m_scrollSpeed < 0 && m_offset < m_scrollOffset) ||
-        (m_scrollSpeed > 0 && m_offset > m_scrollOffset))
-    {
-      m_offset = m_scrollOffset;
-      m_scrollSpeed = 0;
-    }
-  }
-  m_scrollLastTime = currentTime;
 
   // first we update visibility of all our items, to ensure our size and
   // alignment computations are correct.
@@ -76,7 +62,7 @@ void CGUIControlGroupList::Process(unsigned int currentTime, CDirtyRegionList &d
   {
     CGUIMessage message(GUI_MSG_LABEL_RESET, GetParentID(), m_pageControl, (int)m_height, (int)m_totalSize);
     SendWindowMessage(message);
-    CGUIMessage message2(GUI_MSG_ITEM_SELECT, GetParentID(), m_pageControl, (int)m_offset);
+    CGUIMessage message2(GUI_MSG_ITEM_SELECT, GetParentID(), m_pageControl, (int)m_scroller.GetValue());
     SendWindowMessage(message2);
   }
   // we run through the controls, rendering as we go
@@ -87,9 +73,9 @@ void CGUIControlGroupList::Process(unsigned int currentTime, CDirtyRegionList &d
     // with respect to animations
     CGUIControl *control = *it;
     if (m_orientation == VERTICAL)
-      g_graphicsContext.SetOrigin(m_posX, m_posY + pos - m_offset);
+      g_graphicsContext.SetOrigin(m_posX, m_posY + pos - m_scroller.GetValue());
     else
-      g_graphicsContext.SetOrigin(m_posX + pos - m_offset, m_posY);
+      g_graphicsContext.SetOrigin(m_posX + pos - m_scroller.GetValue(), m_posY);
     control->DoProcess(currentTime, dirtyregions);
 
     if (control->IsVisible())
@@ -119,9 +105,9 @@ void CGUIControlGroupList::Render()
     else
     {
       if (m_orientation == VERTICAL)
-        g_graphicsContext.SetOrigin(m_posX, m_posY + pos - m_offset);
+        g_graphicsContext.SetOrigin(m_posX, m_posY + pos - m_scroller.GetValue());
       else
-        g_graphicsContext.SetOrigin(m_posX + pos - m_offset, m_posY);
+        g_graphicsContext.SetOrigin(m_posX + pos - m_scroller.GetValue(), m_posY);
       control->DoRender();
     }
     if (control->IsVisible())
@@ -131,9 +117,9 @@ void CGUIControlGroupList::Render()
   if (focusedControl)
   {
     if (m_orientation == VERTICAL)
-      g_graphicsContext.SetOrigin(m_posX, m_posY + focusedPos - m_offset);
+      g_graphicsContext.SetOrigin(m_posX, m_posY + focusedPos - m_scroller.GetValue());
     else
-      g_graphicsContext.SetOrigin(m_posX + focusedPos - m_offset, m_posY);
+      g_graphicsContext.SetOrigin(m_posX + focusedPos - m_scroller.GetValue(), m_posY);
     focusedControl->DoRender();
   }
   if (render) g_graphicsContext.RestoreClipRegion();
@@ -161,9 +147,9 @@ bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
             ScrollTo(0);
           else if (IsLastFocusableControl(control))
             ScrollTo(m_totalSize - Size());
-          else if (offset < m_offset)
+          else if (offset < m_scroller.GetValue())
             ScrollTo(offset);
-          else if (offset + Size(control) > m_offset + Size())
+          else if (offset + Size(control) > m_scroller.GetValue() + Size())
             ScrollTo(offset + Size(control) - Size());
           break;
         }
@@ -185,7 +171,7 @@ bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
           continue;
         if (control->HasID(m_focusedControl))
         {
-          if (offset >= m_offset && offset + Size(control) <= m_offset + Size())
+          if (offset >= m_scroller.GetValue() && offset + Size(control) <= m_scroller.GetValue() + Size())
             return CGUIControlGroup::OnMessage(message);
           break;
         }
@@ -198,7 +184,7 @@ bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
         CGUIControl *control = *it;
         if (!control->IsVisible())
           continue;
-        if (control->CanFocus() && offset >= m_offset && offset + Size(control) <= m_offset + Size())
+        if (control->CanFocus() && offset >= m_scroller.GetValue() && offset + Size(control) <= m_scroller.GetValue() + Size())
         {
           m_focusedControl = control->GetID();
           break;
@@ -232,9 +218,9 @@ void CGUIControlGroupList::ValidateOffset()
   }
   if (m_totalSize > 0) m_totalSize -= m_itemGap;
   // check our m_offset range
-  if (m_offset > m_totalSize - Size())
-    m_offset = m_totalSize - Size();
-  if (m_offset < 0) m_offset = 0;
+  if (m_scroller.GetValue() > m_totalSize - Size())
+    m_scroller.SetValue(m_totalSize - Size());
+  if (m_scroller.GetValue() < 0) m_scroller.SetValue(0);
 }
 
 void CGUIControlGroupList::AddControl(CGUIControl *control, int position /*= -1*/)
@@ -316,7 +302,7 @@ void CGUIControlGroupList::AddControl(CGUIControl *control, int position /*= -1*
 void CGUIControlGroupList::ClearAll()
 {
   CGUIControlGroup::ClearAll();
-  m_offset = 0;
+  m_scroller.SetValue(0);
 }
 
 inline float CGUIControlGroupList::Size(const CGUIControl *control) const
@@ -331,9 +317,8 @@ inline float CGUIControlGroupList::Size() const
 
 void CGUIControlGroupList::ScrollTo(float offset)
 {
-  m_scrollOffset = offset;
-  m_scrollSpeed = (m_scrollOffset - m_offset) / m_scrollTime;
-  if (m_scrollSpeed)
+  m_scroller.ScrollTo(offset);
+  if (m_scroller.IsScrolling())
     SetInvalid();
 }
 
@@ -351,10 +336,10 @@ EVENT_RESULT CGUIControlGroupList::SendMouseEvent(const CPoint &point, const CMo
       CGUIControl *child = *i;
       if (child->IsVisible())
       {
-        if (pos + Size(child) > m_offset && pos < m_offset + Size())
+        if (pos + Size(child) > m_scroller.GetValue() && pos < m_scroller.GetValue() + Size())
         { // we're on screen
-          float offsetX = m_orientation == VERTICAL ? m_posX : m_posX + alignOffset + pos - m_offset;
-          float offsetY = m_orientation == VERTICAL ? m_posY + alignOffset + pos - m_offset : m_posY;
+          float offsetX = m_orientation == VERTICAL ? m_posX : m_posX + alignOffset + pos - m_scroller.GetValue();
+          float offsetY = m_orientation == VERTICAL ? m_posY + alignOffset + pos - m_scroller.GetValue() : m_posY;
           EVENT_RESULT ret = child->SendMouseEvent(childPoint - CPoint(offsetX, offsetY), event);
           if (ret)
           { // we've handled the action, and/or have focused an item
@@ -384,9 +369,9 @@ void CGUIControlGroupList::UnfocusFromPoint(const CPoint &point)
     CGUIControl *child = *it;
     if (child->IsVisible())
     {
-      if (pos + Size(child) > m_offset && pos < m_offset + Size())
+      if (pos + Size(child) > m_scroller.GetValue() && pos < m_scroller.GetValue() + Size())
       { // we're on screen
-        CPoint offset = (m_orientation == VERTICAL) ? CPoint(m_posX, m_posY + alignOffset + pos - m_offset) : CPoint(m_posX + alignOffset + pos - m_offset, m_posY);
+        CPoint offset = (m_orientation == VERTICAL) ? CPoint(m_posX, m_posY + alignOffset + pos - m_scroller.GetValue()) : CPoint(m_posX + alignOffset + pos - m_scroller.GetValue(), m_posY);
         child->UnfocusFromPoint(controlCoords - offset);
       }
       pos += Size(child) + m_itemGap;
@@ -400,9 +385,9 @@ bool CGUIControlGroupList::GetCondition(int condition, int data) const
   switch (condition)
   {
   case CONTAINER_HAS_NEXT:
-    return (m_totalSize >= Size() && m_offset < m_totalSize - Size());
+    return (m_totalSize >= Size() && m_scroller.GetValue() < m_totalSize - Size());
   case CONTAINER_HAS_PREVIOUS:
-    return (m_offset > 0);
+    return (m_scroller.GetValue() > 0);
   default:
     return false;
   }
@@ -457,12 +442,12 @@ EVENT_RESULT CGUIControlGroupList::OnMouseEvent(const CPoint &point, const CMous
       CGUIControl *control = *it;
       if (!control->IsVisible()) continue;
       float nextOffset = offset + Size(control) + m_itemGap;
-      if (event.m_id == ACTION_MOUSE_WHEEL_DOWN && nextOffset > m_offset && m_offset < m_totalSize - Size()) // past our current offset
+      if (event.m_id == ACTION_MOUSE_WHEEL_DOWN && nextOffset > m_scroller.GetValue() && m_scroller.GetValue() < m_totalSize - Size()) // past our current offset
       {
         ScrollTo(nextOffset);
         return EVENT_RESULT_HANDLED;
       }
-      else if (event.m_id == ACTION_MOUSE_WHEEL_UP && nextOffset >= m_offset && m_offset > 0) // at least at our current offset
+      else if (event.m_id == ACTION_MOUSE_WHEEL_UP && nextOffset >= m_scroller.GetValue() && m_scroller.GetValue() > 0) // at least at our current offset
       {
         ScrollTo(offset);
         return EVENT_RESULT_HANDLED;

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -35,7 +35,7 @@
 class CGUIControlGroupList : public CGUIControlGroup
 {
 public:
-  CGUIControlGroupList(int parentID, int controlID, float posX, float posY, float width, float height, float itemGap, int pageControl, ORIENTATION orientation, bool useControlPositions, uint32_t alignment, unsigned int scrollTime);
+  CGUIControlGroupList(int parentID, int controlID, float posX, float posY, float width, float height, float itemGap, int pageControl, ORIENTATION orientation, bool useControlPositions, uint32_t alignment, const CScroller& scroller);
   virtual ~CGUIControlGroupList(void);
   virtual CGUIControlGroupList *Clone() const { return new CGUIControlGroupList(*this); };
 
@@ -63,13 +63,9 @@ protected:
   float m_itemGap;
   int m_pageControl;
 
-  float m_offset; // measurement in pixels of our origin
   float m_totalSize;
 
-  float m_scrollSpeed;
-  float m_scrollOffset;
-  unsigned int m_scrollLastTime;
-  unsigned int m_scrollTime;
+  CScroller m_scroller;
 
   bool m_useControlPositions;
   ORIENTATION m_orientation;

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -23,8 +23,8 @@
 #include "GUIListItem.h"
 #include "Key.h"
 
-CGUIFixedListContainer::CGUIFixedListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, int scrollTime, int preloadItems, int fixedPosition, int cursorRange)
-    : CGUIBaseContainer(parentID, controlID, posX, posY, width, height, orientation, scrollTime, preloadItems)
+CGUIFixedListContainer::CGUIFixedListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems, int fixedPosition, int cursorRange)
+    : CGUIBaseContainer(parentID, controlID, posX, posY, width, height, orientation, scroller, preloadItems)
 {
   ControlType = GUICONTAINER_FIXEDLIST;
   m_type = VIEW_TYPE_LIST;
@@ -148,15 +148,15 @@ void CGUIFixedListContainer::ValidateOffset()
   SetCursor(std::max(GetCursor(), minCursor));
   SetCursor(std::min(GetCursor(), maxCursor));
   // and finally ensure our offset is valid
-  if (GetOffset() + maxCursor >= (int)m_items.size() || m_scrollOffset > ((int)m_items.size() - maxCursor - 1) * m_layout->Size(m_orientation))
+  if (GetOffset() + maxCursor >= (int)m_items.size() || m_scroller.GetValue() > ((int)m_items.size() - maxCursor - 1) * m_layout->Size(m_orientation))
   {
     SetOffset(std::max(-minCursor, (int)m_items.size() - maxCursor - 1));
-    m_scrollOffset = GetOffset() * m_layout->Size(m_orientation);
+    m_scroller.SetValue(GetOffset() * m_layout->Size(m_orientation));
   }
-  if (GetOffset() < -minCursor || m_scrollOffset < -minCursor * m_layout->Size(m_orientation))
+  if (GetOffset() < -minCursor || m_scroller.GetValue() < -minCursor * m_layout->Size(m_orientation))
   {
     SetOffset(-minCursor);
-    m_scrollOffset = GetOffset() * m_layout->Size(m_orientation);
+    m_scroller.SetValue(GetOffset() * m_layout->Size(m_orientation));
   }
 }
 

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -148,12 +148,13 @@ void CGUIFixedListContainer::ValidateOffset()
   SetCursor(std::max(GetCursor(), minCursor));
   SetCursor(std::min(GetCursor(), maxCursor));
   // and finally ensure our offset is valid
-  if (GetOffset() + maxCursor >= (int)m_items.size() || m_scroller.GetValue() > ((int)m_items.size() - maxCursor - 1) * m_layout->Size(m_orientation))
+  // don't validate offset if we are scrolling in case the tween image exceed <0, 1> range
+  if (GetOffset() + maxCursor >= (int)m_items.size() || (!m_scroller.IsScrolling() && m_scroller.GetValue() > ((int)m_items.size() - maxCursor - 1) * m_layout->Size(m_orientation)))
   {
     SetOffset(std::max(-minCursor, (int)m_items.size() - maxCursor - 1));
     m_scroller.SetValue(GetOffset() * m_layout->Size(m_orientation));
   }
-  if (GetOffset() < -minCursor || m_scroller.GetValue() < -minCursor * m_layout->Size(m_orientation))
+  if (GetOffset() < -minCursor || (!m_scroller.IsScrolling() && m_scroller.GetValue() < -minCursor * m_layout->Size(m_orientation)))
   {
     SetOffset(-minCursor);
     m_scroller.SetValue(GetOffset() * m_layout->Size(m_orientation));

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -125,9 +125,9 @@ void CGUIFixedListContainer::Scroll(int amount)
     offset = -minCursor;
     SetCursor(minCursor);
   }
-  if (offset > (int)m_items.size() - maxCursor)
+  if (offset > (int)m_items.size() - 1 - maxCursor)
   {
-    offset = m_items.size() - maxCursor;
+    offset = m_items.size() - 1 - maxCursor;
     SetCursor(maxCursor);
   }
   ScrollToOffset(offset);

--- a/xbmc/guilib/GUIFixedListContainer.h
+++ b/xbmc/guilib/GUIFixedListContainer.h
@@ -35,7 +35,7 @@
 class CGUIFixedListContainer : public CGUIBaseContainer
 {
 public:
-  CGUIFixedListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, int scrollTime, int preloadItems, int fixedPosition, int cursorRange);
+  CGUIFixedListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems, int fixedPosition, int cursorRange);
   virtual ~CGUIFixedListContainer(void);
   virtual CGUIFixedListContainer *Clone() const { return new CGUIFixedListContainer(*this); };
 

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -24,8 +24,8 @@
 #include "GUIInfoManager.h"
 #include "Key.h"
 
-CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, int scrollTime, int preloadItems)
-    : CGUIBaseContainer(parentID, controlID, posX, posY, width, height, orientation, scrollTime, preloadItems)
+CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems)
+    : CGUIBaseContainer(parentID, controlID, posX, posY, width, height, orientation, scroller, preloadItems)
 {
   ControlType = GUICONTAINER_LIST;
   m_type = VIEW_TYPE_LIST;
@@ -196,15 +196,15 @@ void CGUIListContainer::Scroll(int amount)
 void CGUIListContainer::ValidateOffset()
 { // first thing is we check the range of our offset
   if (!m_layout) return;
-  if (GetOffset() > (int)m_items.size() - m_itemsPerPage || m_scrollOffset > ((int)m_items.size() - m_itemsPerPage) * m_layout->Size(m_orientation))
+  if (GetOffset() > (int)m_items.size() - m_itemsPerPage || m_scroller.GetValue() > ((int)m_items.size() - m_itemsPerPage) * m_layout->Size(m_orientation))
   {
     SetOffset(std::max(0, (int)m_items.size() - m_itemsPerPage));
-    m_scrollOffset = GetOffset() * m_layout->Size(m_orientation);
+    m_scroller.SetValue(GetOffset() * m_layout->Size(m_orientation));
   }
-  if (GetOffset() < 0 || m_scrollOffset < 0)
+  if (GetOffset() < 0 || m_scroller.GetValue() < 0)
   {
     SetOffset(0);
-    m_scrollOffset = 0;
+    m_scroller.SetValue(0);
   }
 }
 

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -194,14 +194,16 @@ void CGUIListContainer::Scroll(int amount)
 }
 
 void CGUIListContainer::ValidateOffset()
-{ // first thing is we check the range of our offset
+{
   if (!m_layout) return;
-  if (GetOffset() > (int)m_items.size() - m_itemsPerPage || m_scroller.GetValue() > ((int)m_items.size() - m_itemsPerPage) * m_layout->Size(m_orientation))
+  // first thing is we check the range of our offset
+  // don't validate offset if we are scrolling in case the tween image exceed <0, 1> range
+  if (GetOffset() > (int)m_items.size() - m_itemsPerPage || (!m_scroller.IsScrolling() && m_scroller.GetValue() > ((int)m_items.size() - m_itemsPerPage) * m_layout->Size(m_orientation)))
   {
     SetOffset(std::max(0, (int)m_items.size() - m_itemsPerPage));
     m_scroller.SetValue(GetOffset() * m_layout->Size(m_orientation));
   }
-  if (GetOffset() < 0 || m_scroller.GetValue() < 0)
+  if (GetOffset() < 0 || (!m_scroller.IsScrolling() && m_scroller.GetValue() < 0))
   {
     SetOffset(0);
     m_scroller.SetValue(0);

--- a/xbmc/guilib/GUIListContainer.h
+++ b/xbmc/guilib/GUIListContainer.h
@@ -35,7 +35,7 @@
 class CGUIListContainer : public CGUIBaseContainer
 {
 public:
-  CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, int scrollTime, int preloadItems);
+  CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
 //#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
   CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height,
                          const CLabelInfo& labelInfo, const CLabelInfo& labelInfo2,

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -384,14 +384,16 @@ void CGUIPanelContainer::Scroll(int amount)
 }
 
 void CGUIPanelContainer::ValidateOffset()
-{ // first thing is we check the range of our offset
+{
   if (!m_layout) return;
-  if (GetOffset() > (int)GetRows() - m_itemsPerPage || m_scroller.GetValue() > ((int)GetRows() - m_itemsPerPage) * m_layout->Size(m_orientation))
+  // first thing is we check the range of our offset
+  // don't validate offset if we are scrolling in case the tween image exceed <0, 1> range
+  if (GetOffset() > (int)GetRows() - m_itemsPerPage || (!m_scroller.IsScrolling() && m_scroller.GetValue() > ((int)GetRows() - m_itemsPerPage) * m_layout->Size(m_orientation)))
   {
     SetOffset(std::max(0, (int)GetRows() - m_itemsPerPage));
     m_scroller.SetValue(GetOffset() * m_layout->Size(m_orientation));
   }
-  if (GetOffset() < 0 || m_scroller.GetValue() < 0)
+  if (GetOffset() < 0 || (!m_scroller.IsScrolling() && m_scroller.GetValue() < 0))
   {
     SetOffset(0);
     m_scroller.SetValue(0);

--- a/xbmc/guilib/GUIPanelContainer.h
+++ b/xbmc/guilib/GUIPanelContainer.h
@@ -35,7 +35,7 @@
 class CGUIPanelContainer : public CGUIBaseContainer
 {
 public:
-  CGUIPanelContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, int scrollTime, int preloadItems);
+  CGUIPanelContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
   virtual ~CGUIPanelContainer(void);
   virtual CGUIPanelContainer *Clone() const { return new CGUIPanelContainer(*this); };
 

--- a/xbmc/guilib/GUIWrappingListContainer.cpp
+++ b/xbmc/guilib/GUIWrappingListContainer.cpp
@@ -24,8 +24,8 @@
 #include "Key.h"
 #include "utils/log.h"
 
-CGUIWrappingListContainer::CGUIWrappingListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, int scrollTime, int preloadItems, int fixedPosition)
-    : CGUIBaseContainer(parentID, controlID, posX, posY, width, height, orientation, scrollTime, preloadItems)
+CGUIWrappingListContainer::CGUIWrappingListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems, int fixedPosition)
+    : CGUIBaseContainer(parentID, controlID, posX, posY, width, height, orientation, scroller, preloadItems)
 {
   SetCursor(fixedPosition);
   ControlType = GUICONTAINER_WRAPLIST;

--- a/xbmc/guilib/GUIWrappingListContainer.h
+++ b/xbmc/guilib/GUIWrappingListContainer.h
@@ -34,7 +34,7 @@
 class CGUIWrappingListContainer : public CGUIBaseContainer
 {
 public:
-  CGUIWrappingListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, int scrollTime, int preloadItems, int fixedPosition);
+  CGUIWrappingListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems, int fixedPosition);
   virtual ~CGUIWrappingListContainer(void);
   virtual CGUIWrappingListContainer *Clone() const { return new CGUIWrappingListContainer(*this); };
 

--- a/xbmc/guilib/Tween.h
+++ b/xbmc/guilib/Tween.h
@@ -69,7 +69,7 @@ public:
   virtual float Tween(float time, float start, float change, float duration)=0;
   void Free() { _ref--; if (_ref==0) delete this; }
   void IncRef() { _ref++; }
-
+  virtual bool HasResumePoint() const { return m_tweenerType == EASE_INOUT; }
 protected:
   int _ref;
   TweenerType m_tweenerType;
@@ -83,6 +83,7 @@ public:
   {
     return change * time / duration + start;
   }
+  virtual bool HasResumePoint() const { return false; }
 };
 
 
@@ -213,7 +214,6 @@ public:
       }
     return change * ((time-1) * time * ((s + 1) * time + s) + 1) + start;
   }
-
 private:
   float _s;
 
@@ -270,7 +270,6 @@ public:
 
     return easeOut(time, start, change, duration);
   }
-
 protected:
   float easeOut(float time, float start, float change, float duration)
   {
@@ -314,7 +313,6 @@ public:
       }
     return easeOut(time, start, change, duration);
   }
-
 protected:
   float _a;
   float _p;

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -41,52 +41,7 @@ CAnimEffect::CAnimEffect(const TiXmlElement *node, EFFECT_TYPE effect)
   if (TIXML_SUCCESS == node->QueryFloatAttribute("time", &temp)) m_length = (unsigned int)(temp * g_SkinInfo->GetEffectsSlowdown());
   if (TIXML_SUCCESS == node->QueryFloatAttribute("delay", &temp)) m_delay = (unsigned int)(temp * g_SkinInfo->GetEffectsSlowdown());
 
-  const char *tween = node->Attribute("tween");
-  if (tween)
-  {
-    if (strcmpi(tween, "linear")==0)
-      m_pTweener = new LinearTweener();
-    else if (strcmpi(tween, "quadratic")==0)
-      m_pTweener = new QuadTweener();
-    else if (strcmpi(tween, "cubic")==0)
-      m_pTweener = new CubicTweener();
-    else if (strcmpi(tween, "sine")==0)
-      m_pTweener = new SineTweener();
-    else if (strcmpi(tween, "back")==0)
-      m_pTweener = new BackTweener();
-    else if (strcmpi(tween, "circle")==0)
-      m_pTweener = new CircleTweener();
-    else if (strcmpi(tween, "bounce")==0)
-      m_pTweener = new BounceTweener();
-    else if (strcmpi(tween, "elastic")==0)
-      m_pTweener = new ElasticTweener();
-
-    const char *easing = node->Attribute("easing");
-    if (m_pTweener && easing)
-    {
-      if (strcmpi(easing, "in")==0)
-        m_pTweener->SetEasing(EASE_IN);
-      else if (strcmpi(easing, "out")==0)
-        m_pTweener->SetEasing(EASE_OUT);
-      else if (strcmpi(easing, "inout")==0)
-        m_pTweener->SetEasing(EASE_INOUT);
-    }
-  }
-
-  float accel = 0;
-  node->QueryFloatAttribute("acceleration", &accel);
-
-  if (!m_pTweener)
-  { // no tweener is specified - use a linear tweener
-    // or quadratic if we have acceleration
-    if (accel)
-    {
-      m_pTweener = new QuadTweener(accel);
-      m_pTweener->SetEasing(EASE_IN);
-    }
-    else
-      m_pTweener = new LinearTweener();
-  }
+  m_pTweener = GetTweener(node);
 }
 
 CAnimEffect::CAnimEffect(unsigned int delay, unsigned int length, EFFECT_TYPE effect)
@@ -145,6 +100,59 @@ void CAnimEffect::ApplyState(ANIMATION_STATE state, const CPoint &center)
 {
   float offset = (state == ANIM_STATE_APPLIED) ? 1.0f : 0.0f;
   ApplyEffect(offset, center);
+}
+
+Tweener* CAnimEffect::GetTweener(const TiXmlElement *pAnimationNode)
+{
+  Tweener* m_pTweener = NULL;
+  const char *tween = pAnimationNode->Attribute("tween");
+  if (tween)
+  {
+    if (strcmpi(tween, "linear")==0)
+      m_pTweener = new LinearTweener();
+    else if (strcmpi(tween, "quadratic")==0)
+      m_pTweener = new QuadTweener();
+    else if (strcmpi(tween, "cubic")==0)
+      m_pTweener = new CubicTweener();
+    else if (strcmpi(tween, "sine")==0)
+      m_pTweener = new SineTweener();
+    else if (strcmpi(tween, "back")==0)
+      m_pTweener = new BackTweener();
+    else if (strcmpi(tween, "circle")==0)
+      m_pTweener = new CircleTweener();
+    else if (strcmpi(tween, "bounce")==0)
+      m_pTweener = new BounceTweener();
+    else if (strcmpi(tween, "elastic")==0)
+      m_pTweener = new ElasticTweener();
+
+    const char *easing = pAnimationNode->Attribute("easing");
+    if (m_pTweener && easing)
+    {
+      if (strcmpi(easing, "in")==0)
+        m_pTweener->SetEasing(EASE_IN);
+      else if (strcmpi(easing, "out")==0)
+        m_pTweener->SetEasing(EASE_OUT);
+      else if (strcmpi(easing, "inout")==0)
+        m_pTweener->SetEasing(EASE_INOUT);
+    }
+  }
+
+  float accel = 0;
+  pAnimationNode->QueryFloatAttribute("acceleration", &accel);
+
+  if (!m_pTweener)
+  { // no tweener is specified - use a linear tweener
+    // or quadratic if we have acceleration
+    if (accel)
+    {
+      m_pTweener = new QuadTweener(accel);
+      m_pTweener->SetEasing(EASE_IN);
+    }
+    else
+      m_pTweener = new LinearTweener();
+  }
+
+  return m_pTweener;
 }
 
 CFadeEffect::CFadeEffect(const TiXmlElement *node, bool reverseDefaults) : CAnimEffect(node, EFFECT_TYPE_FADE)
@@ -695,4 +703,106 @@ void CAnimation::AddEffect(CAnimEffect *effect)
   // our length is the maximum of all the effect lengths
   if (effect->GetLength() > m_delay + m_length)
     m_length = effect->GetLength() - m_delay;
+}
+
+CScroller::CScroller(unsigned int duration /* = 200 */, Tweener *tweener /* = NULL */)
+{
+  m_scrollValue = 0;
+  m_delta = 0;
+  m_startTime = 0;
+  m_startPosition = 0;
+  m_hasResumePoint = false;
+  m_lastTime = 0;
+  m_duration = duration > 0 ? duration : 1;
+  m_pTweener = tweener;
+  if (m_pTweener) m_pTweener->IncRef();
+}
+
+CScroller::CScroller(const CScroller& right)
+{
+  m_pTweener = NULL;
+  *this = right;
+}
+
+const CScroller &CScroller::operator=(const CScroller &right)
+{
+  if (&right == this) return *this;
+
+  m_scrollValue = right.m_scrollValue;
+  m_delta = right.m_delta;
+  m_startTime = right.m_startTime;
+  m_startPosition = right.m_startPosition;
+  m_hasResumePoint = right.m_hasResumePoint;
+  m_lastTime = right.m_lastTime;
+  m_duration = right.m_duration;
+  if (m_pTweener)
+    m_pTweener->Free();
+  m_pTweener = right.m_pTweener;
+  if (m_pTweener)
+    m_pTweener->IncRef();
+  return *this;
+}
+
+CScroller::~CScroller()
+{
+  if (m_pTweener) m_pTweener->Free();
+}
+
+void CScroller::ScrollTo(float endPos)
+{
+  float delta = endPos - m_scrollValue;
+    // if there is scrolling running in same direction - set resume point
+  m_hasResumePoint = m_delta != 0 && delta * m_delta > 0 && m_pTweener ? m_pTweener->HasResumePoint() : 0;
+
+  m_delta = delta;
+  m_startPosition = m_scrollValue;
+  m_startTime = m_lastTime;
+}
+
+float CScroller::Tween(float progress)
+{
+  if (m_pTweener)
+  {
+    if (m_hasResumePoint) // tweener with in_and_out easing
+    {
+      // time linear transformation (y = a*x + b): 0 -> resumePoint and 1 -> 1
+      // resumePoint = a * 0 + b and 1 = a * 1 + b
+      // a = 1 - resumePoint , b = resumePoint
+      // our resume point is 0.5
+      // a = 0.5 , b = 0.5
+      progress = 0.5f * progress + 0.5f;
+      // tweener value linear transformation (y = a*x + b): resumePointValue -> 0 and 1 -> 1
+      // 0 = a * resumePointValue and 1 = a * 1 + b
+      // a = 1 / ( 1 - resumePointValue) , b = -resumePointValue / (1 - resumePointValue)
+      // we assume resumePointValue = Tween(resumePoint) = Tween(0.5) = 0.5
+      // (this is true for tweener with in_and_out easing - it's rotationally symmetric about (0.5,0.5) continuous function)
+      // a = 2 , b = -1
+      return (2 * m_pTweener->Tween(progress, 0, 1, 1) - 1);
+    }
+    else 
+      return m_pTweener->Tween(progress, 0, 1, 1);
+  }
+  else
+    return progress;
+}
+
+bool CScroller::Update(unsigned int time)
+{
+  m_lastTime = time;
+  if (m_delta != 0)
+  {
+    if (time - m_startTime >= m_duration) // we are finished
+    {
+      m_scrollValue = m_startPosition + m_delta;
+      m_startTime = 0;
+      m_hasResumePoint = false;
+      m_delta = 0;
+      m_startPosition = 0;
+    }
+    else
+      m_scrollValue = m_startPosition + Tween((float)(time - m_startTime) / m_duration) * m_delta;
+    return true;
+  }
+  else
+    return false;
 }

--- a/xbmc/guilib/VisibleEffect.h
+++ b/xbmc/guilib/VisibleEffect.h
@@ -66,6 +66,7 @@ public:
   const TransformMatrix &GetTransform() const { return m_matrix; };
   EFFECT_TYPE GetType() const { return m_effect; };
 
+  static Tweener* GetTweener(const TiXmlElement *pAnimationNode);
 protected:
   TransformMatrix m_matrix;
   EFFECT_TYPE m_effect;
@@ -201,4 +202,61 @@ private:
   unsigned int m_amount;
 
   std::vector<CAnimEffect *> m_effects;
+};
+
+/**
+ * Class used to handle scrolling, allow using tweeners.
+ * Usage:
+ *   start scrolling using ScrollTo() method / stop scrolling using Stop() method
+ *   update scroll value each frame with current time using Update() method
+ *   get/set scroll value using GetValue()/SetValue()
+ */
+class CScroller
+{
+public:
+  CScroller(unsigned int duration = 200, Tweener *tweener = NULL);
+  CScroller(const CScroller& right);
+  const CScroller &operator=(const CScroller &src);
+  ~CScroller();
+
+  /**
+   * Set target value scroller will be scrolling to
+   * @param endPos target 
+   */
+  void ScrollTo(float endPos);
+  
+  /**
+   * Immediately stop scrolling
+   */
+  void Stop() { m_delta = 0; };
+  /**
+   * Update the scroller to where it would be at the given time point, calculating a new Value.
+   * @param time time point
+   * @return True if we are scrolling at given time point
+   */
+  bool Update(unsigned int time);
+
+  /**
+   * Value of scroll
+   */
+  float GetValue() const { return m_scrollValue; };
+  void SetValue(float scrollValue) { m_scrollValue = scrollValue; };
+
+  bool IsScrolling() const { return m_delta != 0; };
+  bool IsScrollingUp() const { return m_delta < 0; };
+  bool IsScrollingDown() const { return m_delta > 0; };
+
+  unsigned int GetDuration() const { return m_duration; };
+private:
+  float Tween(float progress);
+
+  float        m_scrollValue;
+  float        m_delta;                   //!< Brief distance that we have to travel during scroll
+  float        m_startPosition;           //!< Brief starting position of scroll
+  bool         m_hasResumePoint;          //!< Brief check if we should tween from middle of the tween
+  unsigned int m_startTime;               //!< Brief starting time of scroll
+  unsigned int m_lastTime;                //!< Brief last remember time (updated each time Scroll() method is called)
+
+  unsigned int m_duration;                //!< Brief duration of scroll
+  Tweener* m_pTweener;
 };


### PR DESCRIPTION
This adds basic tween support for containers and grouplists.

usage:

<pre>&lt;scrolltime tween="sine" easing="out"&gt;500&lt;/scrolltime&gt;</pre>


Some basic math when applying new scroll over already running scroll is presented here: http://dl.dropbox.com/u/28792047/xbmc/scroll_tweening.png

New class handling scrolling is added in existing guilib/VisibleEffect.h/cpp currently - if requested will move to seperate files.
