### PR TITLE
Library customisation via XML

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		7C0A7FC813A9E75400AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC413A9E75400AFC2BD /* DirtyRegionSolvers.cpp */; };
 		7C0A7FC913A9E75400AFC2BD /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC613A9E75400AFC2BD /* DirtyRegionTracker.cpp */; };
 		7C0A7FCC13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FCA13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp */; };
+		7C1F6F8C13ED17CC001726AB /* LibraryDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F6F8A13ED17CC001726AB /* LibraryDirectory.cpp */; };
 		7C89627013B702F3003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89626E13B702F3003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C99B73F133D372300FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B73D133D372300FC2B16 /* CacheCircular.cpp */; };
 		7C99B7AA134072CD00FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */; };
@@ -952,6 +953,8 @@
 		7C0A7FC713A9E75400AFC2BD /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
 		7C0A7FCA13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowDebugInfo.cpp; sourceTree = "<group>"; };
 		7C0A7FCB13A9E76E00AFC2BD /* GUIWindowDebugInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowDebugInfo.h; sourceTree = "<group>"; };
+		7C1F6F8A13ED17CC001726AB /* LibraryDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LibraryDirectory.cpp; sourceTree = "<group>"; };
+		7C1F6F8B13ED17CC001726AB /* LibraryDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryDirectory.h; sourceTree = "<group>"; };
 		7C89626E13B702F3003631FE /* GUIWindowScreensaverDim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowScreensaverDim.cpp; sourceTree = "<group>"; };
 		7C89626F13B702F3003631FE /* GUIWindowScreensaverDim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowScreensaverDim.h; sourceTree = "<group>"; };
 		7C99B73D133D372300FC2B16 /* CacheCircular.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheCircular.cpp; sourceTree = "<group>"; };
@@ -4083,6 +4086,8 @@
 				F56C7400131EC151000AD0F6 /* ISO9660Directory.h */,
 				F56C7401131EC151000AD0F6 /* LastFMDirectory.cpp */,
 				F56C7402131EC151000AD0F6 /* LastFMDirectory.h */,
+				7C1F6F8A13ED17CC001726AB /* LibraryDirectory.cpp */,
+				7C1F6F8B13ED17CC001726AB /* LibraryDirectory.h */,
 				F56C7403131EC151000AD0F6 /* MultiPathDirectory.cpp */,
 				F56C7404131EC152000AD0F6 /* MultiPathDirectory.h */,
 				F56C7405131EC152000AD0F6 /* MultiPathFile.cpp */,
@@ -6768,6 +6773,7 @@
 				DFD4D22213D7286E00A47C47 /* SystemClock.cpp in Sources */,
 				7CEE2E6D13D6B7A8000ABF2A /* TimeSmoother.cpp in Sources */,
 				F5E6209F13E9081400D5F2CD /* InfoBool.cpp in Sources */,
+				7C1F6F8C13ED17CC001726AB /* LibraryDirectory.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		7C0A7F9D13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7F9B13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp */; };
 		7C0A7FB213A9E72E00AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FAE13A9E72E00AFC2BD /* DirtyRegionSolvers.cpp */; };
 		7C0A7FB313A9E72E00AFC2BD /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FB013A9E72E00AFC2BD /* DirtyRegionTracker.cpp */; };
+		7C1F6F7A13ED178F001726AB /* LibraryDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F6F7813ED178F001726AB /* LibraryDirectory.cpp */; };
 		7C89628013B7031E003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89627E13B7031E003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C99B6E9133D36E200FC2B16 /* CacheCircular.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */; };
 		7C99B7BE1340730000FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */; };
@@ -953,6 +954,8 @@
 		7C0A7FAF13A9E72E00AFC2BD /* DirtyRegionSolvers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionSolvers.h; sourceTree = "<group>"; };
 		7C0A7FB013A9E72E00AFC2BD /* DirtyRegionTracker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirtyRegionTracker.cpp; sourceTree = "<group>"; };
 		7C0A7FB113A9E72E00AFC2BD /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
+		7C1F6F7813ED178F001726AB /* LibraryDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LibraryDirectory.cpp; sourceTree = "<group>"; };
+		7C1F6F7913ED178F001726AB /* LibraryDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryDirectory.h; sourceTree = "<group>"; };
 		7C89627E13B7031E003631FE /* GUIWindowScreensaverDim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowScreensaverDim.cpp; sourceTree = "<group>"; };
 		7C89627F13B7031E003631FE /* GUIWindowScreensaverDim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowScreensaverDim.h; sourceTree = "<group>"; };
 		7C99B6E7133D36E200FC2B16 /* CacheCircular.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheCircular.cpp; sourceTree = "<group>"; };
@@ -4442,6 +4445,8 @@
 				F56C83E3131F42E8000AD0F6 /* ISO9660Directory.h */,
 				F56C83E4131F42E8000AD0F6 /* LastFMDirectory.cpp */,
 				F56C83E5131F42E8000AD0F6 /* LastFMDirectory.h */,
