### PR TITLE
<onback> support to controls

### DIFF
--- a/addons/skin.confluence/720p/MyVideoNav.xml
+++ b/addons/skin.confluence/720p/MyVideoNav.xml
@@ -37,6 +37,7 @@
 				<onright>50</onright>
 				<onup>9000</onup>
 				<ondown>9000</ondown>
+				<onback>50</onback>
 				<itemgap>0</itemgap>
 				<control type="label" id="200">
 					<width>250</width>

--- a/addons/skin.confluence/720p/MyVideoPlaylist.xml
+++ b/addons/skin.confluence/720p/MyVideoPlaylist.xml
@@ -25,6 +25,7 @@
 				<height>600</height>
 				<onleft>9000</onleft>
 				<onright>50</onright>
+				<onback>50</onback>
 				<onup>9000</onup>
 				<ondown>9000</ondown>
 				<itemgap>0</itemgap>

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -63,14 +63,8 @@ void CGUIDialogBusy::Render()
   CGUIDialog::Render();
 }
 
-bool CGUIDialogBusy::OnAction(const CAction &action)
+bool CGUIDialogBusy::OnBack(int actionID)
 {
-  if(action.GetID() == ACTION_NAV_BACK 
-  || action.GetID() == ACTION_PREVIOUS_MENU)
-  {
-    m_bCanceled = true;
-    return true;
-  }
-  else
-    return CGUIDialog::OnAction(action);
+  m_bCanceled = true;
+  return true;
 }

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -29,7 +29,7 @@ class CGUIDialogBusy: public CGUIDialog
 public:
   CGUIDialogBusy(void);
   virtual ~CGUIDialogBusy(void);
-  virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
 

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -81,8 +81,7 @@ CGUIDialogFileBrowser::~CGUIDialogFileBrowser()
 
 bool CGUIDialogFileBrowser::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PARENT_DIR ||
-     (action.GetID() == ACTION_NAV_BACK && !m_vecItems->IsVirtualDirectoryRoot()))
+  if (action.GetID() == ACTION_PARENT_DIR)
   {
     GoParentFolder();
     return true;
@@ -110,6 +109,16 @@ bool CGUIDialogFileBrowser::OnAction(const CAction &action)
   }
 
   return CGUIDialog::OnAction(action);
+}
+
+bool CGUIDialogFileBrowser::OnBack(int actionID)
+{
+  if (actionID == ACTION_NAV_BACK && !m_vecItems->IsVirtualDirectoryRoot())
+  {
+    GoParentFolder();
+    return true;
+  }
+  return CGUIDialog::OnBack(actionID);
 }
 
 bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)

--- a/xbmc/dialogs/GUIDialogFileBrowser.h
+++ b/xbmc/dialogs/GUIDialogFileBrowser.h
@@ -37,6 +37,7 @@ public:
   virtual ~CGUIDialogFileBrowser(void);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void FrameMove();
   virtual void OnWindowLoaded();
   virtual void OnWindowUnload();

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -58,14 +58,10 @@ CGUIDialogMediaSource::~CGUIDialogMediaSource()
   delete m_paths;
 }
 
-bool CGUIDialogMediaSource::OnAction(const CAction &action)
+bool CGUIDialogMediaSource::OnBack(int actionID)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU ||
-      action.GetID() == ACTION_NAV_BACK)
-  {
-    m_confirmed = false;
-  }
-  return CGUIDialog::OnAction(action);
+  m_confirmed = false;
+  return CGUIDialog::OnBack(actionID);
 }
 
 bool CGUIDialogMediaSource::OnMessage(CGUIMessage& message)

--- a/xbmc/dialogs/GUIDialogMediaSource.h
+++ b/xbmc/dialogs/GUIDialogMediaSource.h
@@ -34,7 +34,7 @@ public:
   CGUIDialogMediaSource(void);
   virtual ~CGUIDialogMediaSource(void);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void OnWindowLoaded();
   static bool ShowAndAddMediaSource(const CStdString &type);
   static bool ShowAndEditMediaSource(const CStdString &type, const CMediaSource &share);

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -56,9 +56,7 @@ CGUIDialogNumeric::~CGUIDialogNumeric(void)
 
 bool CGUIDialogNumeric::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_NAV_BACK || action.GetID() == ACTION_PREVIOUS_MENU)
-    OnCancel();
-  else if (action.GetID() == ACTION_NEXT_ITEM)
+  if (action.GetID() == ACTION_NEXT_ITEM)
     OnNext();
   else if (action.GetID() == ACTION_PREV_ITEM)
     OnPrevious();
@@ -87,6 +85,12 @@ bool CGUIDialogNumeric::OnAction(const CAction &action)
   }
   else
     return CGUIDialog::OnAction(action);
+  return true;
+}
+
+bool CGUIDialogNumeric::OnBack(int actionID)
+{
+  OnCancel();
   return true;
 }
 

--- a/xbmc/dialogs/GUIDialogNumeric.h
+++ b/xbmc/dialogs/GUIDialogNumeric.h
@@ -32,6 +32,7 @@ public:
   virtual ~CGUIDialogNumeric(void);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void FrameMove();
 
   bool IsConfirmed() const;

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -137,19 +137,14 @@ bool CGUIDialogProgress::OnMessage(CGUIMessage& message)
   return CGUIDialog::OnMessage(message);
 }
 
