### PR TITLE
HQ Scalers Speedup (Windows)

### DIFF
--- a/system/shaders/convolutionsep-4x4_d3d.fx
+++ b/system/shaders/convolutionsep-4x4_d3d.fx
@@ -1,0 +1,163 @@
+/*
+ *      Copyright (C) 2005-2010 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+texture g_Texture;
+texture g_KernelTexture;
+float2  g_StepXY;
+
+sampler RGBSampler =
+  sampler_state {
+    Texture = <g_Texture>;
+    AddressU = CLAMP;
+    AddressV = CLAMP;
+    MipFilter = LINEAR;
+    MinFilter = POINT;
+    MagFilter = POINT;
+  };
+
+sampler KernelSampler =
+  sampler_state
+  {
+    Texture = <g_KernelTexture>;
+    AddressU = CLAMP;
+    AddressV = CLAMP;
+    MipFilter = LINEAR;
+    MinFilter = LINEAR;
+    MagFilter = LINEAR;
+  };
+
+struct VS_OUTPUT
+{
+  float4 Position   : POSITION;
+  float2 TextureUV  : TEXCOORD0;
+};
+
+struct PS_OUTPUT
+{
+  float4 RGBColor : COLOR0;
+};
+
+half4 weight(float pos)
+{
+  half4 w;
+#ifdef HAS_RGBA
+  w = tex1D(KernelSampler, pos);
+#else
+  w = tex1D(KernelSampler, pos).bgra;
+#endif
+
+#ifdef HAS_FLOAT_TEXTURE
+  return w;
+#else
+  return w * 2.0 - 1.0;
+#endif
+}
+
+half3 pixel(float xpos, float ypos)
+{
+  return tex2D(RGBSampler, float2(xpos, ypos)).rgb;
+}
+
+half3 getLine(float ypos, float4 xpos, half4 linetaps)
+{
+  return
+    pixel(xpos.r, ypos) * linetaps.r +
+    pixel(xpos.g, ypos) * linetaps.g +
+    pixel(xpos.b, ypos) * linetaps.b +
+    pixel(xpos.a, ypos) * linetaps.a;
+}
+
+PS_OUTPUT CONVOLUTION4x4Horiz(VS_OUTPUT In)
+{
+  PS_OUTPUT OUT;
+
+  float2 pos = In.TextureUV + g_StepXY * 0.5;
+  float2 f = frac(pos / g_StepXY);
+
+  half4 linetaps   = weight(1.0 - f.x);
+  half4 columntaps = weight(1.0 - f.y);
+
+  // kernel generation code made sure taps add up to 1, no need to adjust here.
+
+  float2 xystart = (-1.0 - f) * g_StepXY + In.TextureUV;
+  float4 xpos = float4(
+      xystart.x,
+      xystart.x + g_StepXY.x,
+      xystart.x + g_StepXY.x * 2.0,
+      xystart.x + g_StepXY.x * 3.0);
+
+  OUT.RGBColor.rgb =
+    getLine(xystart.y                   , xpos, linetaps) * columntaps.r +
+    getLine(xystart.y + g_StepXY.y      , xpos, linetaps) * columntaps.g +
+    getLine(xystart.y + g_StepXY.y * 2.0, xpos, linetaps) * columntaps.b +
+    getLine(xystart.y + g_StepXY.y * 3.0, xpos, linetaps) * columntaps.a;
+
+  OUT.RGBColor.a = 1.0;
+  return OUT;
+}
+
+PS_OUTPUT CONVOLUTION4x4Vert(VS_OUTPUT In)
+{
+  PS_OUTPUT OUT;
+
+  float2 pos = In.TextureUV + g_StepXY * 0.5;
+  float2 f = frac(pos / g_StepXY);
+
+  half4 linetaps   = weight(1.0 - f.x);
+  half4 columntaps = weight(1.0 - f.y);
+
+  // kernel generation code made sure taps add up to 1, no need to adjust here.
+
+  float2 xystart = (-1.0 - f) * g_StepXY + In.TextureUV;
+  float4 xpos = float4(
+      xystart.x,
+      xystart.x + g_StepXY.x,
+      xystart.x + g_StepXY.x * 2.0,
+      xystart.x + g_StepXY.x * 3.0);
+
+  OUT.RGBColor.rgb =
+    getLine(xystart.y                   , xpos, linetaps) * columntaps.r +
+    getLine(xystart.y + g_StepXY.y      , xpos, linetaps) * columntaps.g +
+    getLine(xystart.y + g_StepXY.y * 2.0, xpos, linetaps) * columntaps.b +
+    getLine(xystart.y + g_StepXY.y * 3.0, xpos, linetaps) * columntaps.a;
+
+  OUT.RGBColor.a = 1.0;
+  return OUT;
+}
+
+technique SCALER_T
+{
+  pass P0
+  {
+    PixelShader  = compile ps_3_0 CONVOLUTION4x4Horiz();
+    ZEnable = False;
+    FillMode = Solid;
+    FogEnable = False;
+  }
+  pass P1
+  {
+    PixelShader  = compile ps_3_0 CONVOLUTION4x4Vert();
+    ZEnable = False;
+    FillMode = Solid;
+    FogEnable = False;
+  }
+
+};

--- a/system/shaders/convolutionsep-4x4_d3d.fx
+++ b/system/shaders/convolutionsep-4x4_d3d.fx
@@ -22,7 +22,8 @@
 texture g_Texture;
 texture g_KernelTexture;
 texture g_IntermediateTexture;
-float2  g_StepXY;
+float2  g_StepXY_P0;
+float2  g_StepXY_P1;
 
 sampler RGBSampler =
   sampler_state {
@@ -82,84 +83,84 @@ half4 weight(float pos)
 #endif
 }
 
-half3 pixel(float xpos, float ypos)
+half3 pixel(sampler samp, float xpos, float ypos)
 {
-  return tex2D(RGBSampler, float2(xpos, ypos)).rgb;
+  return tex2D(samp, float2(xpos, ypos)).rgb;
 }
+
+// Code for first pass - horizontal
 
 half3 getLine(float ypos, float4 xpos, half4 linetaps)
 {
   return
-    pixel(xpos.r, ypos) * linetaps.r +
-    pixel(xpos.g, ypos) * linetaps.g +
-    pixel(xpos.b, ypos) * linetaps.b +
-    pixel(xpos.a, ypos) * linetaps.a;
+    pixel(RGBSampler, xpos.r, ypos) * linetaps.r +
+    pixel(RGBSampler, xpos.g, ypos) * linetaps.g +
+    pixel(RGBSampler, xpos.b, ypos) * linetaps.b +
+    pixel(RGBSampler, xpos.a, ypos) * linetaps.a;
 }
 
 PS_OUTPUT CONVOLUTION4x4Horiz(VS_OUTPUT In)
 {
   PS_OUTPUT OUT;
 
-  float2 pos = In.TextureUV + g_StepXY * 0.5;
-  float2 f = frac(pos / g_StepXY);
+  float2 pos = In.TextureUV + g_StepXY_P0 * 0.5;
+  float2 f = frac(pos / g_StepXY_P0);
 
-  half4 linetaps   = weight(1.0 - f.x);
-  half4 columntaps = weight(1.0 - f.y);
+  half4 linetaps = weight(1.0 - f.x);
 
   // kernel generation code made sure taps add up to 1, no need to adjust here.
 
-  float2 xystart = (-1.0 - f) * g_StepXY + In.TextureUV;
+  float2 xystart;
+  xystart.x = (-1.0 - f.x) * g_StepXY_P0.x + In.TextureUV.x;
+  xystart.y = In.TextureUV.y;
+
   float4 xpos = float4(
       xystart.x,
-      xystart.x + g_StepXY.x,
-      xystart.x + g_StepXY.x * 2.0,
-      xystart.x + g_StepXY.x * 3.0);
+      xystart.x + g_StepXY_P0.x,
+      xystart.x + g_StepXY_P0.x * 2.0,
+      xystart.x + g_StepXY_P0.x * 3.0);
 
-  OUT.RGBColor.rgb =
-    getLine(xystart.y                   , xpos, linetaps) * columntaps.r +
-    getLine(xystart.y + g_StepXY.y      , xpos, linetaps) * columntaps.g +
-    getLine(xystart.y + g_StepXY.y * 2.0, xpos, linetaps) * columntaps.b +
-    getLine(xystart.y + g_StepXY.y * 3.0, xpos, linetaps) * columntaps.a;
-
+  OUT.RGBColor.rgb = getLine(xystart.y, xpos, linetaps);
   OUT.RGBColor.a = 1.0;
+
   return OUT;
+}
+
+// Code for second pass - vertical
+
+half3 getRow(float xpos, float4 ypos, half4 columntaps)
+{
+  return
+    pixel(IntermediateSampler, xpos, ypos.r) * columntaps.r +
+    pixel(IntermediateSampler, xpos, ypos.g) * columntaps.g +
+    pixel(IntermediateSampler, xpos, ypos.b) * columntaps.b +
+    pixel(IntermediateSampler, xpos, ypos.a) * columntaps.a;
 }
 
 PS_OUTPUT CONVOLUTION4x4Vert(VS_OUTPUT In)
 {
   PS_OUTPUT OUT;
 
-  float2 pos = In.TextureUV + g_StepXY * 0.5;
-  float2 f = frac(pos / g_StepXY);
+  float2 pos = In.TextureUV + g_StepXY_P1 * 0.5;
+  float2 f = frac(pos / g_StepXY_P1);
 
-  half4 linetaps   = weight(1.0 - f.x);
   half4 columntaps = weight(1.0 - f.y);
 
   // kernel generation code made sure taps add up to 1, no need to adjust here.
 
-  float2 xystart = (-1.0 - f) * g_StepXY + In.TextureUV;
-  float4 xpos = float4(
-      xystart.x,
-      xystart.x + g_StepXY.x,
-      xystart.x + g_StepXY.x * 2.0,
-      xystart.x + g_StepXY.x * 3.0);
+  float2 xystart;
+  xystart.x = In.TextureUV.x;
+  xystart.y = (-1.0 - f.y) * g_StepXY_P1.y + In.TextureUV.y;
 
-  OUT.RGBColor.rgb =
-    getLine(xystart.y                   , xpos, linetaps) * columntaps.r +
-    getLine(xystart.y + g_StepXY.y      , xpos, linetaps) * columntaps.g +
-    getLine(xystart.y + g_StepXY.y * 2.0, xpos, linetaps) * columntaps.b +
-    getLine(xystart.y + g_StepXY.y * 3.0, xpos, linetaps) * columntaps.a;
+  float4 ypos = float4(
+      xystart.y,
+      xystart.y + g_StepXY_P1.y,
+      xystart.y + g_StepXY_P1.y * 2.0,
+      xystart.y + g_StepXY_P1.y * 3.0);
 
+  OUT.RGBColor.rgb = getRow(xystart.x, ypos, columntaps);
   OUT.RGBColor.a = 1.0;
-  return OUT;
-}
 
-PS_OUTPUT Nothing(VS_OUTPUT In)
-{
-  PS_OUTPUT OUT;
-
-  OUT.RGBColor.rgb = tex2D(IntermediateSampler, In.TextureUV).rgb;
-  OUT.RGBColor.a = 1.0;
   return OUT;
 }
 
@@ -174,7 +175,7 @@ technique SCALER_T
   }
   pass P1
   {
-    PixelShader  = compile ps_3_0 Nothing();
+    PixelShader  = compile ps_3_0 CONVOLUTION4x4Vert();
     ZEnable = False;
     FillMode = Solid;
     FogEnable = False;

--- a/system/shaders/convolutionsep-4x4_d3d.fx
+++ b/system/shaders/convolutionsep-4x4_d3d.fx
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2010 Team XBMC
+ *      Copyright (C) 2005-2011 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -21,6 +21,7 @@
 
 texture g_Texture;
 texture g_KernelTexture;
+texture g_IntermediateTexture;
 float2  g_StepXY;
 
 sampler RGBSampler =
@@ -42,6 +43,16 @@ sampler KernelSampler =
     MipFilter = LINEAR;
     MinFilter = LINEAR;
     MagFilter = LINEAR;
+  };
+
+sampler IntermediateSampler =
+  sampler_state {
+    Texture = <g_IntermediateTexture>;
+    AddressU = CLAMP;
+    AddressV = CLAMP;
+    MipFilter = LINEAR;
+    MinFilter = POINT;
+    MagFilter = POINT;
   };
 
 struct VS_OUTPUT
@@ -143,6 +154,15 @@ PS_OUTPUT CONVOLUTION4x4Vert(VS_OUTPUT In)
   return OUT;
 }
 
+PS_OUTPUT Nothing(VS_OUTPUT In)
+{
+  PS_OUTPUT OUT;
+
+  OUT.RGBColor.rgb = tex2D(IntermediateSampler, In.TextureUV).rgb;
+  OUT.RGBColor.a = 1.0;
+  return OUT;
+}
+
 technique SCALER_T
 {
   pass P0
@@ -154,7 +174,7 @@ technique SCALER_T
   }
   pass P1
   {
-    PixelShader  = compile ps_3_0 CONVOLUTION4x4Vert();
+    PixelShader  = compile ps_3_0 Nothing();
     ZEnable = False;
     FillMode = Solid;
     FogEnable = False;

--- a/system/shaders/convolutionsep-6x6_d3d.fx
+++ b/system/shaders/convolutionsep-6x6_d3d.fx
@@ -22,7 +22,8 @@
 texture g_Texture;
 texture g_KernelTexture;
 texture g_IntermediateTexture;
-float2  g_StepXY;
+float2  g_StepXY_P0;
+float2  g_StepXY_P1;
 
 sampler RGBSampler =
   sampler_state {
@@ -82,98 +83,96 @@ half3 weight(float pos)
 #endif
 }
 
-half3 pixel(float xpos, float ypos)
+half3 pixel(sampler samp, float xpos, float ypos)
 {
-  return tex2D(RGBSampler, float2(xpos, ypos)).rgb;
+  return tex2D(samp, float2(xpos, ypos)).rgb;
 }
+
+// Code for first pass - horizontal
 
 half3 getLine(float ypos, float3 xpos1, float3 xpos2, half3 linetaps1, half3 linetaps2)
 {
   return
-    pixel(xpos1.r, ypos) * linetaps1.r +
-    pixel(xpos1.g, ypos) * linetaps2.r +
-    pixel(xpos1.b, ypos) * linetaps1.g +
-    pixel(xpos2.r, ypos) * linetaps2.g +
-    pixel(xpos2.g, ypos) * linetaps1.b +
-    pixel(xpos2.b, ypos) * linetaps2.b;
+    pixel(RGBSampler, xpos1.r, ypos) * linetaps1.r +
+    pixel(RGBSampler, xpos1.g, ypos) * linetaps2.r +
+    pixel(RGBSampler, xpos1.b, ypos) * linetaps1.g +
+    pixel(RGBSampler, xpos2.r, ypos) * linetaps2.g +
+    pixel(RGBSampler, xpos2.g, ypos) * linetaps1.b +
+    pixel(RGBSampler, xpos2.b, ypos) * linetaps2.b;
 }
 
 PS_OUTPUT CONVOLUTION6x6Horiz(VS_OUTPUT In)
 {
   PS_OUTPUT OUT;
 
-  float2 pos = In.TextureUV + g_StepXY * 0.5;
-  float2 f = frac(pos / g_StepXY);
+  float2 pos = In.TextureUV + g_StepXY_P0 * 0.5;
+  float2 f = frac(pos / g_StepXY_P0);
 
-  half3 linetaps1   = weight((1.0 - f.x) / 2.0);
-  half3 linetaps2   = weight((1.0 - f.x) / 2.0 + 0.5);
-  half3 columntaps1 = weight((1.0 - f.y) / 2.0);
-  half3 columntaps2 = weight((1.0 - f.y) / 2.0 + 0.5);
+  half3 linetaps1 = weight((1.0 - f.x) / 2.0);
+  half3 linetaps2 = weight((1.0 - f.x) / 2.0 + 0.5);
 
   // kernel generation code made sure taps add up to 1, no need to adjust here.
 
-  float2 xystart = (-2.0 - f) * g_StepXY + In.TextureUV;
+  float2 xystart;
+  xystart.x = (-2.0 - f.x) * g_StepXY_P0.x + In.TextureUV.x;
+  xystart.y = In.TextureUV.y;
+
   float3 xpos1 = float3(
       xystart.x,
-      xystart.x + g_StepXY.x,
-      xystart.x + g_StepXY.x * 2.0);
+      xystart.x + g_StepXY_P0.x,
+      xystart.x + g_StepXY_P0.x * 2.0);
   float3 xpos2 = half3(
-      xystart.x + g_StepXY.x * 3.0,
-      xystart.x + g_StepXY.x * 4.0,
-      xystart.x + g_StepXY.x * 5.0);
+      xystart.x + g_StepXY_P0.x * 3.0,
+      xystart.x + g_StepXY_P0.x * 4.0,
+      xystart.x + g_StepXY_P0.x * 5.0);
 
-  OUT.RGBColor.rgb = getLine(xystart.y                   , xpos1, xpos2, linetaps1, linetaps2) * columntaps1.r +
-					 getLine(xystart.y + g_StepXY.y      , xpos1, xpos2, linetaps1, linetaps2) * columntaps2.r +
-					 getLine(xystart.y + g_StepXY.y * 2.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps1.g +
-					 getLine(xystart.y + g_StepXY.y * 3.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps2.g +
-					 getLine(xystart.y + g_StepXY.y * 4.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps1.b +
-					 getLine(xystart.y + g_StepXY.y * 5.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps2.b;
-
+  OUT.RGBColor.rgb = getLine(xystart.y, xpos1, xpos2, linetaps1, linetaps2);
   OUT.RGBColor.a = 1.0;
+
   return OUT;
+}
+
+// Code for second pass - vertical
+
+half3 getRow(float xpos, float3 ypos1, float3 ypos2, half3 columntaps1, half3 columntaps2)
+{
+  return
+    pixel(IntermediateSampler, xpos, ypos1.r) * columntaps1.r +
+    pixel(IntermediateSampler, xpos, ypos1.g) * columntaps2.r +
+    pixel(IntermediateSampler, xpos, ypos1.b) * columntaps1.g +
+    pixel(IntermediateSampler, xpos, ypos2.r) * columntaps2.g +
+    pixel(IntermediateSampler, xpos, ypos2.g) * columntaps1.b +
+    pixel(IntermediateSampler, xpos, ypos2.b) * columntaps2.b;
 }
 
 PS_OUTPUT CONVOLUTION6x6Vert(VS_OUTPUT In)
 {
   PS_OUTPUT OUT;
 
-  float2 pos = In.TextureUV + g_StepXY * 0.5;
-  float2 f = frac(pos / g_StepXY);
+  float2 pos = In.TextureUV + g_StepXY_P1 * 0.5;
+  float2 f = frac(pos / g_StepXY_P1);
 
-  half3 linetaps1   = weight((1.0 - f.x) / 2.0);
-  half3 linetaps2   = weight((1.0 - f.x) / 2.0 + 0.5);
   half3 columntaps1 = weight((1.0 - f.y) / 2.0);
   half3 columntaps2 = weight((1.0 - f.y) / 2.0 + 0.5);
 
   // kernel generation code made sure taps add up to 1, no need to adjust here.
 
-  float2 xystart = (-2.0 - f) * g_StepXY + In.TextureUV;
-  float3 xpos1 = float3(
-      xystart.x,
-      xystart.x + g_StepXY.x,
-      xystart.x + g_StepXY.x * 2.0);
-  float3 xpos2 = half3(
-      xystart.x + g_StepXY.x * 3.0,
-      xystart.x + g_StepXY.x * 4.0,
-      xystart.x + g_StepXY.x * 5.0);
+  float2 xystart;
+  xystart.x = In.TextureUV.x;
+  xystart.y = (-2.0 - f.y) * g_StepXY_P1.y + In.TextureUV.y;
 
-  OUT.RGBColor.rgb = getLine(xystart.y                   , xpos1, xpos2, linetaps1, linetaps2) * columntaps1.r +
-					 getLine(xystart.y + g_StepXY.y      , xpos1, xpos2, linetaps1, linetaps2) * columntaps2.r +
-					 getLine(xystart.y + g_StepXY.y * 2.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps1.g +
-					 getLine(xystart.y + g_StepXY.y * 3.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps2.g +
-					 getLine(xystart.y + g_StepXY.y * 4.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps1.b +
-					 getLine(xystart.y + g_StepXY.y * 5.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps2.b;
+  float3 ypos1 = float3(
+      xystart.y,
+      xystart.y + g_StepXY_P1.y,
+      xystart.y + g_StepXY_P1.y * 2.0);
+  float3 ypos2 = half3(
+      xystart.y + g_StepXY_P1.y * 3.0,
+      xystart.y + g_StepXY_P1.y * 4.0,
+      xystart.y + g_StepXY_P1.y * 5.0);
 
+  OUT.RGBColor.rgb = getRow(xystart.x, ypos1, ypos2, columntaps1, columntaps2);
   OUT.RGBColor.a = 1.0;
-  return OUT;
-}
 
-PS_OUTPUT Nothing(VS_OUTPUT In)
-{
-  PS_OUTPUT OUT;
-
-  OUT.RGBColor.rgb = tex2D(IntermediateSampler, In.TextureUV).rgb;
-  OUT.RGBColor.a = 1.0;
   return OUT;
 }
 
@@ -188,7 +187,7 @@ technique SCALER_T
   }
   pass P1
   {
-    PixelShader  = compile ps_3_0 Nothing();
+    PixelShader  = compile ps_3_0 CONVOLUTION6x6Vert();
     ZEnable = False;
     FillMode = Solid;
     FogEnable = False;

--- a/system/shaders/convolutionsep-6x6_d3d.fx
+++ b/system/shaders/convolutionsep-6x6_d3d.fx
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2010 Team XBMC
+ *      Copyright (C) 2005-2011 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -21,6 +21,7 @@
 
 texture g_Texture;
 texture g_KernelTexture;
+texture g_IntermediateTexture;
 float2  g_StepXY;
 
 sampler RGBSampler =
@@ -42,6 +43,16 @@ sampler KernelSampler =
     MipFilter = LINEAR;
     MinFilter = LINEAR;
     MagFilter = LINEAR;
+  };
+
+sampler IntermediateSampler =
+  sampler_state {
+    Texture = <g_IntermediateTexture>;
+    AddressU = CLAMP;
+    AddressV = CLAMP;
+    MipFilter = LINEAR;
+    MinFilter = POINT;
+    MagFilter = POINT;
   };
 
 struct VS_OUTPUT
@@ -157,6 +168,15 @@ PS_OUTPUT CONVOLUTION6x6Vert(VS_OUTPUT In)
   return OUT;
 }
 
+PS_OUTPUT Nothing(VS_OUTPUT In)
+{
+  PS_OUTPUT OUT;
+
+  OUT.RGBColor.rgb = tex2D(IntermediateSampler, In.TextureUV).rgb;
+  OUT.RGBColor.a = 1.0;
+  return OUT;
+}
+
 technique SCALER_T
 {
   pass P0
@@ -168,7 +188,7 @@ technique SCALER_T
   }
   pass P1
   {
-    PixelShader  = compile ps_3_0 CONVOLUTION6x6Vert();
+    PixelShader  = compile ps_3_0 Nothing();
     ZEnable = False;
     FillMode = Solid;
     FogEnable = False;

--- a/system/shaders/convolutionsep-6x6_d3d.fx
+++ b/system/shaders/convolutionsep-6x6_d3d.fx
@@ -1,0 +1,176 @@
+/*
+ *      Copyright (C) 2005-2010 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+texture g_Texture;
+texture g_KernelTexture;
+float2  g_StepXY;
+
+sampler RGBSampler =
+  sampler_state {
+    Texture = <g_Texture>;
+    AddressU = CLAMP;
+    AddressV = CLAMP;
+    MipFilter = LINEAR;
+    MinFilter = POINT;
+    MagFilter = POINT;
+  };
+
+sampler KernelSampler =
+  sampler_state
+  {
+    Texture = <g_KernelTexture>;
+    AddressU = CLAMP;
+    AddressV = CLAMP;
+    MipFilter = LINEAR;
+    MinFilter = LINEAR;
+    MagFilter = LINEAR;
+  };
+
+struct VS_OUTPUT
+{
+  float4 Position   : POSITION;
+  float2 TextureUV  : TEXCOORD0;
+};
+
+struct PS_OUTPUT
+{
+  float4 RGBColor : COLOR0;
+};
+
+half3 weight(float pos)
+{
+  half3 w;
+#ifdef HAS_RGBA
+  w = tex1D(KernelSampler, pos).rgb;
+#else
+  w = tex1D(KernelSampler, pos).bgr;
+#endif
+
+#ifdef HAS_FLOAT_TEXTURE
+  return w;
+#else
+  return w * 2.0 - 1.0;
+#endif
+}
+
+half3 pixel(float xpos, float ypos)
+{
+  return tex2D(RGBSampler, float2(xpos, ypos)).rgb;
+}
+
+half3 getLine(float ypos, float3 xpos1, float3 xpos2, half3 linetaps1, half3 linetaps2)
+{
+  return
+    pixel(xpos1.r, ypos) * linetaps1.r +
+    pixel(xpos1.g, ypos) * linetaps2.r +
+    pixel(xpos1.b, ypos) * linetaps1.g +
+    pixel(xpos2.r, ypos) * linetaps2.g +
+    pixel(xpos2.g, ypos) * linetaps1.b +
+    pixel(xpos2.b, ypos) * linetaps2.b;
+}
+
+PS_OUTPUT CONVOLUTION6x6Horiz(VS_OUTPUT In)
+{
+  PS_OUTPUT OUT;
+
+  float2 pos = In.TextureUV + g_StepXY * 0.5;
+  float2 f = frac(pos / g_StepXY);
+
+  half3 linetaps1   = weight((1.0 - f.x) / 2.0);
+  half3 linetaps2   = weight((1.0 - f.x) / 2.0 + 0.5);
+  half3 columntaps1 = weight((1.0 - f.y) / 2.0);
+  half3 columntaps2 = weight((1.0 - f.y) / 2.0 + 0.5);
+
+  // kernel generation code made sure taps add up to 1, no need to adjust here.
+
+  float2 xystart = (-2.0 - f) * g_StepXY + In.TextureUV;
+  float3 xpos1 = float3(
+      xystart.x,
+      xystart.x + g_StepXY.x,
+      xystart.x + g_StepXY.x * 2.0);
+  float3 xpos2 = half3(
+      xystart.x + g_StepXY.x * 3.0,
+      xystart.x + g_StepXY.x * 4.0,
+      xystart.x + g_StepXY.x * 5.0);
+
+  OUT.RGBColor.rgb = getLine(xystart.y                   , xpos1, xpos2, linetaps1, linetaps2) * columntaps1.r +
+					 getLine(xystart.y + g_StepXY.y      , xpos1, xpos2, linetaps1, linetaps2) * columntaps2.r +
+					 getLine(xystart.y + g_StepXY.y * 2.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps1.g +
+					 getLine(xystart.y + g_StepXY.y * 3.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps2.g +
+					 getLine(xystart.y + g_StepXY.y * 4.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps1.b +
+					 getLine(xystart.y + g_StepXY.y * 5.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps2.b;
+
+  OUT.RGBColor.a = 1.0;
+  return OUT;
+}
+
+PS_OUTPUT CONVOLUTION6x6Vert(VS_OUTPUT In)
+{
+  PS_OUTPUT OUT;
+
+  float2 pos = In.TextureUV + g_StepXY * 0.5;
+  float2 f = frac(pos / g_StepXY);
+
+  half3 linetaps1   = weight((1.0 - f.x) / 2.0);
+  half3 linetaps2   = weight((1.0 - f.x) / 2.0 + 0.5);
+  half3 columntaps1 = weight((1.0 - f.y) / 2.0);
+  half3 columntaps2 = weight((1.0 - f.y) / 2.0 + 0.5);
+
+  // kernel generation code made sure taps add up to 1, no need to adjust here.
+
+  float2 xystart = (-2.0 - f) * g_StepXY + In.TextureUV;
+  float3 xpos1 = float3(
+      xystart.x,
+      xystart.x + g_StepXY.x,
+      xystart.x + g_StepXY.x * 2.0);
+  float3 xpos2 = half3(
+      xystart.x + g_StepXY.x * 3.0,
+      xystart.x + g_StepXY.x * 4.0,
+      xystart.x + g_StepXY.x * 5.0);
+
+  OUT.RGBColor.rgb = getLine(xystart.y                   , xpos1, xpos2, linetaps1, linetaps2) * columntaps1.r +
+					 getLine(xystart.y + g_StepXY.y      , xpos1, xpos2, linetaps1, linetaps2) * columntaps2.r +
+					 getLine(xystart.y + g_StepXY.y * 2.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps1.g +
+					 getLine(xystart.y + g_StepXY.y * 3.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps2.g +
+					 getLine(xystart.y + g_StepXY.y * 4.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps1.b +
+					 getLine(xystart.y + g_StepXY.y * 5.0, xpos1, xpos2, linetaps1, linetaps2) * columntaps2.b;
+
+  OUT.RGBColor.a = 1.0;
+  return OUT;
+}
+
+technique SCALER_T
+{
+  pass P0
+  {
+    PixelShader  = compile ps_3_0 CONVOLUTION6x6Horiz();
+    ZEnable = False;
+    FillMode = Solid;
+    FogEnable = False;
+  }
+  pass P1
+  {
+    PixelShader  = compile ps_3_0 CONVOLUTION6x6Vert();
+    ZEnable = False;
+    FillMode = Solid;
+    FogEnable = False;
+  }
+};

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -683,15 +683,14 @@ bool CConvolutionShaderSeparable::ChooseIntermediateD3DFormat()
 {
   DWORD usage = D3DUSAGE_RENDERTARGET;
 
-  // Try for higher precision than the output of the scaler to preserve quality
-  if      (g_Windowing.IsTextureFormatOk(D3DFMT_A2R10G10B10, usage)) m_IntermediateFormat = D3DFMT_A2R10G10B10;
-  else if (g_Windowing.IsTextureFormatOk(D3DFMT_A2B10G10R10, usage)) m_IntermediateFormat = D3DFMT_A2B10G10R10;
-  else if (g_Windowing.IsTextureFormatOk(D3DFMT_A8R8G8B8, usage))    m_IntermediateFormat = D3DFMT_A8R8G8B8;
-  else if (g_Windowing.IsTextureFormatOk(D3DFMT_A8B8G8R8, usage))    m_IntermediateFormat = D3DFMT_A8B8G8R8;
-  else if (g_Windowing.IsTextureFormatOk(D3DFMT_X8R8G8B8, usage))    m_IntermediateFormat = D3DFMT_X8R8G8B8;
-  else if (g_Windowing.IsTextureFormatOk(D3DFMT_X8B8G8R8, usage))    m_IntermediateFormat = D3DFMT_X8B8G8R8;
-  else if (g_Windowing.IsTextureFormatOk(D3DFMT_R8G8B8, usage))      m_IntermediateFormat = D3DFMT_R8G8B8;
-  else return false;
+  // Need a float texture, as the output of the first pass can contain negative values.
+  if      (g_Windowing.IsTextureFormatOk(D3DFMT_A16B16G16R16F, usage)) m_IntermediateFormat = D3DFMT_A16B16G16R16F;
+  else if (g_Windowing.IsTextureFormatOk(D3DFMT_A32B32G32R32F, usage)) m_IntermediateFormat = D3DFMT_A32B32G32R32F;
+  else
+  {
+    CLog::Log(LOGNOTICE, __FUNCTION__": no float format available for the intermediate render target");
+    return false;
+  }
 
   CLog::Log(LOGDEBUG, __FUNCTION__": format %i", m_IntermediateFormat);
 

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -800,45 +800,47 @@ void CConvolutionShaderSeparable::PrepareParameters(unsigned int sourceWidth, un
     CUSTOMVERTEX* v;
     CWinShader::LockVertexBuffer((void**)&v);
 
-    v[0].x = destRect.x1;
-    v[0].y = destRect.y1;
+    // Manipulate the coordinates to work only on the active parts of the textures,
+    // and therefore avoid the need to clear surfaces/render targets
+    v[0].x = 0;
+    v[0].y = 0;
     v[0].tu = sourceRect.x1 / sourceWidth;
     v[0].tv = sourceRect.y1 / sourceHeight;
 
-    v[1].x = destRect.x2;
-    v[1].y = destRect.y1;
+    v[1].x = destRect.x2 - destRect.x1;
+    v[1].y = 0;
     v[1].tu = sourceRect.x2 / sourceWidth;
     v[1].tv = sourceRect.y1 / sourceHeight;
 
-    v[2].x = destRect.x2;
-    v[2].y = destRect.y2;
+    v[2].x = destRect.x2 - destRect.x1;
+    v[2].y = destRect.y2 - destRect.y1;
     v[2].tu = sourceRect.x2 / sourceWidth;
     v[2].tv = sourceRect.y2 / sourceHeight;
 
-    v[3].x = destRect.x1;
-    v[3].y = destRect.y2;
+    v[3].x = 0;
+    v[3].y = destRect.y2 - destRect.y1;
     v[3].tu = sourceRect.x1 / sourceWidth;
     v[3].tv = sourceRect.y2 / sourceHeight;
 
-    v[4].x = 0;
-    v[4].y = 0;
+    v[4].x = destRect.x1;
+    v[4].y = destRect.y1;
     v[4].tu = 0;
     v[4].tv = 0;
 
-    v[5].x = m_destWidth;
-    v[5].y = 0;
-    v[5].tu = 1;
+    v[5].x = destRect.x2;
+    v[5].y = destRect.y1;
+    v[5].tu = (destRect.x2 - destRect.x1) / m_destWidth;
     v[5].tv = 0;
 
-    v[6].x = m_destWidth;
-    v[6].y = m_destHeight;
-    v[6].tu = 1;
-    v[6].tv = 1;
+    v[6].x = destRect.x2;
+    v[6].y = destRect.y2;
+    v[6].tu = (destRect.x2 - destRect.x1) / m_destWidth;
+    v[6].tv = (destRect.y2 - destRect.y1) / m_destHeight;
 
-    v[7].x = 0;
-    v[7].y = m_destHeight;
+    v[7].x = destRect.x1;
+    v[7].y = destRect.y2;
     v[7].tu = 0;
-    v[7].tv = 1;
+    v[7].tv = (destRect.y2 - destRect.y1) / m_destHeight;
 
     // -0.5 offset to compensate for D3D rasterization
     // set z and rhw

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -103,12 +103,56 @@ private:
 class CConvolutionShader : public CWinShader
 {
 public:
+  virtual bool Create(ESCALINGMETHOD method) = 0;
+  virtual void Render(CD3DTexture &sourceTexture,
+                               unsigned int sourceWidth, unsigned int sourceHeight,
+                               CRect sourceRect,
+                               CRect destRect) = 0;
+
+  struct CUSTOMVERTEX {
+      FLOAT x, y, z;
+      FLOAT rhw;
+      FLOAT tu, tv;
+  };
+};
+
+class CConvolutionShader1Pass : public CConvolutionShader
+{
+public:
   virtual bool Create(ESCALINGMETHOD method);
   virtual void Render(CD3DTexture &sourceTexture,
                                unsigned int sourceWidth, unsigned int sourceHeight,
                                CRect sourceRect,
                                CRect destRect);
-  virtual ~CConvolutionShader();
+  virtual ~CConvolutionShader1Pass();
+
+protected:
+  virtual bool KernelTexFormat();
+  virtual bool CreateHQKernel(ESCALINGMETHOD method);
+  virtual void PrepareParameters(unsigned int sourceWidth, unsigned int sourceHeight,
+                               CRect sourceRect,
+                               CRect destRect);
+  virtual void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps, int texStepsCount);
+
+
+private:
+  CD3DTexture   m_HQKernelTexture;
+  D3DFORMAT     m_format;
+  bool          m_floattex;
+  bool          m_rgba;
+  unsigned int  m_sourceWidth, m_sourceHeight;
+  CRect         m_sourceRect, m_destRect;
+};
+
+class CConvolutionShaderSeparable : public CConvolutionShader
+{
+public:
+  virtual bool Create(ESCALINGMETHOD method);
+  virtual void Render(CD3DTexture &sourceTexture,
+                               unsigned int sourceWidth, unsigned int sourceHeight,
+                               CRect sourceRect,
+                               CRect destRect);
+  virtual ~CConvolutionShaderSeparable();
 
 protected:
   virtual bool KernelTexFormat();
@@ -125,12 +169,6 @@ private:
   bool          m_rgba;
   unsigned int  m_sourceWidth, m_sourceHeight;
   CRect         m_sourceRect, m_destRect;
-
-  struct CUSTOMVERTEX {
-      FLOAT x, y, z;
-      FLOAT rhw;
-      FLOAT tu, tv;
-  };
 };
 
 class CTestShader : public CWinShader

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -167,7 +167,7 @@ protected:
                                unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
                                CRect destRect);
-  virtual void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps, int texStepsCount);
+  virtual void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps1, int texStepsCount1, float* texSteps2, int texStepsCount2);
 
 private:
   CD3DTexture   m_IntermediateTarget;

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -51,7 +51,7 @@ protected:
   virtual bool LockVertexBuffer(void **data);
   virtual bool UnlockVertexBuffer();
   virtual bool LoadEffect(CStdString filename, DefinesMap* defines);
-  virtual bool Execute();
+  virtual bool Execute(std::vector<LPDIRECT3DSURFACE9> *vecRT, unsigned int vertexIndexStep);
 
   CD3DEffect   m_effect;
 
@@ -106,6 +106,7 @@ public:
   virtual bool Create(ESCALINGMETHOD method) = 0;
   virtual void Render(CD3DTexture &sourceTexture,
                                unsigned int sourceWidth, unsigned int sourceHeight,
+                               unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
                                CRect destRect) = 0;
 
@@ -122,6 +123,7 @@ public:
   virtual bool Create(ESCALINGMETHOD method);
   virtual void Render(CD3DTexture &sourceTexture,
                                unsigned int sourceWidth, unsigned int sourceHeight,
+                               unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
                                CRect destRect);
   virtual ~CConvolutionShader1Pass();
@@ -147,27 +149,35 @@ private:
 class CConvolutionShaderSeparable : public CConvolutionShader
 {
 public:
+  CConvolutionShaderSeparable();
   virtual bool Create(ESCALINGMETHOD method);
   virtual void Render(CD3DTexture &sourceTexture,
                                unsigned int sourceWidth, unsigned int sourceHeight,
+                               unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
                                CRect destRect);
   virtual ~CConvolutionShaderSeparable();
 
 protected:
-  virtual bool KernelTexFormat();
+  virtual bool ChooseIntermediateD3DFormat();
+  virtual bool CreateIntermediateRenderTarget(unsigned int width, unsigned int height);
+  virtual bool ChooseKernelD3DFormat();
   virtual bool CreateHQKernel(ESCALINGMETHOD method);
   virtual void PrepareParameters(unsigned int sourceWidth, unsigned int sourceHeight,
+                               unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
                                CRect destRect);
   virtual void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps, int texStepsCount);
 
 private:
+  CD3DTexture   m_IntermediateTarget;
+  D3DFORMAT     m_IntermediateFormat;
   CD3DTexture   m_HQKernelTexture;
-  D3DFORMAT     m_format;
+  D3DFORMAT     m_KernelFormat;
   bool          m_floattex;
   bool          m_rgba;
   unsigned int  m_sourceWidth, m_sourceHeight;
+  unsigned int  m_destWidth, m_destHeight;
   CRect         m_sourceRect, m_destRect;
 };
 

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -109,6 +109,16 @@ public:
                                unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
                                CRect destRect) = 0;
+  virtual ~CConvolutionShader();
+
+protected:
+  virtual bool ChooseKernelD3DFormat();
+  virtual bool CreateHQKernel(ESCALINGMETHOD method);
+
+  CD3DTexture   m_HQKernelTexture;
+  D3DFORMAT     m_KernelFormat;
+  bool          m_floattex;
+  bool          m_rgba;
 
   struct CUSTOMVERTEX {
       FLOAT x, y, z;
@@ -126,11 +136,8 @@ public:
                                unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
                                CRect destRect);
-  virtual ~CConvolutionShader1Pass();
 
 protected:
-  virtual bool KernelTexFormat();
-  virtual bool CreateHQKernel(ESCALINGMETHOD method);
   virtual void PrepareParameters(unsigned int sourceWidth, unsigned int sourceHeight,
                                CRect sourceRect,
                                CRect destRect);
@@ -138,10 +145,6 @@ protected:
 
 
 private:
-  CD3DTexture   m_HQKernelTexture;
-  D3DFORMAT     m_format;
-  bool          m_floattex;
-  bool          m_rgba;
   unsigned int  m_sourceWidth, m_sourceHeight;
   CRect         m_sourceRect, m_destRect;
 };
@@ -161,8 +164,6 @@ public:
 protected:
   virtual bool ChooseIntermediateD3DFormat();
   virtual bool CreateIntermediateRenderTarget(unsigned int width, unsigned int height);
-  virtual bool ChooseKernelD3DFormat();
-  virtual bool CreateHQKernel(ESCALINGMETHOD method);
   virtual void PrepareParameters(unsigned int sourceWidth, unsigned int sourceHeight,
                                unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
@@ -172,10 +173,6 @@ protected:
 private:
   CD3DTexture   m_IntermediateTarget;
   D3DFORMAT     m_IntermediateFormat;
-  CD3DTexture   m_HQKernelTexture;
-  D3DFORMAT     m_KernelFormat;
-  bool          m_floattex;
-  bool          m_rgba;
   unsigned int  m_sourceWidth, m_sourceHeight;
   unsigned int  m_destWidth, m_destHeight;
   CRect         m_sourceRect, m_destRect;

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -1076,11 +1076,8 @@ bool CWinRenderer::Supports(ESCALINGMETHOD method)
     {
       if(method == VS_SCALINGMETHOD_CUBIC
       || method == VS_SCALINGMETHOD_LANCZOS2
-      || method == VS_SCALINGMETHOD_LANCZOS3_FAST)
-        return true;
-
-      //lanczos3 is only allowed through advancedsettings.xml because it's very slow
-      if (g_advancedSettings.m_videoAllowLanczos3 && method == VS_SCALINGMETHOD_LANCZOS3)
+      || method == VS_SCALINGMETHOD_LANCZOS3_FAST
+      || method == VS_SCALINGMETHOD_LANCZOS3)
         return true;
     }
   }

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -234,6 +234,8 @@ bool CWinRenderer::Configure(unsigned int width, unsigned int height, unsigned i
   // calculate the input frame aspect ratio
   CalculateFrameAspectRatio(d_width, d_height);
   ChooseBestResolution(fps);
+  m_destWidth = g_settings.m_ResInfo[m_resolution].iWidth;
+  m_destHeight = g_settings.m_ResInfo[m_resolution].iHeight;
   SetViewMode(g_settings.m_currentVideoSettings.m_ViewMode);
   ManageDisplay();
 
@@ -909,7 +911,7 @@ void CWinRenderer::Stage1()
 
 void CWinRenderer::Stage2()
 {
-  m_scalerShader->Render(m_IntermediateTarget, m_sourceWidth, m_sourceHeight, m_sourceRect, m_destRect);
+  m_scalerShader->Render(m_IntermediateTarget, m_sourceWidth, m_sourceHeight, m_destWidth, m_destHeight, m_sourceRect, m_destRect);
 }
 
 void CWinRenderer::RenderProcessor(DWORD flags)

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -513,7 +513,17 @@ void CWinRenderer::UpdatePSVideoFilter()
 
   if (m_bUseHQScaler)
   {
-    m_scalerShader = new CConvolutionShader();
+    switch(m_scalingMethod)
+    {
+    case VS_SCALINGMETHOD_CUBIC:
+    case VS_SCALINGMETHOD_LANCZOS2:
+      m_scalerShader = new CConvolutionShader1Pass();
+      break;
+    default:
+      m_scalerShader = new CConvolutionShaderSeparable();
+      break;
+    }
+
     if (!m_scalerShader->Create(m_scalingMethod))
     {
       SAFE_DELETE(m_scalerShader);

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -271,6 +271,11 @@ protected:
   // clear colour for "black" bars
   DWORD                m_clearColour;
   unsigned int         m_flags;
+
+  // Width and height of the render target
+  // the separable HQ scalers need this info, but could the m_destRect be used instead?
+  unsigned int         m_destWidth;
+  unsigned int         m_destHeight;
 };
 
 #else


### PR DESCRIPTION
This branch separates the HQ convolution scalers in two passes for a nice speedup (3 taps faster than current 2 taps :)) It makes yadif double rate with HQ scalers workable on my computer.

GPU usage on 25fps DVD->1080p upscaling
ATI4550:
Before: 2 taps 40%, 3 taps: 70%
After: 2 taps 28%, 3 taps: 36%

G210 (pretty close to Ion)
Before: 2 taps 50% 3 taps: drops frames
After: 2 taps 35%, 3 taps: 46%

There is no noticeable difference in picture quality because convolution shaders can mathematically be losslessly separated in two passes. Any difference would be a bug in my code or a precision issue. The intermediate texture depth is larger than the source and destination bitdepth so the precision should be under control.

I created this PR to get feedback and as a heads up for someone to port to GL.
While the shaders themselves are fully functional, the code is not ready to merge as is, as I left the 1 pass implementation in there as well as an easy way to switch between 1 pass and 2 pass for easy performance comparison/visual defect checking/etc. 1 pass will completely go away in the actual merge.

To switch between 1 pass and 2 pass, change the HQ scaler in the OSD.
Bicubic, lanczos2: 1 pass with 2 taps
Lanczos3 optim, Lanczos3: 2 passes, with 2 and 3 taps respectively.

Since 3 taps is now cheaper than 2 taps used to be, I don't think that Lanczos3 needs to be protected by an advanced setting anymore.