+				7C1F6F7813ED178F001726AB /* LibraryDirectory.cpp */,
+				7C1F6F7913ED178F001726AB /* LibraryDirectory.h */,
 				F56C83E6131F42E8000AD0F6 /* MultiPathDirectory.cpp */,
 				F56C83E7131F42E8000AD0F6 /* MultiPathDirectory.h */,
 				F56C83E8131F42E8000AD0F6 /* MultiPathFile.cpp */,
@@ -6783,6 +6788,7 @@
 				DFD4D1FE13D7283500A47C47 /* SystemClock.cpp in Sources */,
 				7CEE2E7F13D6B7D4000ABF2A /* TimeSmoother.cpp in Sources */,
 				F5E6209613E907E200D5F2CD /* InfoBool.cpp in Sources */,
+				7C1F6F7A13ED178F001726AB /* LibraryDirectory.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -514,6 +514,8 @@
 		43EA42B0136C2274002C82A5 /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807114B135DB5CC002F601B /* InputOperations.cpp */; };
 		7C0A7EC013A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */; };
 		7C0A7EC113A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */; };
+		7C1F6EBB13ECCFA7001726AB /* LibraryDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F6EB913ECCFA7001726AB /* LibraryDirectory.cpp */; };
+		7C1F6EBC13ECCFA7001726AB /* LibraryDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F6EB913ECCFA7001726AB /* LibraryDirectory.cpp */; };
 		7C2D6AE40F35453E00DD2E85 /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
 		7C45DBE910F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
 		7C45DBEA10F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
@@ -2401,6 +2403,8 @@
 		6E97BDC40DA2B620003A2A89 /* Socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Socket.h; sourceTree = "<group>"; };
 		7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppParamParser.cpp; sourceTree = "<group>"; };
 		7C0A7EBF13A5DBCE00AFC2BD /* AppParamParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppParamParser.h; sourceTree = "<group>"; };
+		7C1F6EB913ECCFA7001726AB /* LibraryDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LibraryDirectory.cpp; sourceTree = "<group>"; };
+		7C1F6EBA13ECCFA7001726AB /* LibraryDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibraryDirectory.h; sourceTree = "<group>"; };
 		7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpecialProtocol.cpp; sourceTree = "<group>"; };
 		7C2D6AE30F35453E00DD2E85 /* SpecialProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialProtocol.h; sourceTree = "<group>"; };
 		7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DAVDirectory.cpp; sourceTree = "<group>"; };
@@ -5649,6 +5653,8 @@
 				E38E16F40D25F9FA00618676 /* ISO9660Directory.h */,
 				E38E16F50D25F9FA00618676 /* LastFMDirectory.cpp */,
 				E38E16F60D25F9FA00618676 /* LastFMDirectory.h */,
+				7C1F6EB913ECCFA7001726AB /* LibraryDirectory.cpp */,
+				7C1F6EBA13ECCFA7001726AB /* LibraryDirectory.h */,
 				E38E17080D25F9FA00618676 /* MultiPathDirectory.cpp */,
 				E38E17090D25F9FA00618676 /* MultiPathDirectory.h */,
 				F50629780E57B9680066625A /* MultiPathFile.cpp */,
@@ -8084,6 +8090,7 @@
 				3802709A13D5A653009493DD /* SystemClock.cpp in Sources */,
 				7CEE2E5B13D6B71E000ABF2A /* TimeSmoother.cpp in Sources */,
 				7C89674613C03B22003631FE /* InfoBool.cpp in Sources */,
+				7C1F6EBB13ECCFA7001726AB /* LibraryDirectory.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8979,6 +8986,7 @@
 				4308680D13E3F65700698436 /* Implementation.cpp in Sources */,
 				4308681213E3F66600698436 /* DVDOverlayCodecTX3G.cpp in Sources */,
 				7C89674813C03B22003631FE /* InfoBool.cpp in Sources */,