-bool CGUIDialogProgress::OnAction(const CAction &action)
+bool CGUIDialogProgress::OnBack(int actionID)
 {
-  if (action.GetID() == ACTION_NAV_BACK || action.GetID() == ACTION_PREVIOUS_MENU)
+  if (m_bCanCancel)
   {
-    if (m_bCanCancel)
-    {
-      m_bCanceled = true;
-      return true;
-    }
-    else
-      return false;
+    m_bCanceled = true;
+    return true;
   }
-  return CGUIDialog::OnAction(action);
+  return false;
 }
 
 void CGUIDialogProgress::OnWindowLoaded()

--- a/xbmc/dialogs/GUIDialogProgress.h
+++ b/xbmc/dialogs/GUIDialogProgress.h
@@ -33,7 +33,7 @@ public:
 
   void StartModal();
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void OnWindowLoaded();
   void Progress();
   void ProgressKeys();

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -78,12 +78,10 @@ CGUIDialogSmartPlaylistEditor::~CGUIDialogSmartPlaylistEditor()
   delete m_ruleLabels;
 }
 
-bool CGUIDialogSmartPlaylistEditor::OnAction(const CAction &action)
+bool CGUIDialogSmartPlaylistEditor::OnBack(int actionID)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU ||
-      action.GetID() == ACTION_NAV_BACK)
-    m_cancelled = true;
-  return CGUIDialog::OnAction(action);
+  m_cancelled = true;
+  return CGUIDialog::OnBack(actionID);
 }
 
 bool CGUIDialogSmartPlaylistEditor::OnMessage(CGUIMessage& message)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
@@ -35,7 +35,7 @@ public:
   CGUIDialogSmartPlaylistEditor(void);
   virtual ~CGUIDialogSmartPlaylistEditor(void);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void OnWindowLoaded();
 
   static bool EditPlaylist(const CStdString &path, const CStdString &type = "");

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -51,12 +51,10 @@ CGUIDialogSmartPlaylistRule::~CGUIDialogSmartPlaylistRule()
 {
 }
 
-bool CGUIDialogSmartPlaylistRule::OnAction(const CAction &action)
+bool CGUIDialogSmartPlaylistRule::OnBack(int actionID)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU ||
-      action.GetID() == ACTION_NAV_BACK)
-    m_cancelled = true;
-  return CGUIDialog::OnAction(action);
+  m_cancelled = true;
+  return CGUIDialog::OnBack(actionID);
 }
 
 bool CGUIDialogSmartPlaylistRule::OnMessage(CGUIMessage& message)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
@@ -31,7 +31,7 @@ public:
   CGUIDialogSmartPlaylistRule(void);
   virtual ~CGUIDialogSmartPlaylistRule(void);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void OnInitWindow();
 
   static bool EditRule(CSmartPlaylistRule &rule, const CStdString& type="songs");

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -61,18 +61,11 @@ bool CGUIDialogYesNo::OnMessage(CGUIMessage& message)
   return CGUIDialogBoxBase::OnMessage(message);
 }
 
-bool CGUIDialogYesNo::OnAction(const CAction& action)
+bool CGUIDialogYesNo::OnBack(int actionID)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU ||
-      action.GetID() == ACTION_NAV_BACK)
-  {
-    m_bCanceled = true;
-    m_bConfirmed = false;
-    Close();
-    return true;
-  }
-
-  return CGUIDialogBoxBase::OnAction(action);
+  m_bCanceled = true;
+  m_bConfirmed = false;
+  return CGUIDialogBoxBase::OnBack(actionID);
 }
 
 // \brief Show CGUIDialogYesNo dialog, then wait for user to dismiss it.

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -30,7 +30,7 @@ public:
   CGUIDialogYesNo(int overrideId = -1);
   virtual ~CGUIDialogYesNo(void);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction& action);
+  virtual bool OnBack(int actionID);
 
   static bool ShowAndGetInput(int heading, int line0, int line1, int line2, int iNoLabel=-1, int iYesLabel=-1);
   static bool ShowAndGetInput(int heading, int line0, int line1, int line2, bool& bCanceled);

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -290,6 +290,7 @@ bool CGUIBaseContainer::OnAction(const CAction &action)
   case ACTION_MOVE_RIGHT:
   case ACTION_MOVE_DOWN:
   case ACTION_MOVE_UP:
