### PR TITLE
[fix] - don't open the osd modal dialog if it is already opened

### DIFF
--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -678,8 +678,9 @@ EVENT_RESULT CGUIWindowFullScreen::OnMouseEvent(const CPoint &point, const CMous
   }
   if (event.m_id != ACTION_MOUSE_MOVE || event.m_offsetX || event.m_offsetY)
   { // some other mouse action has occurred - bring up the OSD
+    // if it is not already running
     CGUIDialogVideoOSD *pOSD = (CGUIDialogVideoOSD *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_OSD);
-    if (pOSD)
+    if (pOSD && !pOSD->IsDialogRunning())
     {
       pOSD->SetAutoClose(3000);
       pOSD->DoModal();


### PR DESCRIPTION
This is a fix which i had to do in preparation for getting scrollbars and slidecontrols gesture_pan aware.

I want to ask the control if it wants pan with or without inertial scrolling using the GESTURE_NOTIFY message. If i did this in the osd modal dialog it falls through all checked mouse events and did the DoModal again, where it then never returned (caught in the domodal_internal loop) - so the sendmessage get stuck.

@JM ... is this the right fix here?