+				7C1F6EBC13ECCFA7001726AB /* LibraryDirectory.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1028,6 +1028,7 @@
     <ClCompile Include="..\..\xbmc\FileSystem\IDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\FileSystem\IFile.cpp" />
     <ClCompile Include="..\..\xbmc\FileSystem\LastFMDirectory.cpp" />
+    <ClCompile Include="..\..\xbmc\FileSystem\LibraryDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\FileSystem\MultiPathDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\FileSystem\MultiPathFile.cpp" />
     <ClCompile Include="..\..\xbmc\FileSystem\MusicDatabaseDirectory.cpp" />
@@ -1901,6 +1902,7 @@
     <ClInclude Include="..\..\xbmc\FileSystem\HTSPSession.h" />
     <ClInclude Include="..\..\xbmc\FileSystem\HTTPDirectory.h" />
     <ClInclude Include="..\..\xbmc\FileSystem\LastFMDirectory.h" />
+    <ClInclude Include="..\..\xbmc\FileSystem\LibraryDirectory.h" />
     <ClInclude Include="..\..\xbmc\FileSystem\MultiPathDirectory.h" />
     <ClInclude Include="..\..\xbmc\FileSystem\MultiPathFile.h" />
     <ClInclude Include="..\..\xbmc\FileSystem\MusicDatabaseDirectory.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -771,6 +771,9 @@
     <ClCompile Include="..\..\xbmc\FileSystem\LastFMDirectory.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\FileSystem\LibraryDirectory.cpp">
+      <Filter>filesystem</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\FileSystem\MultiPathDirectory.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
@@ -3124,6 +3127,9 @@
       <Filter>filesystem</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\FileSystem\LastFMDirectory.h">
+      <Filter>filesystem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\FileSystem\LibraryDirectory.h">
       <Filter>filesystem</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\FileSystem\MultiPathDirectory.h">

--- a/system/library/video.xml
+++ b/system/library/video.xml
@@ -1,0 +1,173 @@
+<library>
+  <!-- default path to go to when first entering the library.  This is the path of a node -->
+  <default>movies</default>
+
+  <!-- nodes.  Each node must have a unique id (if non-unique we'll just take the first) -->
+
+  <node id="movies" visible="Library.HasContent(Movies)">
+    <!-- a virtual folder -->
+    <label>342</label>
+    <icon>DefaultMovies.png</icon>
+
+    <node id="genres" type="folder">
+      <label>135</label>
+      <path>videodb://1/1</path>
+      <icon>DefaultGenre.png</icon>
+    </node>
+    <node id="titles" type="folder">
+      <label>369</label>
+      <path>videodb://1/2</path>
+      <icon>DefaultMovieTitle.png</icon>
+    </node>
+    <node id="years" type="folder">
+      <label>562</label>
+      <path>videodb://1/3</path>
+      <icon>DefaultYear.png</icon>
+    </node>
+    <node id="actors" type="folder">
+      <label>344</label>
+      <path>videodb://1/4</path>
+      <icon>DefaultActor.png</icon>
+    </node>
+    <node id="directors" type="folder">
+      <label>20348</label>
+      <path>videodb://1/5</path>
+      <icon>DefaultDirector.png</icon>
+    </node>
+    <node id="studios" type="folder">
+      <label>20388</label>
+      <path>videodb://1/6</path>
+      <icon>DefaultStudios.png</icon>
+    </node>
+    <node id="sets" type="folder">
+      <label>20434</label>
+      <path>videodb://1/7</path>
+      <icon>DefaultSets.png</icon>
+    </node>
+    <node id="country" type="folder">
+      <label>20451</label>
+      <path>videodb://1/8</path>
+      <icon>DefaultCountry.png</icon>
+    </node>
+  </node>
+
+  <node id="tvshows" visible="Library.HasContent(TVShows)">
+    <!-- a virtual folder -->
+    <label>20343</label>
+    <icon>DefaultTVShows.png</icon>
+
+    <node id="genres" type="folder">
+      <label>135</label>
+      <path>videodb://2/1</path>
+      <icon>DefaultGenre.png</icon>
+    </node>
+    <node id="titles" type="folder">
+      <label>369</label>
+      <path>videodb://2/2</path>
+      <icon>DefaultTVShowTitle.png</icon>
+    </node>
+    <node id="years" type="folder">
+      <label>562</label>
+      <path>videodb://2/3</path>
+      <icon>DefaultYear.png</icon>
+    </node>
+    <node id="actors" type="folder">
+      <label>344</label>
+      <path>videodb://2/4</path>
+      <icon>DefaultActor.png</icon>
+    </node>
+    <node id="studios" type="folder">
+      <label>20388</label>
+      <path>videodb://2/5</path>
+      <icon>DefaultStudios.png</icon>
+    </node>
+  </node>
+
+  <node id="musicvideos" visible="Library.HasContent(MusicVideos)">
+    <!-- a virtual folder -->
+    <label>20389</label>
+    <icon>DefaultMusicVideos.png</icon>
+
+    <node id="genres" type="folder">
+      <label>135</label>
+      <path>videodb://3/1</path>
+      <icon>DefaultGenre.png</icon>
+    </node>
+    <node id="titles" type="folder">
+      <label>369</label>
+      <path>videodb://3/2</path>
+      <icon>DefaultMusicVideoTitle.png</icon>
+    </node>
+    <node id="years" type="folder">
+      <label>562</label>
+      <path>videodb://3/3</path>
+      <icon>DefaultYear.png</icon>
+    </node>
+    <node id="actors" type="folder">
+      <label>133</label>
+      <path>videodb://3/4</path>
+      <icon>DefaultArtist.png</icon>
+    </node>
+    <node id="albums" type="folder">
+      <label>132</label>
+      <path>videodb://3/5</path>
+      <icon>DefaultAlbum.png</icon>
+    </node>
+    <node id="directors" type="folder">
+      <label>20348</label>
+      <path>videodb://3/6</path>
+      <icon>DefaultDirector.png</icon>
+    </node>
+    <node id="studios" type="folder">
+      <label>20388</label>
+      <path>videodb://3/7</path>
+      <icon>DefaultStudios.png</icon>
+    </node>
+  </node>
+
+  <node type="filter" id="recentlyaddedmovies" visible="Library.HasContent(Movies)">
+    <label>20386</label>
+    <icon>DefaultRecentlyAddedMovies.png</icon>
+    <content>movies</content>
+      <match>all</match>
+      <limit>25</limit>
+      <order direction="descending">dateadded</order>
+  </node>
+
+  <node type="filter" id="recentlyaddedepisodes" visible="Library.HasContent(TVShows)">
+    <label>20387</label>
+    <icon>DefaultRecentlyAddedEpisodes.png</icon>
+    <content>episodes</content>
+      <match>all</match>
+      <limit>25</limit>
+      <order direction="descending">dateadded</order>
+  </node>
+
+  <node type="filter" id="recentlyaddedmusicvideos" visible="Library.HasContent(MusicVideos)">
+    <label>20390</label>
+    <icon>DefaultRecentlyAddedMusicVideos.png</icon>
+    <content>musicvideos</content>
+      <match>all</match>
+      <limit>25</limit>
+      <order direction="descending">dateadded</order>
+  </node>
+
+  <node type="folder">
+    <label>744</label>
+    <icon>DefaultFolder.png</icon>
+    <path>sources://video</path>
+  </node>
+
+  <node type="folder">
+    <label>136</label>
+    <icon>DefaultVideoPlaylists.png</icon>
+    <path>special://videoplaylists/</path>
+  </node>
+
+  <node type="folder">
+    <label>1037</label>
+    <icon>DefaultAddonVideo.png</icon>
+    <path>addons://sources/video/</path>
+  </node>
+
+</library>

--- a/system/library/video.xml
+++ b/system/library/video.xml
@@ -39,7 +39,7 @@
       <path>videodb://1/6</path>
       <icon>DefaultStudios.png</icon>
     </node>
-    <node id="sets" type="folder">
+    <node id="sets" type="folder" visible="Library.HasContent(MovieSets)">
       <label>20434</label>
       <path>videodb://1/7</path>
       <icon>DefaultSets.png</icon>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -754,6 +754,7 @@ int CGUIInfoManager::TranslateSingleString(const CStdString &strCondition)
         else if (cat == "movies") return LIBRARY_HAS_MOVIES;
         else if (cat == "tvshows") return LIBRARY_HAS_TVSHOWS;
         else if (cat == "musicvideos") return LIBRARY_HAS_MUSICVIDEOS;
+        else if (cat == "moviesets") return LIBRARY_HAS_MOVIE_SETS;
       }
     }
     else if (cat.name == "musicplayer")
@@ -4217,6 +4218,9 @@ void CGUIInfoManager::SetLibraryBool(int condition, bool value)
     case LIBRARY_HAS_MOVIES:
       m_libraryHasMovies = value ? 1 : 0;
       break;
+    case LIBRARY_HAS_MOVIE_SETS:
+      m_libraryHasMovieSets = value ? 1 : 0;
+      break;
     case LIBRARY_HAS_TVSHOWS:
       m_libraryHasTVShows = value ? 1 : 0;
       break;
@@ -4234,6 +4238,7 @@ void CGUIInfoManager::ResetLibraryBools()
   m_libraryHasMovies = -1;
   m_libraryHasTVShows = -1;
   m_libraryHasMusicVideos = -1;
+  m_libraryHasMovieSets = -1;
 }
 
 bool CGUIInfoManager::GetLibraryBool(int condition)
@@ -4263,6 +4268,19 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
       }
     }
     return m_libraryHasMovies > 0;
+  }
+  else if (condition == LIBRARY_HAS_MOVIE_SETS)
+  {
+    if (m_libraryHasMovieSets < 0)
+    {
+      CVideoDatabase db;
+      if (db.Open())
+      {
+        m_libraryHasMovieSets = db.HasSets() ? 1 : 0;
+        db.Close();
+      }
+    }
+    return m_libraryHasMovieSets > 0;
   }
   else if (condition == LIBRARY_HAS_TVSHOWS)
   {

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -370,11 +370,12 @@ namespace INFO
 #define LIBRARY_HAS_MUSIC           720
 #define LIBRARY_HAS_VIDEO           721
 #define LIBRARY_HAS_MOVIES          722
-#define LIBRARY_HAS_TVSHOWS         723
-#define LIBRARY_HAS_MUSICVIDEOS     724
-#define LIBRARY_IS_SCANNING         725
-#define LIBRARY_IS_SCANNING_VIDEO   726
-#define LIBRARY_IS_SCANNING_MUSIC   727
+#define LIBRARY_HAS_MOVIE_SETS      723
+#define LIBRARY_HAS_TVSHOWS         724
+#define LIBRARY_HAS_MUSICVIDEOS     725
+#define LIBRARY_IS_SCANNING         726
+#define LIBRARY_IS_SCANNING_VIDEO   727
+#define LIBRARY_IS_SCANNING_MUSIC   728
 
 #define SYSTEM_PLATFORM_XBOX        740
 #define SYSTEM_PLATFORM_LINUX       741
@@ -748,6 +749,7 @@ protected:
   int m_libraryHasMovies;
   int m_libraryHasTVShows;
   int m_libraryHasMusicVideos;
+  int m_libraryHasMovieSets;
 
   CCriticalSection m_critInfo;
 };

--- a/xbmc/GUIViewState.cpp
+++ b/xbmc/GUIViewState.cpp
@@ -89,6 +89,9 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
       return new CGUIViewStateVideoMovies(items);
   }
 
+  if (url.GetProtocol() == "library")
+    return new CGUIViewStateLibrary(items);
+
   if (items.IsPlayList())
     return new CGUIViewStateMusicPlaylist(items);
 
@@ -472,4 +475,19 @@ void CGUIViewStateFromItems::SaveViewState()
   SaveViewToDb(m_items.m_strPath, g_windowManager.GetActiveWindow());
 }
 
+CGUIViewStateLibrary::CGUIViewStateLibrary(const CFileItemList &items) : CGUIViewState(items)
+{
+  AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Foldername, empty
+  SetSortMethod(SORT_METHOD_NONE);
+  SetSortOrder(SORT_ORDER_NONE);
+
+  SetViewAsControl(DEFAULT_VIEW_LIST);
+
+  LoadViewState(items.m_strPath, g_windowManager.GetActiveWindow());
+}
+
+void CGUIViewStateLibrary::SaveViewState()
+{
+  SaveViewToDb(m_items.m_strPath, g_windowManager.GetActiveWindow());
+}
 

--- a/xbmc/GUIViewState.cpp
+++ b/xbmc/GUIViewState.cpp
@@ -73,7 +73,8 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
   if (url.GetProtocol()=="musicsearch")
     return new CGUIViewStateMusicSearch(items);
 
-  if (items.IsSmartPlayList() || url.GetProtocol() == "upnp")
+  if (items.IsSmartPlayList() || url.GetProtocol() == "upnp" ||
+      (url.GetProtocol() == "library" && items.GetProperty("library.filter")))
   {
     if (items.GetContent() == "songs")
       return new CGUIViewStateMusicSmartPlaylist(items);

--- a/xbmc/GUIViewState.h
+++ b/xbmc/GUIViewState.h
@@ -110,3 +110,12 @@ public:
 protected:
   virtual void SaveViewState();
 };
+
+class CGUIViewStateLibrary : public CGUIViewState
+{
+public:
+  CGUIViewStateLibrary(const CFileItemList& items);
+
+protected:
+  virtual void SaveViewState();
+};

--- a/xbmc/filesystem/FactoryDirectory.cpp
+++ b/xbmc/filesystem/FactoryDirectory.cpp
@@ -33,6 +33,7 @@
 #include "MusicDatabaseDirectory.h"
 #include "MusicSearchDirectory.h"
 #include "VideoDatabaseDirectory.h"
+#include "LibraryDirectory.h"
 #include "AddonsDirectory.h"
 #include "SourcesDirectory.h"
 #include "LastFMDirectory.h"
@@ -139,6 +140,7 @@ IDirectory* CFactoryDirectory::Create(const CStdString& strPath)
   if (strProtocol == "musicdb") return new CMusicDatabaseDirectory();
   if (strProtocol == "musicsearch") return new CMusicSearchDirectory();
   if (strProtocol == "videodb") return new CVideoDatabaseDirectory();
+  if (strProtocol == "library") return new CLibraryDirectory();
   if (strProtocol == "filereader")
     return CFactoryDirectory::Create(url.GetFileName());
 

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -1,0 +1,138 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "LibraryDirectory.h"
+#include "utils/URIUtils.h"
+#include "utils/StringUtils.h"
+#include "utils/XMLUtils.h"
+#include "guilib/GUIControlFactory.h" // for label parsing
+#include "guilib/TextureManager.h"
+#include "FileItem.h"
+#include "File.h"
+#include "settings/Settings.h"
+#include "URL.h"
+#include "GUIInfoManager.h"
+#include "utils/log.h"
+
+using namespace std;
+using namespace XFILE;
+
+CLibraryDirectory::CLibraryDirectory(void)
+{
+}
+
+CLibraryDirectory::~CLibraryDirectory(void)
+{
+}
+
+bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
+{
+  TiXmlElement *node = GetNode(strPath);
+  if (!node)
+    return false;
+
+  CStdString label;
+  if (XMLUtils::GetString(node, "label", label))
+    label = CGUIControlFactory::FilterLabel(label);
+
+  // now that we have our node, return all subnodes of this one, and set the label and thumb etc.
+  TiXmlElement *child = node->FirstChildElement("node");
+  while (child)
+  {
+    CStdString label, icon;
+    if (XMLUtils::GetString(child, "label", label))
+      label = CGUIControlFactory::FilterLabel(label);
+    XMLUtils::GetString(child, "icon", icon);
+    CStdString condition = child->Attribute("visible");
+    CFileItemPtr item;
+    if (condition.IsEmpty() || g_infoManager.EvaluateBool(condition))
+    {
+      CStdString type = child->Attribute("type");
+      if (type == "folder")
+      { // folder type - grab our path
+        CStdString path;
+        XMLUtils::GetPath(child, "path", path);
+        item.reset(new CFileItem(path, true));
+      }
+      else if (type.IsEmpty() || type == "filter")
+      { // virtual folder or filter
+        CStdString id = child->Attribute("id");
+        if (!id.IsEmpty())
+          item.reset(new CFileItem(URIUtils::AddFileToFolder(strPath, id), true));
+        else // illegal
+          CLog::Log(LOGERROR, "virtual folder or filter <node>'s must have a valid id");
+      }
+    }
+    if (item)
+    {
+      item->SetLabel(label);
+      if (!icon.IsEmpty() && g_TextureManager.HasTexture(icon))
+        item->SetIconImage(icon);
+      items.Add(item);
+    }
+    child = child->NextSiblingElement("node");
+  }
+  items.SetLabel(label);
+  return true;
+}
+
+bool CLibraryDirectory::Exists(const char* strPath)
+{
+  return GetNode(strPath) != NULL;
+}
+
+TiXmlElement *CLibraryDirectory::GetNode(const CStdString &path)
+{
+  // step 1: load our xml
+  CURL url(path);
+  CStdString xmlFile = URIUtils::AddFileToFolder(g_settings.GetDatabaseFolder(), url.GetHostName() + ".xml");
+  if (!CFile::Exists(xmlFile))
+    xmlFile = URIUtils::AddFileToFolder("special://xbmc/system/library/", url.GetHostName() + ".xml");
+  if (!m_doc.LoadFile(xmlFile))
+    return NULL;
+
+  // step 2: sanitize the xml
+  TiXmlElement *node = m_doc.RootElement();
+  if (!node || node->ValueStr() != "library")
+    return NULL;
+
+  // step 3: parse the xml to find which node this path corresponds to
+  vector<CStdString> nodes;
+  StringUtils::SplitString(url.GetFileName(), "/", nodes);
+  for (vector<CStdString>::iterator i = nodes.begin(); i != nodes.end(); ++i)
+  {
+    if (i->IsEmpty())
+      continue;
+    TiXmlElement *subNode = node->FirstChildElement("node");
+    while (subNode)
+    {
+      if (*i == subNode->Attribute("id"))
+      {
+        node = subNode;
+        break;
+      }
+      subNode = subNode->NextSiblingElement("node");
+    }
+    if (!subNode)
+      return NULL; // didn't find requested node
+  }
+  return node;
+}

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -20,6 +20,8 @@
  */
 
 #include "LibraryDirectory.h"