+  case ACTION_NAV_BACK:
     {
       if (!HasFocus()) return false;
       if (action.GetHoldTime() > HOLD_TIME_START &&

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -52,6 +52,7 @@ CGUIControl::CGUIControl()
   m_controlRight = 0;
   m_controlUp = 0;
   m_controlDown = 0;
+  m_controlBack = 0;
   m_controlNext = 0;
   m_controlPrev = 0;
   ControlType = GUICONTROL_UNKNOWN;
@@ -85,6 +86,7 @@ CGUIControl::CGUIControl(int parentID, int controlID, float posX, float posY, fl
   m_controlRight = 0;
   m_controlUp = 0;
   m_controlDown = 0;
+  m_controlBack = 0;
   m_controlNext = 0;
   m_controlPrev = 0;
   ControlType = GUICONTROL_UNKNOWN;
@@ -222,6 +224,9 @@ bool CGUIControl::OnAction(const CAction &action)
       OnRight();
       return true;
 
+    case ACTION_NAV_BACK:
+      return OnBack();
+
     case ACTION_NEXT_CONTROL:
       OnNextControl();
       return true;
@@ -293,6 +298,22 @@ void CGUIControl::OnRight()
       SendWindowMessage(msg);
     }
   }
+}
+
+bool CGUIControl::OnBack()
+{
+  if (m_backActions.size())
+  {
+    ExecuteActions(m_backActions);
+    return true;
+  }
+  else if (m_controlBack && m_controlID != m_controlBack)
+  {
+    // Send a message to the window with the sender set as the window
+    CGUIMessage msg(GUI_MSG_MOVE, GetParentID(), GetID(), ACTION_NAV_BACK);
+    return SendWindowMessage(msg);
+  }
+  return false;
 }
 
 void CGUIControl::OnNextControl()
@@ -501,12 +522,13 @@ CRect CGUIControl::CalcRenderRegion() const
   return CRect(tl.x, tl.y, br.x, br.y);
 }
 
-void CGUIControl::SetNavigation(int up, int down, int left, int right)
+void CGUIControl::SetNavigation(int up, int down, int left, int right, int back)
 {
   m_controlUp = up;
   m_controlDown = down;
   m_controlLeft = left;
   m_controlRight = right;
+  m_controlBack = back;
 }
 
 void CGUIControl::SetTabNavigation(int next, int prev)
@@ -516,12 +538,14 @@ void CGUIControl::SetTabNavigation(int next, int prev)
 }
 
 void CGUIControl::SetNavigationActions(const vector<CGUIActionDescriptor> &up, const vector<CGUIActionDescriptor> &down,
-                                       const vector<CGUIActionDescriptor> &left, const vector<CGUIActionDescriptor> &right, bool replace)
+                                       const vector<CGUIActionDescriptor> &left, const vector<CGUIActionDescriptor> &right,
+                                       const vector<CGUIActionDescriptor> &back, bool replace)
 {
   if (m_leftActions.empty()  || replace) m_leftActions  = left;
   if (m_rightActions.empty() || replace) m_rightActions = right;
   if (m_upActions.empty()    || replace) m_upActions    = up;
   if (m_downActions.empty()  || replace) m_downActions  = down;
+  if (m_backActions.empty()  || replace) m_backActions  = back;
 }
 
 void CGUIControl::SetWidth(float width)
@@ -921,6 +945,8 @@ int CGUIControl::GetNextControl(int direction) const
     return m_controlLeft;
   case ACTION_MOVE_RIGHT:
     return m_controlRight;
+  case ACTION_NAV_BACK:
+    return m_controlBack;
   default:
     return -1;
   }

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -202,43 +202,34 @@ void CGUIControl::Render()
 
 bool CGUIControl::OnAction(const CAction &action)
 {
-  switch (action.GetID())
+  if (HasFocus())
   {
-  case ACTION_MOVE_DOWN:
-    if (!HasFocus()) return false;
-    OnDown();
-    return true;
-    break;
+    switch (action.GetID())
+    {
+    case ACTION_MOVE_DOWN:
+      OnDown();
+      return true;
 
-  case ACTION_MOVE_UP:
-    if (!HasFocus()) return false;
-    OnUp();
-    return true;
-    break;
+    case ACTION_MOVE_UP:
+      OnUp();
+      return true;
 
-  case ACTION_MOVE_LEFT:
-    if (!HasFocus()) return false;
-    OnLeft();
-    return true;
-    break;
+    case ACTION_MOVE_LEFT:
+      OnLeft();
+      return true;
 
-  case ACTION_MOVE_RIGHT:
-    if (!HasFocus()) return false;
-    OnRight();
-    return true;
-    break;
+    case ACTION_MOVE_RIGHT:
+      OnRight();
+      return true;
 
-  case ACTION_NEXT_CONTROL:
-      if (!HasFocus()) return false;
+    case ACTION_NEXT_CONTROL:
       OnNextControl();
       return true;
-      break;
 
-  case ACTION_PREV_CONTROL:
-      if (!HasFocus()) return false;
+    case ACTION_PREV_CONTROL:
       OnPrevControl();
       return true;
-      break;
+    }
   }
   return false;
 }

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -97,6 +97,7 @@ public:
   virtual void OnDown();
   virtual void OnLeft();
   virtual void OnRight();
+  virtual bool OnBack();
   virtual void OnNextControl();
   virtual void OnPrevControl();
   virtual void OnFocus() {};
@@ -174,7 +175,7 @@ public:
    */
   virtual CRect CalcRenderRegion() const;
 
