### PR TITLE
linux: build without alsa if libasound is not present

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -92,6 +92,7 @@ librtmp_not_found="== Could not find libRTMP. RTMP support disabled. =="
 librtmp_disabled="== RTMP support disabled. =="
 libnfs_not_found="== Could not find libnfs. NFS support disabled. =="
 libnfs_disabled="== NFS support disabled. =="
+alsa_not_found="== Could not find ALSA. ALSA support disabled. =="
 
 
 # External library message strings
@@ -667,8 +668,8 @@ else
   AC_CHECK_LIB([SDL_image],  [main],, AC_MSG_ERROR($missing_library))
 
   PKG_CHECK_MODULES([ALSA],  [alsa],
-    [INCLUDES="$INCLUDES $ALSA_CFLAGS"; LIBS="$LIBS $ALSA_LIBS"],
-    AC_MSG_ERROR($missing_library))
+    [INCLUDES="$INCLUDES $ALSA_CFLAGS"; LIBS="$LIBS $ALSA_LIBS"; use_alsa=yes],
+    AC_MSG_NOTICE($alsa_not_found); use_alsa=no)
   PKG_CHECK_MODULES([ENCA],  [enca],
     [INCLUDES="$INCLUDES $ENCA_CFLAGS"; LIBS="$LIBS $ENCA_LIBS"],
     AC_MSG_ERROR($missing_library))
@@ -1198,6 +1199,15 @@ else
   fi
 fi
 
+if test "$use_alsa" = "yes"; then
+  USE_ALSA=1
+  AC_DEFINE([USE_ALSA],[1],["Define to 1 if alsa is installed"])
+  final_message="$final_message\n  ALSA:\t\tYes"
+else
+  USE_ALSA=0
+  final_message="$final_message\n  ALSA:\t\tNo"
+fi
+
 if test "x$use_vdpau" != "xno"; then
   final_message="$final_message\n  VDPAU:\tYes"
 else
@@ -1509,6 +1519,7 @@ AC_SUBST(USE_VDA)
 AC_SUBST(USE_OPENMAX)
 AC_SUBST(USE_PULSE)
 AC_SUBST(USE_XRANDR)
+AC_SUBST(USE_ALSA)
 AC_SUBST(USE_TEXTUREPACKER)
 AC_SUBST(USE_TEXTUREPACKER_NATIVE)
 AC_SUBST(USE_TEXTUREPACKER_NATIVE_ROOT)

--- a/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
@@ -1,4 +1,3 @@
-#ifndef __APPLE__
 /*
 * XBMC Media Center
 * Copyright (c) 2002 d7o3g4q and RUNTiME
@@ -718,4 +717,3 @@ void CALSADirectSound::GenSoundLabel(AudioSinkList& vAudioSinks, CStdString sink
     vAudioSinks.push_back(AudioSink(label, finalSink));
   }
 }
-#endif

--- a/xbmc/cores/AudioRenderers/AudioRendererFactory.cpp
+++ b/xbmc/cores/AudioRenderers/AudioRendererFactory.cpp
@@ -39,7 +39,7 @@
 #else
   #include "CoreAudioRenderer.h"
 #endif
-#elif defined(_LINUX)
+#elif defined(USE_ALSA)
 #include "ALSADirectSound.h"
 #endif
 
@@ -151,7 +151,7 @@ IAudioRenderer* CAudioRendererFactory::Create(IAudioCallback* pCallback, int iCh
   #else
     CreateAndReturnOnValidInitialize(CCoreAudioRenderer);
   #endif
-#elif defined(_LINUX)
+#elif defined(USE_ALSA)
   CreateAndReturnOnValidInitialize(CALSADirectSound);
 #endif
 
@@ -176,7 +176,7 @@ void CAudioRendererFactory::EnumerateAudioSinks(AudioSinkList& vAudioSinks, bool
   #if !defined(__arm__)
     CCoreAudioRenderer::EnumerateAudioSinks(vAudioSinks, passthrough);
   #endif
-#elif defined(_LINUX)
+#elif defined(USE_ALSA)
   CALSADirectSound::EnumerateAudioSinks(vAudioSinks, passthrough);
 #endif
 }
@@ -203,7 +203,7 @@ IAudioRenderer *CAudioRendererFactory::CreateFromUri(const CStdString &soundsyst
     if (soundsystem.Equals("coreaudio"))
       ReturnNewRenderer(CCoreAudioRenderer);
   #endif
-#elif defined(_LINUX)
+#elif defined(USE_ALSA)
   if (soundsystem.Equals("alsa"))
     ReturnNewRenderer(CALSADirectSound);
 #endif

--- a/xbmc/cores/AudioRenderers/Makefile.in
+++ b/xbmc/cores/AudioRenderers/Makefile.in
@@ -10,8 +10,11 @@ else
 SRCS = \
 	NullDirectSound.cpp \
 	AudioRendererFactory.cpp \
-	ALSADirectSound.cpp \
 
+endif
+
+ifeq (@USE_ALSA@,1)
+SRCS+=	ALSADirectSound.cpp
 endif
 
 ifeq (@USE_PULSE@,1)

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -67,7 +67,7 @@
 #include "LinuxTimezone.h"
 #include <dlfcn.h>
 #include "cores/AudioRenderers/AudioRendererFactory.h"
-#ifndef __APPLE__
+#if defined(USE_ALSA)
 #include "cores/AudioRenderers/ALSADirectSound.h"
 #endif
 #ifdef HAS_HAL


### PR DESCRIPTION
This is useful on embedded platforms where alsa is not used.

The only reason for the PR is the change to configure.in, the rest should be straightforward.

XBMC will now build without alsa support rather than failing when it's not found. I debated whether we should force failure for standard desktop builds, or to add a configure switch, but in the end decided not to make it too complicated. desktop builds will almost always want alsa, and if not it HAVE_ALSA can be undef'd. For 99% of builds, behavior is unchanged.

Will push tomorrow if there are no objections.