+#include "playlists/SmartPlayList.h"
+#include "SmartPlaylistDirectory.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
@@ -52,6 +54,24 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
   CStdString label;
   if (XMLUtils::GetString(node, "label", label))
     label = CGUIControlFactory::FilterLabel(label);
+
+  // check if our node is a filter node
+  CStdString type = node->Attribute("type");
+  if (type == "filter")
+  {
+    CSmartPlaylist playlist;
+    CStdString type;
+    XMLUtils::GetString(node, "content", type);
+    playlist.SetType(type);
+    playlist.SetName(label);
+    if (playlist.LoadFromXML(node) &&
+        CSmartPlaylistDirectory::GetDirectory(playlist, items))
+    {
+      items.SetProperty("library.filter", "true");
+      return true;
+    }
+    return false;
+  }
 
   // now that we have our node, return all subnodes of this one, and set the label and thumb etc.
   TiXmlElement *child = node->FirstChildElement("node");

--- a/xbmc/filesystem/LibraryDirectory.h
+++ b/xbmc/filesystem/LibraryDirectory.h
@@ -1,0 +1,44 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "IDirectory.h"
+#include "lib/tinyXML/tinyxml.h"
+
+namespace XFILE
+{
+  class CLibraryDirectory : public IDirectory
+  {
+  public:
+    CLibraryDirectory();
+    virtual ~CLibraryDirectory();
+    virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items);
+    virtual bool Exists(const char* strPath);
+    virtual bool IsAllowed(const CStdString& strFile) const { return true; };
+  private:
+    /*! \brief parse the given path, load our xml file and return the node corresponding to this path
+     \param the library:// path to parse
+     \return a pointer to the corresponding <node> TiXmlElement, NULL if not found.
+     */
+    TiXmlElement *GetNode(const CStdString &path);
+    TiXmlDocument m_doc;
+  };
+}