-  virtual void SetNavigation(int up, int down, int left, int right);
+  virtual void SetNavigation(int up, int down, int left, int right, int back = 0);
   virtual void SetTabNavigation(int next, int prev);
 
   /*! \brief Set actions to perform on navigation
@@ -183,16 +184,19 @@ public:
    \param down vector of CGUIActionDescriptors to execute on down
    \param left vector of CGUIActionDescriptors to execute on left
    \param right vector of CGUIActionDescriptors to execute on right
+   \param back vector of CGUIActionDescriptors to execute on back
    \param replace Actions are set only if replace is true or there is no previously set action.  Defaults to true
    \sa SetNavigation, ExecuteActions
    */
   virtual void SetNavigationActions(const std::vector<CGUIActionDescriptor> &up, const std::vector<CGUIActionDescriptor> &down,
-                                    const std::vector<CGUIActionDescriptor> &left, const std::vector<CGUIActionDescriptor> &right, bool replace = true);
+                                    const std::vector<CGUIActionDescriptor> &left, const std::vector<CGUIActionDescriptor> &right,
+                                    const std::vector<CGUIActionDescriptor> &back, bool replace = true);
   void ExecuteActions(const std::vector<CGUIActionDescriptor> &actions);
   int GetControlIdUp() const { return m_controlUp;};
   int GetControlIdDown() const { return m_controlDown;};
   int GetControlIdLeft() const { return m_controlLeft;};
   int GetControlIdRight() const { return m_controlRight;};
+  int GetControlIdBack() const { return m_controlBack; };
   virtual int GetNextControl(int direction) const;
   virtual void SetFocus(bool focus);
   virtual void SetWidth(float width);
@@ -306,6 +310,7 @@ protected:
   int m_controlRight;
   int m_controlUp;
   int m_controlDown;
+  int m_controlBack;
   int m_controlNext;
   int m_controlPrev;
 
@@ -313,6 +318,7 @@ protected:
   std::vector<CGUIActionDescriptor> m_rightActions;
   std::vector<CGUIActionDescriptor> m_upActions;
   std::vector<CGUIActionDescriptor> m_downActions;
+  std::vector<CGUIActionDescriptor> m_backActions;
   std::vector<CGUIActionDescriptor> m_nextActions;
   std::vector<CGUIActionDescriptor> m_prevActions;
 

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -595,8 +595,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   float width = 0, height = 0;
   float minWidth = 0;
 
-  int left = 0, right = 0, up = 0, down = 0, next = 0, prev = 0;
-  vector<CGUIActionDescriptor> leftActions, rightActions, upActions, downActions, nextActions, prevActions;
+  int left = 0, right = 0, up = 0, down = 0, back = 0, next = 0, prev = 0;
+  vector<CGUIActionDescriptor> leftActions, rightActions, upActions, downActions, backActions, nextActions, prevActions;
 
   int pageControl = 0;
   CGUIInfoColor colorDiffuse(0xFFFFFFFF);
@@ -745,6 +745,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   if (!GetNavigation(pControlNode, "ondown", down, downActions)) down = id;
   if (!GetNavigation(pControlNode, "onleft", left, leftActions)) left = id;
   if (!GetNavigation(pControlNode, "onright", right, rightActions)) right = id;
+  if (!GetNavigation(pControlNode, "onback", back, backActions)) back = 0;
   if (!GetNavigation(pControlNode, "onnext", next, nextActions)) next = id;
   if (!GetNavigation(pControlNode, "onprev", prev, prevActions)) prev = id;
 
@@ -1317,9 +1318,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     control->SetEnableCondition(enableCondition);
     control->SetAnimations(animations);
     control->SetColorDiffuse(colorDiffuse);
-    control->SetNavigation(up, down, left, right);
+    control->SetNavigation(up, down, left, right, back);
     control->SetTabNavigation(next,prev);
-    control->SetNavigationActions(upActions, downActions, leftActions, rightActions);
+    control->SetNavigationActions(upActions, downActions, leftActions, rightActions, backActions);
     control->SetPulseOnSelect(bPulse);
     if (hasCamera)
       control->SetCamera(camera);

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -282,29 +282,29 @@ void CGUIControlGroupList::AddControl(CGUIControl *control, int position /*= -1*
       if (m_orientation == VERTICAL)
       {
         if (before) // update the DOWN action to point to us
-          before->SetNavigation(before->GetControlIdUp(), control->GetID(), GetControlIdLeft(), GetControlIdRight());
+          before->SetNavigation(before->GetControlIdUp(), control->GetID(), GetControlIdLeft(), GetControlIdRight(), GetControlIdBack());
         if (after) // update the UP action to point to us
-          after->SetNavigation(control->GetID(), after->GetControlIdDown(), GetControlIdLeft(), GetControlIdRight());
+          after->SetNavigation(control->GetID(), after->GetControlIdDown(), GetControlIdLeft(), GetControlIdRight(), GetControlIdBack());
       }
       else
       {
         if (before) // update the RIGHT action to point to us
-          before->SetNavigation(GetControlIdUp(), GetControlIdDown(), before->GetControlIdLeft(), control->GetID());
+          before->SetNavigation(GetControlIdUp(), GetControlIdDown(), before->GetControlIdLeft(), control->GetID(), GetControlIdBack());
         if (after) // update the LEFT action to point to us
-          after->SetNavigation(GetControlIdUp(), GetControlIdDown(), control->GetID(), after->GetControlIdRight());
+          after->SetNavigation(GetControlIdUp(), GetControlIdDown(), control->GetID(), after->GetControlIdRight(), GetControlIdBack());
       }
     }
     // now the control's nav
     std::vector<CGUIActionDescriptor> empty;
     if (m_orientation == VERTICAL)
     {
-      control->SetNavigation(beforeID, afterID, GetControlIdLeft(), GetControlIdRight());
-      control->SetNavigationActions(empty, empty, m_leftActions, m_rightActions, false);
+      control->SetNavigation(beforeID, afterID, GetControlIdLeft(), GetControlIdRight(), GetControlIdBack());
+      control->SetNavigationActions(empty, empty, m_leftActions, m_rightActions, empty, false);
     }
     else
     {
-      control->SetNavigation(GetControlIdUp(), GetControlIdDown(), beforeID, afterID);
-      control->SetNavigationActions(m_upActions, m_downActions, empty, empty, false);
+      control->SetNavigation(GetControlIdUp(), GetControlIdDown(), beforeID, afterID, GetControlIdBack());
+      control->SetNavigationActions(m_upActions, m_downActions, empty, empty, empty, false);
     }
 
     if (!m_useControlPositions)

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -72,12 +72,13 @@ bool CGUIDialog::OnAction(const CAction &action)
   if (!action.IsMouse() && m_autoClosing)
     SetAutoClose(m_showDuration);
 
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
-  {
-    Close();
-    return true;
-  }
   return CGUIWindow::OnAction(action);
+}
+
+bool CGUIDialog::OnBack(int actionID)
+{
+  Close();
+  return true;
 }
 
 bool CGUIDialog::OnMessage(CGUIMessage& message)

--- a/xbmc/guilib/GUIDialog.h
+++ b/xbmc/guilib/GUIDialog.h
@@ -48,6 +48,8 @@ public:
 
   void DoModal(int iWindowID = WINDOW_INVALID, const CStdString &param = ""); // modal
   void Show(); // modeless
+  
+  virtual bool OnBack(int actionID);
 
   virtual bool IsDialogRunning() const { return m_active; };
   virtual bool IsDialog() const { return true;};

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -389,10 +389,8 @@ bool CGUIWindow::OnAction(const CAction &action)
 
   // default implementations
   if (action.GetID() == ACTION_NAV_BACK || action.GetID() == ACTION_PREVIOUS_MENU)
-  {
-    g_windowManager.PreviousWindow();
-    return true;
-  }
+    return OnBack(action.GetID());
+
   return false;
 }
 
@@ -789,6 +787,12 @@ void CGUIWindow::ResetControlStates()
   m_lastControlID = 0;
   m_focusedControl = 0;
   m_controlStates.clear();
+}
+
+bool CGUIWindow::OnBack(int actionID)
+{
+  g_windowManager.PreviousWindow();
+  return true;
 }
 
 bool CGUIWindow::OnMove(int fromControl, int moveAction)

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -113,6 +113,8 @@ public:
   // on to the currently focused control.  Returns true if the action has been handled
   // and does not need to be passed further down the line (to our global action handlers)
   virtual bool OnAction(const CAction &action);
+  
+  virtual bool OnBack(int actionID);
 
   /*! \brief Clear the background (if necessary) prior to rendering the window
    */

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindow.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindow.cpp
@@ -69,13 +69,9 @@ CGUIPythonWindow::~CGUIPythonWindow(void)
 
 bool CGUIPythonWindow::OnAction(const CAction &action)
 {
-  bool ret = false;
-  // if we don't have callback window or we don't want to close window
-  // do the base class window first, and the call to python after this
-  if (!pCallbackWindow || !(action.GetID() == ACTION_NAV_BACK || action.GetID() == ACTION_PREVIOUS_MENU))
-    ret = CGUIWindow::OnAction(action);
-  else
-    ret = true;
+  // call the base class first, then call python
+  bool ret = CGUIWindow::OnAction(action);
+
   // workaround - for scripts which try to access the active control (focused) when there is none.
   // for example - the case when the mouse enters the screen.
   CGUIControl *pControl = GetFocusedControl();
@@ -92,6 +88,14 @@ bool CGUIPythonWindow::OnAction(const CAction &action)
     PulseActionEvent();
   }
   return ret;
+}
+
+bool CGUIPythonWindow::OnBack(int actionID)
+{
+  // if we have a callback window then python handles the closing
+  if (!pCallbackWindow)
+    return CGUIWindow::OnBack(actionID);
+  return true;
 }
 
 bool CGUIPythonWindow::OnMessage(CGUIMessage& message)

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindow.h
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindow.h
@@ -49,6 +49,7 @@ public:
   virtual ~CGUIPythonWindow(void);
   virtual bool    OnMessage(CGUIMessage& message);
   virtual bool    OnAction(const CAction &action);