--- a/xbmc/filesystem/Makefile.in
+++ b/xbmc/filesystem/Makefile.in
@@ -48,6 +48,7 @@ SRCS=AddonsDirectory.cpp \
      iso9660.cpp \
      ISO9660Directory.cpp \
      LastFMDirectory.cpp \
+     LibraryDirectory.cpp \
      MultiPathDirectory.cpp \
      MultiPathFile.cpp \
      MusicDatabaseDirectory.cpp \

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -44,6 +44,11 @@ namespace XFILE
     CSmartPlaylist playlist;
     if (!playlist.Load(strPath))
       return false;
+    return GetDirectory(playlist, items);
+  }
+  
+  bool CSmartPlaylistDirectory::GetDirectory(CSmartPlaylist &playlist, CFileItemList& items)
+  {
     bool success = false, success2 = false;
     if (playlist.GetType().Equals("tvshows"))
     {

--- a/xbmc/filesystem/SmartPlaylistDirectory.h
+++ b/xbmc/filesystem/SmartPlaylistDirectory.h
@@ -23,6 +23,8 @@
 
 #include "IFileDirectory.h"
 
+class CSmartPlaylist;
+
 namespace XFILE
 {
   class CSmartPlaylistDirectory : public IFileDirectory
@@ -34,6 +36,8 @@ namespace XFILE
     virtual bool IsAllowed(const CStdString &strFile) const { return true; };
     virtual bool ContainsFiles(const CStdString& strPath);
     virtual bool Remove(const char *strPath);
+
+    static bool GetDirectory(CSmartPlaylist &playlist, CFileItemList& items);
 
     static CStdString GetPlaylistByName(const CStdString& name, const CStdString& playlistType);
   };

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -811,6 +811,15 @@ bool CSmartPlaylist::Load(const CStdString &path)
   // encoding:
   CStdString encoding;
   XMLUtils::GetEncoding(&m_xmlDoc, encoding);
+  
+  // from here we decode from XML
+  return LoadFromXML(root, encoding);
+}
+
+bool CSmartPlaylist::LoadFromXML(TiXmlElement *root, const CStdString &encoding)
+{
+  if (!root)
+    return false;
 
   TiXmlHandle match = ((TiXmlHandle)root->FirstChild("match")).FirstChild();
   if (match.Node())

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -147,6 +147,7 @@ public:
   bool Save(const CStdString &path);
 
   TiXmlElement *OpenAndReadName(const CStdString &path);
+  bool LoadFromXML(TiXmlElement *root, const CStdString &encoding = "UTF-8");
 
   void SetName(const CStdString &name);
   void SetType(const CStdString &type); // music, video, mixed

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -54,7 +54,6 @@ int CGUIViewStateWindowVideo::GetPlaylist()
 VECSOURCES& CGUIViewStateWindowVideo::GetSources()
 {
   AddLiveTVSources();
-  AddAddonsSource("video", g_localizeStrings.Get(1037), "DefaultAddonVideo.png");
   return CGUIViewState::GetSources();
 }
 
@@ -404,9 +403,8 @@ VECSOURCES& CGUIViewStateWindowVideoNav::GetSources()
 {
   //  Setup shares we want to have
   m_sources.clear();
-  //  Musicdb shares
   CFileItemList items;
-  CDirectory::GetDirectory("videodb://", items, "", true, false, DIR_CACHE_ONCE, true, false);
+  CDirectory::GetDirectory("library://video/", items, "", true, false, DIR_CACHE_ONCE, true, false);
   for (int i=0; i<items.Size(); ++i)
   {
     CFileItemPtr item=items[i];
@@ -416,35 +414,6 @@ VECSOURCES& CGUIViewStateWindowVideoNav::GetSources()
     share.m_strThumbnailImage= item->GetIconImage();
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
     m_sources.push_back(share);
-  }
-
-  if (g_settings.GetSourcesFromType("video")->empty())
-  { // no sources - add the "Add Source" item
-    CMediaSource share;
-    share.strName=g_localizeStrings.Get(999); // "Add Videos"
-    share.strPath = "sources://add/";
-    share.m_strThumbnailImage = CUtil::GetDefaultFolderThumb("DefaultAddSource.png");
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    m_sources.push_back(share);
-  }
-  else
-  {
-    { // Files share
-      CMediaSource share;
-      share.strName=g_localizeStrings.Get(744); // Files
-      share.strPath = "sources://video/";
-      share.m_strThumbnailImage = CUtil::GetDefaultFolderThumb("DefaultFolder.png");
-      share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-      m_sources.push_back(share);
-    }
-    { // Playlists share
-      CMediaSource share;
-      share.strName=g_localizeStrings.Get(136); // Playlists
-      share.strPath = "special://videoplaylists/";
-      share.m_strThumbnailImage = CUtil::GetDefaultFolderThumb("DefaultVideoPlaylists.png");
-      share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-      m_sources.push_back(share);
-    }
   }
   return CGUIViewStateWindowVideo::GetSources();
 }

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -510,7 +510,7 @@ CGUIViewStateVideoMovies::CGUIViewStateVideoMovies(const CFileItemList& items) :
   AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%T", "%O"));
   AddSortMethod(SORT_METHOD_YEAR,562, LABEL_MASKS("%T", "%Y"));
 
-  if (items.IsSmartPlayList())
+  if (items.IsSmartPlayList() || items.GetProperty("library.filter"))
   {
     AddSortMethod(SORT_METHOD_PLAYLIST_ORDER, 559, LABEL_MASKS("%T", "%R"));
     SetSortMethod(SORT_METHOD_PLAYLIST_ORDER);
@@ -549,7 +549,7 @@ CGUIViewStateVideoMusicVideos::CGUIViewStateVideoMusicVideos(const CFileItemList
     AddSortMethod(SORT_METHOD_ALBUM,558, LABEL_MASKS("%B - %T", "%Y"));
   }
 
-  if (items.IsSmartPlayList())
+  if (items.IsSmartPlayList() || items.GetProperty("library.filter"))
   {
     AddSortMethod(SORT_METHOD_PLAYLIST_ORDER, 559, LABEL_MASKS("%A - %T", "%Y"));
     SetSortMethod(SORT_METHOD_PLAYLIST_ORDER);
@@ -579,7 +579,7 @@ CGUIViewStateVideoTVShows::CGUIViewStateVideoTVShows(const CFileItemList& items)
 
   AddSortMethod(SORT_METHOD_YEAR,562,LABEL_MASKS("%L","%Y","%L","%Y"));
 
-  if (items.IsSmartPlayList())
+  if (items.IsSmartPlayList() || items.GetProperty("library.filter"))
   {
     AddSortMethod(SORT_METHOD_PLAYLIST_ORDER, 559, LABEL_MASKS("%L", "%M", "%L", "%M"));
     SetSortMethod(SORT_METHOD_PLAYLIST_ORDER);
@@ -623,7 +623,7 @@ CGUIViewStateVideoEpisodes::CGUIViewStateVideoEpisodes(const CFileItemList& item
     AddSortMethod(SORT_METHOD_DATE,552,LABEL_MASKS("%Z - %H. %T","%J"));
   }
 
-  if (items.IsSmartPlayList())
+  if (items.IsSmartPlayList() || items.GetProperty("library.filter"))
   {
     AddSortMethod(SORT_METHOD_PLAYLIST_ORDER, 559, LABEL_MASKS("%Z - %H. %T", "%R"));
     SetSortMethod(SORT_METHOD_PLAYLIST_ORDER);


### PR DESCRIPTION
These commits allow the video library to be configured via XML.  The pre-supplied video.xml defaults to the nodes the user typically sees when flattening of the video library is disabled.  Additional virtual folders or filters (smartplaylists) can be added as needed.  The XML file can be overridden in userdata/Database.

This pull request is an initial discussion point.  Still to do are:
1.  Determine what (if anything) to do with the existing flattening option.  Options:
   a. Add an extra XML file for the flattened version and switch between them as needed.
   b. Just use flattening and allow some other way to access Genres/Directors etc (perhaps via an "Extras" folder?)
   c. Switch conditionally within the XML (though this will require some infomanager changes and will complicate the XML).
2.  Consider whether we need more than just the single-layer smart playlist filtering (i.e. do we need rules that combine OR and AND together?)

Comments (and review) most welcome.