+  virtual bool    OnBack(int actionID);
   void             SetCallbackWindow(void* state, void *object);
   void             WaitForActionEvent(unsigned int timeout);
   void             PulseActionEvent();

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.cpp
@@ -64,13 +64,8 @@ bool CGUIPythonWindowXML::Update(const CStdString &strPath)
 
 bool CGUIPythonWindowXML::OnAction(const CAction &action)
 {
-  bool ret = false;
-  // if we don't have callback window or we don't want to close window
-  // do the base class window first, and the call to python after this
-  if (!pCallbackWindow || !(action.GetID() == ACTION_NAV_BACK || action.GetID() == ACTION_PREVIOUS_MENU))
-    ret = CGUIWindow::OnAction(action);  // we don't currently want the mediawindow actions here
-  else
-    ret = true;
+  // call the base class first, then call python
+  bool ret = CGUIWindow::OnAction(action);
   if(pCallbackWindow)
   {
     PyXBMCAction* inf = new PyXBMCAction(pCallbackWindow);
@@ -81,6 +76,14 @@ bool CGUIPythonWindowXML::OnAction(const CAction &action)
     PulseActionEvent();
   }
   return ret;
+}
+
+bool CGUIPythonWindowXML::OnBack(int actionID)
+{
+  // if we have a callback window then python handles the closing
+  if (!pCallbackWindow)
+    return CGUIWindow::OnBack(actionID);
+  return true;
 }
 
 bool CGUIPythonWindowXML::OnClick(int iItem) {

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.h
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.h
@@ -36,6 +36,7 @@ public:
   virtual ~CGUIPythonWindowXML(void);
   virtual bool      OnMessage(CGUIMessage& message);
   virtual bool      OnAction(const CAction &action);
+  virtual bool      OnBack(int actionID);
   virtual void      AllocResources(bool forceLoad = false);
   virtual void      FreeResources(bool forceUnLoad = false);
   void              Process(unsigned int currentTime, CDirtyRegionList &regions);

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -142,10 +142,13 @@ bool CGUIDialogSongInfo::OnAction(const CAction &action)
       SetRating(rating - 1);
     return true;
   }
-  else if (action.GetID() == ACTION_PREVIOUS_MENU ||
-           action.GetID() == ACTION_NAV_BACK)
-    m_cancelled = true;
   return CGUIDialog::OnAction(action);
+}
+
+bool CGUIDialogSongInfo::OnBack(int actionID)
+{
+  m_cancelled = true;
+  return CGUIDialog::OnBack(actionID);
 }
 
 void CGUIDialogSongInfo::OnInitWindow()

--- a/xbmc/music/dialogs/GUIDialogSongInfo.h
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.h
@@ -34,6 +34,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   void SetSong(CFileItem *item);
   virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   bool NeedsUpdate() const { return m_needsUpdate; };
 
   virtual bool HasListItems() const { return true; };

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -85,22 +85,15 @@ CGUIWindowMusicBase::~CGUIWindowMusicBase ()
 {
 }
 
-/// \brief Handle actions on window.
-/// \param action Action that can be reacted on.
-bool CGUIWindowMusicBase::OnAction(const CAction& action)
+bool CGUIWindowMusicBase::OnBack(int actionID)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU ||
-      action.GetID() == ACTION_NAV_BACK)
+  CGUIDialogMusicScan *musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
+  if (musicScan && !musicScan->IsDialogRunning())
   {
-    CGUIDialogMusicScan *musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-    if (musicScan && !musicScan->IsDialogRunning())
-    {
-      CUtil::ThumbCacheClear();
-      CUtil::RemoveTempFiles();
-    }
+    CUtil::ThumbCacheClear();
+    CUtil::RemoveTempFiles();
   }
-
-  return CGUIMediaWindow::OnAction(action);
+  return CGUIMediaWindow::OnBack(actionID);
 }
 
 /*!

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -46,7 +46,7 @@ public:
   CGUIWindowMusicBase(int id, const CStdString &xmlFile);
   virtual ~CGUIWindowMusicBase(void);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction& action);
+  virtual bool OnBack(int actionID);
 
   void OnInfo(CFileItem *pItem, bool bShowInfo = false);
   static void SetupFanart(CFileItemList& items);

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -218,7 +218,7 @@ bool CGUIWindowMusicPlayList::OnAction(const CAction &action)
     // Playlist has no parent dirs
     return true;
   }
-  if (action.GetID() == ACTION_SHOW_PLAYLIST || action.GetID() == ACTION_NAV_BACK)
+  if (action.GetID() == ACTION_SHOW_PLAYLIST)
   {
     g_windowManager.PreviousWindow();
     return true;
@@ -233,6 +233,13 @@ bool CGUIWindowMusicPlayList::OnAction(const CAction &action)
     return true;
   }
   return CGUIWindowMusicBase::OnAction(action);
+}
+
+bool CGUIWindowMusicPlayList::OnBack(int actionID)
+{
+  if (actionID == ACTION_NAV_BACK)
+    return CGUIWindow::OnBack(actionID); // base class goes up a folder, but none to go up
+  return CGUIWindowMusicBase::OnBack(actionID);
 }
 
 bool CGUIWindowMusicPlayList::MoveCurrentPlayListItem(int iItem, int iAction, bool bUpdate /* = true */)

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.h
@@ -32,6 +32,7 @@ public:
 
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
 
   void RemovePlayListItem(int iItem);
   void MoveItem(int iStart, int iDest);

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -59,13 +59,11 @@ CGUIWindowMusicPlaylistEditor::~CGUIWindowMusicPlaylistEditor(void)
   delete m_playlist;
 }
 
-bool CGUIWindowMusicPlaylistEditor::OnAction(const CAction &action)
+bool CGUIWindowMusicPlaylistEditor::OnBack(int actionID)
 {
-  if (action.GetID() == ACTION_NAV_BACK && !m_viewControl.HasControl(GetFocusedControlID()))
-  { // base class would normally go up a folder here, but we don't do this
-    return CGUIWindow::OnAction(action);
-  }
-  return CGUIWindowMusicBase::OnAction(action);
+  if (actionID == ACTION_NAV_BACK && !m_viewControl.HasControl(GetFocusedControlID()))
+    return CGUIWindow::OnBack(actionID); // base class goes up a folder, but none to go up
+  return CGUIWindowMusicBase::OnBack(actionID);
 }
 
 bool CGUIWindowMusicPlaylistEditor::OnMessage(CGUIMessage& message)

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
@@ -33,7 +33,7 @@ public:
   virtual ~CGUIWindowMusicPlaylistEditor(void);
 
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
 
 protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -51,12 +51,10 @@ CGUIDialogNetworkSetup::~CGUIDialogNetworkSetup()
 {
 }
 
-bool CGUIDialogNetworkSetup::OnAction(const CAction &action)
+bool CGUIDialogNetworkSetup::OnBack(int actionID)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU ||
-      action.GetID() == ACTION_NAV_BACK)
-    m_confirmed = false;
-  return CGUIDialog::OnAction(action);
+  m_confirmed = false;
+  return CGUIDialog::OnBack(actionID);
 }
 
 bool CGUIDialogNetworkSetup::OnMessage(CGUIMessage& message)

--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -46,7 +46,7 @@ public:
   CGUIDialogNetworkSetup(void);
   virtual ~CGUIDialogNetworkSetup(void);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void OnInitWindow();
 
   static bool ShowAndGetNetworkAddress(CStdString &path);

--- a/xbmc/settings/GUIDialogSettings.cpp
+++ b/xbmc/settings/GUIDialogSettings.cpp
@@ -201,16 +201,10 @@ void CGUIDialogSettings::UpdateSetting(unsigned int id)
   }
 }
 
-bool CGUIDialogSettings::OnAction(const CAction& action)
+bool CGUIDialogSettings::OnBack(int actionID)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU ||
-      action.GetID() == ACTION_NAV_BACK)
-  {
-    OnCancel();
-    Close();
-    return true;
-  }
-  return CGUIDialog::OnAction(action);
+  OnCancel();
+  return CGUIDialog::OnBack(actionID);
 }
 
 void CGUIDialogSettings::OnClick(int iID)

--- a/xbmc/settings/GUIDialogSettings.h
+++ b/xbmc/settings/GUIDialogSettings.h
@@ -71,7 +71,7 @@ public:
 protected:
   virtual void OnOkay() {};
   virtual void OnCancel() {};
-  virtual bool OnAction(const CAction& action);
+  virtual bool OnBack(int actionID);
   virtual void OnInitWindow();
   virtual void SetupPage();
   virtual void CreateSettings() {};

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -154,14 +154,11 @@ CGUIWindowSettingsCategory::~CGUIWindowSettingsCategory(void)
   delete m_pOriginalEdit;
 }
 
-bool CGUIWindowSettingsCategory::OnAction(const CAction &action)
+bool CGUIWindowSettingsCategory::OnBack(int actionID)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
-  {
-    g_settings.Save();
-    m_lastControlID = 0; // don't save the control as we go to a different window each time
-  }
-  return CGUIWindow::OnAction(action);
+  g_settings.Save();
+  m_lastControlID = 0; // don't save the control as we go to a different window each time
+  return CGUIWindow::OnBack(actionID);
 }
 
 bool CGUIWindowSettingsCategory::OnMessage(CGUIMessage &message)

--- a/xbmc/settings/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/GUIWindowSettingsCategory.h
@@ -33,7 +33,7 @@ public:
   CGUIWindowSettingsCategory(void);
   virtual ~CGUIWindowSettingsCategory(void);
   virtual bool OnMessage(CGUIMessage &message);
-  virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void FrameMove();
   virtual void Render();
   virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -46,16 +46,16 @@ CGUIDialogTeletext::~CGUIDialogTeletext()
 
 bool CGUIDialogTeletext::OnAction(const CAction& action)
 {
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
-  {
-    m_bClose = true;
-    return true;
-  }
-
   if (m_TextDecoder.HandleAction(action))
     return true;
 
   return CGUIDialog::OnAction(action);
+}
+
+bool CGUIDialogTeletext::OnBack(int actionID)
+{
+  m_bClose = true;
+  return true;
 }
 
 bool CGUIDialogTeletext::OnMessage(CGUIMessage& message)

--- a/xbmc/video/dialogs/GUIDialogTeletext.h
+++ b/xbmc/video/dialogs/GUIDialogTeletext.h
@@ -32,6 +32,7 @@ public:
   virtual ~CGUIDialogTeletext(void);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction& action);
+  virtual bool OnBack(int actionID);
   virtual void Render();
   virtual void OnInitWindow();
   virtual void OnDeinitWindow(int nextWindowID);

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -199,7 +199,7 @@ bool CGUIWindowVideoPlaylist::OnAction(const CAction &action)
     // Playlist has no parent dirs
     return true;
   }
-  if (action.GetID() == ACTION_SHOW_PLAYLIST || action.GetID() == ACTION_NAV_BACK)
+  if (action.GetID() == ACTION_SHOW_PLAYLIST)
   {
     g_windowManager.PreviousWindow();
     return true;
@@ -214,6 +214,13 @@ bool CGUIWindowVideoPlaylist::OnAction(const CAction &action)
     return true;
   }
   return CGUIWindowVideoBase::OnAction(action);
+}
+
+bool CGUIWindowVideoPlaylist::OnBack(int actionID)
+{
+  if (actionID == ACTION_NAV_BACK)
+    return CGUIWindow::OnBack(actionID); // base class goes up a folder, but none to go up
+  return CGUIWindowVideoBase::OnBack(actionID);
 }
 
 bool CGUIWindowVideoPlaylist::MoveCurrentPlayListItem(int iItem, int iAction, bool bUpdate /* = true */)

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.h
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.h
@@ -31,6 +31,7 @@ public:
 
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
 
 protected:
   virtual bool OnPlayMedia(int iItem);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -153,8 +153,7 @@ CFileItemPtr CGUIMediaWindow::GetCurrentListItem(int offset)
 
 bool CGUIMediaWindow::OnAction(const CAction &action)
 {
-  if (action.GetID() == ACTION_PARENT_DIR ||
-     (action.GetID() == ACTION_NAV_BACK && !(m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->m_strPath == m_startDirectory)))
+  if (action.GetID() == ACTION_PARENT_DIR)
   {
     GoParentFolder();
     return true;
@@ -197,6 +196,16 @@ bool CGUIMediaWindow::OnAction(const CAction &action)
   }
 
   return false;
+}
+
+bool CGUIMediaWindow::OnBack(int actionID)
+{
+  if (actionID == ACTION_NAV_BACK && !(m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->m_strPath == m_startDirectory))
+  {
+    GoParentFolder();
+    return true;
+  }
+  return CGUIWindow::OnBack(actionID);
 }
 
 bool CGUIMediaWindow::OnMessage(CGUIMessage& message)

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -37,6 +37,7 @@ public:
   virtual ~CGUIMediaWindow(void);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void OnWindowLoaded();
   virtual void OnWindowUnload();
   virtual void OnInitWindow();

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -164,8 +164,7 @@ bool CGUIWindowFileManager::OnAction(const CAction &action)
       }
       return true;
     }
-    if (action.GetID() == ACTION_PARENT_DIR ||
-       (action.GetID() == ACTION_NAV_BACK && !m_vecItems[list]->IsVirtualDirectoryRoot()))
+    if (action.GetID() == ACTION_PARENT_DIR)
     {
       GoParentFolder(list);
       return true;
@@ -179,6 +178,17 @@ bool CGUIWindowFileManager::OnAction(const CAction &action)
     }
   }
   return CGUIWindow::OnAction(action);
+}
+
+bool CGUIWindowFileManager::OnBack(int actionID)
+{
+  int list = GetFocusedList();
+  if (list >= 0 && list <= 1 && actionID == ACTION_NAV_BACK && !m_vecItems[list]->IsVirtualDirectoryRoot())
+  {
+    GoParentFolder(list);
+    return true;
+  }
+  return CGUIWindow::OnBack(actionID);
 }
 
 bool CGUIWindowFileManager::OnMessage(CGUIMessage& message)

--- a/xbmc/windows/GUIWindowFileManager.h
+++ b/xbmc/windows/GUIWindowFileManager.h
@@ -43,6 +43,7 @@ public:
   virtual ~CGUIWindowFileManager(void);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual bool OnFileCallback(void* pContext, int ipercent, float avgSpeed);
   const CFileItem &CurrentDirectory(int indx) const;
 

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -137,9 +137,13 @@ bool CGUIWindowLoginScreen::OnAction(const CAction &action)
       CBuiltins::Execute(action.GetName());
     return true;
   }
-  if (action.GetID() == ACTION_PREVIOUS_MENU || action.GetID() == ACTION_NAV_BACK)
-    return false; // no escape from the login window
   return CGUIWindow::OnAction(action);
+}
+
+bool CGUIWindowLoginScreen::OnBack(int actionID)
+{
+  // no escape from the login window
+  return false;
 }
 
 void CGUIWindowLoginScreen::FrameMove()

--- a/xbmc/windows/GUIWindowLoginScreen.h
+++ b/xbmc/windows/GUIWindowLoginScreen.h
@@ -34,6 +34,7 @@ public:
   virtual ~CGUIWindowLoginScreen(void);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
+  virtual bool OnBack(int actionID);
   virtual void FrameMove();
   virtual bool HasListItems() const { return true; };
   virtual CFileItemPtr GetCurrentListItem(int offset = 0);


### PR DESCRIPTION
With the unification of ACTION_NAV_BACK it's now possible for controls to process <onback> messages.  This hooks support up for the skin and refactors the existing window-level handling to ensure it occurs after the controls have a bite of the apple.

Skin work needs doing - I've done VideoNav and VideoPlaylist as an example.

@Jezz_X: Would appreciate you handling the skin side.
