### PR TITLE
switch CFileItem::m_strPath to private, and add GetPath/SetPath for access

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -527,7 +527,7 @@ bool CApplication::Create()
       CFileItemList items;
       CUtil::GetRecursiveListing("special://xbmc/userdata",items,"");
       for (int i=0;i<items.Size();++i)
-          CFile::Cache(items[i]->m_strPath,"special://masterprofile/"+URIUtils::GetFileName(items[i]->m_strPath));
+          CFile::Cache(items[i]->GetPath(),"special://masterprofile/"+URIUtils::GetFileName(items[i]->GetPath()));
     }
     g_settings.m_logFolder = "special://masterprofile/";
   }
@@ -1738,13 +1738,13 @@ bool CApplication::LoadUserWindows()
       {
         if (items[i]->m_bIsFolder)
           continue;
-        CStdString skinFile = URIUtils::GetFileName(items[i]->m_strPath);
+        CStdString skinFile = URIUtils::GetFileName(items[i]->GetPath());
         if (skinFile.Left(6).CompareNoCase("custom") == 0)
         {
           TiXmlDocument xmlDoc;
-          if (!xmlDoc.LoadFile(items[i]->m_strPath))
+          if (!xmlDoc.LoadFile(items[i]->GetPath()))
           {
-            CLog::Log(LOGERROR, "unable to load:%s, Line %d\n%s", items[i]->m_strPath.c_str(), xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
+            CLog::Log(LOGERROR, "unable to load:%s, Line %d\n%s", items[i]->GetPath().c_str(), xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
             continue;
           }
 
@@ -2334,7 +2334,7 @@ bool CApplication::OnAction(const CAction &action)
         CMusicDatabase db;
         if (db.Open())      // OpenForWrite() ?
         {
-          db.SetSongRating(m_itemCurrentFile->m_strPath, m_itemCurrentFile->GetMusicInfoTag()->GetRating());
+          db.SetSongRating(m_itemCurrentFile->GetPath(), m_itemCurrentFile->GetMusicInfoTag()->GetRating());
           db.Close();
         }
         // send a message to all windows to tell them to update the fileitem (eg playlistplayer, media windows)
@@ -3303,11 +3303,11 @@ bool CApplication::PlayMedia(const CFileItem& item, int iPlaylist)
   {
     CDirectory dir;
     CFileItemList items;
-    if (dir.GetDirectory(item.m_strPath, items) && items.Size())
+    if (dir.GetDirectory(item.GetPath(), items) && items.Size())
     {
       CSmartPlaylist smartpl;
       //get name and type of smartplaylist, this will always succeed as GetDirectory also did this.
-      smartpl.OpenAndReadName(item.m_strPath);
+      smartpl.OpenAndReadName(item.GetPath());
       CPlayList playlist;
       playlist.Add(items);
       return ProcessAndStartPlaylist(smartpl.GetName(), playlist, (smartpl.GetType() == "songs" || smartpl.GetType() == "albums") ? PLAYLIST_MUSIC:PLAYLIST_VIDEO);
@@ -3319,7 +3319,7 @@ bool CApplication::PlayMedia(const CFileItem& item, int iPlaylist)
 
     //is or could be a playlist
     auto_ptr<CPlayList> pPlayList (CPlayListFactory::Create(item));
-    bool gotPlayList = (pPlayList.get() && pPlayList->Load(item.m_strPath));
+    bool gotPlayList = (pPlayList.get() && pPlayList->Load(item.GetPath()));
 
     if (dlgCache)
     {
@@ -3332,10 +3332,10 @@ bool CApplication::PlayMedia(const CFileItem& item, int iPlaylist)
     {
 
       if (iPlaylist != PLAYLIST_NONE)
-        return ProcessAndStartPlaylist(item.m_strPath, *pPlayList, iPlaylist);
+        return ProcessAndStartPlaylist(item.GetPath(), *pPlayList, iPlaylist);
       else
       {
-        CLog::Log(LOGWARNING, "CApplication::PlayMedia called to play a playlist %s but no idea which playlist to use, playing first item", item.m_strPath.c_str());
+        CLog::Log(LOGWARNING, "CApplication::PlayMedia called to play a playlist %s but no idea which playlist to use, playing first item", item.GetPath().c_str());
         if(pPlayList->size())
           return PlayFile(*(*pPlayList)[0], false);
       }
@@ -3368,15 +3368,15 @@ bool CApplication::PlayStack(const CFileItem& item, bool bRestart)
   CVideoDatabase dbs;
   if (dbs.Open())
   {
-    dbs.GetVideoSettings(item.m_strPath, g_settings.m_currentVideoSettings);
-    haveTimes = dbs.GetStackTimes(item.m_strPath, times);
+    dbs.GetVideoSettings(item.GetPath(), g_settings.m_currentVideoSettings);
+    haveTimes = dbs.GetStackTimes(item.GetPath(), times);
     dbs.Close();
   }
 
 
   // calculate the total time of the stack
   CStackDirectory dir;
-  dir.GetDirectory(item.m_strPath, *m_currentStack);
+  dir.GetDirectory(item.GetPath(), *m_currentStack);
   long totalTime = 0;
   for (int i = 0; i < m_currentStack->Size(); i++)
   {
@@ -3385,7 +3385,7 @@ bool CApplication::PlayStack(const CFileItem& item, bool bRestart)
     else
     {
       int duration;
-      if (!CDVDFileInfo::GetFileDuration((*m_currentStack)[i]->m_strPath, duration))
+      if (!CDVDFileInfo::GetFileDuration((*m_currentStack)[i]->GetPath(), duration))
       {
         m_currentStack->Clear();
         return false;
@@ -3403,13 +3403,13 @@ bool CApplication::PlayStack(const CFileItem& item, bool bRestart)
     if (dbs.Open())
     {
       if( !haveTimes )
-        dbs.SetStackTimes(item.m_strPath, times);
+        dbs.SetStackTimes(item.GetPath(), times);
 
       if( item.m_lStartOffset == STARTOFFSET_RESUME )
       {
         // can only resume seek here, not dvdstate
         CBookmark bookmark;
-        if( dbs.GetResumeBookMark(item.m_strPath, bookmark) )
+        if( dbs.GetResumeBookMark(item.GetPath(), bookmark) )
           seconds = bookmark.timeInSeconds;
         else
           seconds = 0.0f;
@@ -3478,15 +3478,15 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
   if (item.IsPlugin())
   { // we modify the item so that it becomes a real URL
     CFileItem item_new(item);
-    if (XFILE::CPluginDirectory::GetPluginResult(item.m_strPath, item_new))
+    if (XFILE::CPluginDirectory::GetPluginResult(item.GetPath(), item_new))
       return PlayFile(item_new, false);
     return false;
   }
 
-  if (URIUtils::IsUPnP(item.m_strPath))
+  if (URIUtils::IsUPnP(item.GetPath()))
   {
     CFileItem item_new(item);
-    if (XFILE::CUPnPDirectory::GetResource(item.m_strPath, item_new))
+    if (XFILE::CUPnPDirectory::GetResource(item.GetPath(), item_new))
       return PlayFile(item_new, false);
     return false;
   }
@@ -3500,7 +3500,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
   //Is TuxBox, this should probably be moved to CFileTuxBox
   if(item.IsTuxBox())
   {
-    CLog::Log(LOGDEBUG, "%s - TuxBox URL Detected %s",__FUNCTION__, item.m_strPath.c_str());
+    CLog::Log(LOGDEBUG, "%s - TuxBox URL Detected %s",__FUNCTION__, item.GetPath().c_str());
 
     if(g_tuxboxService.IsRunning())
       g_tuxboxService.Stop();
@@ -3550,13 +3550,13 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
       // open the d/b and retrieve the bookmarks for the current movie
       CVideoDatabase dbs;
       dbs.Open();
-      dbs.GetVideoSettings(item.m_strPath, g_settings.m_currentVideoSettings);
+      dbs.GetVideoSettings(item.GetPath(), g_settings.m_currentVideoSettings);
 
       if( item.m_lStartOffset == STARTOFFSET_RESUME )
       {
         options.starttime = 0.0f;
         CBookmark bookmark;
-        CStdString path = item.m_strPath;
+        CStdString path = item.GetPath();
         if (item.IsDVD()) 
           path = item.GetVideoInfoTag()->m_strFileNameAndPath;
         if(dbs.GetResumeBookMark(path, bookmark))
@@ -3656,7 +3656,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
   }
   else
   {
-    CLog::Log(LOGERROR, "Error creating player for item %s (File doesn't exist?)", item.m_strPath.c_str());
+    CLog::Log(LOGERROR, "Error creating player for item %s (File doesn't exist?)", item.GetPath().c_str());
     bResult = false;
   }
 
@@ -3986,7 +3986,7 @@ void CApplication::SaveFileState()
 void CApplication::UpdateFileState()
 {
   // Did the file change?
-  if (m_progressTrackingItem->m_strPath != "" && m_progressTrackingItem->m_strPath != CurrentFile())
+  if (m_progressTrackingItem->GetPath() != "" && m_progressTrackingItem->GetPath() != CurrentFile())
   {
     SaveFileState();
 
@@ -3997,7 +3997,7 @@ void CApplication::UpdateFileState()
   {
     if (IsPlayingVideo() || IsPlayingAudio())
     {
-      if (m_progressTrackingItem->m_strPath == "")
+      if (m_progressTrackingItem->GetPath() == "")
       {
         // Init some stuff
         *m_progressTrackingItem = CurrentFileItem();
@@ -4389,14 +4389,14 @@ bool CApplication::OnMessage(CGUIMessage& message)
           {
             if (!m_itemCurrentFile->HasMusicInfoTag() || !m_itemCurrentFile->GetMusicInfoTag()->Loaded())
             {
-              IMusicInfoTagLoader* tagloader = CMusicInfoTagLoaderFactory::CreateLoader(m_itemCurrentFile->m_strPath);
-              tagloader->Load(m_itemCurrentFile->m_strPath,*m_itemCurrentFile->GetMusicInfoTag());
+              IMusicInfoTagLoader* tagloader = CMusicInfoTagLoaderFactory::CreateLoader(m_itemCurrentFile->GetPath());
+              tagloader->Load(m_itemCurrentFile->GetPath(),*m_itemCurrentFile->GetMusicInfoTag());
               delete tagloader;
             }
             m_pKaraokeMgr->Start(m_itemCurrentFile->GetMusicInfoTag()->GetURL());
           }
           else
-            m_pKaraokeMgr->Start(m_itemCurrentFile->m_strPath);
+            m_pKaraokeMgr->Start(m_itemCurrentFile->GetPath());
         }
 #endif
         // Let scrobbler know about the track
@@ -4563,7 +4563,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr)
 #ifdef HAS_PYTHON
         if (item.IsPythonScript())
         { // a python script
-          g_pythonParser.evalFile(item.m_strPath.c_str(),ADDON::AddonPtr());
+          g_pythonParser.evalFile(item.GetPath().c_str(),ADDON::AddonPtr());
         }
         else
 #endif
@@ -4836,7 +4836,7 @@ void CApplication::Restart(bool bSamePosition)
 
 const CStdString& CApplication::CurrentFile()
 {
-  return m_itemCurrentFile->m_strPath;
+  return m_itemCurrentFile->GetPath();
 }
 
 CFileItem& CApplication::CurrentFileItem()
@@ -5259,7 +5259,7 @@ void CApplication::SaveCurrentFileSettings()
     {
       CVideoDatabase dbs;
       dbs.Open();
-      dbs.SetVideoSettings(m_itemCurrentFile->m_strPath, g_settings.m_currentVideoSettings);
+      dbs.SetVideoSettings(m_itemCurrentFile->GetPath(), g_settings.m_currentVideoSettings);
       dbs.Close();
     }
   }

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -364,7 +364,7 @@ case TMSG_POWERDOWN:
             {
               pSlideShow->Add(items[i].get());
             }
-            pSlideShow->Select(items[0]->m_strPath);
+            pSlideShow->Select(items[0]->GetPath());
           }
         }
         else
@@ -798,9 +798,7 @@ void CApplicationMessenger::ExecBuiltIn(const CStdString &command, bool wait)
 
 void CApplicationMessenger::MediaPlay(string filename)
 {
-  CFileItem item;
-  item.m_strPath = filename;
-  item.m_bIsFolder = false;
+  CFileItem item(filename, false);
   if (item.IsAudio())
     item.SetMusicThumb();
   else

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -172,10 +172,10 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
       CFileItemPtr pItem = vecItems[i];
 
       // is the current item a (non system) folder?
-      if (pItem->m_bIsFolder && pItem->m_strPath != "." && pItem->m_strPath != "..")
+      if (pItem->m_bIsFolder && pItem->GetPath() != "." && pItem->GetPath() != "..")
       {
         // Check if the current foldername indicates a DVD structure (name is "VIDEO_TS")
-        if (pItem->m_strPath.Find( "VIDEO_TS" ) != -1 && bAllowVideo
+        if (pItem->GetPath().Find( "VIDEO_TS" ) != -1 && bAllowVideo
         && (bypassSettings || g_guiSettings.GetBool("dvds.autorun")))
         {
           CUtil::PlayDVD("dvd", restart);
@@ -186,7 +186,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
         // Check if the current foldername indicates a Blu-Ray structure (default is "BDMV").
         // A BR should also include an "AACS" folder for encryption, Sony-BRs can also include update folders for PS3 (PS3_UPDATE / PS3_VPRM).
         // ToDo: for the time beeing, the DVD autorun settings are used to determine if the BR should be started automatically.
-        if (pItem->m_strPath.Find( "BDMV" ) != -1 && bAllowVideo
+        if (pItem->GetPath().Find( "BDMV" ) != -1 && bAllowVideo
         && (bypassSettings || g_guiSettings.GetBool("dvds.autorun")))
         {
           CUtil::PlayDVD("bd", restart);
@@ -196,9 +196,9 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
 
         // Video CDs can have multiple file formats. First we need to determine which one is used on the CD
         CStdString strExt;
-        if (pItem->m_strPath.Find("MPEGAV") != -1)
+        if (pItem->GetPath().Find("MPEGAV") != -1)
           strExt = ".dat";
-        if (pItem->m_strPath.Find("MPEG2") != -1)
+        if (pItem->GetPath().Find("MPEG2") != -1)
           strExt = ".mpg";
 
         // If a file format was extracted we are sure this is a VCD. Autoplay if settings indicate we should.
@@ -206,7 +206,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
              && (bypassSettings || g_guiSettings.GetBool("dvds.autorun")))
         {
           CFileItemList items;
-          CDirectory::GetDirectory(pItem->m_strPath, items, strExt);
+          CDirectory::GetDirectory(pItem->GetPath(), items, strExt);
           if (items.Size())
           {
             items.Sort(SORT_METHOD_LABEL, SORT_ORDER_ASC);
@@ -219,12 +219,12 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
           }
         }
         /* Probably want this if/when we add some automedia action dialog...
-        else if (pItem->m_strPath.Find("PICTURES") != -1 && bAllowPictures
+        else if (pItem->GetPath().Find("PICTURES") != -1 && bAllowPictures
               && (bypassSettings))
         {
           bPlaying = true;
           CStdString strExec;
-          strExec.Format("XBMC.RecursiveSlideShow(%s)", pItem->m_strPath.c_str());
+          strExec.Format("XBMC.RecursiveSlideShow(%s)", pItem->GetPath().c_str());
           CBuiltins::Execute(strExec);
           return true;
         }
@@ -254,7 +254,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
           // TODO: remove this once the app/player is capable of handling stacks immediately
           CStackDirectory dir;
           CFileItemList items;
-          dir.GetDirectory(pItem->m_strPath, items);
+          dir.GetDirectory(pItem->GetPath(), items);
           itemlist.Append(items);
         }
         else
@@ -318,9 +318,9 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
       CFileItemPtr  pItem = vecItems[i];
       if (pItem->m_bIsFolder)
       {
-        if (pItem->m_strPath != "." && pItem->m_strPath != ".." )
+        if (pItem->GetPath() != "." && pItem->GetPath() != ".." )
         {
-          if (RunDisc(pDir, pItem->m_strPath, nAddedToPlaylist, false, bypassSettings, restart))
+          if (RunDisc(pDir, pItem->GetPath(), nAddedToPlaylist, false, bypassSettings, restart))
           {
             bPlaying = true;
             break;

--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -91,7 +91,7 @@ void CBackgroundInfoLoader::Run()
         }
         catch (...)
         {
-          CLog::Log(LOGERROR, "%s::LoadItem - Unhandled exception for item %s", __FUNCTION__, pItem->m_strPath.c_str());
+          CLog::Log(LOGERROR, "%s::LoadItem - Unhandled exception for item %s", __FUNCTION__, pItem->GetPath().c_str());
         }
       }
     }

--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -376,9 +376,9 @@ bool CCueDocument::ResolvePath(CStdString &strPath, const CStdString &strBase)
     CDirectory::GetDirectory(strDirectory,items);
     for (int i=0;i<items.Size();++i)
     {
-      if (items[i]->m_strPath.Equals(strPath))
+      if (items[i]->GetPath().Equals(strPath))
       {
-        strPath = items[i]->m_strPath;
+        strPath = items[i]->GetPath();
         return true;
       }
     }

--- a/xbmc/Favourites.cpp
+++ b/xbmc/Favourites.cpp
@@ -79,7 +79,7 @@ bool CFavourites::LoadFavourites(CStdString& strPath, CFileItemList& items)
       if(!items.Contains(favourite->FirstChild()->Value()))
       {
         CFileItemPtr item(new CFileItem(name));
-        item->m_strPath = favourite->FirstChild()->Value();
+        item->SetPath(favourite->FirstChild()->Value());
         if (thumb) item->SetThumbnailImage(thumb);
         items.Add(item);
       }
@@ -104,7 +104,7 @@ bool CFavourites::Save(const CFileItemList &items)
     favNode.SetAttribute("name", item->GetLabel().c_str());
     if (item->HasThumbnail())
       favNode.SetAttribute("thumb", item->GetThumbnailImage().c_str());
-    TiXmlText execute(item->m_strPath);
+    TiXmlText execute(item->GetPath());
     favNode.InsertEndChild(execute);
     rootNode->InsertEndChild(favNode);
   }
@@ -132,9 +132,9 @@ bool CFavourites::AddOrRemove(CFileItem *item, int contextWindow)
   { // create our new favourite item
     CFileItemPtr favourite(new CFileItem(item->GetLabel()));
     if (item->GetLabel().IsEmpty())
-      favourite->SetLabel(CUtil::GetTitleFromPath(item->m_strPath, item->m_bIsFolder));
+      favourite->SetLabel(CUtil::GetTitleFromPath(item->GetPath(), item->m_bIsFolder));
     favourite->SetThumbnailImage(item->GetThumbnailImage());
-    favourite->m_strPath = executePath;
+    favourite->SetPath(executePath);
     items.Add(favourite);
   }
 
@@ -172,17 +172,17 @@ CStdString CFavourites::GetExecutePath(const CFileItem *item, int contextWindow)
   CStdString execute;
   if (item->m_bIsFolder && (g_advancedSettings.m_playlistAsFolders ||
                             !(item->IsSmartPlayList() || item->IsPlayList())))
-    execute.Format("ActivateWindow(%i,%s)", contextWindow, Paramify(item->m_strPath));
+    execute.Format("ActivateWindow(%i,%s)", contextWindow, Paramify(item->GetPath()));
   else if (item->IsScript())
-    execute.Format("RunScript(%s)", Paramify(item->m_strPath.Mid(9)));
+    execute.Format("RunScript(%s)", Paramify(item->GetPath().Mid(9)));
   else if (contextWindow == WINDOW_PROGRAMS)
-    execute.Format("RunXBE(%s)", Paramify(item->m_strPath));
+    execute.Format("RunXBE(%s)", Paramify(item->GetPath()));
   else  // assume a media file
   {
     if (item->IsVideoDb() && item->HasVideoInfoTag())
       execute.Format("PlayMedia(%s)", Paramify(item->GetVideoInfoTag()->m_strFileNameAndPath));
     else
-      execute.Format("PlayMedia(%s)", Paramify(item->m_strPath));
+      execute.Format("PlayMedia(%s)", Paramify(item->GetPath()));
   }
   return execute;
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -241,7 +241,7 @@ const CFileItem& CFileItem::operator=(const CFileItem& item)
   CGUIListItem::operator=(item);
   m_bLabelPreformated=item.m_bLabelPreformated;
   FreeMemory();
-  m_strPath = item.m_strPath;
+  m_strPath = item.GetPath();
   m_bIsParentFolder = item.m_bIsParentFolder;
   m_iDriveType = item.m_iDriveType;
   m_bIsShareOrDrive = item.m_bIsShareOrDrive;
@@ -1113,7 +1113,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
   if (!item)
     return false;
 
-  if (item->m_strPath == m_strPath && item->m_lStartOffset == m_lStartOffset) return true;
+  if (item->GetPath() == m_strPath && item->m_lStartOffset == m_lStartOffset) return true;
   if (IsMusicDb() && HasMusicInfoTag())
   {
     CFileItem dbItem(m_musicInfoTag->GetURL(), false);
@@ -1139,7 +1139,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
     return IsSamePath(&dbItem);
   }
   if (HasProperty("original_listitem_url"))
-    return (GetProperty("original_listitem_url") == item->m_strPath);
+    return (GetProperty("original_listitem_url") == item->GetPath());
   return false;
 }
 
@@ -1188,11 +1188,9 @@ CFileItemList::CFileItemList()
   m_replaceListing = false;
 }
 
-CFileItemList::CFileItemList(const CStdString& strPath)
+CFileItemList::CFileItemList(const CStdString& strPath) : CFileItem(strPath, true)
 {
-  m_strPath=strPath;
   m_fastLookup = false;
-  m_bIsFolder=true;
   m_cacheToDisc=CACHE_IF_SLOW;
   m_sortMethod=SORT_METHOD_NONE;
   m_sortOrder=SORT_ORDER_NONE;
@@ -1235,7 +1233,7 @@ void CFileItemList::SetFastLookup(bool fastLookup)
     for (unsigned int i=0; i < m_items.size(); i++)
     {
       CFileItemPtr pItem = m_items[i];
-      CStdString path(pItem->m_strPath); path.ToLower();
+      CStdString path(pItem->GetPath()); path.ToLower();
       m_map.insert(MAPFILEITEMSPAIR(path, pItem));
     }
   }
@@ -1256,7 +1254,7 @@ bool CFileItemList::Contains(const CStdString& fileName) const
   for (unsigned int i = 0; i < m_items.size(); i++)
   {
     const CFileItemPtr pItem = m_items[i];
-    if (pItem->m_strPath.Equals(checkPath))
+    if (pItem->GetPath().Equals(checkPath))
       return true;
   }
   return false;
@@ -1297,7 +1295,7 @@ void CFileItemList::Add(const CFileItemPtr &pItem)
   m_items.push_back(pItem);
   if (m_fastLookup)
   {
-    CStdString path(pItem->m_strPath); 
+    CStdString path(pItem->GetPath()); 
     path.ToLower();
     m_map.insert(MAPFILEITEMSPAIR(path, pItem));
   }
@@ -1317,7 +1315,7 @@ void CFileItemList::AddFront(const CFileItemPtr &pItem, int itemPosition)
   }
   if (m_fastLookup)
   {
-    CStdString path(pItem->m_strPath); path.ToLower();
+    CStdString path(pItem->GetPath()); path.ToLower();
     m_map.insert(MAPFILEITEMSPAIR(path, pItem));
   }
 }
@@ -1333,7 +1331,7 @@ void CFileItemList::Remove(CFileItem* pItem)
       m_items.erase(it);
       if (m_fastLookup)
       {
-        CStdString path(pItem->m_strPath); path.ToLower();
+        CStdString path(pItem->GetPath()); path.ToLower();
         m_map.erase(path);
       }
       break;
@@ -1350,7 +1348,7 @@ void CFileItemList::Remove(int iItem)
     CFileItemPtr pItem = *(m_items.begin() + iItem);
     if (m_fastLookup)
     {
-      CStdString path(pItem->m_strPath); path.ToLower();
+      CStdString path(pItem->GetPath()); path.ToLower();
       m_map.erase(path);
     }
     m_items.erase(m_items.begin() + iItem);
@@ -1371,7 +1369,7 @@ void CFileItemList::Assign(const CFileItemList& itemlist, bool append)
   if (!append)
     Clear();
   Append(itemlist);
-  m_strPath = itemlist.m_strPath;
+  SetPath(itemlist.GetPath());
   m_sortDetails = itemlist.m_sortDetails;
   m_replaceListing = itemlist.m_replaceListing;
   m_content = itemlist.m_content;
@@ -1441,7 +1439,7 @@ CFileItemPtr CFileItemList::Get(const CStdString& strPath)
   for (unsigned int i = 0; i < m_items.size(); i++)
   {
     CFileItemPtr pItem = m_items[i];
-    if (pItem->m_strPath.Equals(pathToCheck))
+    if (pItem->GetPath().Equals(pathToCheck))
       return pItem;
   }
 
@@ -1465,7 +1463,7 @@ const CFileItemPtr CFileItemList::Get(const CStdString& strPath) const
   for (unsigned int i = 0; i < m_items.size(); i++)
   {
     CFileItemPtr pItem = m_items[i];
-    if (pItem->m_strPath.Equals(pathToCheck))
+    if (pItem->GetPath().Equals(pathToCheck))
       return pItem;
   }
 
@@ -1841,7 +1839,7 @@ void CFileItemList::FilterCueItems()
       if (pItem->IsCUESheet())
       {
         CCueDocument cuesheet;
-        if (cuesheet.Parse(pItem->m_strPath))
+        if (cuesheet.Parse(pItem->GetPath()))
         {
           VECSONGS newitems;
           cuesheet.GetSongs(newitems);
@@ -1867,7 +1865,7 @@ void CFileItemList::FilterCueItems()
               else
               {
                 // try removing the .cue extension...
-                strMediaFile = pItem->m_strPath;
+                strMediaFile = pItem->GetPath();
                 URIUtils::RemoveExtension(strMediaFile);
                 CFileItem item(strMediaFile, false);
                 if (item.IsAudio() && Contains(strMediaFile))
@@ -1880,7 +1878,7 @@ void CFileItemList::FilterCueItems()
                   StringUtils::SplitString(g_settings.m_musicExtensions, "|", extensions);
                   for (unsigned int i = 0; i < extensions.size(); i++)
                   {
-                    strMediaFile = URIUtils::ReplaceExtension(pItem->m_strPath, extensions[i]);
+                    strMediaFile = URIUtils::ReplaceExtension(pItem->GetPath(), extensions[i]);
                     CFileItem item(strMediaFile, false);
                     if (!item.IsCUESheet() && !item.IsPlayList() && Contains(strMediaFile))
                     {
@@ -1893,7 +1891,7 @@ void CFileItemList::FilterCueItems()
             }
             if (bFoundMediaFile)
             {
-              itemstodelete.push_back(pItem->m_strPath);
+              itemstodelete.push_back(pItem->GetPath());
               itemstodelete.push_back(strMediaFile);
               // get the additional stuff (year, genre etc.) from the underlying media files tag.
               CMusicInfoTag tag;
@@ -1934,13 +1932,13 @@ void CFileItemList::FilterCueItems()
             }
             else
             { // remove the .cue sheet from the directory
-              itemstodelete.push_back(pItem->m_strPath);
+              itemstodelete.push_back(pItem->GetPath());
             }
           }
         }
         else
         { // remove the .cue sheet from the directory (can't parse it - no point listing it)
-          itemstodelete.push_back(pItem->m_strPath);
+          itemstodelete.push_back(pItem->GetPath());
         }
       }
     }
@@ -1951,7 +1949,7 @@ void CFileItemList::FilterCueItems()
     for (int j = 0; j < (int)m_items.size(); j++)
     {
       CFileItemPtr pItem = m_items[j];
-      if (stricmp(pItem->m_strPath.c_str(), itemstodelete[i].c_str()) == 0)
+      if (stricmp(pItem->GetPath().c_str(), itemstodelete[i].c_str()) == 0)
       { // delete this item
         m_items.erase(m_items.begin() + j);
         break;
@@ -1980,7 +1978,7 @@ void CFileItemList::Stack()
   CSingleLock lock(m_lock);
 
   // not allowed here
-  if (IsVirtualDirectoryRoot() || IsLiveTV() || m_strPath.Left(10).Equals("sources://"))
+  if (IsVirtualDirectoryRoot() || IsLiveTV() || GetPath().Left(10).Equals("sources://"))
     return;
 
   SetProperty("isstacked", "1");
@@ -2002,8 +2000,8 @@ void CFileItemList::Stack()
       if( !item->IsRemote()
         || item->IsSmb()
         || item->IsNfs() 
-        || URIUtils::IsInRAR(item->m_strPath)
-        || URIUtils::IsInZIP(item->m_strPath)
+        || URIUtils::IsInRAR(item->GetPath())
+        || URIUtils::IsInZIP(item->GetPath())
         )
       {
         // stack cd# folders if contains only a single video file
@@ -2012,7 +2010,7 @@ void CFileItemList::Stack()
         if (folderName.Left(2).Equals("CD") && StringUtils::IsNaturalNumber(folderName.Mid(2)))
         {
           CFileItemList items;
-          CDirectory::GetDirectory(item->m_strPath,items,g_settings.m_videoExtensions,true);
+          CDirectory::GetDirectory(item->GetPath(),items,g_settings.m_videoExtensions,true);
           // optimized to only traverse listing once by checking for filecount
           // and recording last file item for later use
           int nFiles = 0;
@@ -2038,12 +2036,12 @@ void CFileItemList::Stack()
         {
           CStdString path;
           CStdString dvdPath;
-          URIUtils::AddFileToFolder(item->m_strPath, "VIDEO_TS.IFO", path);
+          URIUtils::AddFileToFolder(item->GetPath(), "VIDEO_TS.IFO", path);
           if (CFile::Exists(path))
             dvdPath = path;
           else
           {
-            URIUtils::AddFileToFolder(item->m_strPath, "VIDEO_TS", dvdPath);
+            URIUtils::AddFileToFolder(item->GetPath(), "VIDEO_TS", dvdPath);
             URIUtils::AddFileToFolder(dvdPath, "VIDEO_TS.IFO", path);
             dvdPath.Empty();
             if (CFile::Exists(path))
@@ -2052,12 +2050,12 @@ void CFileItemList::Stack()
 #ifdef HAVE_LIBBLURAY
           if (dvdPath.IsEmpty())
           {
-            URIUtils::AddFileToFolder(item->m_strPath, "index.bdmv", path);
+            URIUtils::AddFileToFolder(item->GetPath(), "index.bdmv", path);
             if (CFile::Exists(path))
               dvdPath = path;
             else
             {
-              URIUtils::AddFileToFolder(item->m_strPath, "BDMV", dvdPath);
+              URIUtils::AddFileToFolder(item->GetPath(), "BDMV", dvdPath);
               URIUtils::AddFileToFolder(dvdPath, "index.bdmv", path);
               dvdPath.Empty();
               if (CFile::Exists(path))
@@ -2074,7 +2072,7 @@ void CFileItemList::Stack()
               item->SetUserVideoThumb();
 
             item->m_bIsFolder = false;
-            item->m_strPath = dvdPath;
+            item->SetPath(dvdPath);
             item->SetLabel2("");
             item->SetLabelPreformated(true);
             m_sortMethod = SORT_METHOD_NONE; /* sorting is now broken */
@@ -2139,7 +2137,7 @@ void CFileItemList::Stack()
     vector<int>           stack;
     VECCREGEXP::iterator  expr        = stackRegExps.begin();
 
-    URIUtils::Split(item1->m_strPath, filePath, file1);
+    URIUtils::Split(item1->GetPath(), filePath, file1);
     int j;
     while (expr != stackRegExps.end())
     {
@@ -2169,7 +2167,7 @@ void CFileItemList::Stack()
           }
 
           CStdString file2, filePath2;
-          URIUtils::Split(item2->m_strPath, filePath2, file2);
+          URIUtils::Split(item2->GetPath(), filePath2, file2);
 
           if (expr->RegFind(file2, offset) != -1)
           {
@@ -2242,13 +2240,13 @@ void CFileItemList::Stack()
         // dont actually stack a multipart rar set, just remove all items but the first
         CStdString stackPath;
         if (Get(stack[0])->IsRAR())
-          stackPath = Get(stack[0])->m_strPath;
+          stackPath = Get(stack[0])->GetPath();
         else
         {
           CStackDirectory dir;
           stackPath = dir.ConstructStackPath(*this, stack);
         }
-        item1->m_strPath = stackPath;
+        item1->SetPath(stackPath);
         // clean up list
         for (unsigned k = 1; k < stack.size(); k++)
           Remove(i+1);
@@ -2272,10 +2270,10 @@ bool CFileItemList::Load(int windowID)
   CFile file;
   if (file.Open(GetDiscCacheFile(windowID)))
   {
-    CLog::Log(LOGDEBUG,"Loading fileitems [%s]",m_strPath.c_str());
+    CLog::Log(LOGDEBUG,"Loading fileitems [%s]",GetPath().c_str());
     CArchive ar(&file, CArchive::load);
     ar >> *this;
-    CLog::Log(LOGDEBUG,"  -- items: %i, directory: %s sort method: %i, ascending: %s",Size(),m_strPath.c_str(), m_sortMethod, m_sortOrder ? "true" : "false");
+    CLog::Log(LOGDEBUG,"  -- items: %i, directory: %s sort method: %i, ascending: %s",Size(),GetPath().c_str(), m_sortMethod, m_sortOrder ? "true" : "false");
     ar.Close();
     file.Close();
     return true;
@@ -2290,7 +2288,7 @@ bool CFileItemList::Save(int windowID)
   if (iSize <= 0)
     return false;
 
-  CLog::Log(LOGDEBUG,"Saving fileitems [%s]",m_strPath.c_str());
+  CLog::Log(LOGDEBUG,"Saving fileitems [%s]",GetPath().c_str());
 
   CFile file;
   if (file.OpenForWrite(GetDiscCacheFile(windowID), true)) // overwrite always
@@ -2311,14 +2309,14 @@ void CFileItemList::RemoveDiscCache(int windowID) const
   CStdString cacheFile(GetDiscCacheFile(windowID));
   if (CFile::Exists(cacheFile))
   {
-    CLog::Log(LOGDEBUG,"Clearing cached fileitems [%s]",m_strPath.c_str());
+    CLog::Log(LOGDEBUG,"Clearing cached fileitems [%s]",GetPath().c_str());
     CFile::Delete(cacheFile);
   }
 }
 
 CStdString CFileItemList::GetDiscCacheFile(int windowID) const
 {
-  CStdString strPath=m_strPath;
+  CStdString strPath(GetPath());
   URIUtils::RemoveSlashAtEnd(strPath);
 
   Crc32 crc;
@@ -2342,9 +2340,9 @@ bool CFileItemList::AlwaysCache() const
 {
   // some database folders are always cached
   if (IsMusicDb())
-    return CMusicDatabaseDirectory::CanCache(m_strPath);
+    return CMusicDatabaseDirectory::CanCache(GetPath());
   if (IsVideoDb())
-    return CVideoDatabaseDirectory::CanCache(m_strPath);
+    return CVideoDatabaseDirectory::CanCache(GetPath());
   return false;
 }
 
@@ -2909,7 +2907,7 @@ void CFileItemList::Swap(unsigned int item1, unsigned int item2)
 bool CFileItemList::UpdateItem(const CFileItem *item)
 {
   if (!item) return false;
-  CFileItemPtr oldItem = Get(item->m_strPath);
+  CFileItemPtr oldItem = Get(item->GetPath());
   if (oldItem)
     *oldItem = *item;
   return oldItem;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -78,6 +78,9 @@ public:
   virtual ~CFileItem(void);
   virtual CGUIListItem *Clone() const { return new CFileItem(*this); };
 
+  const CStdString &GetPath() const { return m_strPath; };
+  void SetPath(const CStdString &path) { m_strPath = path; };
+
   void Reset();
   const CFileItem& operator=(const CFileItem& item);
   virtual void Archive(CArchive& ar);
@@ -281,7 +284,6 @@ private:
   CStdString GetPreviouslyCachedMusicThumb() const;
 
 public:
-  CStdString m_strPath;            ///< complete path to item
   bool m_bIsShareOrDrive;    ///< is this a root share/drive
   int m_iDriveType;     ///< If \e m_bIsShareOrDrive is \e true, use to get the share type. Types see: CMediaSource::m_iDriveType
   CDateTime m_dateTime;             ///< file creation date & time
@@ -296,7 +298,9 @@ public:
   CStdString m_strLockCode;
   int m_iHasLock; // 0 - no lock 1 - lock, but unlocked 2 - locked
   int m_iBadPwdCount;
+
 private:
+  CStdString m_strPath;            ///< complete path to item
 
   SPECIAL_SORT m_specialSort;
   bool m_bIsParentFolder;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -118,7 +118,7 @@ bool CGUIInfoManager::OnMessage(CGUIMessage &message)
     if (message.GetParam1() == GUI_MSG_UPDATE_ITEM && message.GetItem())
     {
       CFileItemPtr item = boost::static_pointer_cast<CFileItem>(message.GetItem());
-      if (item && m_currentFile->m_strPath.Equals(item->m_strPath))
+      if (item && m_currentFile->GetPath().Equals(item->GetPath()))
         *m_currentFile = *item;
       return true;
     }
@@ -1115,7 +1115,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
       else if (m_currentFile->HasVideoInfoTag())
         strLabel = m_currentFile->GetVideoInfoTag()->m_strFileNameAndPath;
       if (strLabel.IsEmpty())
-        strLabel = m_currentFile->m_strPath;
+        strLabel = m_currentFile->GetPath();
     }
     if (info == PLAYER_PATH)
     {
@@ -1270,7 +1270,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
         if (info==CONTAINER_FOLDERNAME)
           strLabel = ((CGUIMediaWindow*)window)->CurrentDirectory().GetLabel();
         else
-          strLabel = CURL(((CGUIMediaWindow*)window)->CurrentDirectory().m_strPath).GetWithoutUserDetails();
+          strLabel = CURL(((CGUIMediaWindow*)window)->CurrentDirectory().GetPath()).GetWithoutUserDetails();
       }
       break;
     }
@@ -1279,7 +1279,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
       CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
       if (window)
       {
-        CURL url(((CGUIMediaWindow*)window)->CurrentDirectory().m_strPath);
+        CURL url(((CGUIMediaWindow*)window)->CurrentDirectory().GetPath());
         if (url.GetProtocol().Equals("plugin"))
         {
           strLabel = url.GetFileName();
@@ -3112,7 +3112,7 @@ CStdString CGUIInfoManager::GetVideoLabel(int item)
       return g_application.m_pPlayer->GetPlayingTitle();
     if (!m_currentFile->GetLabel().IsEmpty())
       return m_currentFile->GetLabel();
-    return CUtil::GetTitleFromPath(m_currentFile->m_strPath);
+    return CUtil::GetTitleFromPath(m_currentFile->GetPath());
   }
   else if (item == VIDEOPLAYER_PLAYLISTLEN)
   {
@@ -3315,14 +3315,14 @@ void CGUIInfoManager::SetCurrentAlbumThumb(const CStdString thumbFileName)
 
 void CGUIInfoManager::SetCurrentSong(CFileItem &item)
 {
-  CLog::Log(LOGDEBUG,"CGUIInfoManager::SetCurrentSong(%s)",item.m_strPath.c_str());
+  CLog::Log(LOGDEBUG,"CGUIInfoManager::SetCurrentSong(%s)",item.GetPath().c_str());
   *m_currentFile = item;
 
   m_currentFile->LoadMusicTag();
   if (m_currentFile->GetMusicInfoTag()->GetTitle().IsEmpty())
   {
     // No title in tag, show filename only
-    m_currentFile->GetMusicInfoTag()->SetTitle(CUtil::GetTitleFromPath(m_currentFile->m_strPath));
+    m_currentFile->GetMusicInfoTag()->SetTitle(CUtil::GetTitleFromPath(m_currentFile->GetPath()));
   }
   m_currentFile->GetMusicInfoTag()->SetLoaded(true);
 
@@ -3353,13 +3353,13 @@ void CGUIInfoManager::SetCurrentSong(CFileItem &item)
 
 void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
 {
-  CLog::Log(LOGDEBUG,"CGUIInfoManager::SetCurrentMovie(%s)",item.m_strPath.c_str());
+  CLog::Log(LOGDEBUG,"CGUIInfoManager::SetCurrentMovie(%s)",item.GetPath().c_str());
   *m_currentFile = item;
 
   CVideoDatabase dbs;
   if (dbs.Open())
   {
-    dbs.LoadVideoInfo(item.m_strPath, *m_currentFile->GetVideoInfoTag());
+    dbs.LoadVideoInfo(item.GetPath(), *m_currentFile->GetVideoInfoTag());
     dbs.Close();
   }
 
@@ -3698,7 +3698,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info) const
       else if (item->IsVideoDb() && item->HasVideoInfoTag())
         strFile = URIUtils::GetFileName(item->GetVideoInfoTag()->m_strFileNameAndPath);
       else
-        strFile = URIUtils::GetFileName(item->m_strPath);
+        strFile = URIUtils::GetFileName(item->GetPath());
 
       if (info==LISTITEM_FILE_EXTENSION)
       {
@@ -3824,7 +3824,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info) const
   case LISTITEM_THUMB:
     return item->GetThumbnailImage();
   case LISTITEM_FOLDERPATH:
-    return CURL(item->m_strPath).GetWithoutUserDetails();
+    return CURL(item->GetPath()).GetWithoutUserDetails();
   case LISTITEM_FOLDERNAME:
   case LISTITEM_PATH:
     {
@@ -3839,7 +3839,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info) const
           URIUtils::GetParentPath(item->GetVideoInfoTag()->m_strFileNameAndPath, path);
       }
       else
-        URIUtils::GetParentPath(item->m_strPath, path);
+        URIUtils::GetParentPath(item->GetPath(), path);
       path = CURL(path).GetWithoutUserDetails();
       if (info==LISTITEM_FOLDERNAME)
       {
@@ -3857,14 +3857,14 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info) const
       else if (item->IsVideoDb() && item->HasVideoInfoTag())
         path = item->GetVideoInfoTag()->m_strFileNameAndPath;
       else
-        path = item->m_strPath;
+        path = item->GetPath();
       path = CURL(path).GetWithoutUserDetails();
       CURL::Decode(path);
       return path;
     }
   case LISTITEM_PICTURE_PATH:
     if (item->IsPicture() && (!item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR()))
-      return item->m_strPath;
+      return item->GetPath();
     break;
   case LISTITEM_PICTURE_DATETIME:
     if (item->HasPictureInfoTag())
@@ -4006,12 +4006,12 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
   }
   else if (condition == LISTITEM_ISPLAYING)
   {
-    if (item->IsFileItem() && !m_currentFile->m_strPath.IsEmpty())
+    if (item->IsFileItem() && !m_currentFile->GetPath().IsEmpty())
     {
       if (!g_application.m_strPlayListFile.IsEmpty())
       {
         //playlist file that is currently playing or the playlistitem that is currently playing.
-        return g_application.m_strPlayListFile.Equals(((const CFileItem *)item)->m_strPath) || m_currentFile->IsSamePath((const CFileItem *)item);
+        return g_application.m_strPlayListFile.Equals(((const CFileItem *)item)->GetPath()) || m_currentFile->IsSamePath((const CFileItem *)item);
       }
       return m_currentFile->IsSamePath((const CFileItem *)item);
     }
@@ -4081,7 +4081,7 @@ CStdString CGUIInfoManager::GetPictureLabel(int info) const
   else if (info == SLIDE_FILE_PATH)
   {
     CStdString path;
-    URIUtils::GetDirectory(m_currentSlide->m_strPath, path);
+    URIUtils::GetDirectory(m_currentSlide->GetPath(), path);
     return CURL(path).GetWithoutUserDetails();
   }
   else if (info == SLIDE_FILE_SIZE)
@@ -4105,10 +4105,10 @@ CStdString CGUIInfoManager::GetPictureLabel(int info) const
 
 void CGUIInfoManager::SetCurrentSlide(CFileItem &item)
 {
-  if (m_currentSlide->m_strPath != item.m_strPath)
+  if (m_currentSlide->GetPath() != item.GetPath())
   {
     if (!item.HasPictureInfoTag() && !item.GetPictureInfoTag()->Loaded())
-      item.GetPictureInfoTag()->Load(item.m_strPath);
+      item.GetPictureInfoTag()->Load(item.GetPath());
     *m_currentSlide = item;
   }
 }

--- a/xbmc/GUIViewControl.cpp
+++ b/xbmc/GUIViewControl.cpp
@@ -198,7 +198,7 @@ void CGUIViewControl::SetSelectedItem(const CStdString &itemPath)
   int item = -1;
   for (int i = 0; i < m_fileItems->Size(); ++i)
   {
-    CStdString strPath =(*m_fileItems)[i]->m_strPath;
+    CStdString strPath =(*m_fileItems)[i]->GetPath();
     URIUtils::RemoveSlashAtEnd(strPath);
     if (strPath.CompareNoCase(comparePath) == 0)
     {

--- a/xbmc/GUIViewState.cpp
+++ b/xbmc/GUIViewState.cpp
@@ -95,7 +95,7 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
   if (url.GetProtocol() == "lastfm")
     return new CGUIViewStateMusicLastFM(items);
 
-  if (items.m_strPath == "special://musicplaylists/")
+  if (items.GetPath() == "special://musicplaylists/")
     return new CGUIViewStateWindowMusicSongs(items);
 
   if (windowId==WINDOW_MUSIC_NAV)
@@ -453,7 +453,7 @@ CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGU
   SetSortOrder(SORT_ORDER_ASC);
   if (items.IsPlugin())
   {
-    CURL url(items.m_strPath);
+    CURL url(items.GetPath());
     AddonPtr addon;
     if (CAddonMgr::Get().GetAddon(url.GetHostName(),addon) && addon)
     {
@@ -464,12 +464,12 @@ CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGU
         m_playlist = PLAYLIST_VIDEO;
     }
   }
-  LoadViewState(items.m_strPath, g_windowManager.GetActiveWindow());
+  LoadViewState(items.GetPath(), g_windowManager.GetActiveWindow());
 }
 
 void CGUIViewStateFromItems::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, g_windowManager.GetActiveWindow());
+  SaveViewToDb(m_items.GetPath(), g_windowManager.GetActiveWindow());
 }
 
 

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -433,7 +433,7 @@ void CPartyModeManager::Add(CFileItemPtr &pItem)
 
   CPlayList& playlist = g_playlistPlayer.GetPlaylist(iPlaylist);
   playlist.Add(pItem);
-  CLog::Log(LOGINFO,"PARTY MODE MANAGER: Adding randomly selected song at %i:[%s]", playlist.size() - 1, pItem->m_strPath.c_str());
+  CLog::Log(LOGINFO,"PARTY MODE MANAGER: Adding randomly selected song at %i:[%s]", playlist.size() - 1, pItem->GetPath().c_str());
   m_iMatchingSongsPicked++;
 }
 

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -135,7 +135,7 @@ int CPlayListPlayer::GetNextSong()
     // otherwise immediately abort playback
     if (m_iCurrentSong >= 0 && m_iCurrentSong < playlist.size() && playlist[m_iCurrentSong]->GetPropertyBOOL("unplayable"))
     {
-      CLog::Log(LOGERROR,"Playlist Player: RepeatOne stuck on unplayable item: %i, path [%s]", m_iCurrentSong, playlist[m_iCurrentSong]->m_strPath.c_str());
+      CLog::Log(LOGERROR,"Playlist Player: RepeatOne stuck on unplayable item: %i, path [%s]", m_iCurrentSong, playlist[m_iCurrentSong]->GetPath().c_str());
       CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_STOPPED, 0, 0, m_iCurrentPlayList, m_iCurrentSong);
       g_windowManager.SendThreadMessage(msg);
       Reset();
@@ -253,7 +253,7 @@ bool CPlayListPlayer::Play(int iSong, bool bAutoPlay /* = false */, bool bPlayPr
   unsigned int playAttempt = XbmcThreads::SystemClockMillis();
   if (!g_application.PlayFile(*item, bAutoPlay))
   {
-    CLog::Log(LOGERROR,"Playlist Player: skipping unplayable item: %i, path [%s]", m_iCurrentSong, item->m_strPath.c_str());
+    CLog::Log(LOGERROR,"Playlist Player: skipping unplayable item: %i, path [%s]", m_iCurrentSong, item->GetPath().c_str());
     playlist.SetUnPlayable(m_iCurrentSong);
 
     // abort on 100 failed CONSECTUTIVE songs

--- a/xbmc/SortFileItem.cpp
+++ b/xbmc/SortFileItem.cpp
@@ -121,7 +121,7 @@ void SSortFileItem::ByFile(CFileItemPtr &item)
 {
   if (!item) return;
 
-  CURL url(item->m_strPath);
+  CURL url(item->GetPath());
   CStdString label;
   label.Format("%s %d", url.GetFileNameWithoutPath().c_str(), item->m_lStartOffset);
   item->SetSortLabel(label);
@@ -132,7 +132,7 @@ void SSortFileItem::ByFullPath(CFileItemPtr &item)
   if (!item) return;
 
   CStdString label;
-  label.Format("%s %d", item->m_strPath, item->m_lStartOffset);
+  label.Format("%s %d", item->GetPath(), item->m_lStartOffset);
   item->SetSortLabel(label);
 }
 

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -73,7 +73,7 @@ CStdString CThumbLoader::GetCachedThumb(const CFileItem &item)
 {
   CTextureDatabase db;
   if (db.Open())
-    return db.GetTextureForPath(item.m_strPath);
+    return db.GetTextureForPath(item.GetPath());
   return "";
 }
 
@@ -95,7 +95,7 @@ CThumbExtractor::CThumbExtractor(const CFileItem& item, const CStdString& listpa
   m_thumb = thumb;
   m_item = item;
 
-  m_path = item.m_strPath;
+  m_path = item.GetPath();
 
   if (item.IsVideoDb() && item.HasVideoInfoTag())
     m_path = item.GetVideoInfoTag()->m_strFileNameAndPath;
@@ -217,7 +217,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
       else if (!item.m_bIsFolder && item.IsVideo() && g_guiSettings.GetBool("myvideos.extractthumb") &&
                g_guiSettings.GetBool("myvideos.extractflags"))
       {
-        CThumbExtractor* extract = new CThumbExtractor(item, pItem->m_strPath, true, cachedThumb);
+        CThumbExtractor* extract = new CThumbExtractor(item, pItem->GetPath(), true, cachedThumb);
         AddJob(extract);
       }
     }
@@ -237,7 +237,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
        (!pItem->GetVideoInfoTag()->HasStreamDetails() ||
          pItem->GetVideoInfoTag()->m_streamDetails.GetVideoDuration() <= 0))
   {
-    CThumbExtractor* extract = new CThumbExtractor(*pItem,pItem->m_strPath,false);
+    CThumbExtractor* extract = new CThumbExtractor(*pItem,pItem->GetPath(),false);
     AddJob(extract);
   }
   return true;
@@ -248,7 +248,7 @@ void CVideoThumbLoader::OnJobComplete(unsigned int jobID, bool success, CJob* jo
   if (success)
   {
     CThumbExtractor* loader = (CThumbExtractor*)job;
-    loader->m_item.m_strPath = loader->m_listpath;
+    loader->m_item.SetPath(loader->m_listpath);
     CVideoInfoTag* info = loader->m_item.GetVideoInfoTag();
     if (m_pStreamDetailsObs)
       m_pStreamDetailsObs->OnStreamDetails(info->m_streamDetails, info->m_strFileNameAndPath, info->m_iFileId);
@@ -293,7 +293,7 @@ bool CProgramThumbLoader::FillThumb(CFileItem &item)
   {
     CTextureDatabase db;
     if (db.Open())
-      db.SetTextureForPath(item.m_strPath, thumb);
+      db.SetTextureForPath(item.GetPath(), thumb);
     thumb = CTextureCache::Get().CheckAndCacheImage(thumb);
   }
   item.SetThumbnailImage(thumb);
@@ -306,7 +306,7 @@ CStdString CProgramThumbLoader::GetLocalThumb(const CFileItem &item)
   if (item.IsShortCut())
   {
     CShortcut shortcut;
-    if ( shortcut.Create( item.m_strPath ) )
+    if ( shortcut.Create( item.GetPath() ) )
     {
       // use the shortcut's thumb
       if (!shortcut.m_strThumb.IsEmpty())

--- a/xbmc/ThumbnailCache.cpp
+++ b/xbmc/ThumbnailCache.cpp
@@ -195,7 +195,7 @@ CStdString CThumbnailCache::GetEpisodeThumb(const CVideoInfoTag* videoInfo)
 CStdString CThumbnailCache::GetVideoThumb(const CFileItem &item)
 {
   if (item.IsStack())
-    return GetThumb(CStackDirectory::GetFirstStackedFile(item.m_strPath), g_settings.GetVideoThumbFolder(), true);
+    return GetThumb(CStackDirectory::GetFirstStackedFile(item.GetPath()), g_settings.GetVideoThumbFolder(), true);
   else if (item.IsVideoDb() && item.HasVideoInfoTag())
   {
     if (item.m_bIsFolder && !item.GetVideoInfoTag()->m_strPath.IsEmpty())
@@ -203,7 +203,7 @@ CStdString CThumbnailCache::GetVideoThumb(const CFileItem &item)
     else if (!item.GetVideoInfoTag()->m_strFileNameAndPath.IsEmpty())
       return GetThumb(item.GetVideoInfoTag()->m_strFileNameAndPath, g_settings.GetVideoThumbFolder(), true);
   }
-  return GetThumb(item.m_strPath, g_settings.GetVideoThumbFolder(), true);
+  return GetThumb(item.GetPath(), g_settings.GetVideoThumbFolder(), true);
 }
 
 CStdString CThumbnailCache::GetFanart(const CFileItem &item)
@@ -229,7 +229,7 @@ CStdString CThumbnailCache::GetFanart(const CFileItem &item)
   if (item.HasMusicInfoTag())
     return GetThumb(item.GetMusicInfoTag()->GetArtist(),g_settings.GetMusicFanartFolder());
 
-  return GetThumb(item.m_strPath,g_settings.GetVideoFanartFolder());
+  return GetThumb(item.GetPath(),g_settings.GetVideoFanartFolder());
 }
 
 CStdString CThumbnailCache::GetThumb(const CStdString &path, const CStdString &path2, bool split /* = false */)

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -528,9 +528,9 @@ CStdString CURL::GetWithoutUserDetails() const
     vector<CStdString> newItems;
     for (int i=0;i<items.Size();++i)
     {
-      CURL url(items[i]->m_strPath);
-      items[i]->m_strPath = url.GetWithoutUserDetails();
-      newItems.push_back(items[i]->m_strPath);
+      CURL url(items[i]->GetPath());
+      items[i]->SetPath(url.GetWithoutUserDetails());
+      newItems.push_back(items[i]->GetPath());
     }
     dir.ConstructStackPath(newItems,strURL);
     return strURL;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -718,7 +718,7 @@ void CUtil::RemoveTempFiles()
   {
     if (items[i]->m_bIsFolder)
       continue;
-    XFILE::CFile::Delete(items[i]->m_strPath);
+    XFILE::CFile::Delete(items[i]->GetPath());
   }
 }
 
@@ -731,10 +731,10 @@ void CUtil::ClearSubtitles()
   {
     if (!items[i]->m_bIsFolder)
     {
-      if ( items[i]->m_strPath.Find("subtitle") >= 0 || items[i]->m_strPath.Find("vobsub_queue") >= 0 )
+      if ( items[i]->GetPath().Find("subtitle") >= 0 || items[i]->GetPath().Find("vobsub_queue") >= 0 )
       {
-        CLog::Log(LOGDEBUG, "%s - Deleting temporary subtitle %s", __FUNCTION__, items[i]->m_strPath.c_str());
-        CFile::Delete(items[i]->m_strPath);
+        CLog::Log(LOGDEBUG, "%s - Deleting temporary subtitle %s", __FUNCTION__, items[i]->GetPath().c_str());
+        CFile::Delete(items[i]->GetPath());
       }
     }
   }
@@ -1645,9 +1645,9 @@ void CUtil::DeleteDirectoryCache(const CStdString &prefix)
   {
     if (items[i]->m_bIsFolder)
       continue;
-    CStdString fileName = URIUtils::GetFileName(items[i]->m_strPath);
+    CStdString fileName = URIUtils::GetFileName(items[i]->GetPath());
     if (fileName.Left(prefix.GetLength()) == prefix)
-      XFILE::CFile::Delete(items[i]->m_strPath);
+      XFILE::CFile::Delete(items[i]->GetPath());
   }
 }
 
@@ -1767,7 +1767,7 @@ void CUtil::GetRecursiveListing(const CStdString& strPath, CFileItemList& items,
   for (int i=0;i<myItems.Size();++i)
   {
     if (myItems[i]->m_bIsFolder)
-      CUtil::GetRecursiveListing(myItems[i]->m_strPath,items,strMask,bUseFileDirectories);
+      CUtil::GetRecursiveListing(myItems[i]->GetPath(),items,strMask,bUseFileDirectories);
     else
       items.Add(myItems[i]);
   }
@@ -1779,10 +1779,10 @@ void CUtil::GetRecursiveDirsListing(const CStdString& strPath, CFileItemList& it
   CDirectory::GetDirectory(strPath,myItems,"",false);
   for (int i=0;i<myItems.Size();++i)
   {
-    if (myItems[i]->m_bIsFolder && !myItems[i]->m_strPath.Equals(".."))
+    if (myItems[i]->m_bIsFolder && !myItems[i]->GetPath().Equals(".."))
     {
       item.Add(myItems[i]);
-      CUtil::GetRecursiveDirsListing(myItems[i]->m_strPath,item);
+      CUtil::GetRecursiveDirsListing(myItems[i]->GetPath(),item);
     }
   }
 }
@@ -1933,7 +1933,7 @@ void CUtil::GetSkinThemes(vector<CStdString>& vecTheme)
     if (!pItem->m_bIsFolder)
     {
       CStdString strExtension;
-      URIUtils::GetExtension(pItem->m_strPath, strExtension);
+      URIUtils::GetExtension(pItem->GetPath(), strExtension);
       if ((strExtension == ".xpr" && pItem->GetLabel().CompareNoCase("Textures.xpr")) ||
           (strExtension == ".xbt" && pItem->GetLabel().CompareNoCase("Textures.xbt")))
       {
@@ -2359,12 +2359,12 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
       
       for (int j = 0; j < items.Size(); j++)
       {
-        URIUtils::Split(items[j]->m_strPath, strPath, strItem);
+        URIUtils::Split(items[j]->GetPath(), strPath, strItem);
         
         // is this a rar or zip-file
         if (URIUtils::IsRAR(strItem) || URIUtils::IsZIP(strItem))
         {
-          ScanArchiveForSubtitles( items[j]->m_strPath, strMovieFileNameNoExt, vecSubtitles );
+          ScanArchiveForSubtitles( items[j]->GetPath(), strMovieFileNameNoExt, vecSubtitles );
         }
         else    // not a rar/zip file
         {
@@ -2373,8 +2373,8 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
             //Cache subtitle with same name as movie
             if (URIUtils::GetExtension(strItem).Equals(sub_exts[i]) && strItem.Left(fnl).Equals(strMovieFileNameNoExt))
             {
-              vecSubtitles.push_back( items[j]->m_strPath ); 
-              CLog::Log(LOGINFO, "%s: found subtitle file %s\n", __FUNCTION__, items[j]->m_strPath.c_str() );
+              vecSubtitles.push_back( items[j]->GetPath() ); 
+              CLog::Log(LOGINFO, "%s: found subtitle file %s\n", __FUNCTION__, items[j]->GetPath().c_str() );
             }
           }
         }
@@ -2439,7 +2439,7 @@ int CUtil::ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStd
   }
   for (int it= 0 ; it <ItemList.Size();++it)
   {
-   CStdString strPathInRar = ItemList[it]->m_strPath;
+   CStdString strPathInRar = ItemList[it]->GetPath();
    CStdString strExt = URIUtils::GetExtension(strPathInRar);
    
    CLog::Log(LOGDEBUG, "ScanArchiveForSubtitles:: Found file %s", strPathInRar.c_str());

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -231,7 +231,7 @@ bool CAddonInstaller::InstallFromZip(const CStdString &path)
   }
 
   // TODO: possibly add support for github generated zips here?
-  CStdString archive = URIUtils::AddFileToFolder(items[0]->m_strPath, "addon.xml");
+  CStdString archive = URIUtils::AddFileToFolder(items[0]->GetPath(), "addon.xml");
 
   TiXmlDocument xml;
   AddonPtr addon;
@@ -379,7 +379,7 @@ bool CAddonInstallJob::DoWork()
       CFile::Delete(package);
       return false;
     }
-    installFrom = archivedFiles[0]->m_strPath;
+    installFrom = archivedFiles[0]->GetPath();
   }
 
   // run any pre-install functions

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -308,7 +308,7 @@ void CGUIDialogAddonInfo::OnJobComplete(unsigned int jobID, bool success,
   {
     CFile file;
     if (file.Open("special://temp/"+
-      URIUtils::GetFileName(((CFileOperationJob*)job)->GetItems()[0]->m_strPath)))
+      URIUtils::GetFileName(((CFileOperationJob*)job)->GetItems()[0]->GetPath())))
     {
       char* temp = new char[(size_t)file.GetLength()+1];
       file.Read(temp,file.GetLength());

--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -40,12 +40,12 @@ CGUIViewStateAddonBrowser::CGUIViewStateAddonBrowser(const CFileItemList& items)
   SetViewAsControl(DEFAULT_VIEW_AUTO);
 
   SetSortOrder(SORT_ORDER_ASC);
-  LoadViewState(items.m_strPath, WINDOW_ADDON_BROWSER);
+  LoadViewState(items.GetPath(), WINDOW_ADDON_BROWSER);
 }
 
 void CGUIViewStateAddonBrowser::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_ADDON_BROWSER);
+  SaveViewToDb(m_items.GetPath(), WINDOW_ADDON_BROWSER);
 }
 
 CStdString CGUIViewStateAddonBrowser::GetExtensions()

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -81,8 +81,8 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
       m_rootDir.AllowNonLocalSources(false);
 
       // is this the first time the window is opened?
-      if (m_vecItems->m_strPath == "?" && message.GetStringParam().IsEmpty())
-        m_vecItems->m_strPath = "";
+      if (m_vecItems->GetPath() == "?" && message.GetStringParam().IsEmpty())
+        m_vecItems->SetPath("");
     }
     break;
   case GUI_MSG_CLICKED:
@@ -142,7 +142,7 @@ void CGUIWindowAddonBrowser::GetContextButtons(int itemNumber,
                                                CContextButtons& buttons)
 {
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
-  if (pItem->m_strPath.Equals("addons://enabled/"))
+  if (pItem->GetPath().Equals("addons://enabled/"))
     buttons.Add(CONTEXT_BUTTON_SCAN,24034);
   
   AddonPtr addon;
@@ -165,7 +165,7 @@ bool CGUIWindowAddonBrowser::OnContextButton(int itemNumber,
                                              CONTEXT_BUTTON button)
 {
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
-  if (pItem->m_strPath.Equals("addons://enabled/"))
+  if (pItem->GetPath().Equals("addons://enabled/"))
   {
     if (button == CONTEXT_BUTTON_SCAN)
     {
@@ -207,7 +207,7 @@ bool CGUIWindowAddonBrowser::OnContextButton(int itemNumber,
 bool CGUIWindowAddonBrowser::OnClick(int iItem)
 {
   CFileItemPtr item = m_vecItems->Get(iItem);
-  if (item->m_strPath == "addons://install/")
+  if (item->GetPath() == "addons://install/")
   {
     // pop up filebrowser to grab an installed folder
     VECSOURCES shares = g_settings.m_fileSources;
@@ -227,7 +227,7 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem)
                                            g_localizeStrings.Get(24066),""))
       {
         if (CAddonInstaller::Get().Cancel(item->GetProperty("Addon.ID")))
-          Update(m_vecItems->m_strPath);
+          Update(m_vecItems->GetPath());
       }
       return true;
     }
@@ -259,12 +259,12 @@ bool CGUIWindowAddonBrowser::GetDirectory(const CStdString& strDirectory,
     CAddonsDirectory::GenerateListing(url,addons,items);
     result = true;
     items.SetProperty("reponame",g_localizeStrings.Get(24067));
-    items.m_strPath = strDirectory;
+    items.SetPath(strDirectory);
 
     if (m_guiState.get() && !m_guiState->HideParentDirItems())
     {
       CFileItemPtr pItem(new CFileItem(".."));
-      pItem->m_strPath = m_history.GetParentPath();
+      pItem->SetPath(m_history.GetParentPath());
       pItem->m_bIsFolder = true;
       pItem->m_bIsShareOrDrive = false;
       items.AddFront(pItem, 0);
@@ -377,7 +377,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(TYPE type, CStdString &addonID, bool s
   }
   if (dialog->GetSelectedLabel() >= 0)
   {
-    addonID = dialog->GetSelectedItem().m_strPath;
+    addonID = dialog->GetSelectedItem().GetPath();
     return 1;
   }
   return 0;

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -222,7 +222,7 @@ void CScraper::ClearCache()
     {
       // wipe cache
       if (items[i]->m_dateTime + m_persistence <= CDateTime::GetCurrentDateTime())
-        CFile::Delete(items[i]->m_strPath);
+        CFile::Delete(items[i]->GetPath());
     }
   }
   else

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -256,7 +256,7 @@ bool CCDDARipper::RipTrack(CFileItem* pItem)
 {
   // don't rip non cdda items
   CStdString strExt;
-  URIUtils::GetExtension(pItem->m_strPath, strExt);
+  URIUtils::GetExtension(pItem->GetPath(), strExt);
   if (strExt.CompareNoCase(".cdda") != 0) 
   {
     CLog::Log(LOGDEBUG, "cddaripper: file is not a cdda track");
@@ -271,7 +271,7 @@ bool CCDDARipper::RipTrack(CFileItem* pItem)
 
   CStdString strFile = URIUtils::AddFileToFolder(strDirectory, CUtil::MakeLegalFileName(GetTrackName(pItem), legalType));
 
-  return Rip(pItem->m_strPath, strFile.c_str(), *pItem->GetMusicInfoTag());
+  return Rip(pItem->GetPath(), strFile.c_str(), *pItem->GetMusicInfoTag());
 }
 
 bool CCDDARipper::RipCD()
@@ -294,10 +294,10 @@ bool CCDDARipper::RipCD()
   {
     CFileItemPtr pItem = vecItems[i];
     CMusicInfoTagLoaderFactory factory;
-    auto_ptr<IMusicInfoTagLoader> pLoader (factory.CreateLoader(pItem->m_strPath));
+    auto_ptr<IMusicInfoTagLoader> pLoader (factory.CreateLoader(pItem->GetPath()));
     if (NULL != pLoader.get())
     {
-      pLoader->Load(pItem->m_strPath, *pItem->GetMusicInfoTag()); // get tag from file
+      pLoader->Load(pItem->GetPath(), *pItem->GetMusicInfoTag()); // get tag from file
       if (!pItem->GetMusicInfoTag()->Loaded())
         break;  //  No CDDB info available
     }
@@ -320,11 +320,11 @@ bool CCDDARipper::RipCD()
     unsigned int tick = XbmcThreads::SystemClockMillis();
 
     // don't rip non cdda items
-    if (item->m_strPath.Find(".cdda") < 0)
+    if (item->GetPath().Find(".cdda") < 0)
       continue;
 
     // return false if Rip returned false (this means an error or the user cancelled
-    if (!Rip(item->m_strPath, strFile.c_str(), *item->GetMusicInfoTag()))
+    if (!Rip(item->GetPath(), strFile.c_str(), *item->GetMusicInfoTag()))
       return false;
 
     tick = XbmcThreads::SystemClockMillis() - tick;
@@ -453,7 +453,7 @@ CStdString CCDDARipper::GetAlbumDirName(const MUSIC_INFO::CMusicInfoTag& infoTag
 CStdString CCDDARipper::GetTrackName(CFileItem *item)
 {
   // get track number from "cdda://local/01.cdda"
-  int trackNumber = atoi(item->m_strPath.substr(13, item->m_strPath.size() - 13 - 5).c_str());
+  int trackNumber = atoi(item->GetPath().substr(13, item->GetPath().size() - 13 - 5).c_str());
 
   // Format up our ripped file label
   CFileItem destItem(*item);

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -98,7 +98,7 @@ bool CExternalPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &opti
   try
   {
     m_bIsPlaying = true;
-    m_launchFilename = file.m_strPath;
+    m_launchFilename = file.GetPath();
     CLog::Log(LOGNOTICE, "%s: %s", __FUNCTION__, m_launchFilename.c_str());
     Create();
 

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -330,7 +330,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
         for (int i = 1; i < files.Size(); i++)
         {
            int duration = 0;
-           if (CDVDFileInfo::GetFileDuration(files[i]->m_strPath, duration))
+           if (CDVDFileInfo::GetFileDuration(files[i]->GetPath(), duration))
              p->m_iDuration = p->m_iDuration + duration;
         }
       }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHTSP.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHTSP.cpp
@@ -248,7 +248,7 @@ bool CDVDInputStreamHTSP::UpdateItem(CFileItem& item)
   CHTSPSession::ParseItem(channel, m_tag, m_event, item);
   item.SetThumbnailImage(channel.icon);
   item.SetCachedVideoThumb();
-  return current.m_strPath  != item.m_strPath
+  return current.GetPath()  != item.GetPath()
       || current.m_strTitle != item.m_strTitle;
 }
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamStack.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamStack.cpp
@@ -68,9 +68,9 @@ bool CDVDInputStreamStack::Open(const char* path, const std::string& content)
   {
     TFile file(new CFile());
 
-    if (!file->Open(items[index]->m_strPath, READ_TRUNCATED))
+    if (!file->Open(items[index]->GetPath(), READ_TRUNCATED))
     {
-      CLog::Log(LOGERROR, "CDVDInputStreamStack::Open - failed to open stack part '%s' - skipping", items[index]->m_strPath.c_str());
+      CLog::Log(LOGERROR, "CDVDInputStreamStack::Open - failed to open stack part '%s' - skipping", items[index]->GetPath().c_str());
       continue;
     }
     TSeg segment;
@@ -79,7 +79,7 @@ bool CDVDInputStreamStack::Open(const char* path, const std::string& content)
 
     if(segment.length <= 0)
     {
-      CLog::Log(LOGERROR, "CDVDInputStreamStack::Open - failed to get file length for '%s' - skipping", items[index]->m_strPath.c_str());
+      CLog::Log(LOGERROR, "CDVDInputStreamStack::Open - failed to get file length for '%s' - skipping", items[index]->GetPath().c_str());
       continue;
     }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -336,7 +336,7 @@ bool CDVDPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
 {
   try
   {
-    CLog::Log(LOGNOTICE, "DVDPlayer: Opening: %s", file.m_strPath.c_str());
+    CLog::Log(LOGNOTICE, "DVDPlayer: Opening: %s", file.GetPath().c_str());
 
     // if playing a file close it first
     // this has to be changed so we won't have to close it.
@@ -352,7 +352,7 @@ bool CDVDPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
     m_PlayerOptions = options;
     m_item     = file;
     m_mimetype  = file.GetMimeType();
-    m_filename = file.m_strPath;
+    m_filename = file.GetPath();
 
     m_ready.Reset();
     Create();

--- a/xbmc/cores/paplayer/AudioDecoder.cpp
+++ b/xbmc/cores/paplayer/AudioDecoder.cpp
@@ -85,11 +85,11 @@ bool CAudioDecoder::Create(const CFileItem &file, __int64 seekOffset, unsigned i
     filecache = g_guiSettings.GetInt("cacheaudio.lan");
 
   // create our codec
-  m_codec=CodecFactory::CreateCodecDemux(file.m_strPath, file.GetMimeType(), filecache * 1024);
+  m_codec=CodecFactory::CreateCodecDemux(file.GetPath(), file.GetMimeType(), filecache * 1024);
 
-  if (!m_codec || !m_codec->Init(file.m_strPath, filecache * 1024))
+  if (!m_codec || !m_codec->Init(file.GetPath(), filecache * 1024))
   {
-    CLog::Log(LOGERROR, "CAudioDecoder: Unable to Init Codec while loading file %s", file.m_strPath.c_str());
+    CLog::Log(LOGERROR, "CAudioDecoder: Unable to Init Codec while loading file %s", file.GetPath().c_str());
     Destroy();
     return false;
   }

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -153,7 +153,7 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
   m_bStopPlaying = false;
   m_bytesSentOut = 0;
 
-  CLog::Log(LOGINFO, "PAPlayer: Playing %s", file.m_strPath.c_str());
+  CLog::Log(LOGINFO, "PAPlayer: Playing %s", file.GetPath().c_str());
 
   m_timeOffset = (__int64)(options.starttime * 1000);
 
@@ -225,7 +225,7 @@ bool PAPlayer::QueueNextFile(const CFileItem &file, bool checkCrossFading)
   if (IsPaused())
     Pause();
 
-  if (file.m_strPath == m_currentFile->m_strPath &&
+  if (file.GetPath() == m_currentFile->GetPath() &&
       file.m_lStartOffset > 0 &&
       file.m_lStartOffset == m_currentFile->m_lEndOffset)
   { // continuing on a .cue sheet item - return true to say we'll handle the transistion
@@ -243,7 +243,7 @@ bool PAPlayer::QueueNextFile(const CFileItem &file, bool checkCrossFading)
   }
 
   // ok, we're good to go on queuing this one up
-  CLog::Log(LOGINFO, "PAPlayer: Queuing next file %s", file.m_strPath.c_str());
+  CLog::Log(LOGINFO, "PAPlayer: Queuing next file %s", file.GetPath().c_str());
 
   m_bQueueFailed = false;
   if (checkCrossFading)
@@ -587,7 +587,7 @@ bool PAPlayer::ProcessPAP()
     // Check for EOF and queue the next track if applicable
     if (m_decoder[m_currentDecoder].GetStatus() == STATUS_ENDED)
     { // time to swap tracks
-      if (m_nextFile->m_strPath != m_currentFile->m_strPath ||
+      if (m_nextFile->GetPath() != m_currentFile->GetPath() ||
           !m_nextFile->m_lStartOffset ||
           m_nextFile->m_lStartOffset != m_currentFile->m_lEndOffset)
       { // don't have a .cue sheet item

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -135,9 +135,9 @@ void CPlayerCoreFactory::GetPlayers( VECPLAYERCORES &vecCores, const bool audio,
 
 void CPlayerCoreFactory::GetPlayers( const CFileItem& item, VECPLAYERCORES &vecCores)
 {
-  CURL url(item.m_strPath);
+  CURL url(item.GetPath());
 
-  CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers(%s)", item.m_strPath.c_str());
+  CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers(%s)", item.GetPath().c_str());
 
   // Process rules
   for(unsigned int i = 0; i < s_vecCoreSelectionRules.size(); i++)
@@ -157,7 +157,7 @@ void CPlayerCoreFactory::GetPlayers( const CFileItem& item, VECPLAYERCORES &vecC
     {
 //      bAdd = true;
 //      DVDPlayerCodec codec;
-//      if (!codec.Init(item.m_strPath,2048))
+//      if (!codec.Init(item.GetPath(),2048))
 //        bAdd = false;
 //      codec.DeInit();
     }

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -138,7 +138,7 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, VECPLAYERCORES &vec
         !MatchesRegExp(CStreamDetails::VideoAspectToAspectDescription(streamDetails.GetVideoAspect()),  regExp)) return;
   }
 
-  CURL url(item.m_strPath);
+  CURL url(item.GetPath());
 
   if (CompileRegExp(m_fileTypes, regExp) && !MatchesRegExp(url.GetFileType(), regExp)) return;
 
@@ -146,7 +146,7 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, VECPLAYERCORES &vec
 
   if (CompileRegExp(m_mimeTypes, regExp) && !MatchesRegExp(item.GetMimeType(), regExp)) return;
 
-  if (CompileRegExp(m_fileName, regExp) && !MatchesRegExp(item.m_strPath, regExp)) return;
+  if (CompileRegExp(m_fileName, regExp) && !MatchesRegExp(item.GetPath(), regExp)) return;
 
   CLog::Log(LOGDEBUG, "CPlayerSelectionRule::GetPlayers: matches rule: %s", m_name.c_str());
 

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -316,7 +316,7 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
   switch (button)
   {
   case CONTEXT_BUTTON_EJECT_DRIVE:
-    return g_mediaManager.Eject(item->m_strPath);
+    return g_mediaManager.Eject(item->GetPath());
 
 #ifdef HAS_DVD_DRIVE
   case CONTEXT_BUTTON_PLAY_DISC:
@@ -327,7 +327,7 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
 
   case CONTEXT_BUTTON_EJECT_DISC:
 #ifdef _WIN32
-    CWIN32Util::ToggleTray(g_mediaManager.TranslateDevicePath(item->m_strPath)[0]);
+    CWIN32Util::ToggleTray(g_mediaManager.TranslateDevicePath(item->GetPath())[0]);
 #else
     CIoSupport::ToggleTray();
 #endif
@@ -464,7 +464,7 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
         CStdString cachedThumb;
         if (type == "music")
         {
-          cachedThumb = item->m_strPath;
+          cachedThumb = item->GetPath();
           URIUtils::RemoveSlashAtEnd(cachedThumb);
           cachedThumb = CThumbnailCache::GetMusicThumb(cachedThumb);
         }
@@ -475,8 +475,8 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
           CTextureDatabase db;
           if (db.Open())
           {
-            cachedThumb = CTextureCache::GetUniqueImage(item->m_strPath, URIUtils::GetExtension(strThumb));
-            db.SetTextureForPath(item->m_strPath, cachedThumb);
+            cachedThumb = CTextureCache::GetUniqueImage(item->GetPath(), URIUtils::GetExtension(strThumb));
+            db.SetTextureForPath(item->GetPath(), cachedThumb);
           }
         }
         XFILE::CFile::Cache(strThumb, cachedThumb);
@@ -590,7 +590,7 @@ CMediaSource *CGUIDialogContextMenu::GetShare(const CStdString &type, const CFil
     }
     else
     {
-      if (!testShare.strPath.Equals(item->m_strPath))
+      if (!testShare.strPath.Equals(item->GetPath()))
         continue;
     }
     // paths match, what about share name - only match the leftmost

--- a/xbmc/dialogs/GUIDialogFavourites.cpp
+++ b/xbmc/dialogs/GUIDialogFavourites.cpp
@@ -96,7 +96,7 @@ void CGUIDialogFavourites::OnClick(int item)
 
   // grab our message, close the dialog, and send
   CFileItemPtr pItem = (*m_favourites)[item];
-  CStdString execute(pItem->m_strPath);
+  CStdString execute(pItem->GetPath());
 
   Close();
 

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -87,7 +87,7 @@ bool CGUIDialogFileBrowser::OnAction(const CAction &action)
     GoParentFolder();
     return true;
   }
-  if ((action.GetID() == ACTION_CONTEXT_MENU || action.GetID() == ACTION_MOUSE_RIGHT_CLICK) && m_Directory->m_strPath.IsEmpty())
+  if ((action.GetID() == ACTION_CONTEXT_MENU || action.GetID() == ACTION_MOUSE_RIGHT_CLICK) && m_Directory->GetPath().IsEmpty())
   {
     int iItem = m_viewControl.GetSelectedItem();
     if ((!m_addSourceType.IsEmpty() && iItem != m_vecItems->Size()-1))
@@ -156,10 +156,10 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
       }
 
       // find the parent folder if we are a file browser (don't do this for folders)
-      m_Directory->m_strPath = m_selectedPath;
+      m_Directory->SetPath(m_selectedPath);
       if (!m_browsingForFolders && !bIsDir)
-        URIUtils::GetParentPath(m_selectedPath, m_Directory->m_strPath);
-      Update(m_Directory->m_strPath);
+        m_Directory->SetPath(URIUtils::GetParentPath(m_selectedPath));
+      Update(m_Directory->GetPath());
       m_viewControl.SetSelectedItem(m_selectedPath);
       return CGUIDialog::OnMessage(message);
     }
@@ -199,7 +199,7 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
           if (iItem == 0)
             strPath = m_selectedPath;
           else
-            strPath = (*m_vecItems)[iItem]->m_strPath;
+            strPath = (*m_vecItems)[iItem]->GetPath();
 
           URIUtils::AddFileToFolder(strPath,"1",strTest);
           CFile file;
@@ -221,7 +221,7 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
             {
               CFileItemPtr pItem = (*m_vecItems)[iItem];
               if (pItem->IsSelected())
-                m_markedPath.push_back(pItem->m_strPath);
+                m_markedPath.push_back(pItem->GetPath());
             }
           }
           m_bConfirmed = true;
@@ -240,9 +240,9 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
         if (CGUIDialogKeyboard::ShowAndGetInput(strInput,g_localizeStrings.Get(119),false))
         {
           CStdString strPath;
-          URIUtils::AddFileToFolder(m_vecItems->m_strPath,strInput,strPath);
+          URIUtils::AddFileToFolder(m_vecItems->GetPath(),strInput,strPath);
           if (CDirectory::Create(strPath))
-            Update(m_vecItems->m_strPath);
+            Update(m_vecItems->GetPath());
           else
             CGUIDialogOK::ShowAndGetInput(20069,20072,20073,0);
         }
@@ -267,18 +267,18 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
         if (m_Directory->IsVirtualDirectoryRoot() && IsActive())
         {
           int iItem = m_viewControl.GetSelectedItem();
-          Update(m_Directory->m_strPath);
+          Update(m_Directory->GetPath());
           m_viewControl.SetSelectedItem(iItem);
         }
         else if (m_Directory->IsRemovable())
         { // check that we have this removable share still
-          if (!m_rootDir.IsInSource(m_Directory->m_strPath))
+          if (!m_rootDir.IsInSource(m_Directory->GetPath()))
           { // don't have this share any more
             if (IsActive()) Update("");
             else
             {
               m_history.ClearPathHistory();
-              m_Directory->m_strPath="";
+              m_Directory->SetPath("");
             }
           }
         }
@@ -289,7 +289,7 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
         if (m_Directory->IsVirtualDirectoryRoot() && IsActive())
         {
           int iItem = m_viewControl.GetSelectedItem();
-          Update(m_Directory->m_strPath);
+          Update(m_Directory->GetPath());
           m_viewControl.SetSelectedItem(iItem);
         }
         return true;
@@ -298,11 +298,11 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
       {
         if (IsActive())
         {
-          if((message.GetStringParam() == m_Directory->m_strPath) ||
-             (m_Directory->IsMultiPath() && XFILE::CMultiPathDirectory::HasPath(m_Directory->m_strPath, message.GetStringParam())))
+          if((message.GetStringParam() == m_Directory->GetPath()) ||
+             (m_Directory->IsMultiPath() && XFILE::CMultiPathDirectory::HasPath(m_Directory->GetPath(), message.GetStringParam())))
           {
             int iItem = m_viewControl.GetSelectedItem();
-            Update(m_Directory->m_strPath);
+            Update(m_Directory->GetPath());
             m_viewControl.SetSelectedItem(iItem);
           }
         }
@@ -338,9 +338,9 @@ void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
     CFileItemPtr pItem = (*m_vecItems)[iItem];
     if (!pItem->IsParentFolder())
     {
-      strSelectedItem = pItem->m_strPath;
+      strSelectedItem = pItem->GetPath();
       URIUtils::RemoveSlashAtEnd(strSelectedItem);
-      m_history.SetSelectedItem(strSelectedItem, m_Directory->m_strPath==""?"empty":m_Directory->m_strPath);
+      m_history.SetSelectedItem(strSelectedItem, m_Directory->GetPath().IsEmpty()?"empty":m_Directory->GetPath());
     }
   }
 
@@ -367,7 +367,7 @@ void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
       if (URIUtils::GetParentPath(strDirectory, strParentPath))
       {
         CFileItemPtr pItem(new CFileItem(".."));
-        pItem->m_strPath = strParentPath;
+        pItem->SetPath(strParentPath);
         pItem->m_bIsFolder = true;
         pItem->m_bIsShareOrDrive = false;
         items.AddFront(pItem, 0);
@@ -378,7 +378,7 @@ void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
       // yes, this is the root of a share
       // add parent path to the virtual directory
       CFileItemPtr pItem(new CFileItem(".."));
-      pItem->m_strPath = "";
+      pItem->SetPath("");
       pItem->m_bIsShareOrDrive = false;
       pItem->m_bIsFolder = true;
       items.AddFront(pItem, 0);
@@ -387,7 +387,7 @@ void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
 
     ClearFileItems();
     m_vecItems->Copy(items);
-    m_Directory->m_strPath = strDirectory;
+    m_Directory->SetPath(strDirectory);
     m_strParentPath = strParentPath;
   }
 
@@ -413,19 +413,19 @@ void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
 
   OnSort();
 
-  if (m_Directory->m_strPath.IsEmpty() && m_addNetworkShareEnabled &&
+  if (m_Directory->GetPath().IsEmpty() && m_addNetworkShareEnabled &&
      (g_settings.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
       g_settings.IsMasterUser() || g_passwordManager.bMasterUser))
   { // we are in the virtual directory - add the "Add Network Location" item
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(1032)));
-    pItem->m_strPath = "net://";
+    pItem->SetPath("net://");
     pItem->m_bIsFolder = true;
     m_vecItems->Add(pItem);
   }
-  if (m_Directory->m_strPath.IsEmpty() && !m_addSourceType.IsEmpty())
+  if (m_Directory->GetPath().IsEmpty() && !m_addSourceType.IsEmpty())
   {
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(21359)));
-    pItem->m_strPath = "source://";
+    pItem->SetPath("source://");
     pItem->m_bIsFolder = true;
     m_vecItems->Add(pItem);
   }
@@ -433,7 +433,7 @@ void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
   m_viewControl.SetItems(*m_vecItems);
   m_viewControl.SetCurrentView((m_browsingForImages && CAutoSwitch::ByFileCount(*m_vecItems)) ? DEFAULT_VIEW_ICONS : DEFAULT_VIEW_LIST);
 
-  CStdString strPath2 = m_Directory->m_strPath;
+  CStdString strPath2 = m_Directory->GetPath();
   URIUtils::RemoveSlashAtEnd(strPath2);
   strSelectedItem = m_history.GetSelectedItem(strPath2==""?"empty":strPath2);
 
@@ -441,7 +441,7 @@ void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
   for (int i = 0; i < (int)m_vecItems->Size(); ++i)
   {
     CFileItemPtr pItem = (*m_vecItems)[i];
-    strPath2 = pItem->m_strPath;
+    strPath2 = pItem->GetPath();
     URIUtils::RemoveSlashAtEnd(strPath2);
     if (strPath2 == strSelectedItem)
     {
@@ -455,7 +455,7 @@ void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)
   if (!bSelectedFound)
     m_viewControl.SetSelectedItem(0);
 
-  m_history.AddPath(m_Directory->m_strPath);
+  m_history.AddPath(m_Directory->GetPath());
 
   if (m_browsingForImages)
     m_thumbLoader.Load(*m_vecItems);
@@ -469,9 +469,9 @@ void CGUIDialogFileBrowser::FrameMove()
     // if we are browsing for folders, and not in the root directory, then we use the parent path,
     // else we use the current file's path
     if (m_browsingForFolders && !m_Directory->IsVirtualDirectoryRoot())
-      m_selectedPath = m_Directory->m_strPath;
+      m_selectedPath = m_Directory->GetPath();
     else
-      m_selectedPath = (*m_vecItems)[item]->m_strPath;
+      m_selectedPath = (*m_vecItems)[item]->GetPath();
     if (m_selectedPath == "net://")
     {
       SET_CONTROL_LABEL(CONTROL_LABEL_PATH, g_localizeStrings.Get(1032)); // "Add Network Location..."
@@ -483,7 +483,7 @@ void CGUIDialogFileBrowser::FrameMove()
       CStdString safePath = url.GetWithoutUserDetails();
       SET_CONTROL_LABEL(CONTROL_LABEL_PATH, safePath);
     }
-    if ((!m_browsingForFolders && (*m_vecItems)[item]->m_bIsFolder) || ((*m_vecItems)[item]->m_strPath == "image://Browse"))
+    if ((!m_browsingForFolders && (*m_vecItems)[item]->m_bIsFolder) || ((*m_vecItems)[item]->GetPath() == "image://Browse"))
     {
       CONTROL_DISABLE(CONTROL_OK);
     }
@@ -515,16 +515,16 @@ void CGUIDialogFileBrowser::OnClick(int iItem)
 {
   if ( iItem < 0 || iItem >= (int)m_vecItems->Size() ) return ;
   CFileItemPtr pItem = (*m_vecItems)[iItem];
-  CStdString strPath = pItem->m_strPath;
+  CStdString strPath = pItem->GetPath();
 
   if (pItem->m_bIsFolder)
   {
-    if (pItem->m_strPath == "net://")
+    if (pItem->GetPath() == "net://")
     { // special "Add Network Location" item
       OnAddNetworkLocation();
       return;
     }
-    if (pItem->m_strPath == "source://")
+    if (pItem->GetPath() == "source://")
     { // special "Add Source" item
       OnAddMediaSource();
       return;
@@ -536,20 +536,20 @@ void CGUIDialogFileBrowser::OnClick(int iItem)
     }
     if ( pItem->m_bIsShareOrDrive )
     {
-      if ( !HaveDiscOrConnection( pItem->m_strPath, pItem->m_iDriveType ) )
+      if ( !HaveDiscOrConnection( pItem->m_iDriveType ) )
         return ;
     }
     Update(strPath);
   }
   else if (!m_browsingForFolders)
   {
-    m_selectedPath = pItem->m_strPath;
+    m_selectedPath = pItem->GetPath();
     m_bConfirmed = true;
     Close();
   }
 }
 
-bool CGUIDialogFileBrowser::HaveDiscOrConnection( CStdString& strPath, int iDriveType )
+bool CGUIDialogFileBrowser::HaveDiscOrConnection( int iDriveType )
 {
   if ( iDriveType == CMediaSource::SOURCE_TYPE_DVD )
   {
@@ -574,7 +574,7 @@ bool CGUIDialogFileBrowser::HaveDiscOrConnection( CStdString& strPath, int iDriv
 
 void CGUIDialogFileBrowser::GoParentFolder()
 {
-  CStdString strPath(m_strParentPath), strOldPath(m_Directory->m_strPath);
+  CStdString strPath(m_strParentPath), strOldPath(m_Directory->GetPath());
   if (strPath.size() == 2)
     if (strPath[1] == ':')
       URIUtils::AddSlashAtEnd(strPath);
@@ -897,7 +897,7 @@ void CGUIDialogFileBrowser::OnAddNetworkLocation()
     }
   }
   m_rootDir.SetSources(m_shares);
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
 }
 
 void CGUIDialogFileBrowser::OnAddMediaSource()
@@ -979,11 +979,11 @@ bool CGUIDialogFileBrowser::OnPopupMenu(int iItem)
       m_addNetworkShareEnabled = true;
       m_selectedPath = "";
 
-      Update(m_Directory->m_strPath);
+      Update(m_Directory->GetPath());
     }
     else
     {
-      g_settings.DeleteSource(m_addSourceType,(*m_vecItems)[iItem]->GetLabel(),(*m_vecItems)[iItem]->m_strPath);
+      g_settings.DeleteSource(m_addSourceType,(*m_vecItems)[iItem]->GetLabel(),(*m_vecItems)[iItem]->GetPath());
       SetSources(*g_settings.GetSourcesFromType(m_addSourceType));
       Update("");
     }

--- a/xbmc/dialogs/GUIDialogFileBrowser.h
+++ b/xbmc/dialogs/GUIDialogFileBrowser.h
@@ -66,7 +66,7 @@ protected:
   void OnSort();
   void ClearFileItems();
   void Update(const CStdString &strDirectory);
-  bool HaveDiscOrConnection( CStdString& strPath, int iDriveType );
+  bool HaveDiscOrConnection( int iDriveType );
   bool OnPopupMenu(int iItem);
   void OnAddNetworkLocation();
   void OnAddMediaSource();

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -230,7 +230,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
   bool allowNetworkShares(m_type != "programs");
   VECSOURCES extraShares;
 
-  if (m_name != CUtil::GetTitleFromPath(m_paths->Get(item)->m_strPath))
+  if (m_name != CUtil::GetTitleFromPath(m_paths->Get(item)->GetPath()))
     m_bNameChanged=true;
 
   if (m_type == "music")
@@ -351,7 +351,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
   if (CGUIDialogFileBrowser::ShowAndGetSource(path, allowNetworkShares, extraShares.size()==0?NULL:&extraShares))
   {
     if (item < m_paths->Size()) // if the skin does funky things, m_paths may have been cleared
-      m_paths->Get(item)->m_strPath = path;
+      m_paths->Get(item)->SetPath(path);
     if (!m_bNameChanged || m_name.IsEmpty())
     {
       CURL url(path);
@@ -367,15 +367,17 @@ void CGUIDialogMediaSource::OnPath(int item)
 {
   if (item < 0 || item > m_paths->Size()) return;
 
-  if (m_name != CUtil::GetTitleFromPath(m_paths->Get(item)->m_strPath))
+  if (m_name != CUtil::GetTitleFromPath(m_paths->Get(item)->GetPath()))
     m_bNameChanged=true;
 
-  CGUIDialogKeyboard::ShowAndGetInput(m_paths->Get(item)->m_strPath, g_localizeStrings.Get(1021), false);
-  URIUtils::AddSlashAtEnd(m_paths->Get(item)->m_strPath);
+  CStdString path(m_paths->Get(item)->GetPath());
+  CGUIDialogKeyboard::ShowAndGetInput(path, g_localizeStrings.Get(1021), false);
+  URIUtils::AddSlashAtEnd(path);
+  m_paths->Get(item)->SetPath(path);
 
   if (!m_bNameChanged || m_name.IsEmpty())
   {
-    CURL url(m_paths->Get(item)->m_strPath);
+    CURL url(m_paths->Get(item)->GetPath());
     m_name = url.GetWithoutUserDetails();
     URIUtils::RemoveSlashAtEnd(m_name);
     m_name = CUtil::GetTitleFromPath(m_name);
@@ -421,7 +423,7 @@ void CGUIDialogMediaSource::UpdateButtons()
   if (!m_paths->Size()) // sanity
     return;
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_OK, !m_paths->Get(0)->m_strPath.IsEmpty() && !m_name.IsEmpty());
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_OK, !m_paths->Get(0)->GetPath().IsEmpty() && !m_name.IsEmpty());
   CONTROL_ENABLE_ON_CONDITION(CONTROL_PATH_REMOVE, m_paths->Size() > 1);
   // name
   SET_CONTROL_LABEL2(CONTROL_NAME, m_name);
@@ -433,7 +435,7 @@ void CGUIDialogMediaSource::UpdateButtons()
   {
     CFileItemPtr item = m_paths->Get(i);
     CStdString path;
-    CURL url(item->m_strPath);
+    CURL url(item->GetPath());
     path = url.GetWithoutUserDetails();
     if (path.IsEmpty()) path = "<"+g_localizeStrings.Get(231)+">"; // <None>
     item->SetLabel(path);
@@ -533,7 +535,7 @@ vector<CStdString> CGUIDialogMediaSource::GetPaths()
 {
   vector<CStdString> paths;
   for (int i = 0; i < m_paths->Size(); i++)
-    if (!m_paths->Get(i)->m_strPath.IsEmpty())
-      paths.push_back(m_paths->Get(i)->m_strPath);
+    if (!m_paths->Get(i)->GetPath().IsEmpty())
+      paths.push_back(m_paths->Get(i)->GetPath());
   return paths;
 }

--- a/xbmc/dialogs/GUIDialogPlayEject.cpp
+++ b/xbmc/dialogs/GUIDialogPlayEject.cpp
@@ -109,18 +109,18 @@ bool CGUIDialogPlayEject::ShowAndGetInput(const CFileItem & item,
   }
   else
   {
-    strLine1 = URIUtils::GetFileName(item.m_strPath);
+    strLine1 = URIUtils::GetFileName(item.GetPath());
     URIUtils::RemoveExtension(strLine1);
   }
 
   // Figure out Line 2 of the dialog
   CStdString strLine2;
   TiXmlDocument discStubXML;
-  if (discStubXML.LoadFile(item.m_strPath))
+  if (discStubXML.LoadFile(item.GetPath()))
   {
     TiXmlElement * pRootElement = discStubXML.RootElement();
     if (!pRootElement || strcmpi(pRootElement->Value(), "discstub") != 0)
-      CLog::Log(LOGERROR, "Error loading %s, no <discstub> node", item.m_strPath.c_str());
+      CLog::Log(LOGERROR, "Error loading %s, no <discstub> node", item.GetPath().c_str());
     else
       XMLUtils::GetString(pRootElement, "message", strLine2);
   }

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -124,7 +124,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
           if (addons[j]->IsType((TYPE)i))
           {
             CFileItemPtr item(new CFileItem(TranslateType((TYPE)i,true)));
-            item->m_strPath = URIUtils::AddFileToFolder(strPath,TranslateType((TYPE)i,false));
+            item->SetPath(URIUtils::AddFileToFolder(strPath,TranslateType((TYPE)i,false)));
             item->m_bIsFolder = true;
             CStdString thumb = GetIcon((TYPE)i);
             if (!thumb.IsEmpty() && g_TextureManager.HasTexture(thumb))
@@ -134,7 +134,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
           }
         }
       }
-      items.m_strPath = strPath;
+      items.SetPath(strPath);
       return true;
     }
   }
@@ -143,7 +143,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
     TYPE type = TranslateType(path.GetFileName());
     items.SetProperty("addoncategory",TranslateType(type, true));
     items.SetLabel(TranslateType(type, true));
-    items.m_strPath = strPath;
+    items.SetPath(strPath);
 
     // FIXME: Categorisation of addons needs adding here
     for (unsigned int j=0;j<addons.size();++j)
@@ -153,7 +153,7 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
     }
   }
 
-  items.m_strPath = strPath;
+  items.SetPath(strPath);
   GenerateListing(path, addons, items, reposAsFolders);
   // check for available updates
   if (path.GetHostName().Equals("enabled"))

--- a/xbmc/filesystem/CDDADirectory.cpp
+++ b/xbmc/filesystem/CDDADirectory.cpp
@@ -76,10 +76,12 @@ bool CCDDADirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
 
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->m_bIsFolder = false;
-    pItem->m_strPath.Format("cdda://local/%02.2i.cdda", i);
+    CStdString path;
+    path.Format("cdda://local/%02.2i.cdda", i);
+    pItem->SetPath(path);
 
     struct __stat64 s64;
-    if (CFile::Stat(pItem->m_strPath, &s64) == 0)
+    if (CFile::Stat(pItem->GetPath(), &s64) == 0)
       pItem->m_dwSize = s64.st_size;
 
     items.Add(pItem);

--- a/xbmc/filesystem/DAAPDirectory.cpp
+++ b/xbmc/filesystem/DAAPDirectory.cpp
@@ -111,7 +111,7 @@ bool CDAAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
         // Add item to directory list
         CLog::Log(LOGDEBUG, "DAAPDirectory: Adding item %s", strFile.c_str());
         CFileItemPtr pItem(new CFileItem(strFile));
-        pItem->m_strPath = strRoot + m_thisHost->dbplaylists->playlists[c].itemname + "/";
+        pItem->SetPath(strRoot + m_thisHost->dbplaylists->playlists[c].itemname + "/");
         pItem->m_bIsFolder = true;
         items.Add(pItem);
       }
@@ -144,7 +144,7 @@ bool CDAAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
             strBuffer = cur->artist;
             CLog::Log(LOGDEBUG, "DAAPDirectory: Adding item %s", strBuffer.c_str());
             CFileItemPtr pItem(new CFileItem(strBuffer));
-            pItem->m_strPath = strRoot + cur->artist + "/";
+            pItem->SetPath(strRoot + cur->artist + "/");
             pItem->m_bIsFolder = true;
             items.Add(pItem);
             cur = cur->next;
@@ -176,10 +176,10 @@ bool CDAAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
               CLog::Log(LOGDEBUG, "DAAPDirectory: Adding item %s", m_currentSongItems[idx].itemname);
               CFileItemPtr pItem(new CFileItem(m_currentSongItems[idx].itemname));
 
-
+              CStdString path;
               if( m_thisHost->version_major != 3 )
               {
-                pItem->m_strPath.Format(REQUEST42,
+                path.Format(REQUEST42,
                                         m_thisHost->host,
                                         g_DaapClient.m_iDatabase,
                                         m_currentSongItems[idx].id,
@@ -190,7 +190,7 @@ bool CDAAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
               }
               else
               {
-                pItem->m_strPath.Format(REQUEST45,
+                path.Format(REQUEST45,
                                         m_thisHost->host,
                                         g_DaapClient.m_iDatabase,
                                         m_currentSongItems[idx].id,
@@ -198,10 +198,11 @@ bool CDAAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
                                         m_thisHost->sessionid);
               }
 
+              pItem->SetPath(path);
               pItem->m_bIsFolder = false;
               pItem->m_dwSize = m_currentSongItems[idx].songsize;
 
-              pItem->GetMusicInfoTag()->SetURL(pItem->m_strPath);
+              pItem->GetMusicInfoTag()->SetURL(pItem->GetPath());
               pItem->GetMusicInfoTag()->SetTitle(m_currentSongItems[idx].itemname);
               pItem->GetMusicInfoTag()->SetArtist(m_currentSongItems[idx].songartist);
               pItem->GetMusicInfoTag()->SetAlbum(m_currentSongItems[idx].songalbum);
@@ -238,7 +239,7 @@ bool CDAAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
           CLog::Log(LOGDEBUG, "DAAPDirectory: Adding item %s", curAlbum->album);
           CFileItemPtr pItem(new CFileItem(curAlbum->album));
 
-          pItem->m_strPath = strRoot + curAlbum->album + "/";
+          pItem->SetPath(strRoot + curAlbum->album + "/");
           pItem->m_bIsFolder = true;
           items.Add(pItem);
           curAlbum = curAlbum->next;
@@ -263,9 +264,10 @@ bool CDAAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
             CLog::Log(LOGDEBUG, "DAAPDirectory: Adding item %s", m_currentSongItems[c].itemname);
             CFileItemPtr pItem(new CFileItem(m_currentSongItems[c].itemname));
 
+            CStdString path;
             if( m_thisHost->version_major != 3 )
             {
-              pItem->m_strPath.Format(REQUEST42,
+              path.Format(REQUEST42,
                                       m_thisHost->host,
                                       g_DaapClient.m_iDatabase,
                                       m_currentSongItems[c].id,
@@ -276,7 +278,7 @@ bool CDAAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
             }
             else
             {
-              pItem->m_strPath.Format(REQUEST45,
+              path.Format(REQUEST45,
                                       m_thisHost->host,
                                       g_DaapClient.m_iDatabase,
                                       m_currentSongItems[c].id,
@@ -284,10 +286,11 @@ bool CDAAPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
                                       m_thisHost->sessionid);
             }
 
+            pItem->SetPath(path);
             pItem->m_bIsFolder = false;
             pItem->m_dwSize = m_currentSongItems[c].songsize;
 
-            pItem->GetMusicInfoTag()->SetURL(pItem->m_strPath);
+            pItem->GetMusicInfoTag()->SetURL(pItem->GetPath());
 
             pItem->GetMusicInfoTag()->SetTitle(m_currentSongItems[c].itemname);
             pItem->GetMusicInfoTag()->SetArtist(m_selectedArtist);

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -67,7 +67,7 @@ private:
   public:
     virtual bool DoWork()
     {
-      m_result->m_list.m_strPath = m_result->m_dir;
+      m_result->m_list.SetPath(m_result->m_dir);
       m_result->m_result         = m_imp->GetDirectory(m_result->m_dir, m_result->m_list);
       m_result->m_event.Set();
       return m_result->m_result;
@@ -130,7 +130,7 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, C
 
     // check our cache for this path
     if (g_directoryCache.GetDirectory(strPath, items, cacheDirectory == DIR_CACHE_ALWAYS))
-      items.m_strPath = strPath;
+      items.SetPath(strPath);
     else
     {
       // need to clear the cache (in case the directory fetch fails)
@@ -174,7 +174,7 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, C
         }
         else
         {
-          items.m_strPath = strPath;
+          items.SetPath(strPath);
           result = pDirectory->GetDirectory(realPath, items);
         }
 
@@ -199,7 +199,7 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, C
       CFileItemPtr item = items[i];
       // TODO: we shouldn't be checking the gui setting here;
       // callers should use getHidden instead
-      if ((!item->m_bIsFolder && !pDirectory->IsAllowed(item->m_strPath)) ||
+      if ((!item->m_bIsFolder && !pDirectory->IsAllowed(item->GetPath())) ||
           (item->GetPropertyBOOL("file:hidden") && !getHidden && !g_guiSettings.GetBool("filelists.showhidden")))
       {
         items.Remove(i);
@@ -306,7 +306,7 @@ void CDirectory::FilterFileDirectories(CFileItemList &items, const CStdString &m
     CFileItemPtr pItem=items[i];
     if ((!pItem->m_bIsFolder) && (!pItem->IsInternetStream()))
     {
-      auto_ptr<IFileDirectory> pDirectory(CFactoryFileDirectory::Create(pItem->m_strPath,pItem.get(),mask));
+      auto_ptr<IFileDirectory> pDirectory(CFactoryFileDirectory::Create(pItem->GetPath(),pItem.get(),mask));
       if (pDirectory.get())
         pItem->m_bIsFolder = true;
       else

--- a/xbmc/filesystem/FTPDirectory.cpp
+++ b/xbmc/filesystem/FTPDirectory.cpp
@@ -80,14 +80,14 @@ bool CFTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
 
       CFileItemPtr pItem(new CFileItem(name));
 
-      pItem->m_strPath = path + name;
       pItem->m_bIsFolder = (bool)(parse.getFlagtrycwd() != 0);
+      CStdString filePath = path + name;
       if (pItem->m_bIsFolder)
-        URIUtils::AddSlashAtEnd(pItem->m_strPath);
+        URIUtils::AddSlashAtEnd(filePath);
 
       /* qualify the url with host and all */
-      url.SetFileName(pItem->m_strPath);
-      pItem->m_strPath = url.Get();
+      url.SetFileName(filePath);
+      pItem->SetPath(url.Get());
 
       pItem->m_dwSize = parse.getSize();
       pItem->m_dateTime=parse.getTime();

--- a/xbmc/filesystem/FactoryFileDirectory.cpp
+++ b/xbmc/filesystem/FactoryFileDirectory.cpp
@@ -128,7 +128,7 @@ IFileDirectory* CFactoryFileDirectory::Create(const CStdString& strPath, CFileIt
     }
     else
     { // compressed or more than one file -> create a zip dir
-      pItem->m_strPath = strUrl;
+      pItem->SetPath(strUrl);
       return new CZipDirectory;
     }
     return NULL;
@@ -179,7 +179,7 @@ IFileDirectory* CFactoryFileDirectory::Create(const CStdString& strPath, CFileIt
     {
 #ifdef HAS_FILESYSTEM_RAR
       // compressed or more than one file -> create a rar dir
-      pItem->m_strPath = strUrl;
+      pItem->SetPath(strUrl);
       return new CRarDirectory;
 #else
       return NULL;

--- a/xbmc/filesystem/FileSFTP.cpp
+++ b/xbmc/filesystem/FileSFTP.cpp
@@ -160,8 +160,7 @@ bool CSFTPSession::GetDirectory(const CStdString &base, const CStdString &folder
             pItem->m_dwSize = attributes->size;
           }
 
-          pItem->m_strPath = base;
-          pItem->m_strPath += localPath;
+          pItem->SetPath(base + localPath);
           items.Add(pItem);
 
           {

--- a/xbmc/filesystem/HDDirectory.cpp
+++ b/xbmc/filesystem/HDDirectory.cpp
@@ -115,10 +115,10 @@ bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items
           if (strLabel != "." && strLabel != "..")
           {
             CFileItemPtr pItem(new CFileItem(strLabel));
-            pItem->m_strPath = strRoot;
-            pItem->m_strPath += strLabel;
+            CStdString itemPath = strRoot + strLabel;
+            URIUtils::AddSlashAtEnd(itemPath);
+            pItem->SetPath(itemPath);
             pItem->m_bIsFolder = true;
-            URIUtils::AddSlashAtEnd(pItem->m_strPath);
             FileTimeToLocalFileTime(&wfd.ftLastWriteTime, &localTime);
             pItem->m_dateTime=localTime;
 
@@ -130,8 +130,7 @@ bool CHDDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &items
         else
         {
           CFileItemPtr pItem(new CFileItem(strLabel));
-          pItem->m_strPath = strRoot;
-          pItem->m_strPath += strLabel;
+          pItem->SetPath(strRoot + strLabel);
           pItem->m_bIsFolder = false;
           pItem->m_dwSize = CUtil::ToInt64(wfd.nFileSizeHigh, wfd.nFileSizeLow);
           FileTimeToLocalFileTime(&wfd.ftLastWriteTime, &localTime);

--- a/xbmc/filesystem/HDHomeRun.cpp
+++ b/xbmc/filesystem/HDHomeRun.cpp
@@ -140,8 +140,9 @@ bool CDirectoryHomeRun::GetDirectory(const CStdString& strPath, CFileItemList &i
     else
       label.Format("Current Stream: Channel %s, SNR %d", status.channel, status.signal_to_noise_quality);
 
-    CFileItemPtr item(new CFileItem("hdhomerun://" + url.GetHostName() + "/" + url.GetFileName(), false));
-    URIUtils::RemoveSlashAtEnd(item->m_strPath);
+    CStdString path = "hdhomerun://" + url.GetHostName() + "/" + url.GetFileName();
+    URIUtils::RemoveSlashAtEnd(path);
+    CFileItemPtr item(new CFileItem(path, false));
     item->SetLabel(label);
     item->SetLabelPreformated(true);
     items.Add(item);

--- a/xbmc/filesystem/HTSPDirectory.cpp
+++ b/xbmc/filesystem/HTSPDirectory.cpp
@@ -381,7 +381,7 @@ bool CHTSPDirectory::GetChannels( const CURL &base
     CFileItemPtr item(new CFileItem("", true));
 
     url.SetFileName("");
-    item->m_strPath = url.Get();
+    item->SetPath(url.Get());
     CHTSPSession::ParseItem(it->second, tag, event, *item);
     item->m_bIsFolder = false;
     item->SetLabel(item->m_strTitle);
@@ -437,7 +437,7 @@ bool CHTSPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
 
     item.reset(new CFileItem("", true));
     url.SetFileName("tags/0/");
-    item->m_strPath = url.Get();
+    item->SetPath(url.Get());
     item->SetLabel(g_localizeStrings.Get(22018));
     item->SetLabelPreformated(true);
     items.Add(item);
@@ -451,7 +451,7 @@ bool CHTSPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
 
       item.reset(new CFileItem("", true));
       url.SetFileName(filename);
-      item->m_strPath = url.Get();
+      item->SetPath(url.Get());
       item->SetLabel(label);
       item->SetLabelPreformated(true);
       item->SetThumbnailImage(it->second.icon);

--- a/xbmc/filesystem/HTSPSession.cpp
+++ b/xbmc/filesystem/HTSPSession.cpp
@@ -621,7 +621,7 @@ bool CHTSPSession::ParseItem(const SChannel& channel, int tagid, const SEvent& e
 
   CStdString temp;
 
-  CURL url(item.m_strPath);
+  CURL url(item.GetPath());
   temp.Format("tags/%d/%d.ts", tagid, channel.id);
   url.SetFileName(temp);
 
@@ -638,7 +638,7 @@ bool CHTSPSession::ParseItem(const SChannel& channel, int tagid, const SEvent& e
   if(tag->m_strShowTitle.length() > 0)
     tag->m_strTitle += " : " + tag->m_strShowTitle;
 
-  item.m_strPath  = url.Get();
+  item.SetPath(url.Get());
   item.m_strTitle = tag->m_strTitle;
   item.SetThumbnailImage(channel.icon);
   item.SetMimeType("video/X-htsp");

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -80,14 +80,14 @@ bool CHTTPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
         URIUtils::RemoveSlashAtEnd(strName);
 
         CFileItemPtr pItem(new CFileItem(strName));
-        pItem->m_strPath = strBasePath + strLink;
+        pItem->SetPath(strBasePath + strLink);
         pItem->SetProperty("IsHTTPDirectory", true);
 
-        if(URIUtils::HasSlashAtEnd(pItem->m_strPath))
+        if(URIUtils::HasSlashAtEnd(pItem->GetPath()))
           pItem->m_bIsFolder = true;
 
-        url.SetFileName(pItem->m_strPath);
-        pItem->m_strPath = url.Get();
+        url.SetFileName(pItem->GetPath());
+        pItem->SetPath(url.Get());
 
         if (!pItem->m_bIsFolder && g_advancedSettings.m_bHTTPDirectoryStatFilesize)
         {

--- a/xbmc/filesystem/ISO9660Directory.cpp
+++ b/xbmc/filesystem/ISO9660Directory.cpp
@@ -79,10 +79,10 @@ bool CISO9660Directory::GetDirectory(const CStdString& strPath, CFileItemList &i
         if (strDir != "." && strDir != "..")
         {
           CFileItemPtr pItem(new CFileItem(wfd.cFileName));
-          pItem->m_strPath = strRoot;
-          pItem->m_strPath += wfd.cFileName;
+          CStdString path = strRoot + wfd.cFileName;
+          URIUtils::AddSlashAtEnd(path);
+          pItem->SetPath(path);
           pItem->m_bIsFolder = true;
-          URIUtils::AddSlashAtEnd(pItem->m_strPath);
           FILETIME localTime;
           FileTimeToLocalFileTime(&wfd.ftLastWriteTime, &localTime);
           pItem->m_dateTime=localTime;
@@ -92,8 +92,7 @@ bool CISO9660Directory::GetDirectory(const CStdString& strPath, CFileItemList &i
       else
       {
         CFileItemPtr pItem(new CFileItem(wfd.cFileName));
-        pItem->m_strPath = strRoot;
-        pItem->m_strPath += wfd.cFileName;
+        pItem->SetPath(strRoot + wfd.cFileName);
         pItem->m_bIsFolder = false;
         pItem->m_dwSize = CUtil::ToInt64(wfd.nFileSizeHigh, wfd.nFileSizeLow);
         FILETIME localTime;

--- a/xbmc/filesystem/LastFMDirectory.cpp
+++ b/xbmc/filesystem/LastFMDirectory.cpp
@@ -121,7 +121,7 @@ void CLastFMDirectory::AddEntry(int iString, CStdString strPath, CStdString strI
 
   CFileItemPtr pItem(new CFileItem);
   pItem->SetLabel(strLabel);
-  pItem->m_strPath = strPath;
+  pItem->SetPath(strPath);
   pItem->m_bIsFolder = bFolder;
   pItem->SetLabelPreformated(true);
   //the extra info is used in the mediawindows to determine which items are needed in the contextmenu
@@ -162,7 +162,7 @@ void CLastFMDirectory::AddListEntry(const char *name, const char *artist, const 
   }
 
   pItem->SetLabel(strName);
-  pItem->m_strPath = strPath;
+  pItem->SetPath(strPath);
   pItem->m_bIsFolder = true;
   pItem->SetLabelPreformated(true);
 

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -215,7 +215,7 @@ CStdString CMultiPathDirectory::ConstructMultiPath(const CFileItemList& items, c
   CStdString newPath = "multipath://";
   //CLog::Log(LOGDEBUG, "-- adding path: %s", strPath.c_str());
   for (unsigned int i = 0; i < stack.size(); ++i)
-    AddToMultiPath(newPath, items[stack[i]]->m_strPath);
+    AddToMultiPath(newPath, items[stack[i]]->GetPath());
 
   //CLog::Log(LOGDEBUG, "Final path: %s", newPath.c_str());
   return newPath;
@@ -268,7 +268,7 @@ void CMultiPathDirectory::MergeItems(CFileItemList &items)
 
     vector<int> stack;
     stack.push_back(i);
-    CLog::Log(LOGDEBUG,"Testing path: [%03i] %s", i, pItem1->m_strPath.c_str());
+    CLog::Log(LOGDEBUG,"Testing path: [%03i] %s", i, pItem1->GetPath().c_str());
 
     int j = i + 1;
     do
@@ -282,7 +282,7 @@ void CMultiPathDirectory::MergeItems(CFileItemList &items)
       if (!pItem2->IsFileFolder())
       {
         stack.push_back(j);
-        CLog::Log(LOGDEBUG,"  Adding path: [%03i] %s", j, pItem2->m_strPath.c_str());
+        CLog::Log(LOGDEBUG,"  Adding path: [%03i] %s", j, pItem2->GetPath().c_str());
       }
       j++;
     }
@@ -295,8 +295,8 @@ void CMultiPathDirectory::MergeItems(CFileItemList &items)
       CStdString newPath = ConstructMultiPath(items, stack);
       for (unsigned int k = stack.size() - 1; k > 0; --k)
         items.Remove(stack[k]);
-      pItem1->m_strPath = newPath;
-      CLog::Log(LOGDEBUG,"  New path: %s", pItem1->m_strPath.c_str());
+      pItem1->SetPath(newPath);
+      CLog::Log(LOGDEBUG,"  New path: %s", pItem1->GetPath().c_str());
     }
 
     i++;

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -55,7 +55,7 @@ bool CMusicDatabaseDirectory::GetDirectory(const CStdString& strPath, CFileItemL
     CFileItemPtr item = items[i];
     if (item->m_bIsFolder && !item->HasIcon() && !item->HasThumbnail())
     {
-      CStdString strImage = GetIcon(item->m_strPath);
+      CStdString strImage = GetIcon(item->GetPath());
       if (!strImage.IsEmpty() && g_TextureManager.HasTexture(strImage))
         item->SetIconImage(strImage);
     }
@@ -115,11 +115,11 @@ bool CMusicDatabaseDirectory::HasAlbumInfo(const CStdString& strDirectory)
 
 void CMusicDatabaseDirectory::ClearDirectoryCache(const CStdString& strDirectory)
 {
-  CFileItem directory(strDirectory, true);
-  URIUtils::RemoveSlashAtEnd(directory.m_strPath);
+  CStdString path(strDirectory);
+  URIUtils::RemoveSlashAtEnd(path);
 
   Crc32 crc;
-  crc.ComputeFromLowerCase(directory.m_strPath);
+  crc.ComputeFromLowerCase(path);
 
   CStdString strFileName;
   strFileName.Format("special://temp/%08x.fi", (unsigned __int32) crc);

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -294,14 +294,14 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
   /* no need for all genres
   case NODE_TYPE_GENRE:
     pItem.reset(new CFileItem(g_localizeStrings.Get(15105)));  // "All Genres"
-    pItem->m_strPath = BuildPath() + "-1/";
+    pItem->GetPath() = BuildPath() + "-1/";
     break;
   */
 
   case NODE_TYPE_ARTIST:
     if (GetType() == NODE_TYPE_OVERVIEW) return;
     pItem.reset(new CFileItem(g_localizeStrings.Get(15103)));  // "All Artists"
-    pItem->m_strPath = BuildPath() + "-1/";
+    pItem->SetPath(BuildPath() + "-1/");
     break;
 
     //  All album related nodes
@@ -313,7 +313,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
   case NODE_TYPE_ALBUM_TOP100:
   case NODE_TYPE_YEAR_ALBUM:
     pItem.reset(new CFileItem(g_localizeStrings.Get(15102)));  // "All Albums"
-    pItem->m_strPath = BuildPath() + "-1/";
+    pItem->SetPath(BuildPath() + "-1/");
     break;
 
     //  All song related nodes
@@ -324,7 +324,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
   case NODE_TYPE_SONG_TOP100:
   case NODE_TYPE_SONG:
     pItem = new CFileItem(g_localizeStrings.Get(15104));  // "All Songs"
-    pItem->m_strPath = BuildPath() + "-1/";
+    pItem->GetPath() = BuildPath() + "-1/";
     break;*/
   default:
     break;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -88,7 +88,7 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(OverviewChildren[i].label)));
     CStdString strDir;
     strDir.Format("%ld/", OverviewChildren[i].id);
-    pItem->m_strPath = BuildPath() + strDir;
+    pItem->SetPath(BuildPath() + strDir);
     pItem->m_bIsFolder = true;
     pItem->SetCanQueue(false);
     items.Add(pItem);

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
@@ -61,7 +61,7 @@ bool CDirectoryNodeTop100::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(Top100Children[i].label)));
     CStdString strDir;
     strDir.Format("%ld/", Top100Children[i].id);
-    pItem->m_strPath += BuildPath() + strDir;
+    pItem->SetPath(BuildPath() + strDir);
     pItem->m_bIsFolder = true;
     items.Add(pItem);
   }

--- a/xbmc/filesystem/MusicFileDirectory.cpp
+++ b/xbmc/filesystem/MusicFileDirectory.cpp
@@ -52,7 +52,8 @@ bool CMusicFileDirectory::GetDirectory(const CStdString& strPath1, CFileItemList
     CStdString strLabel;
     strLabel.Format("%s - %s %02.2i", strFileName.c_str(),g_localizeStrings.Get(554).c_str(),i+1);
     CFileItemPtr pItem(new CFileItem(strLabel));
-    pItem->m_strPath.Format("%s%s-%i.%s", strPath.c_str(),strFileName.c_str(),i+1,m_strExt.c_str());
+    strLabel.Format("%s%s-%i.%s", strPath.c_str(),strFileName.c_str(),i+1,m_strExt.c_str());
+    pItem->SetPath(strLabel);
 
     if (m_tag.Loaded())
       *pItem->GetMusicInfoTag() = m_tag;

--- a/xbmc/filesystem/MusicSearchDirectory.cpp
+++ b/xbmc/filesystem/MusicSearchDirectory.cpp
@@ -49,7 +49,7 @@ bool CMusicSearchDirectory::GetDirectory(const CStdString& strPath, CFileItemLis
     return false;
 
   // and retrieve the search details
-  items.m_strPath = strPath;
+  items.SetPath(strPath);
   unsigned int time = XbmcThreads::SystemClockMillis();
   CMusicDatabase db;
   db.Open();

--- a/xbmc/filesystem/MythSession.cpp
+++ b/xbmc/filesystem/MythSession.cpp
@@ -193,7 +193,7 @@ void CMythSession::SetFileItemMetaData(CFileItem &item, cmyth_proginfo_t program
   /*
    * Set further FileItem and VideoInfoTag meta-data based on whether it is LiveTV or not.
    */
-  CURL url(item.m_strPath);
+  CURL url(item.GetPath());
   if (url.GetFileName().Left(9) == "channels/")
   {
     /*
@@ -230,7 +230,7 @@ void CMythSession::SetFileItemMetaData(CFileItem &item, cmyth_proginfo_t program
     if (!number.IsEmpty())
     {
       url.SetFileName("channels/" + number + ".ts"); // e.g. channels/3.ts
-      item.m_strPath = url.Get();
+      item.SetPath(url.Get());
     }
     CStdString chanicon = GetValue(m_dll->proginfo_chanicon(program));
     if (!chanicon.IsEmpty())

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -55,10 +55,11 @@ bool CNFSDirectory::GetDirectoryFromExportList(const CStdString& strPath, CFileI
       URIUtils::RemoveSlashAtEnd(nonConstStrPath);
            
       CFileItemPtr pItem(new CFileItem(currentExport));
-      pItem->m_strPath = nonConstStrPath + currentExport;
+      CStdString path(nonConstStrPath + currentExport);
+      URIUtils::AddSlashAtEnd(path);
+      pItem->SetPath(path);
       pItem->m_dateTime=0;
 
-      URIUtils::AddSlashAtEnd(pItem->m_strPath);
       pItem->m_bIsFolder = true;
       items.Add(pItem);
   }
@@ -84,10 +85,11 @@ bool CNFSDirectory::GetServerList(CFileItemList &items)
       CStdString currentExport(srv->addr);
 
       CFileItemPtr pItem(new CFileItem(currentExport));
-      pItem->m_strPath = "nfs://" + currentExport;
+      CStdString path("nfs://" + currentExport);
+      URIUtils::AddSlashAtEnd(path);
       pItem->m_dateTime=0;
 
-      URIUtils::AddSlashAtEnd(pItem->m_strPath);
+      pItem->SetPath(path);
       pItem->m_bIsFolder = true;
       items.Add(pItem);
       ret = true; //added at least one entry
@@ -182,12 +184,12 @@ bool CNFSDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
       FileTimeToLocalFileTime(&fileTime, &localTime);
 
       CFileItemPtr pItem(new CFileItem(strName));
-      pItem->m_strPath = strPath + strName;
+      CStdString path(strPath + strName);
       pItem->m_dateTime=localTime;      
 
       if (bIsDir)
       {
-        URIUtils::AddSlashAtEnd(pItem->m_strPath);
+        URIUtils::AddSlashAtEnd(path);
         pItem->m_bIsFolder = true;
       }
       else
@@ -195,6 +197,7 @@ bool CNFSDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
         pItem->m_bIsFolder = false;
         pItem->m_dwSize = iSize;
       }
+      pItem->SetPath(path);
       items.Add(pItem);
     }
   }

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -98,7 +98,7 @@ bool CPluginDirectory::StartScript(const CStdString& strPath, bool retrievingDir
   // clear out our status variables
   m_fileResult->Reset();
   m_listItems->Clear();
-  m_listItems->m_strPath = strPath;
+  m_listItems->SetPath(strPath);
   m_cancelled = false;
   m_success = false;
   m_totalItems = 0;
@@ -141,8 +141,8 @@ bool CPluginDirectory::GetPluginResult(const CStdString& strPath, CFileItem &res
   if (success)
   { // update the play path and metadata, saving the old one as needed
     if (!resultItem.HasProperty("original_listitem_url"))
-      resultItem.SetProperty("original_listitem_url", resultItem.m_strPath);
-    resultItem.m_strPath = newDir->m_fileResult->m_strPath;
+      resultItem.SetProperty("original_listitem_url", resultItem.GetPath());
+    resultItem.SetPath(newDir->m_fileResult->GetPath());
     resultItem.SetMimeType(newDir->m_fileResult->GetMimeType(false));
     resultItem.UpdateInfo(*newDir->m_fileResult);
   }

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -535,17 +535,17 @@ static void ParseItem(CFileItem* item, TiXmlElement* root, const CStdString& pat
   if(best != resources.end())
   {
     item->SetMimeType(best->mime);
-    item->m_strPath = best->path;
+    item->SetPath(best->path);
     item->m_dwSize  = best->size;
 
     if(best->duration)
       item->SetProperty("duration", StringUtils::SecondsToTimeString(best->duration));    
 
     /* handling of mimetypes fo directories are sub optimal at best */
-    if(best->mime == "application/rss+xml" && item->m_strPath.Left(7).Equals("http://"))
-      item->m_strPath.replace(0, 7, "rss://");
+    if(best->mime == "application/rss+xml" && item->GetPath().Left(7).Equals("http://"))
+      item->SetPath("rss://" + item->GetPath().Mid(7));
 
-    if(item->m_strPath.Left(6).Equals("rss://"))
+    if(item->GetPath().Left(6).Equals("rss://"))
       item->m_bIsFolder = true;
     else
       item->m_bIsFolder = false;
@@ -630,7 +630,7 @@ bool CRSSDirectory::GetDirectory(const CStdString& path, CFileItemList &items)
 
     item->SetProperty("isrss", "1");
 
-    if (!item->m_strPath.IsEmpty())
+    if (!item->GetPath().IsEmpty())
       items.Add(item);
   }
 

--- a/xbmc/filesystem/RTVDirectory.cpp
+++ b/xbmc/filesystem/RTVDirectory.cpp
@@ -86,7 +86,7 @@ bool CRTVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
         CFileItemPtr pItem(new CFileItem(rtv[i].friendlyName));
         // This will keep the /Video or / and allow one to set up an auto ReplayTV
         // share of either type--simple file listing or ReplayGuide listing.
-        pItem->m_strPath = strRoot + rtv[i].hostname;
+        pItem->SetPath(strRoot + rtv[i].hostname);
         pItem->m_bIsFolder = true;
         pItem->SetLabelPreformated(true);
         items.Add(pItem);
@@ -254,7 +254,7 @@ bool CRTVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
 
         CFileItemPtr pItem(new CFileItem(szName));
         pItem->m_dateTime=dtDateTime;
-        pItem->m_strPath = strRoot + szPath;
+        pItem->SetPath(strRoot + szPath);
         // Hack to show duration of show in minutes as KB in XMBC because
         // it doesn't currently permit showing duration in minutes.
         // E.g., a 30 minute show will show as 29.3 KB in XBMC.
@@ -306,7 +306,7 @@ bool CRTVDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
           if (strstr(p, ".mpg") && !strstr(p, "circular"))
           {
             CFileItemPtr pItem(new CFileItem(p));
-            pItem->m_strPath = strRoot + p;
+            pItem->SetPath(strRoot + p);
             pItem->m_bIsFolder = false;
             // The list returned by the RTV doesn't include file sizes, unfortunately
             //pItem->m_dwSize = atol(szSize);

--- a/xbmc/filesystem/RarDirectory.cpp
+++ b/xbmc/filesystem/RarDirectory.cpp
@@ -64,7 +64,7 @@ namespace XFILE
       {
         if (items[iEntry]->IsParentFolder())
           continue;
-        URIUtils::AddFileToFolder(strSlashPath,items[iEntry]->m_strPath+strOptions,items[iEntry]->m_strPath);
+        items[iEntry]->SetPath(URIUtils::AddFileToFolder(strSlashPath,items[iEntry]->GetPath()+strOptions));
         items[iEntry]->m_iDriveType = 0;
         //CLog::Log(LOGDEBUG, "RarXFILE::GetDirectory() retrieved file: %s", items[iEntry]->m_strPath.c_str());
       }

--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -127,9 +127,8 @@ bool CRarManager::CacheRarredFile(CStdString& strPathInCache, const CStdString& 
       items.Sort(SORT_METHOD_SIZE, SORT_ORDER_DESC);
       while (items.Size() && CheckFreeSpace(strDir) < iSize)
       {
-        CStdString strPath = items[0]->m_strPath;
         if (!items[0]->m_bIsFolder)
-          if (!CFile::Delete(items[0]->m_strPath))
+          if (!CFile::Delete(items[0]->GetPath()))
             break;
 
         items.Remove(0);
@@ -303,8 +302,7 @@ bool CRarManager::GetFilesInRar(CFileItemList& vecpItems, const CStdString& strR
       {
         dirSet.insert(vec[iDepth]);
         pFileItem.reset(new CFileItem(vec[iDepth]));
-        pFileItem->m_strPath = vec[iDepth];
-        pFileItem->m_strPath += '/';
+        pFileItem->SetPath(vec[iDepth] + '/');
         pFileItem->m_bIsFolder = true;
         pFileItem->m_idepth = pIterator->item.Method;
         pFileItem->m_iDriveType = pIterator->item.HostOS;
@@ -319,7 +317,7 @@ bool CRarManager::GetFilesInRar(CFileItemList& vecpItems, const CStdString& strR
           pFileItem.reset(new CFileItem(strName));
         else
           pFileItem.reset(new CFileItem(vec[iDepth]));
-        pFileItem->m_strPath = strName.c_str()+strPathInRar.size();
+        pFileItem->SetPath(strName.c_str()+strPathInRar.size());
         pFileItem->m_dwSize = pIterator->item.UnpSize;
         pFileItem->m_idepth = pIterator->item.Method;
         pFileItem->m_iDriveType = pIterator->item.HostOS;
@@ -386,7 +384,7 @@ bool CRarManager::IsFileInRar(bool& bResult, const CStdString& strRarPath, const
   int it;
   for (it=0;it<ItemList.Size();++it)
   {
-    if (strPathInRar.compare(ItemList[it]->m_strPath) == 0)
+    if (strPathInRar.compare(ItemList[it]->GetPath()) == 0)
       break;
   }
   if (it != ItemList.Size())

--- a/xbmc/filesystem/SAPDirectory.cpp
+++ b/xbmc/filesystem/SAPDirectory.cpp
@@ -520,7 +520,7 @@ namespace XFILE
         item->SetLabel2(desc.info);
       item->SetLabelPreformated(true);
 
-      item->m_strPath = it->path;
+      item->SetPath(it->path);
       items.Add(item);
     }
 

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -200,7 +200,7 @@ bool CSMBDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
       if (bIsDir)
       {
         CFileItemPtr pItem(new CFileItem(strFile));
-        pItem->m_strPath = strRoot;
+        CStdString path(strRoot);
 
         // needed for network / workgroup browsing
         // skip if root if we are given a server
@@ -210,10 +210,11 @@ bool CSMBDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
           CURL rooturl(strRoot);
           rooturl.SetFileName("");
           rooturl.SetHostName("");
-          pItem->m_strPath = smb.URLEncode(rooturl);
+          path = smb.URLEncode(rooturl);
         }
-        pItem->m_strPath += aDir.name;
-        URIUtils::AddSlashAtEnd(pItem->m_strPath);
+        path += aDir.name;
+        URIUtils::AddSlashAtEnd(path);
+        pItem->SetPath(path);
         pItem->m_bIsFolder = true;
         pItem->m_dateTime=localTime;
         if (hidden)
@@ -223,7 +224,7 @@ bool CSMBDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
       else
       {
         CFileItemPtr pItem(new CFileItem(strFile));
-        pItem->m_strPath = strRoot + aDir.name;
+        pItem->SetPath(strRoot + aDir.name);
         pItem->m_bIsFolder = false;
         pItem->m_dwSize = iSize;
         pItem->m_dateTime=localTime;

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -147,7 +147,7 @@ namespace XFILE
         CFileItemPtr item = list[i];
         if (item->GetLabel().CompareNoCase(name) == 0)
         { // found :)
-          return item->m_strPath;
+          return item->GetPath();
         }
       }
     }

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -60,30 +60,30 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
   {
     const CMediaSource& share = sources[i];
     CFileItemPtr pItem(new CFileItem(share));
-    if (pItem->IsLastFM() || (pItem->m_strPath.Left(14).Equals("musicsearch://")))
+    if (pItem->IsLastFM() || (pItem->GetPath().Left(14).Equals("musicsearch://")))
       pItem->SetCanQueue(false);
-    CStdString strPathUpper = pItem->m_strPath;
+    CStdString strPathUpper = pItem->GetPath();
     strPathUpper.ToUpper();
     
     CStdString strIcon;
     // We have the real DVD-ROM, set icon on disktype
     if (share.m_iDriveType == CMediaSource::SOURCE_TYPE_DVD && share.m_strThumbnailImage.IsEmpty())
     {
-      CUtil::GetDVDDriveIcon( pItem->m_strPath, strIcon );
+      CUtil::GetDVDDriveIcon( pItem->GetPath(), strIcon );
       // CDetectDVDMedia::SetNewDVDShareUrl() caches disc thumb as special://temp/dvdicon.tbn
       CStdString strThumb = "special://temp/dvdicon.tbn";
       if (XFILE::CFile::Exists(strThumb))
         pItem->SetThumbnailImage(strThumb);
     }
-    else if (pItem->m_strPath.Left(9) == "addons://")
+    else if (pItem->GetPath().Left(9) == "addons://")
       strIcon = "DefaultHardDisk.png";
     else if (pItem->IsLastFM()
              || pItem->IsVideoDb()
              || pItem->IsMusicDb()
              || pItem->IsPlugin()
-             || pItem->m_strPath == "special://musicplaylists/"
-             || pItem->m_strPath == "special://videoplaylists/"
-             || pItem->m_strPath == "musicsearch://")
+             || pItem->GetPath() == "special://musicplaylists/"
+             || pItem->GetPath() == "special://videoplaylists/"
+             || pItem->GetPath() == "musicsearch://")
       strIcon = "DefaultFolder.png";
     else if (pItem->IsRemote())
       strIcon = "DefaultNetwork.png";

--- a/xbmc/filesystem/SpecialProtocolDirectory.cpp
+++ b/xbmc/filesystem/SpecialProtocolDirectory.cpp
@@ -41,12 +41,12 @@ bool CSpecialProtocolDirectory::GetDirectory(const CStdString& strPath, CFileIte
   CStdString translatedPath = CSpecialProtocol::TranslatePath(strPath);
   if (CDirectory::GetDirectory(translatedPath, items, m_strFileMask, m_useFileDirectories, m_allowPrompting, m_cacheDirectory, m_extFileInfo, false, true))
   { // replace our paths as necessary
-    items.m_strPath = untranslatedPath;
+    items.SetPath(untranslatedPath);
     for (int i = 0; i < items.Size(); i++)
     {
       CFileItemPtr item = items[i];
-      if (strnicmp(item->m_strPath.c_str(), translatedPath.c_str(), translatedPath.GetLength()) == 0)
-        item->m_strPath = URIUtils::AddFileToFolder(untranslatedPath, item->m_strPath.Mid(translatedPath.GetLength()));
+      if (strnicmp(item->GetPath().c_str(), translatedPath.c_str(), translatedPath.GetLength()) == 0)
+        item->SetPath(URIUtils::AddFileToFolder(untranslatedPath, item->GetPath().Mid(translatedPath.GetLength())));
     }
     return true;
   }

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -59,8 +59,8 @@ namespace XFILE
       // replace double comma's with single ones.
       file.Replace(",,", ",");
       CFileItemPtr item(new CFileItem(file));
-      //URIUtils::AddFileToFolder(folder, file, item->m_strPath);
-      item->m_strPath = file;
+      //URIUtils::AddFileToFolder(folder, file, item->GetPath());
+      item->SetPath(file);
       item->m_bIsFolder = false;
       items.Add(item);
     }
@@ -100,8 +100,8 @@ namespace XFILE
     {
       CStdString strStackTitle;
 
-      CStdString File1 = URIUtils::GetFileName(files[0]->m_strPath);
-      CStdString File2 = URIUtils::GetFileName(files[1]->m_strPath);
+      CStdString File1 = URIUtils::GetFileName(files[0]->GetPath());
+      CStdString File2 = URIUtils::GetFileName(files[1]->GetPath());
 
       std::vector<CRegExp>::iterator itRegExp = RegExps.begin();
       int offset = 0;
@@ -182,7 +182,7 @@ namespace XFILE
     // the files using " , ".
     CStdString stackedPath = "stack://";
     CStdString folder, file;
-    URIUtils::Split(items[stack[0]]->m_strPath, folder, file);
+    URIUtils::Split(items[stack[0]]->GetPath(), folder, file);
     stackedPath += folder;
     // double escape any occurence of commas
     file.Replace(",", ",,");
@@ -190,7 +190,7 @@ namespace XFILE
     for (unsigned int i = 1; i < stack.size(); ++i)
     {
       stackedPath += " , ";
-      file = items[stack[i]]->m_strPath;
+      file = items[stack[i]]->GetPath();
 
       // double escape any occurence of commas
       file.Replace(",", ",,");

--- a/xbmc/filesystem/UDFDirectory.cpp
+++ b/xbmc/filesystem/UDFDirectory.cpp
@@ -62,10 +62,10 @@ bool CUDFDirectory::GetDirectory(const CStdString& strPath,
       if (strDir != "." && strDir != "..")
       {
         CFileItemPtr pItem(new CFileItem((char*)dp->d_name));
-        pItem->m_strPath = strRoot;
-        pItem->m_strPath += (char*)dp->d_name;
+        strDir = strRoot + (char*)dp->d_name;
+        URIUtils::AddSlashAtEnd(strDir);
+        pItem->SetPath(strDir);
         pItem->m_bIsFolder = true;
-        URIUtils::AddSlashAtEnd(pItem->m_strPath);
 
         items.Add(pItem);
       }
@@ -73,8 +73,7 @@ bool CUDFDirectory::GetDirectory(const CStdString& strPath,
     else
     {
       CFileItemPtr pItem(new CFileItem((char*)dp->d_name));
-      pItem->m_strPath = strRoot;
-      pItem->m_strPath += (char*)dp->d_name;
+      pItem->SetPath(strRoot + (char*)dp->d_name);
       pItem->m_bIsFolder = false;
       pItem->m_dwSize = dp->d_filesize;
 

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -185,13 +185,13 @@ bool CUPnPDirectory::GetResource(const CURL& path, CFileItem &item)
     }
 
     // store original path so we remember it
-    item.SetProperty("original_listitem_url",  item.m_strPath);
+    item.SetProperty("original_listitem_url",  item.GetPath());
     item.SetProperty("original_listitem_mime", item.GetMimeType(false));
 
     // if it's an item, path is the first url to the item
     // we hope the server made the first one reachable for us
     // (it could be a format we dont know how to play however)
-    item.m_strPath = (const char*) resource.m_Uri;
+    item.SetPath((const char*) resource.m_Uri);
 
     // look for content type in protocol info
     if (resource.m_ProtocolInfo.IsValid()) {
@@ -260,7 +260,7 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
             NPT_String uuid = (*device)->GetUUID();
 
             CFileItemPtr pItem(new CFileItem((const char*)name));
-            pItem->m_strPath = (const char*) "upnp://" + uuid + "/";
+            pItem->SetPath(CStdString((const char*) "upnp://" + uuid + "/"));
             pItem->m_bIsFolder = true;
             pItem->SetThumbnailImage((const char*)(*device)->GetIconUrl("image/jpeg"));
 
@@ -383,13 +383,13 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
 
             CStdString id = (char*) (*entry)->m_ObjectID;
             CURL::Encode(id);
-            pItem->m_strPath = (const char*) "upnp://" + uuid + "/" + id.c_str() + "/";
+            pItem->SetPath(CStdString((const char*) "upnp://" + uuid + "/" + id.c_str() + "/"));
 
             // if it's a container, format a string as upnp://uuid/object_id
             if (pItem->m_bIsFolder) {
                 CStdString id = (char*) (*entry)->m_ObjectID;
                 CURL::Encode(id);
-                pItem->m_strPath += "/";
+                pItem->SetPath(pItem->GetPath() + "/");
 
                 // look for metadata
                 if( ObjectClass.StartsWith("object.container.album.videoalbum") ) {

--- a/xbmc/filesystem/VTPDirectory.cpp
+++ b/xbmc/filesystem/VTPDirectory.cpp
@@ -51,7 +51,8 @@ bool CVTPDirectory::GetChannels(const CStdString& base, CFileItemList &items)
     CStdString buffer;
     CFileItemPtr item(new CFileItem("", false));
 
-    item->m_strPath.Format("%s/%d.ts", base.c_str(), it->index);
+    buffer.Format("%s/%d.ts", base.c_str(), it->index);
+    item->SetPath(buffer);
     item->m_strTitle = it->name;
     buffer.Format("%d - %s", it->index, it->name);
     item->SetLabel(buffer);

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -56,7 +56,7 @@ bool CVideoDatabaseDirectory::GetDirectory(const CStdString& strPath, CFileItemL
     CFileItemPtr item = items[i];
     if (item->m_bIsFolder && !item->HasIcon() && !item->HasThumbnail())
     {
-      CStdString strImage = GetIcon(item->m_strPath);
+      CStdString strImage = GetIcon(item->GetPath());
       if (!strImage.IsEmpty() && g_TextureManager.HasTexture(strImage))
         item->SetIconImage(strImage);
     }
@@ -114,11 +114,11 @@ bool CVideoDatabaseDirectory::GetQueryParams(const CStdString& strPath, CQueryPa
 
 void CVideoDatabaseDirectory::ClearDirectoryCache(const CStdString& strDirectory)
 {
-  CFileItem directory(strDirectory, true);
-  URIUtils::RemoveSlashAtEnd(directory.m_strPath);
+  CStdString path(strDirectory);
+  URIUtils::RemoveSlashAtEnd(path);
 
   Crc32 crc;
-  crc.ComputeFromLowerCase(directory.m_strPath);
+  crc.ComputeFromLowerCase(path);
 
   CStdString strFileName;
   strFileName.Format("special://temp/%08x.fi", (unsigned __int32) crc);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -289,7 +289,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
     return;
 
   // hack - as the season node might return episodes
-  auto_ptr<CDirectoryNode> pNode(ParseURL(items.m_strPath));
+  auto_ptr<CDirectoryNode> pNode(ParseURL(items.GetPath()));
 
   switch (pNode->GetChildType())
   {
@@ -297,7 +297,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
       {
         CStdString strLabel = g_localizeStrings.Get(20366);
         pItem.reset(new CFileItem(strLabel));  // "All Seasons"
-        pItem->m_strPath = BuildPath() + "-1/";
+        pItem->SetPath(BuildPath() + "-1/");
         // set the number of watched and unwatched items accordingly
         int watched = 0;
         int unwatched = 0;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -65,7 +65,7 @@ bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(MusicVideoChildren[i].label)));
     CStdString strDir;
     strDir.Format("%ld/", MusicVideoChildren[i].id);
-    pItem->m_strPath = BuildPath() + strDir;
+    pItem->SetPath(BuildPath() + strDir);
     pItem->m_bIsFolder = true;
     pItem->SetCanQueue(false);
     items.Add(pItem);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -85,7 +85,7 @@ bool CDirectoryNodeSeasons::GetContent(CFileItemList& items) const
   { // flatten if one season or flatten always
     items.Clear();
     bSuccess=videodatabase.GetEpisodesNav(BuildPath()+"-1/",items,params.GetGenreId(),params.GetYear(),params.GetActorId(),params.GetDirectorId(),params.GetTvShowId());
-    items.m_strPath = BuildPath()+"-1/";
+    items.SetPath(BuildPath()+"-1/");
   }
 
   videodatabase.Close();

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -66,7 +66,7 @@ bool CDirectoryNodeTvShowsOverview::GetContent(CFileItemList& items) const
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(TvShowChildren[i].label)));
     CStdString strDir;
     strDir.Format("%ld/", TvShowChildren[i].id);
-    pItem->m_strPath = BuildPath() + strDir;
+    pItem->SetPath(BuildPath() + strDir);
     pItem->m_bIsFolder = true;
     pItem->SetCanQueue(false);
     items.Add(pItem);

--- a/xbmc/filesystem/VirtualDirectory.cpp
+++ b/xbmc/filesystem/VirtualDirectory.cpp
@@ -84,7 +84,7 @@ bool CVirtualDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
     items.Clear();
 
   // return the root listing
-  items.m_strPath=strPath;
+  items.SetPath(strPath);
 
   // grab our shares
   VECSOURCES shares;

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -146,7 +146,7 @@ bool GetDirectoryFromTxtRecords(CZeroconfBrowser::ZeroconfService zeroconf_servi
       //add slash at end of path since it has to be a folder
       URIUtils::AddSlashAtEnd(path);
       //this is the full path includeing remote stuff (e.x. nfs://ip/path
-      item->m_strPath=urlStr + path;
+      item->SetPath(urlStr + path);
       //remove the slash at the end of the path or GetFileName will not give the last dir
       URIUtils::RemoveSlashAtEnd(path);
       //set the label to the last directory in path
@@ -186,7 +186,7 @@ bool CZeroconfDirectory::GetDirectory(const CStdString& strPath, CFileItemList &
         CStdString service_path = CZeroconfBrowser::ZeroconfService::toPath(*it);
         CURL::Encode(service_path);
         url.SetFileName(service_path);
-        item->m_strPath = url.Get();
+        item->SetPath(url.Get());
 
         //now do the formatting
         CStdString protocol = GetHumanReadableProtocol(it->GetType());

--- a/xbmc/filesystem/ZipDirectory.cpp
+++ b/xbmc/filesystem/ZipDirectory.cpp
@@ -128,14 +128,15 @@ namespace XFILE
 
       pFileItem->SetLabel(pathTokens[baseTokens.size()]);
       if (bIsFolder)
+      {
         pFileItem->m_dwSize = 0;
+        URIUtils::AddSlashAtEnd(strBuffer);
+      }
       else
         pFileItem->m_dwSize = ze->usize;
-      pFileItem->m_strPath = strBuffer;
+      pFileItem->SetPath(strBuffer);
       pFileItem->m_bIsFolder = bIsFolder;
       pFileItem->m_idepth = ze->method;
-      if (bIsFolder)
-        URIUtils::AddSlashAtEnd(pFileItem->m_strPath);
       items.Add(pFileItem);
     }
     items.SetFastLookup(bWasFast);

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -700,7 +700,7 @@ bool CGUIBaseContainer::OnClick(int actionID)
         int controlID = GetID(); // save as these could go away as we send messages
         int parentID = GetParentID();
         vector<CStdString> actions;
-        StringUtils::SplitString(item->m_strPath, " , ", actions);
+        StringUtils::SplitString(item->GetPath(), " , ", actions);
         for (unsigned int i = 0; i < actions.size(); i++)
         {
           CStdString action = actions[i];

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -246,7 +246,7 @@ void CGUIMultiImage::LoadDirectory()
     {
       CFileItemPtr pItem = items[i];
       if (pItem->IsPicture())
-        m_files.push_back(pItem->m_strPath);
+        m_files.push_back(pItem->GetPath());
     }
   }
 

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -49,15 +49,17 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
     // multiple action strings are concat'd together, separated with " , "
     vector<CGUIActionDescriptor> actions;
     CGUIControlFactory::GetMultipleString(item, "onclick", actions);
+    CStdString path;
     for (vector<CGUIActionDescriptor>::iterator it = actions.begin(); it != actions.end(); ++it)
     {
       (*it).m_action.Replace(",", ",,");
-      if (m_strPath.length() > 0)
+      if (path.IsEmpty())
       {
-        m_strPath   += " , ";
+        path += " , ";
       }
-      m_strPath += (*it).m_action;
+      path += (*it).m_action;
     }
+    SetPath(path);
     SetLabel(label.GetLabel(parentID));
     SetLabel2(label2.GetLabel(parentID));
     SetThumbnailImage(thumb.GetLabel(parentID, true));
@@ -91,7 +93,7 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
     icon   = item->Attribute("icon");   icon   = CGUIControlFactory::FilterLabel(icon);
     const char *id = item->Attribute("id");
     SetLabel(CGUIInfoLabel::GetLabel(label, parentID));
-    m_strPath = item->FirstChild()->Value();
+    SetPath(item->FirstChild()->Value());
     SetLabel2(CGUIInfoLabel::GetLabel(label2, parentID));
     SetThumbnailImage(CGUIInfoLabel::GetLabel(thumb, parentID, true));
     SetIconImage(CGUIInfoLabel::GetLabel(icon, parentID, true));

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -385,7 +385,7 @@ bool CButtonTranslator::Load()
       //sort the list for filesystem based prioties, e.g. 01-keymap.xml, 02-keymap-overrides.xml
       files.Sort(SORT_METHOD_FILE, SORT_ORDER_ASC);
       for(int fileIndex = 0; fileIndex<files.Size(); ++fileIndex)
-        success |= LoadKeymap(files[fileIndex]->m_strPath);
+        success |= LoadKeymap(files[fileIndex]->GetPath());
     }
   }
 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -437,8 +437,8 @@ int CBuiltins::Execute(const CStdString& execString)
       CFileItem item(params[0]);
       if (!item.m_bIsFolder)
       {
-        item.m_strPath = params[0];
-        CPluginDirectory::RunScriptWithParams(item.m_strPath);
+        item.SetPath(params[0]);
+        CPluginDirectory::RunScriptWithParams(item.GetPath());
       }
     }
     else
@@ -530,7 +530,7 @@ int CBuiltins::Execute(const CStdString& execString)
     if (item.m_bIsFolder)
     {
       CFileItemList items;
-      CDirectory::GetDirectory(item.m_strPath,items,g_settings.m_videoExtensions);
+      CDirectory::GetDirectory(item.GetPath(),items,g_settings.m_videoExtensions);
       g_playlistPlayer.Add(PLAYLIST_VIDEO,items);
       g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
       g_playlistPlayer.Play();

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -138,13 +138,17 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
       object["file"] = item->GetMusicInfoTag()->GetURL().c_str();
 
     if (!object.isMember("file"))
-      object["file"] = item->m_strPath.c_str();
+      object["file"] = item->GetPath().c_str();
   }
 
   if (ID)
   {
     if (stricmp(ID, "genreid") == 0)
-      object[ID] = atoi(item->m_strPath.TrimRight('/').c_str());
+    {
+      CStdString genre = item->GetPath();
+      genre.TrimRight('/');
+      object[ID] = atoi(genre.c_str());
+    }
     else if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetDatabaseId() > 0)
       object[ID] = (int)item->GetMusicInfoTag()->GetDatabaseId();
     else if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_iDbId > 0)
@@ -209,7 +213,7 @@ bool CFileItemHandler::FillFileItemList(const CVariant &parameterObject, CFileIt
     bool added = false;
     for (int index = 0; index < list.Size(); index++)
     {
-      if (list[index]->m_strPath == file)
+      if (list[index]->GetPath() == file)
       {
         added = true;
         break;

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -50,8 +50,8 @@ JSON_STATUS CFileOperations::GetRootDirectory(const CStdString &method, ITranspo
     {
       if (items[i]->IsSmb())
       {
-        CURL url(items[i]->m_strPath);
-        items[i]->m_strPath = url.GetWithoutUserDetails();
+        CURL url(items[i]->GetPath());
+        items[i]->SetPath(url.GetWithoutUserDetails());
       }
     }
 
@@ -97,13 +97,13 @@ JSON_STATUS CFileOperations::GetDirectory(const CStdString &method, ITransportLa
     CFileItemList filteredDirectories, filteredFiles;
     for (unsigned int i = 0; i < (unsigned int)items.Size(); i++)
     {
-      if (CUtil::ExcludeFileOrFolder(items[i]->m_strPath, regexps))
+      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
         continue;
 
       if (items[i]->IsSmb())
       {
-        CURL url(items[i]->m_strPath);
-        items[i]->m_strPath = url.GetWithoutUserDetails();
+        CURL url(items[i]->GetPath());
+        items[i]->SetPath(url.GetWithoutUserDetails());
       }
 
       if (items[i]->m_bIsFolder)
@@ -114,7 +114,7 @@ JSON_STATUS CFileOperations::GetDirectory(const CStdString &method, ITransportLa
       else
       {
         CFileItem fileItem;
-        if (FillFileItem(items[i]->m_strPath, fileItem, media))
+        if (FillFileItem(items[i]->GetPath(), fileItem, media))
           filteredFiles.Add(CFileItemPtr(new CFileItem(fileItem)));
       }
     }
@@ -229,7 +229,7 @@ bool CFileOperations::FillFileItemList(const CVariant &parameterObject, CFileIte
         CFileItemList filteredDirectories;
         for (unsigned int i = 0; i < (unsigned int)items.Size(); i++)
         {
-          if (CUtil::ExcludeFileOrFolder(items[i]->m_strPath, regexps))
+          if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
             continue;
 
           if (items[i]->m_bIsFolder)
@@ -240,7 +240,7 @@ bool CFileOperations::FillFileItemList(const CVariant &parameterObject, CFileIte
           else
           {
             CFileItem fileItem;
-            if (FillFileItem(items[i]->m_strPath, fileItem, media))
+            if (FillFileItem(items[i]->GetPath(), fileItem, media))
               list.Add(CFileItemPtr(new CFileItem(fileItem)));
           }
         }
@@ -250,7 +250,7 @@ bool CFileOperations::FillFileItemList(const CVariant &parameterObject, CFileIte
           for (int i = 0; i < filteredDirectories.Size(); i++)
           {
             CVariant val = parameterObject;
-            val["directory"] = filteredDirectories[i]->m_strPath;
+            val["directory"] = filteredDirectories[i]->GetPath();
             FillFileItemList(val, list);
           }
         }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -211,7 +211,8 @@ JSON_STATUS CVideoLibrary::GetEpisodeDetails(const CStdString &method, ITranspor
   }
   CFileItemPtr pItem = CFileItemPtr(new CFileItem(infos));
   // We need to set the correct base path to get the valid fanart
-  pItem->m_strPath.Format("videodb://2/2/%ld/%ld/%ld", videodatabase.GetTvShowForEpisode(id), infos.m_iSeason, id);
+  CStdString basePath; basePath.Format("videodb://2/2/%ld/%ld/%ld", videodatabase.GetTvShowForEpisode(id), infos.m_iSeason, id);
+  pItem->SetPath(basePath);
 
   HandleFileItem("episodeid", true, "episodedetails", pItem, parameterObject, parameterObject["fields"], result, false);
 

--- a/xbmc/interfaces/python/xbmcmodule/listitem.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/listitem.cpp
@@ -98,7 +98,7 @@ namespace PYXBMC
     }
     if (path && PyXBMCGetUnicodeString(utf8String, path, 1))
     {
-      self->item->m_strPath = utf8String;
+      self->item->SetPath(utf8String);
     }
     return (PyObject*)self;
   }
@@ -586,7 +586,7 @@ namespace PYXBMC
           if (strcmpi(PyString_AsString(key), "title") == 0)
             self->item->m_strTitle = tmp;
           else if (strcmpi(PyString_AsString(key), "picturepath") == 0)
-            self->item->m_strPath = tmp;
+            self->item->SetPath(tmp);
           else if (strcmpi(PyString_AsString(key), "date") == 0)
           {
             if (strlen(tmp) == 10)
@@ -837,7 +837,7 @@ namespace PYXBMC
       return NULL;
     // set path
     PyXBMCGUILock();
-    self->item->m_strPath = path;
+    self->item->SetPath(path);
     PyXBMCGUIUnlock();
 
     Py_INCREF(Py_None);

--- a/xbmc/interfaces/python/xbmcmodule/player.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/player.cpp
@@ -147,7 +147,7 @@ namespace PYXBMC
       pListItem = (ListItem*)pObjectListItem;
 
       // set m_strPath to the passed url
-      pListItem->item->m_strPath = PyString_AsString(pObject);
+      pListItem->item->SetPath(PyString_AsString(pObject));
 
       CPyThreadState pyState;
       g_application.getApplicationMessenger().PlayFile((const CFileItem)*pListItem->item, false);
@@ -157,7 +157,7 @@ namespace PYXBMC
       CFileItem item(PyString_AsString(pObject), false);
       
       CPyThreadState pyState;
-      g_application.getApplicationMessenger().MediaPlay(item.m_strPath);
+      g_application.getApplicationMessenger().MediaPlay(item.GetPath());
     }
     else if (PlayList_Check(pObject))
     {

--- a/xbmc/interfaces/python/xbmcmodule/pyplaylist.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/pyplaylist.cpp
@@ -88,7 +88,7 @@ namespace PYXBMC
 
   PyObject* PlayListItem_GetFileName(PlayListItem *self, PyObject *key)
   {
-    return Py_BuildValue((char*)"s", self->item->m_strPath.c_str());
+    return Py_BuildValue((char*)"s", self->item->GetPath().c_str());
   }
 
 /* PlayList Fucntions */
@@ -180,7 +180,7 @@ namespace PYXBMC
       pListItem = (ListItem*)pObjectListItem;
 
       // set m_strPath to the passed url
-      pListItem->item->m_strPath = strUrl;
+      pListItem->item->SetPath(strUrl);
 
       items.Add(pListItem->item);
     }
@@ -212,7 +212,7 @@ namespace PYXBMC
     if (!PyArg_ParseTuple(args, (char*)"s", &cFileName)) return NULL;
 
     CFileItem item(cFileName);
-    item.m_strPath=cFileName;
+    item.SetPath(cFileName);
 
     if (item.IsPlayList())
     {
@@ -224,7 +224,7 @@ namespace PYXBMC
       if ( NULL != pPlayList.get())
       {
         // load it
-        if (!pPlayList->Load(item.m_strPath))
+        if (!pPlayList->Load(item.GetPath()))
         {
           //hmmm unable to load playlist?
           return Py_BuildValue((char*)"b", false);
@@ -238,7 +238,7 @@ namespace PYXBMC
         {
           CFileItemPtr playListItem =(*pPlayList)[i];
           if (playListItem->GetLabel().IsEmpty())
-            playListItem->SetLabel(URIUtils::GetFileName(playListItem->m_strPath));
+            playListItem->SetLabel(URIUtils::GetFileName(playListItem->GetPath()));
 
           self->pPlayList->Add(playListItem);
         }

--- a/xbmc/interfaces/python/xbmcmodule/xbmcplugin.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcplugin.cpp
@@ -84,7 +84,7 @@ namespace PYXBMC
     if (!PyXBMCGetUnicodeString(url, pURL, 1) || !ListItem_CheckExact(pItem)) return NULL;
 
     ListItem *pListItem = (ListItem *)pItem;
-    pListItem->item->m_strPath = url;
+    pListItem->item->SetPath(url);
     pListItem->item->m_bIsFolder = (0 != bIsFolder);
 
     // call the directory class to add our item
@@ -152,7 +152,7 @@ namespace PYXBMC
       if (!PyXBMCGetUnicodeString(url, pURL, 1) || !ListItem_CheckExact(pItem)) return NULL;
 
       ListItem *pListItem = (ListItem *)pItem;
-      pListItem->item->m_strPath = url;
+      pListItem->item->SetPath(url);
       pListItem->item->m_bIsFolder = (0 != bIsFolder);
       items.Add(pListItem->item);
     }

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -98,18 +98,18 @@ CGUIViewStateMusicSearch::CGUIViewStateMusicSearch(const CFileItemList& items) :
 
   SetSortOrder(g_settings.m_viewStateMusicNavSongs.m_sortOrder);
 
-  LoadViewState(items.m_strPath, WINDOW_MUSIC_NAV);
+  LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
 }
 
 void CGUIViewStateMusicSearch::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_NAV, &g_settings.m_viewStateMusicNavSongs);
+  SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV, &g_settings.m_viewStateMusicNavSongs);
 }
 
 CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
 {
   CMusicDatabaseDirectory dir;
-  NODE_TYPE NodeType=dir.GetDirectoryChildType(items.m_strPath);
+  NODE_TYPE NodeType=dir.GetDirectoryChildType(items.GetPath());
 
   CStdString strTrackLeft=g_guiSettings.GetString("musicfiles.librarytrackformat");
   if (strTrackLeft.IsEmpty())
@@ -314,7 +314,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
 
       // the "All Albums" entries always default to SORT_METHOD_ALBUM as this is most logical - user can always
       // change it and the change will be saved for this particular path
-      if (dir.IsAllItem(items.m_strPath))
+      if (dir.IsAllItem(items.GetPath()))
         SetSortMethod(g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SORT_METHOD_ALBUM_IGNORE_THE : SORT_METHOD_ALBUM);
       else
         SetSortMethod(g_settings.m_viewStateMusicNavSongs.m_sortMethod);
@@ -340,42 +340,42 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   }
 
-  LoadViewState(items.m_strPath, WINDOW_MUSIC_NAV);
+  LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
 }
 
 void CGUIViewStateMusicDatabase::SaveViewState()
 {
   CMusicDatabaseDirectory dir;
-  NODE_TYPE NodeType=dir.GetDirectoryChildType(m_items.m_strPath);
+  NODE_TYPE NodeType=dir.GetDirectoryChildType(m_items.GetPath());
 
   switch (NodeType)
   {
     case NODE_TYPE_ARTIST:
-      SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_NAV, &g_settings.m_viewStateMusicNavArtists);
+      SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV, &g_settings.m_viewStateMusicNavArtists);
       break;
     case NODE_TYPE_ALBUM_COMPILATIONS:
     case NODE_TYPE_ALBUM:
     case NODE_TYPE_YEAR_ALBUM:
-      SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_NAV, &g_settings.m_viewStateMusicNavAlbums);
+      SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV, &g_settings.m_viewStateMusicNavAlbums);
       break;
     case NODE_TYPE_ALBUM_RECENTLY_ADDED:
     case NODE_TYPE_ALBUM_TOP100:
     case NODE_TYPE_ALBUM_RECENTLY_PLAYED:
-      SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_NAV);
+      SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV);
       break;
     case NODE_TYPE_SINGLES:
     case NODE_TYPE_ALBUM_COMPILATIONS_SONGS:
     case NODE_TYPE_SONG:
     case NODE_TYPE_YEAR_SONG:
-      SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_NAV, &g_settings.m_viewStateMusicNavSongs);
+      SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV, &g_settings.m_viewStateMusicNavSongs);
       break;
     case NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS:
     case NODE_TYPE_ALBUM_RECENTLY_ADDED_SONGS:
     case NODE_TYPE_SONG_TOP100:
-      SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_NAV);
+      SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV);
       break;
     default:
-      SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_NAV);
+      SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV);
       break;
   }
 }
@@ -446,12 +446,12 @@ CGUIViewStateMusicSmartPlaylist::CGUIViewStateMusicSmartPlaylist(const CFileItem
     CLog::Log(LOGERROR,"Music Smart Playlist must be one of songs, mixed or albums");
   }
   
-  LoadViewState(items.m_strPath, WINDOW_MUSIC_NAV);
+  LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
 }
 
 void CGUIViewStateMusicSmartPlaylist::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_NAV, &g_settings.m_viewStateMusicNavSongs);
+  SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV, &g_settings.m_viewStateMusicNavSongs);
 }
 
 CGUIViewStateMusicPlaylist::CGUIViewStateMusicPlaylist(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
@@ -482,12 +482,12 @@ CGUIViewStateMusicPlaylist::CGUIViewStateMusicPlaylist(const CFileItemList& item
   SetViewAsControl(g_settings.m_viewStateMusicFiles.m_viewMode);
   SetSortOrder(g_settings.m_viewStateMusicFiles.m_sortOrder);
 
-  LoadViewState(items.m_strPath, WINDOW_MUSIC_FILES);
+  LoadViewState(items.GetPath(), WINDOW_MUSIC_FILES);
 }
 
 void CGUIViewStateMusicPlaylist::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_FILES);
+  SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_FILES);
 }
 
 
@@ -507,7 +507,7 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
     if (items.IsVideoDb() && items.Size() > (g_guiSettings.GetBool("filelists.showparentdiritems")?1:0))
     {
       XFILE::VIDEODATABASEDIRECTORY::CQueryParams params;
-      XFILE::CVideoDatabaseDirectory::GetQueryParams(items[g_guiSettings.GetBool("filelists.showparentdiritems")?1:0]->m_strPath,params);
+      XFILE::CVideoDatabaseDirectory::GetQueryParams(items[g_guiSettings.GetBool("filelists.showparentdiritems")?1:0]->GetPath(),params);
       if (params.GetMVideoId() != -1)
       {
         if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
@@ -544,12 +544,12 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
 
     SetSortOrder(SORT_ORDER_ASC);
   }
-  LoadViewState(items.m_strPath, WINDOW_MUSIC_NAV);
+  LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
 }
 
 void CGUIViewStateWindowMusicNav::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_NAV);
+  SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_NAV);
 }
 
 void CGUIViewStateWindowMusicNav::AddOnlineShares()
@@ -575,7 +575,7 @@ VECSOURCES& CGUIViewStateWindowMusicNav::GetSources()
     CFileItemPtr item=items[i];
     CMediaSource share;
     share.strName=item->GetLabel();
-    share.strPath = item->m_strPath;
+    share.strPath = item->GetPath();
     share.m_strThumbnailImage = item->GetIconImage();
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
     m_sources.push_back(share);
@@ -625,7 +625,7 @@ CGUIViewStateWindowMusicSongs::CGUIViewStateWindowMusicSongs(const CFileItemList
 
     SetSortOrder(SORT_ORDER_ASC);
   }
-  else if (items.m_strPath == "special://musicplaylists/")
+  else if (items.GetPath() == "special://musicplaylists/")
   { // playlists list sorts by label only, ignoring folders
     AddSortMethod(SORT_METHOD_LABEL_IGNORE_FOLDERS, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
     SetSortMethod(SORT_METHOD_LABEL_IGNORE_FOLDERS);
@@ -648,12 +648,12 @@ CGUIViewStateWindowMusicSongs::CGUIViewStateWindowMusicSongs(const CFileItemList
     SetViewAsControl(g_settings.m_viewStateMusicFiles.m_viewMode);
     SetSortOrder(g_settings.m_viewStateMusicFiles.m_sortOrder);
   }
-  LoadViewState(items.m_strPath, WINDOW_MUSIC_FILES);
+  LoadViewState(items.GetPath(), WINDOW_MUSIC_FILES);
 }
 
 void CGUIViewStateWindowMusicSongs::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_FILES, &g_settings.m_viewStateMusicFiles);
+  SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_FILES, &g_settings.m_viewStateMusicFiles);
 }
 
 VECSOURCES& CGUIViewStateWindowMusicSongs::GetSources()
@@ -678,12 +678,12 @@ CGUIViewStateWindowMusicPlaylist::CGUIViewStateWindowMusicPlaylist(const CFileIt
 
   SetSortOrder(SORT_ORDER_NONE);
 
-  LoadViewState(items.m_strPath, WINDOW_MUSIC_PLAYLIST);
+  LoadViewState(items.GetPath(), WINDOW_MUSIC_PLAYLIST);
 }
 
 void CGUIViewStateWindowMusicPlaylist::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_PLAYLIST);
+  SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_PLAYLIST);
 }
 
 int CGUIViewStateWindowMusicPlaylist::GetPlaylist()
@@ -727,7 +727,7 @@ CGUIViewStateMusicLastFM::CGUIViewStateMusicLastFM(const CFileItemList& items) :
   SetSortOrder(g_settings.m_viewStateMusicLastFM.m_sortOrder);
 
   SetViewAsControl(DEFAULT_VIEW_LIST);
-  LoadViewState(items.m_strPath, WINDOW_MUSIC_FILES);
+  LoadViewState(items.GetPath(), WINDOW_MUSIC_FILES);
 }
 
 bool CGUIViewStateMusicLastFM::AutoPlayNextItem()
@@ -737,6 +737,6 @@ bool CGUIViewStateMusicLastFM::AutoPlayNextItem()
 
 void CGUIViewStateMusicLastFM::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_MUSIC_FILES, &g_settings.m_viewStateMusicLastFM);
+  SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_FILES, &g_settings.m_viewStateMusicLastFM);
 }
 

--- a/xbmc/music/LastFmManager.cpp
+++ b/xbmc/music/LastFmManager.cpp
@@ -331,7 +331,7 @@ bool CLastFmManager::RequestRadioTracks()
       {
         CStdString url = child->Value();
         url.Replace("http:", "lastfm:");
-        newItem->m_strPath = url;
+        newItem->SetPath(url);
       }
     }
     pElement = pTrackElement->FirstChildElement("title");
@@ -874,7 +874,7 @@ bool CLastFmManager::Love(const CMusicInfoTag& musicinfotag)
   if (m_CurrentSong.CurrentSong && !m_CurrentSong.CurrentSong->IsLastFM())
   {
     //path to update the rating for
-    strFilePath = m_CurrentSong.CurrentSong->m_strPath;
+    strFilePath = m_CurrentSong.CurrentSong->GetPath();
   }
   if (CallXmlRpc("loveTrack",strArtist, strTitle))
   {

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -761,13 +761,14 @@ void CMusicDatabase::GetFileItemFromDataset(CFileItem* item, const CStdString& s
   // Get filename with full path
   if (strMusicDBbasePath.IsEmpty())
   {
-    item->m_strPath = strRealPath;
+    item->SetPath(strRealPath);
   }
   else
   {
     CStdString strFileName=m_pDS->fv(song_strFileName).get_asString();
     CStdString strExt=URIUtils::GetExtension(strFileName);
-    item->m_strPath.Format("%s%ld%s", strMusicDBbasePath.c_str(), m_pDS->fv(song_idSong).get_asInt(), strExt.c_str());
+    CStdString path; path.Format("%s%ld%s", strMusicDBbasePath.c_str(), m_pDS->fv(song_idSong).get_asInt(), strExt.c_str());
+    item->SetPath(path);
   }
 }
 
@@ -2427,7 +2428,7 @@ void CMusicDatabase::DeleteCDDBInfo()
       if (items[i]->m_bIsFolder)
         continue;
 
-      CStdString strFile = URIUtils::GetFileName(items[i]->m_strPath);
+      CStdString strFile = URIUtils::GetFileName(items[i]->GetPath());
       strFile.Delete(strFile.size() - 5, 5);
       ULONG lDiscId = strtoul(strFile.c_str(), NULL, 16);
       Xcddb cddb;
@@ -2544,7 +2545,7 @@ bool CMusicDatabase::GetGenresNav(const CStdString& strBaseDir, CFileItemList& i
       pItem->GetMusicInfoTag()->SetGenre(m_pDS->fv("strGenre").get_asString());
       CStdString strDir;
       strDir.Format("%ld/", m_pDS->fv("idGenre").get_asInt());
-      pItem->m_strPath=strBaseDir + strDir;
+      pItem->SetPath(strBaseDir + strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
 
@@ -2592,7 +2593,7 @@ bool CMusicDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
       pItem->GetMusicInfoTag()->SetReleaseDate(stTime);
       CStdString strDir;
       strDir.Format("%ld/", m_pDS->fv("iYear").get_asInt());
-      pItem->m_strPath=strBaseDir + strDir;
+      pItem->SetPath(strBaseDir + strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
 
@@ -2743,7 +2744,7 @@ bool CMusicDatabase::GetArtistsNav(const CStdString& strBaseDir, CFileItemList& 
       CStdString strDir;
       int idArtist = m_pDS->fv("idArtist").get_asInt();
       strDir.Format("%ld/", idArtist);
-      pItem->m_strPath=strBaseDir + strDir;
+      pItem->SetPath(strBaseDir + strDir);
       pItem->m_bIsFolder=true;
       pItem->GetMusicInfoTag()->SetDatabaseId(idArtist);
       if (CFile::Exists(pItem->GetCachedArtistThumb()))

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -58,7 +58,7 @@ void CMusicInfoLoader::OnLoaderStart()
     LoadCache(m_strCacheFileName, *m_mapFileItems);
   else
   {
-    m_mapFileItems->m_strPath=m_pVecItems->m_strPath;
+    m_mapFileItems->SetPath(m_pVecItems->GetPath());
     m_mapFileItems->Load();
     m_mapFileItems->SetFastLookup(true);
   }
@@ -84,12 +84,12 @@ bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
   if (pItem->GetProperty("hasfullmusictag") == "true")
     return false; // already have the information
 
-  CStdString path(pItem->m_strPath);
+  CStdString path(pItem->GetPath());
   if (pItem->IsMusicDb())
   {
     // set the artist / album properties
     XFILE::MUSICDATABASEDIRECTORY::CQueryParams param;
-    XFILE::MUSICDATABASEDIRECTORY::CDirectoryNode::GetDatabaseInfo(pItem->m_strPath,param);
+    XFILE::MUSICDATABASEDIRECTORY::CDirectoryNode::GetDatabaseInfo(pItem->GetPath(),param);
     CArtist artist;
     CMusicDatabase database;
     database.Open();
@@ -131,7 +131,7 @@ bool CMusicInfoLoader::LoadItem(CFileItem* pItem)
     return true;
 
   // first check the cached item
-  CFileItemPtr mapItem = (*m_mapFileItems)[pItem->m_strPath];
+  CFileItemPtr mapItem = (*m_mapFileItems)[pItem->GetPath()];
   if (mapItem && mapItem->m_dateTime==pItem->m_dateTime && mapItem->HasMusicInfoTag() && mapItem->GetMusicInfoTag()->Loaded())
   { // Query map if we previously cached the file on HD
     *pItem->GetMusicInfoTag() = *mapItem->GetMusicInfoTag();
@@ -140,7 +140,7 @@ bool CMusicInfoLoader::LoadItem(CFileItem* pItem)
   }
 
   CStdString strPath;
-  URIUtils::GetDirectory(pItem->m_strPath, strPath);
+  URIUtils::GetDirectory(pItem->GetPath(), strPath);
   URIUtils::AddSlashAtEnd(strPath);
   if (strPath!=m_strPrevPath)
   {
@@ -152,7 +152,7 @@ bool CMusicInfoLoader::LoadItem(CFileItem* pItem)
 
   CSong *song=NULL;
 
-  if ((song=m_songsMap.Find(pItem->m_strPath))!=NULL)
+  if ((song=m_songsMap.Find(pItem->GetPath()))!=NULL)
   {  // Have we loaded this item from database before
     pItem->GetMusicInfoTag()->SetSong(*song);
     pItem->SetThumbnailImage(song->strThumb);
@@ -160,7 +160,7 @@ bool CMusicInfoLoader::LoadItem(CFileItem* pItem)
   else if (pItem->IsMusicDb())
   { // a music db item that doesn't have tag loaded - grab details from the database
     XFILE::MUSICDATABASEDIRECTORY::CQueryParams param;
-    XFILE::MUSICDATABASEDIRECTORY::CDirectoryNode::GetDatabaseInfo(pItem->m_strPath,param);
+    XFILE::MUSICDATABASEDIRECTORY::CDirectoryNode::GetDatabaseInfo(pItem->GetPath(),param);
     CSong song;
     if (m_musicDatabase.GetSongById(param.GetSongId(), song))
     {
@@ -172,10 +172,10 @@ bool CMusicInfoLoader::LoadItem(CFileItem* pItem)
   { // Nothing found, load tag from file,
     // always try to load cddb info
     // get correct tag parser
-    auto_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(pItem->m_strPath));
+    auto_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(pItem->GetPath()));
     if (NULL != pLoader.get())
       // get tag
-      pLoader->Load(pItem->m_strPath, *pItem->GetMusicInfoTag());
+      pLoader->Load(pItem->GetPath(), *pItem->GetMusicInfoTag());
     m_tagReads++;
   }
 

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -72,7 +72,7 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
         CMusicDatabase db;
         if (db.Open())      // OpenForWrite() ?
         {
-          db.SetSongRating(m_song->m_strPath, m_song->GetMusicInfoTag()->GetRating());
+          db.SetSongRating(m_song->GetPath(), m_song->GetMusicInfoTag()->GetRating());
           db.Close();
         }
         m_needsUpdate = true;
@@ -109,7 +109,9 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
         if (window)
         {
           CFileItem item(*m_song);
-          item.m_strPath.Format("musicdb://3/%li",m_albumId);
+          CStdString path;
+          path.Format("musicdb://3/%li",m_albumId);
+          item.SetPath(path);
           item.m_bIsFolder = true;
           window->OnInfo(&item, true);
         }
@@ -157,7 +159,7 @@ void CGUIDialogSongInfo::OnInitWindow()
   if (m_song->GetMusicInfoTag()->GetDatabaseId() == -1)
   {
     CStdString path;
-    URIUtils::GetDirectory(m_song->m_strPath,path);
+    URIUtils::GetDirectory(m_song->GetPath(),path);
     m_albumId = db.GetAlbumIdByPath(path);
   }
   else

--- a/xbmc/music/karaoke/karaokewindowbackground.cpp
+++ b/xbmc/music/karaoke/karaokewindowbackground.cpp
@@ -238,11 +238,11 @@ void CKaraokeWindowBackground::StartVideo( const CStdString& path, __int64 offse
 
   if ( !m_videoPlayer->OpenFile( item, options ) )
   {
-    CLog::Log(LOGERROR, "KaraokeVideoBackground: error opening video file %s", item.m_strPath.c_str());
+    CLog::Log(LOGERROR, "KaraokeVideoBackground: error opening video file %s", item.GetPath().c_str());
     return;
   }
 
-  CLog::Log(LOGDEBUG, "KaraokeVideoBackground: video file %s opened successfully", item.m_strPath.c_str());
+  CLog::Log(LOGDEBUG, "KaraokeVideoBackground: video file %s opened successfully", item.GetPath().c_str());
 
   m_ImgControl->SetVisible( false );
   m_VisControl->SetVisible( false );

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -163,7 +163,7 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
     case GUI_MSG_SCAN_FINISHED:
     case GUI_MSG_REFRESH_THUMBS:
     {
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
     }
     break;
 
@@ -207,7 +207,7 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
         {
           // is delete allowed?
           // must be at the playlists directory
-          if (m_vecItems->m_strPath.Equals("special://musicplaylists/"))
+          if (m_vecItems->GetPath().Equals("special://musicplaylists/"))
             OnDeleteItem(iItem);
 
           // or be at the files window and have file deletion enabled
@@ -247,11 +247,11 @@ void CGUIWindowMusicBase::OnInfoAll(int iItem, bool bCurrent)
 {
   CGUIDialogMusicScan* musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
   CMusicDatabaseDirectory dir;
-  CStdString strPath = m_vecItems->m_strPath;
+  CStdString strPath = m_vecItems->GetPath();
   if (bCurrent)
-    strPath = m_vecItems->Get(iItem)->m_strPath;
+    strPath = m_vecItems->Get(iItem)->GetPath();
 
-  if (dir.HasAlbumInfo(m_vecItems->Get(iItem)->m_strPath))
+  if (dir.HasAlbumInfo(m_vecItems->Get(iItem)->GetPath()))
     musicScan->StartAlbumScan(strPath);
   else
     musicScan->StartArtistScan(strPath);
@@ -278,7 +278,7 @@ void CGUIWindowMusicBase::OnInfo(int iItem, bool bShowInfo)
 void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
 {
   if ((pItem->IsMusicDb() && !pItem->HasMusicInfoTag()) || pItem->IsParentFolder() ||
-       URIUtils::IsSpecial(pItem->m_strPath) || pItem->m_strPath.Left(14).Equals("musicsearch://"))
+       URIUtils::IsSpecial(pItem->GetPath()) || pItem->GetPath().Left(14).Equals("musicsearch://"))
     return; // nothing to do
 
   if (!pItem->m_bIsFolder)
@@ -287,7 +287,7 @@ void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
     return;
   }
 
-  CStdString strPath = pItem->m_strPath;
+  CStdString strPath = pItem->GetPath();
 
   // Try to find an album to lookup from the current item
   CAlbum album;
@@ -300,7 +300,7 @@ void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
   if (pItem->IsMusicDb())
   {
     CQueryParams params;
-    CDirectoryNode::GetDatabaseInfo(pItem->m_strPath, params);
+    CDirectoryNode::GetDatabaseInfo(pItem->GetPath(), params);
     if (params.GetAlbumId() == -1)
     { // artist lookup
       artist.idArtist = params.GetArtistId();
@@ -368,7 +368,7 @@ void CGUIWindowMusicBase::OnInfo(CFileItem *pItem, bool bShowInfo)
   }
 
   if (album.idAlbum == -1 && foundAlbum == false)
-    ShowArtistInfo(artist, pItem->m_strPath, false, bShowInfo);
+    ShowArtistInfo(artist, pItem->GetPath(), false, bShowInfo);
   else
     ShowAlbumInfo(album, strPath, false, bShowInfo);
 }
@@ -412,7 +412,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CArtist& artist, const CStdString
     if (!pDlgAlbumInfo->NeedRefresh())
     {
       if (pDlgAlbumInfo->HasUpdatedThumb())
-        Update(m_vecItems->m_strPath);
+        Update(m_vecItems->GetPath());
 
       return;
     }
@@ -460,7 +460,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CArtist& artist, const CStdString
           UpdateThumb(artistInfo, path);
 */
         // just update for now
-        Update(m_vecItems->m_strPath);
+        Update(m_vecItems->GetPath());
         if (pDlgAlbumInfo->NeedRefresh())
         {
           m_musicdatabase.DeleteArtistInfo(artistInfo.idArtist);
@@ -590,7 +590,7 @@ void CGUIWindowMusicBase::ShowSongInfo(CFileItem* pItem)
     if (dialog->NeedsUpdate())
     { // update our file list
       m_vecItems->RemoveDiscCache(GetID());
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
     }
   }
 }
@@ -633,7 +633,7 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem)
   if (!item->CanQueue())
     item->SetCanQueue(true);
 
-  CLog::Log(LOGDEBUG, "Adding file %s%s to music playlist", item->m_strPath.c_str(), item->m_bIsFolder ? " (folder) " : "");
+  CLog::Log(LOGDEBUG, "Adding file %s%s to music playlist", item->GetPath().c_str(), item->m_bIsFolder ? " (folder) " : "");
   CFileItemList queuedItems;
   AddItemToPlayList(item, queuedItems);
 
@@ -672,11 +672,11 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
   if (pItem->IsMusicDb() && pItem->m_bIsFolder && !pItem->IsParentFolder())
   { // we have a music database folder, just grab the "all" item underneath it
     CMusicDatabaseDirectory dir;
-    if (!dir.ContainsSongs(pItem->m_strPath))
+    if (!dir.ContainsSongs(pItem->GetPath()))
     { // grab the ALL item in this category
       // Genres will still require 2 lookups, and queuing the entire Genre folder
       // will require 3 lookups (genre, artist, album)
-      CFileItemPtr item(new CFileItem(pItem->m_strPath + "-1/", true));
+      CFileItemPtr item(new CFileItem(pItem->GetPath() + "-1/", true));
       item->SetCanQueue(true); // workaround for CanQueue() check above
       AddItemToPlayList(item, queuedItems);
       return;
@@ -694,7 +694,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
 
     // recursive
     CFileItemList items;
-    GetDirectory(pItem->m_strPath, items);
+    GetDirectory(pItem->GetPath(), items);
     //OnRetrieveMusicInfo(items);
     FormatAndSort(items);
     SetupFanart(items);
@@ -709,7 +709,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
       if (pPlayList.get())
       {
         // load it
-        if (!pPlayList->Load(pItem->m_strPath))
+        if (!pPlayList->Load(pItem->GetPath()))
         {
           CGUIDialogOK::ShowAndGetInput(6, 0, 477, 0);
           return; //hmmm unable to load playlist?
@@ -734,7 +734,7 @@ void CGUIWindowMusicBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     }
     else if (!pItem->IsNFO() && pItem->IsAudio())
     {
-      CFileItemPtr itemCheck = queuedItems.Get(pItem->m_strPath);
+      CFileItemPtr itemCheck = queuedItems.Get(pItem->GetPath());
       if (!itemCheck || itemCheck->m_lStartOffset != pItem->m_lStartOffset)
       { // add item
         CFileItemPtr item(new CFileItem(*pItem));
@@ -945,7 +945,7 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
   case CONTEXT_BUTTON_EDIT:
     {
-      CStdString playlist = item->IsPlayList() ? item->m_strPath : m_vecItems->m_strPath; // save path as activatewindow will destroy our items
+      CStdString playlist = item->IsPlayList() ? item->GetPath() : m_vecItems->GetPath(); // save path as activatewindow will destroy our items
       g_windowManager.ActivateWindow(WINDOW_MUSIC_PLAYLIST_EDITOR, playlist);
       // need to update
       m_vecItems->RemoveDiscCache(GetID());
@@ -954,11 +954,11 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
   case CONTEXT_BUTTON_EDIT_SMART_PLAYLIST:
     {
-      CStdString playlist = item->IsSmartPlayList() ? item->m_strPath : m_vecItems->m_strPath; // save path as activatewindow will destroy our items
+      CStdString playlist = item->IsSmartPlayList() ? item->GetPath() : m_vecItems->GetPath(); // save path as activatewindow will destroy our items
       if (CGUIDialogSmartPlaylistEditor::EditPlaylist(playlist, "music"))
       { // need to update
         m_vecItems->RemoveDiscCache(GetID());
-        Update(m_vecItems->m_strPath);
+        Update(m_vecItems->GetPath());
       }
       return true;
     }
@@ -978,7 +978,7 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     }
 
   case CONTEXT_BUTTON_PLAY_PARTYMODE:
-    g_partyModeManager.Enable(PARTYMODECONTEXT_MUSIC, item->m_strPath);
+    g_partyModeManager.Enable(PARTYMODECONTEXT_MUSIC, item->GetPath());
     return true;
 
   case CONTEXT_BUTTON_STOP_SCANNING:
@@ -1003,17 +1003,17 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_LASTFM_UNBAN_ITEM:
     if (CLastFmManager::GetInstance()->Unban(*item->GetMusicInfoTag()))
     {
-      g_directoryCache.ClearDirectory(m_vecItems->m_strPath);
+      g_directoryCache.ClearDirectory(m_vecItems->GetPath());
       m_vecItems->RemoveDiscCache(GetID());
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
     }
     return true;
   case CONTEXT_BUTTON_LASTFM_UNLOVE_ITEM:
     if (CLastFmManager::GetInstance()->Unlove(*item->GetMusicInfoTag()))
     {
-      g_directoryCache.ClearDirectory(m_vecItems->m_strPath);
+      g_directoryCache.ClearDirectory(m_vecItems->GetPath());
       m_vecItems->RemoveDiscCache(GetID());
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
     }
     return true;
   default:
@@ -1070,7 +1070,7 @@ void CGUIWindowMusicBase::PlayItem(int iItem)
   if (pItem->IsDAAP() && pItem->m_bIsFolder)
   {
     CDAAPDirectory dirDAAP;
-    if (dirDAAP.GetCurrLevel(pItem->m_strPath) == 0)
+    if (dirDAAP.GetCurrLevel(pItem->GetPath()) == 0)
       bIsDAAPplaylist = true;
   }
 #endif
@@ -1098,7 +1098,7 @@ void CGUIWindowMusicBase::PlayItem(int iItem)
     }
 
     /*
-    CStdString strPlayListDirectory = m_vecItems->m_strPath;
+    CStdString strPlayListDirectory = m_vecItems->GetPath();
     URIUtils::RemoveSlashAtEnd(strPlayListDirectory);
     */
 
@@ -1117,7 +1117,7 @@ void CGUIWindowMusicBase::PlayItem(int iItem)
   else if (pItem->IsPlayList())
   {
     // load the playlist the old way
-    LoadPlayList(pItem->m_strPath);
+    LoadPlayList(pItem->GetPath());
   }
   else
   {
@@ -1262,7 +1262,7 @@ void CGUIWindowMusicBase::UpdateThumb(const CAlbum &album, const CStdString &pat
   // TODO: Ideally this would only be done when needed - at the moment we appear to be
   //       doing this for every lookup, possibly twice (see ShowAlbumInfo)
   m_vecItems->RemoveDiscCache(GetID());
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
 
   //  Do we have to autoswitch to the thumb control?
   m_guiState.reset(CGUIViewState::GetViewState(GetID(), *m_vecItems));
@@ -1293,7 +1293,7 @@ void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
 
       if (!bProgressVisible && elapsed>1500 && m_dlgProgress)
       { // tag loading takes more then 1.5 secs, show a progress dialog
-        CURL url(items.m_strPath);
+        CURL url(items.GetPath());
         CStdString strStrippedPath = url.GetWithoutUserDetails();
         m_dlgProgress->SetHeading(189);
         m_dlgProgress->SetLine(0, 505);
@@ -1324,7 +1324,7 @@ bool CGUIWindowMusicBase::GetDirectory(const CStdString &strDirectory, CFileItem
     items.SetMusicThumb();
 
   // add in the "New Playlist" item if we're in the playlists folder
-  if ((items.m_strPath == "special://musicplaylists/") && !items.Contains("newplaylist://"))
+  if ((items.GetPath() == "special://musicplaylists/") && !items.Contains("newplaylist://"))
   {
     CFileItemPtr newPlaylist(new CFileItem(g_settings.GetUserDataItem("PartyMode.xsp"),false));
     newPlaylist->SetLabel(g_localizeStrings.Get(16035));
@@ -1352,7 +1352,7 @@ bool CGUIWindowMusicBase::GetDirectory(const CStdString &strDirectory, CFileItem
 
 void CGUIWindowMusicBase::OnPrepareFileItems(CFileItemList &items)
 {
-  if (!items.m_strPath.Equals("plugin://music/"))
+  if (!items.GetPath().Equals("plugin://music/"))
     items.SetCachedMusicThumbs();
 }
 

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -70,7 +70,7 @@ using namespace MUSICDATABASEDIRECTORY;
 CGUIWindowMusicNav::CGUIWindowMusicNav(void)
     : CGUIWindowMusicBase(WINDOW_MUSIC_NAV, "MyMusicNav.xml")
 {
-  m_vecItems->m_strPath = "?";
+  m_vecItems->SetPath("?");
   m_bDisplayEmptyDatabaseMessage = false;
   m_thumbLoader.SetObserver(this);
   m_searchWithEdit = false;
@@ -85,7 +85,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
   switch (message.GetMessage())
   {
   case GUI_MSG_WINDOW_RESET:
-    m_vecItems->m_strPath = "?";
+    m_vecItems->SetPath("?");
     break;
   case GUI_MSG_WINDOW_DEINIT:
     if (m_thumbLoader.IsLoading())
@@ -97,7 +97,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
       m_rootDir.AllowNonLocalSources(false);
 
       // is this the first time the window is opened?
-      if (m_vecItems->m_strPath == "?" && message.GetStringParam().IsEmpty())
+      if (m_vecItems->GetPath() == "?" && message.GetStringParam().IsEmpty())
         message.SetStringParam(g_settings.m_defaultMusicLibSource);
       
       DisplayEmptyDatabaseMessage(false); // reset message state
@@ -112,7 +112,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
       {
         // no library - make sure we focus on a known control, and default to the root.
         SET_CONTROL_FOCUS(CONTROL_BTNTYPE, 0);
-        m_vecItems->m_strPath = "";
+        m_vecItems->SetPath("");
         SetHistoryForPath("");
         Update("");
       }
@@ -195,8 +195,8 @@ bool CGUIWindowMusicNav::OnAction(const CAction& action)
     int item = m_viewControl.GetSelectedItem();
     CMusicDatabaseDirectory dir;
     if (item > -1 && m_vecItems->Get(item)->m_bIsFolder
-                  && (dir.HasAlbumInfo(m_vecItems->Get(item)->m_strPath)||
-                      dir.IsArtistDir(m_vecItems->Get(item)->m_strPath)))
+                  && (dir.HasAlbumInfo(m_vecItems->Get(item)->GetPath())||
+                      dir.IsArtistDir(m_vecItems->Get(item)->GetPath())))
       OnContextButton(item,CONTEXT_BUTTON_INFO);
 
     return true;
@@ -245,7 +245,7 @@ bool CGUIWindowMusicNav::OnClick(int iItem)
   if (iItem < 0 || iItem >= m_vecItems->Size()) return false;
 
   CFileItemPtr item = m_vecItems->Get(iItem);
-  if (item->m_strPath.Left(14) == "musicsearch://")
+  if (item->GetPath().Left(14) == "musicsearch://")
   {
     if (m_searchWithEdit)
       OnSearchUpdate();
@@ -340,11 +340,11 @@ void CGUIWindowMusicNav::UpdateButtons()
     {
       CFileItemPtr pItem = m_vecItems->Get(i);
       if (pItem->IsParentFolder()) iItems--;
-      if (pItem->m_strPath.Left(4).Equals("/-1/")) iItems--;
+      if (pItem->GetPath().Left(4).Equals("/-1/")) iItems--;
     }
     // or the last item
     if (m_vecItems->Size() > 2 &&
-      m_vecItems->Get(m_vecItems->Size()-1)->m_strPath.Left(4).Equals("/-1/"))
+      m_vecItems->Get(m_vecItems->Size()-1)->GetPath().Left(4).Equals("/-1/"))
       iItems--;
   }
   CStdString items;
@@ -355,20 +355,20 @@ void CGUIWindowMusicNav::UpdateButtons()
   CStdString strLabel;
 
   // "Playlists"
-  if (m_vecItems->m_strPath.Equals("special://musicplaylists/"))
+  if (m_vecItems->GetPath().Equals("special://musicplaylists/"))
     strLabel = g_localizeStrings.Get(136);
   // "{Playlist Name}"
   else if (m_vecItems->IsPlayList())
   {
     // get playlist name from path
     CStdString strDummy;
-    URIUtils::Split(m_vecItems->m_strPath, strDummy, strLabel);
+    URIUtils::Split(m_vecItems->GetPath(), strDummy, strLabel);
   }
   // everything else is from a musicdb:// path
   else
   {
     CMusicDatabaseDirectory dir;
-    dir.GetLabel(m_vecItems->m_strPath, strLabel);
+    dir.GetLabel(m_vecItems->GetPath(), strLabel);
   }
 
   SET_CONTROL_LABEL(CONTROL_FILTER, strLabel);
@@ -414,8 +414,8 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
   if (item && (item->GetExtraInfo().Find("lastfm") < 0))
   {
     // are we in the playlists location?
-    bool inPlaylists = m_vecItems->m_strPath.Equals(CUtil::MusicPlaylistsLocation()) ||
-                       m_vecItems->m_strPath.Equals("special://musicplaylists/");
+    bool inPlaylists = m_vecItems->GetPath().Equals(CUtil::MusicPlaylistsLocation()) ||
+                       m_vecItems->GetPath().Equals("special://musicplaylists/");
 
     CMusicDatabaseDirectory dir;
     // enable music info button on an album or on a song.
@@ -428,58 +428,58 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
     {
       if (!item->m_bIsFolder) // music video
        buttons.Add(CONTEXT_BUTTON_INFO, 20393);
-      if (item->m_strPath.Left(14).Equals("videodb://3/4/") &&
-          item->m_strPath.size() > 14 && item->m_bIsFolder)
+      if (item->GetPath().Left(14).Equals("videodb://3/4/") &&
+          item->GetPath().size() > 14 && item->m_bIsFolder)
       {
         long idArtist = m_musicdatabase.GetArtistByName(m_vecItems->Get(itemNumber)->GetLabel());
         if (idArtist > - 1)
           buttons.Add(CONTEXT_BUTTON_INFO,21891);
       }
     }
-    else if (!inPlaylists && (dir.HasAlbumInfo(item->m_strPath)||
-                              dir.IsArtistDir(item->m_strPath)   )      &&
-             !dir.IsAllItem(item->m_strPath) && !item->IsParentFolder() &&
+    else if (!inPlaylists && (dir.HasAlbumInfo(item->GetPath())||
+                              dir.IsArtistDir(item->GetPath())   )      &&
+             !dir.IsAllItem(item->GetPath()) && !item->IsParentFolder() &&
              !item->IsLastFM() && !item->IsPlugin() && !item->IsScript() &&
-             !item->m_strPath.Left(14).Equals("musicsearch://"))
+             !item->GetPath().Left(14).Equals("musicsearch://"))
     {
-      if (dir.IsArtistDir(item->m_strPath))
+      if (dir.IsArtistDir(item->GetPath()))
         buttons.Add(CONTEXT_BUTTON_INFO, 21891);
       else
         buttons.Add(CONTEXT_BUTTON_INFO, 13351);
     }
 
     // enable query all albums button only in album view
-    if (dir.HasAlbumInfo(item->m_strPath) && !dir.IsAllItem(item->m_strPath) &&
+    if (dir.HasAlbumInfo(item->GetPath()) && !dir.IsAllItem(item->GetPath()) &&
         item->m_bIsFolder && !item->IsVideoDb() && !item->IsParentFolder()   &&
        !item->IsLastFM()                                                     &&
-       !item->IsPlugin() && !item->m_strPath.Left(14).Equals("musicsearch://"))
+       !item->IsPlugin() && !item->GetPath().Left(14).Equals("musicsearch://"))
     {
       buttons.Add(CONTEXT_BUTTON_INFO_ALL, 20059);
     }
 
     // enable query all artist button only in album view
-    if (dir.IsArtistDir(item->m_strPath) && !dir.IsAllItem(item->m_strPath) &&
+    if (dir.IsArtistDir(item->GetPath()) && !dir.IsAllItem(item->GetPath()) &&
       item->m_bIsFolder && !item->IsVideoDb())
     {
       ADDON::ScraperPtr info;
-      m_musicdatabase.GetScraperForPath(item->m_strPath, info, ADDON::ADDON_SCRAPER_ARTISTS);
+      m_musicdatabase.GetScraperForPath(item->GetPath(), info, ADDON::ADDON_SCRAPER_ARTISTS);
       if (info && info->Supports(CONTENT_ARTISTS))
         buttons.Add(CONTEXT_BUTTON_INFO_ALL, 21884);
     }
 
     //Set default or clear default
-    NODE_TYPE nodetype = dir.GetDirectoryType(item->m_strPath);
+    NODE_TYPE nodetype = dir.GetDirectoryType(item->GetPath());
     if (!item->IsParentFolder() && !inPlaylists &&
         (nodetype == NODE_TYPE_ROOT     ||
          nodetype == NODE_TYPE_OVERVIEW ||
          nodetype == NODE_TYPE_TOP100))
     {
-      if (!item->m_strPath.Equals(g_settings.m_defaultMusicLibSource))
+      if (!item->GetPath().Equals(g_settings.m_defaultMusicLibSource))
         buttons.Add(CONTEXT_BUTTON_SET_DEFAULT, 13335); // set default
       if (strcmp(g_settings.m_defaultMusicLibSource, ""))
         buttons.Add(CONTEXT_BUTTON_CLEAR_DEFAULT, 13403); // clear default
     }
-    NODE_TYPE childtype = dir.GetDirectoryChildType(item->m_strPath);
+    NODE_TYPE childtype = dir.GetDirectoryChildType(item->GetPath());
     if (childtype == NODE_TYPE_ALBUM               ||
         childtype == NODE_TYPE_ARTIST              ||
         nodetype == NODE_TYPE_GENRE                ||
@@ -522,7 +522,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
         buttons.Add(CONTEXT_BUTTON_DELETE, 646);
       }
     }
-    if (inPlaylists && !URIUtils::GetFileName(item->m_strPath).Equals("PartyMode.xsp")
+    if (inPlaylists && !URIUtils::GetFileName(item->GetPath()).Equals("PartyMode.xsp")
                     && (item->IsPlayList() || item->IsSmartPlayList()))
       buttons.Add(CONTEXT_BUTTON_DELETE, 117);
 
@@ -553,27 +553,29 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         return CGUIWindowMusicBase::OnContextButton(itemNumber,button);
 
       // music videos - artists
-      if (item->m_strPath.Left(14).Equals("videodb://3/4/"))
+      if (item->GetPath().Left(14).Equals("videodb://3/4/"))
       {
         long idArtist = m_musicdatabase.GetArtistByName(item->GetLabel());
         if (idArtist == -1)
           return false;
-        item->m_strPath.Format("musicdb://2/%ld/", idArtist);
+        CStdString path; path.Format("musicdb://2/%ld/", idArtist);
+        item->SetPath(path);
         CGUIWindowMusicBase::OnContextButton(itemNumber,button);
-        Update(m_vecItems->m_strPath);
+        Update(m_vecItems->GetPath());
         m_viewControl.SetSelectedItem(itemNumber);
         return true;
       }
 
       // music videos - albums
-      if (item->m_strPath.Left(14).Equals("videodb://3/5/"))
+      if (item->GetPath().Left(14).Equals("videodb://3/5/"))
       {
         long idAlbum = m_musicdatabase.GetAlbumByName(item->GetLabel());
         if (idAlbum == -1)
           return false;
-        item->m_strPath.Format("musicdb://3/%ld/", idAlbum);
+        CStdString path; path.Format("musicdb://3/%ld/", idAlbum);
+        item->SetPath(path);
         CGUIWindowMusicBase::OnContextButton(itemNumber,button);
-        Update(m_vecItems->m_strPath);
+        Update(m_vecItems->GetPath());
         m_viewControl.SetSelectedItem(itemNumber);
         return true;
       }
@@ -585,7 +587,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         {
           ADDON::ScraperPtr info;
           pWindow->OnInfo(item.get(),info);
-          Update(m_vecItems->m_strPath);
+          Update(m_vecItems->GetPath());
         }
       }
       return true;
@@ -604,7 +606,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     }
 
   case CONTEXT_BUTTON_SET_DEFAULT:
-    g_settings.m_defaultMusicLibSource = GetQuickpathName(item->m_strPath);
+    g_settings.m_defaultMusicLibSource = GetQuickpathName(item->GetPath());
     g_settings.Save();
     return true;
 
@@ -636,19 +638,19 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_MARK_WATCHED:
     CGUIWindowVideoBase::MarkWatched(item,true);
     CUtil::DeleteVideoDatabaseDirectoryCache();
-    Update(m_vecItems->m_strPath);
+    Update(m_vecItems->GetPath());
     return true;
 
   case CONTEXT_BUTTON_MARK_UNWATCHED:
     CGUIWindowVideoBase::MarkWatched(item,false);
     CUtil::DeleteVideoDatabaseDirectoryCache();
-    Update(m_vecItems->m_strPath);
+    Update(m_vecItems->GetPath());
     return true;
 
   case CONTEXT_BUTTON_RENAME:
     CGUIWindowVideoBase::UpdateVideoTitle(item.get());
     CUtil::DeleteVideoDatabaseDirectoryCache();
-    Update(m_vecItems->m_strPath);
+    Update(m_vecItems->GetPath());
     return true;
 
   case CONTEXT_BUTTON_DELETE:
@@ -662,16 +664,16 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CGUIWindowVideoNav::DeleteItem(item.get());
       CUtil::DeleteVideoDatabaseDirectoryCache();
     }
-    Update(m_vecItems->m_strPath);
+    Update(m_vecItems->GetPath());
     return true;
 
   case CONTEXT_BUTTON_SET_CONTENT:
     {
       bool bScan=false;
       ADDON::ScraperPtr scraper;
-      CStdString path(item->m_strPath);
+      CStdString path(item->GetPath());
       CQueryParams params;
-      CDirectoryNode::GetDatabaseInfo(item->m_strPath, params);
+      CDirectoryNode::GetDatabaseInfo(item->GetPath(), params);
       CONTENT_TYPE content = CONTENT_ALBUMS;
       if (params.GetAlbumId() != -1)
         path.Format("musicdb://3/%i/",params.GetAlbumId());
@@ -681,7 +683,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         content = CONTENT_ARTISTS;
       }
 
-      if (m_vecItems->m_strPath.Equals("musicdb://1/") || item->m_strPath.Equals("musicdb://2/"))
+      if (m_vecItems->GetPath().Equals("musicdb://1/") || item->GetPath().Equals("musicdb://2/"))
       {
         content = CONTENT_ARTISTS;
       }
@@ -718,11 +720,11 @@ bool CGUIWindowMusicNav::GetSongsFromPlayList(const CStdString& strPlayList, CFi
   if (m_guiState.get() && !m_guiState->HideParentDirItems())
   {
     CFileItemPtr pItem(new CFileItem(".."));
-    pItem->m_strPath = strParentPath;
+    pItem->SetPath(strParentPath);
     items.Add(pItem);
   }
 
-  items.m_strPath=strPlayList;
+  items.SetPath(strPlayList);
   CLog::Log(LOGDEBUG,"CGUIWindowMusicNav, opening playlist [%s]", strPlayList.c_str());
 
   auto_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPlayList));

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -83,7 +83,7 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
       // global playlist changed outside playlist window
       m_vecItems->RemoveDiscCache(GetID());
       UpdateButtons();
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
 
       if (m_viewControl.HasControl(m_iLastControl) && m_vecItems->Size() <= 0)
       {
@@ -108,7 +108,7 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
       // Setup item cache for tagloader
       m_musicInfoLoader.UseCacheOnHD("special://temp/MusicPlaylist.fi");
 
-      m_vecItems->m_strPath="playlistmusic://";
+      m_vecItems->SetPath("playlistmusic://");
 
       // updatebuttons is called in here
       if (!CGUIWindowMusicBase::OnMessage(message))
@@ -142,7 +142,7 @@ bool CGUIWindowMusicPlayList::OnMessage(CGUIMessage& message)
           g_settings.m_bMyMusicPlaylistShuffle = g_playlistPlayer.IsShuffled(PLAYLIST_MUSIC);
           g_settings.Save();
           UpdateButtons();
-          Update(m_vecItems->m_strPath);
+          Update(m_vecItems->GetPath());
         }
       }
       else if (iControl == CONTROL_BTNSAVE)
@@ -265,7 +265,7 @@ bool CGUIWindowMusicPlayList::MoveCurrentPlayListItem(int iItem, int iAction, bo
     }
 
     if (bUpdate)
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
     return true;
   }
 
@@ -296,7 +296,7 @@ void CGUIWindowMusicPlayList::SavePlayList()
       }
     }
 
-    CStdString strOldDirectory = m_vecItems->m_strPath;
+    CStdString strOldDirectory = m_vecItems->GetPath();
     m_history.SetSelectedItem(strSelectedItem, strOldDirectory);
 
     CPlayListM3U playlist;
@@ -307,13 +307,13 @@ void CGUIWindowMusicPlayList::SavePlayList()
       //  Musicdatabase items should contain the real path instead of a musicdb url
       //  otherwise the user can't save and reuse the playlist when the musicdb gets deleted
       if (pItem->IsMusicDb())
-        pItem->m_strPath=pItem->GetMusicInfoTag()->GetURL();
+        pItem->SetPath(pItem->GetMusicInfoTag()->GetURL());
 
       playlist.Add(pItem);
     }
     CLog::Log(LOGDEBUG, "Saving music playlist: [%s]", strPath.c_str());
     playlist.Save(strPath);
-    Update(m_vecItems->m_strPath); // need to update
+    Update(m_vecItems->GetPath()); // need to update
   }
 }
 
@@ -326,7 +326,7 @@ void CGUIWindowMusicPlayList::ClearPlayList()
     g_playlistPlayer.Reset();
     g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_NONE);
   }
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
   SET_CONTROL_FOCUS(CONTROL_BTNVIEWASICONS, 0);
 }
 
@@ -352,7 +352,7 @@ void CGUIWindowMusicPlayList::RemovePlayListItem(int iItem)
     }
   }
 
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
 
   if (m_vecItems->Size() <= 0)
   {
@@ -429,7 +429,7 @@ bool CGUIWindowMusicPlayList::OnPlayMedia(int iItem)
     if (iPlaylist!=PLAYLIST_NONE)
     {
       if (m_guiState.get())
-        m_guiState->SetPlaylistDirectory(m_vecItems->m_strPath);
+        m_guiState->SetPlaylistDirectory(m_vecItems->GetPath());
 
       g_playlistPlayer.SetCurrentPlaylist( iPlaylist );
       g_playlistPlayer.Play( iItem );
@@ -478,7 +478,7 @@ void CGUIWindowMusicPlayList::OnItemLoaded(CFileItem* pItem)
 
       // No music info and it's not CDDA so we'll just show the filename
       CStdString str;
-      str = CUtil::GetTitleFromPath(pItem->m_strPath);
+      str = CUtil::GetTitleFromPath(pItem->GetPath());
       str.Format("%02.2i. %s ", pItem->m_iprogramCount, str);
       pItem->SetLabel(str);
     }
@@ -656,7 +656,7 @@ void CGUIWindowMusicPlayList::MoveItem(int iStart, int iDest)
     else
       break;
   }
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
 
   if (bRestart)
     m_musicInfoLoader.Load(*m_vecItems);

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -82,8 +82,8 @@ bool CGUIWindowMusicPlaylistEditor::OnMessage(CGUIMessage& message)
 
   case GUI_MSG_WINDOW_INIT:
     {
-      if (m_vecItems->m_strPath == "?")
-        m_vecItems->m_strPath.Empty();
+      if (m_vecItems->GetPath() == "?")
+        m_vecItems->SetPath("");
       CGUIWindowMusicBase::OnMessage(message);
 
       if (message.GetNumStringParams())
@@ -153,7 +153,7 @@ bool CGUIWindowMusicPlaylistEditor::GetDirectory(const CStdString &strDirectory,
     db->SetLabel(g_localizeStrings.Get(14022));
     db->SetLabelPreformated(true);
     db->m_bIsShareOrDrive = true;
-    items.m_strPath = "";
+    items.SetPath("");
     items.Add(db);
     return true;
   }

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -53,7 +53,7 @@
 CGUIWindowMusicSongs::CGUIWindowMusicSongs(void)
     : CGUIWindowMusicBase(WINDOW_MUSIC_FILES, "MyMusicSongs.xml")
 {
-  m_vecItems->m_strPath="?";
+  m_vecItems->SetPath("?");
 
   m_thumbLoader.SetObserver(this);
   // Remove old HD cache every time XBMC is loaded
@@ -78,7 +78,7 @@ bool CGUIWindowMusicSongs::OnMessage(CGUIMessage& message)
       // the window translator does it by using a virtual window id (5)
 
       // is this the first time the window is opened?
-      if (m_vecItems->m_strPath == "?" && message.GetStringParam().IsEmpty())
+      if (m_vecItems->GetPath() == "?" && message.GetStringParam().IsEmpty())
         message.SetStringParam(g_settings.m_defaultMusicSource);
 
       return CGUIWindowMusicBase::OnMessage(message);
@@ -93,10 +93,10 @@ bool CGUIWindowMusicSongs::OnMessage(CGUIMessage& message)
       if (directory.IsHD())
       {
         CStdString strParent;
-        URIUtils::GetParentPath(directory.m_strPath, strParent);
-        if (directory.m_strPath == m_vecItems->m_strPath || strParent == m_vecItems->m_strPath)
+        URIUtils::GetParentPath(directory.GetPath(), strParent);
+        if (directory.GetPath() == m_vecItems->GetPath() || strParent == m_vecItems->GetPath())
         {
-          Update(m_vecItems->m_strPath);
+          Update(m_vecItems->GetPath());
         }
       }
     }
@@ -115,7 +115,7 @@ bool CGUIWindowMusicSongs::OnMessage(CGUIMessage& message)
 
       if (iControl == CONTROL_BTNPLAYLISTS)
       {
-        if (!m_vecItems->m_strPath.Equals("special://musicplaylists/"))
+        if (!m_vecItems->GetPath().Equals("special://musicplaylists/"))
           Update("special://musicplaylists/");
       }
       else if (iControl == CONTROL_BTNSCAN)
@@ -163,13 +163,13 @@ void CGUIWindowMusicSongs::OnScan(int iItem)
 {
   CStdString strPath;
   if (iItem < 0 || iItem >= m_vecItems->Size())
-    strPath = m_vecItems->m_strPath;
+    strPath = m_vecItems->GetPath();
   else if (m_vecItems->Get(iItem)->m_bIsFolder)
-    strPath = m_vecItems->Get(iItem)->m_strPath;
+    strPath = m_vecItems->Get(iItem)->GetPath();
   else
   { // TODO: MUSICDB - should we allow scanning a single item into the database?
     //       This will require changes to the info scanner, which assumes we're running on a folder
-    strPath = m_vecItems->m_strPath;
+    strPath = m_vecItems->GetPath();
   }
   DoScan(strPath);
 }
@@ -201,7 +201,7 @@ bool CGUIWindowMusicSongs::GetDirectory(const CStdString &strDirectory, CFileIte
   items.FilterCueItems();
 
   CStdString label;
-  if (items.GetLabel().IsEmpty() && m_rootDir.IsSource(items.m_strPath, g_settings.GetSourcesFromType("music"), &label)) 
+  if (items.GetLabel().IsEmpty() && m_rootDir.IsSource(items.GetPath(), g_settings.GetSourcesFromType("music"), &label)) 
     items.SetLabel(label);
 
   return true;
@@ -293,8 +293,8 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
   if (item)
   {
     // are we in the playlists location?
-    bool inPlaylists = m_vecItems->m_strPath.Equals(CUtil::MusicPlaylistsLocation()) ||
-                       m_vecItems->m_strPath.Equals("special://musicplaylists/");
+    bool inPlaylists = m_vecItems->GetPath().Equals(CUtil::MusicPlaylistsLocation()) ||
+                       m_vecItems->GetPath().Equals("special://musicplaylists/");
 
     if (m_vecItems->IsVirtualDirectoryRoot())
     {
@@ -322,10 +322,10 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
         if (item->IsAudio() && !item->IsLastFM())
           buttons.Add(CONTEXT_BUTTON_SONG_INFO, 658); // Song Info
         else if (!item->IsParentFolder() && !item->IsLastFM() &&
-                 !item->m_strPath.Left(3).Equals("new") && item->m_bIsFolder)
+                 !item->GetPath().Left(3).Equals("new") && item->m_bIsFolder)
         {
 #if 0
-          if (m_musicdatabase.GetAlbumIdByPath(item->m_strPath) > -1)
+          if (m_musicdatabase.GetAlbumIdByPath(item->GetPath()) > -1)
 #endif
             buttons.Add(CONTEXT_BUTTON_INFO, 13351); // Album Info
         }
@@ -368,7 +368,7 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
         buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353); // Stop Scanning
       else if (!inPlaylists && !m_vecItems->IsInternetStream()           &&
                !item->IsLastFM()                                         &&
-               !item->m_strPath.Equals("add") && !item->IsParentFolder() &&
+               !item->GetPath().Equals("add") && !item->IsParentFolder() &&
                !item->IsPlugin()                                         &&
               (g_settings.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
       {
@@ -416,7 +416,7 @@ bool CGUIWindowMusicSongs::OnContextButton(int itemNumber, CONTEXT_BUTTON button
 
   case CONTEXT_BUTTON_CDDB:
     if (m_musicdatabase.LookupCDDBInfo(true))
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
     return true;
 
   case CONTEXT_BUTTON_DELETE:
@@ -428,7 +428,7 @@ bool CGUIWindowMusicSongs::OnContextButton(int itemNumber, CONTEXT_BUTTON button
     return true;
 
   case CONTEXT_BUTTON_SWITCH_MEDIA:
-    CGUIDialogContextMenu::SwitchMedia("music", m_vecItems->m_strPath);
+    CGUIDialogContextMenu::SwitchMedia("music", m_vecItems->GetPath());
     return true;
   default:
     break;
@@ -482,7 +482,7 @@ void CGUIWindowMusicSongs::OnRemoveSource(int iItem)
     CSongMap songs;
     CMusicDatabase database;
     database.Open();
-    database.RemoveSongsFromPath(m_vecItems->Get(iItem)->m_strPath,songs,false);
+    database.RemoveSongsFromPath(m_vecItems->Get(iItem)->GetPath(),songs,false);
     database.CleanupOrphanedItems();
     g_infoManager.ResetLibraryBools();
   }

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -366,7 +366,7 @@ NPT_String
 CUPnPServer::GetMimeType(const CFileItem& item,
                             const PLT_HttpRequestContext* context /* = NULL */)
 {
-    CStdString path = item.m_strPath;
+    CStdString path = item.GetPath();
     if (item.HasVideoInfoTag() && !item.GetVideoInfoTag()->m_strFileNameAndPath.IsEmpty()) {
         path = item.GetVideoInfoTag()->m_strFileNameAndPath;
     } else if (item.HasMusicInfoTag() && !item.GetMusicInfoTag()->GetURL().IsEmpty()) {
@@ -574,7 +574,7 @@ CUPnPServer::BuildObject(const CFileItem&              item,
     PLT_MediaItemResource resource;
     PLT_MediaObject*      object = NULL;
 
-    CLog::Log(LOGDEBUG, "Building didl for object '%s'", (const char*)item.m_strPath);
+    CLog::Log(LOGDEBUG, "Building didl for object '%s'", (const char*)item.GetPath());
 
     EClientQuirks quirks = GetClientQuirks(context);
 
@@ -591,7 +591,7 @@ CUPnPServer::BuildObject(const CFileItem&              item,
 
     if (!item.m_bIsFolder) {
         object = new PLT_MediaItem();
-        object->m_ObjectID = item.m_strPath;
+        object->m_ObjectID = item.GetPath();
 
         /* Setup object type */
         if (item.IsMusicDb() || item.IsAudio()) {
@@ -662,7 +662,7 @@ CUPnPServer::BuildObject(const CFileItem&              item,
         object = container;
 
         /* Assign a title and id for this container */
-        container->m_ObjectID = item.m_strPath;
+        container->m_ObjectID = item.GetPath();
         container->m_ObjectClass.type = "object.container";
         container->m_ChildrenCount = -1;
 
@@ -670,7 +670,7 @@ CUPnPServer::BuildObject(const CFileItem&              item,
 
         /* this might be overkill, but hey */
         if (item.IsMusicDb()) {
-            MUSICDATABASEDIRECTORY::NODE_TYPE node = CMusicDatabaseDirectory::GetDirectoryType(item.m_strPath);
+            MUSICDATABASEDIRECTORY::NODE_TYPE node = CMusicDatabaseDirectory::GetDirectoryType(item.GetPath());
             switch(node) {
                 case MUSICDATABASEDIRECTORY::NODE_TYPE_ARTIST: {
                       container->m_ObjectClass.type += ".person.musicArtist";
@@ -714,7 +714,7 @@ CUPnPServer::BuildObject(const CFileItem&              item,
                   break;
             }
         } else if (item.IsVideoDb()) {
-            VIDEODATABASEDIRECTORY::NODE_TYPE node = CVideoDatabaseDirectory::GetDirectoryType(item.m_strPath);
+            VIDEODATABASEDIRECTORY::NODE_TYPE node = CVideoDatabaseDirectory::GetDirectoryType(item.GetPath());
             CVideoInfoTag &tag = *(CVideoInfoTag*)item.GetVideoInfoTag();
             switch(node) {
                 case VIDEODATABASEDIRECTORY::NODE_TYPE_GENRE:
@@ -785,7 +785,7 @@ CUPnPServer::BuildObject(const CFileItem&              item,
             object->m_Title = title;
         } else {
             CStdString title, volumeNumber;
-            CUtil::GetVolumeFromFileName(item.m_strPath, title, volumeNumber);
+            CUtil::GetVolumeFromFileName(item.GetPath(), title, volumeNumber);
             if (!item.m_bIsFolder) URIUtils::RemoveExtension(title);
             object->m_Title = title;
         }
@@ -828,7 +828,7 @@ CUPnPServer::Build(CFileItemPtr                  item,
                    const char*                   parent_id /* = NULL */)
 {
     PLT_MediaObject* object = NULL;
-    NPT_String       path = item->m_strPath.c_str();
+    NPT_String       path = item->GetPath().c_str();
 
     //HACK: temporary disabling count as it thrashes HDD
     with_count = false;
@@ -857,7 +857,7 @@ CUPnPServer::Build(CFileItemPtr                  item,
     } else {
         // db path handling
         NPT_String file_path, share_name;
-        file_path = item->m_strPath;
+        file_path = item->GetPath();
         share_name = "";
 
         if (path.StartsWith("musicdb://")) {
@@ -1066,7 +1066,7 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
 
     CLog::Log(LOGINFO, "Received UPnP Browse DirectChildren request for object '%s'", (const char*)object_id);
 
-    items.m_strPath = parent_id;
+    items.SetPath(CStdString(parent_id));
     if (!items.Load()) {
         // cache anything that takes more than a second to retrieve
       unsigned int time = XbmcThreads::SystemClockMillis();
@@ -1921,7 +1921,7 @@ CUPnPRenderer::PlayMedia(const char* uri, const char* meta, PLT_Action* action)
         for(NPT_Cardinal i = 0; i < object->m_Resources.GetItemCount(); i++) {
             if(object->m_Resources[i].m_ProtocolInfo.ToString().StartsWith("xbmc-get:")) {
                 res = &object->m_Resources[i];
-                item.m_strPath = res->m_Uri;
+                item.SetPath(CStdString(res->m_Uri));
                 break;
             }
         }
@@ -1944,7 +1944,7 @@ CUPnPRenderer::PlayMedia(const char* uri, const char* meta, PLT_Action* action)
         } else if (object->m_ObjectClass.type.StartsWith("object.item.imageItem")) {
             bImageFile = true;
         }
-        bImageFile?g_application.getApplicationMessenger().PictureShow(item.m_strPath)
+        bImageFile?g_application.getApplicationMessenger().PictureShow(item.GetPath())
                   :g_application.getApplicationMessenger().MediaPlay(item);
     } else {
         bImageFile = NPT_String(PLT_MediaObject::GetUPnPClass(uri)).StartsWith("object.item.imageItem", true);

--- a/xbmc/pictures/GUIDialogPictureInfo.cpp
+++ b/xbmc/pictures/GUIDialogPictureInfo.cpp
@@ -72,10 +72,10 @@ bool CGUIDialogPictureInfo::OnAction(const CAction& action)
 
 void CGUIDialogPictureInfo::FrameMove()
 {
-  if (g_infoManager.GetCurrentSlide().m_strPath != m_currentPicture)
+  if (g_infoManager.GetCurrentSlide().GetPath() != m_currentPicture)
   {
     UpdatePictureInfo();
-    m_currentPicture = g_infoManager.GetCurrentSlide().m_strPath;
+    m_currentPicture = g_infoManager.GetCurrentSlide().GetPath();
   }
   CGUIDialog::FrameMove();
 }

--- a/xbmc/pictures/GUIViewStatePictures.cpp
+++ b/xbmc/pictures/GUIViewStatePictures.cpp
@@ -57,12 +57,12 @@ CGUIViewStateWindowPictures::CGUIViewStateWindowPictures(const CFileItemList& it
     SetViewAsControl(g_settings.m_viewStatePictures.m_viewMode);
     SetSortOrder(g_settings.m_viewStatePictures.m_sortOrder);
   }
-  LoadViewState(items.m_strPath, WINDOW_PICTURES);
+  LoadViewState(items.GetPath(), WINDOW_PICTURES);
 }
 
 void CGUIViewStateWindowPictures::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_PICTURES, &g_settings.m_viewStatePictures);
+  SaveViewToDb(m_items.GetPath(), WINDOW_PICTURES, &g_settings.m_viewStatePictures);
 }
 
 CStdString CGUIViewStateWindowPictures::GetLockType()

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -82,7 +82,7 @@ bool CGUIWindowPictures::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_INIT:
     {
       // is this the first time accessing this window?
-      if (m_vecItems->m_strPath == "?" && message.GetStringParam().IsEmpty())
+      if (m_vecItems->GetPath() == "?" && message.GetStringParam().IsEmpty())
         message.SetStringParam(g_settings.m_defaultPictureSource);
 
       m_dlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
@@ -211,7 +211,7 @@ void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
 
       if (!bProgressVisible && elapsed>1500 && m_dlgProgress)
       { // tag loading takes more then 1.5 secs, show a progress dialog
-        CURL url(items.m_strPath);
+        CURL url(items.GetPath());
 
         m_dlgProgress->SetHeading(189);
         m_dlgProgress->SetLine(0, 505);
@@ -259,9 +259,9 @@ bool CGUIWindowPictures::OnClick(int iItem)
   {
     CStdString strComicPath;
     if (pItem->IsCBZ())
-      URIUtils::CreateArchivePath(strComicPath, "zip", pItem->m_strPath, "");
+      URIUtils::CreateArchivePath(strComicPath, "zip", pItem->GetPath(), "");
     else
-      URIUtils::CreateArchivePath(strComicPath, "rar", pItem->m_strPath, "");
+      URIUtils::CreateArchivePath(strComicPath, "rar", pItem->GetPath(), "");
 
     OnShowPictureRecursive(strComicPath);
     return true;
@@ -278,7 +278,7 @@ bool CGUIWindowPictures::GetDirectory(const CStdString &strDirectory, CFileItemL
     return false;
 
   CStdString label;
-  if (items.GetLabel().IsEmpty() && m_rootDir.IsSource(items.m_strPath, g_settings.GetSourcesFromType("pictures"), &label)) 
+  if (items.GetLabel().IsEmpty() && m_rootDir.IsSource(items.GetPath(), g_settings.GetSourcesFromType("pictures"), &label)) 
     items.SetLabel(label);
 
   return true;
@@ -296,7 +296,7 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
 {
   if ( iItem < 0 || iItem >= (int)m_vecItems->Size() ) return false;
   CFileItemPtr pItem = m_vecItems->Get(iItem);
-  CStdString strPicture = pItem->m_strPath;
+  CStdString strPicture = pItem->GetPath();
 
 #ifdef HAS_DVD_DRIVE
   if (pItem->IsDVD())
@@ -316,8 +316,8 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
   for (int i = 0; i < (int)m_vecItems->Size();++i)
   {
     CFileItemPtr pItem = m_vecItems->Get(i);
-    if (!pItem->m_bIsFolder && !(URIUtils::IsRAR(pItem->m_strPath) || 
-          URIUtils::IsZIP(pItem->m_strPath)) && (pItem->IsPicture() || (
+    if (!pItem->m_bIsFolder && !(URIUtils::IsRAR(pItem->GetPath()) || 
+          URIUtils::IsZIP(pItem->GetPath())) && (pItem->IsPicture() || (
                                 g_guiSettings.GetBool("pictures.showvideos") &&
                                 pItem->IsVideo())))
     {
@@ -378,12 +378,12 @@ void CGUIWindowPictures::OnSlideShowRecursive(const CStdString &strPicture)
 void CGUIWindowPictures::OnSlideShowRecursive()
 {
   CStdString strEmpty = "";
-  OnSlideShowRecursive(m_vecItems->m_strPath);
+  OnSlideShowRecursive(m_vecItems->GetPath());
 }
 
 void CGUIWindowPictures::OnSlideShow()
 {
-  OnSlideShow(m_vecItems->m_strPath);
+  OnSlideShow(m_vecItems->GetPath());
 }
 
 void CGUIWindowPictures::OnSlideShow(const CStdString &strPicture)
@@ -471,13 +471,13 @@ bool CGUIWindowPictures::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   {
   case CONTEXT_BUTTON_VIEW_SLIDESHOW:
     if (item && item->m_bIsFolder)
-      OnSlideShow(item->m_strPath);
+      OnSlideShow(item->GetPath());
     else
       ShowPicture(itemNumber, true);
     return true;
   case CONTEXT_BUTTON_RECURSIVE_SLIDESHOW:
     if (item)
-      OnSlideShowRecursive(item->m_strPath);
+      OnSlideShowRecursive(item->GetPath());
     return true;
   case CONTEXT_BUTTON_INFO:
     OnInfo(itemNumber);
@@ -498,7 +498,7 @@ bool CGUIWindowPictures::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     Update("");
     return true;
   case CONTEXT_BUTTON_SWITCH_MEDIA:
-    CGUIDialogContextMenu::SwitchMedia("pictures", m_vecItems->m_strPath);
+    CGUIDialogContextMenu::SwitchMedia("pictures", m_vecItems->GetPath());
     return true;
   default:
     break;
@@ -539,7 +539,7 @@ void CGUIWindowPictures::LoadPlayList(const CStdString& strPlayList)
     for (int i = 0; i < (int)playlist.size(); ++i)
     {
       CFileItemPtr pItem = playlist[i];
-      //CLog::Log(LOGDEBUG,"-- playlist item: %s", pItem->m_strPath.c_str());
+      //CLog::Log(LOGDEBUG,"-- playlist item: %s", pItem->GetPath().c_str());
       if (pItem->IsPicture() && !(pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBZ() || pItem->IsCBR()))
         pSlideShow->Add(pItem.get());
     }

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -235,7 +235,7 @@ void CGUIWindowSlideShow::Select(const CStdString& strPicture)
   for (int i = 0; i < m_slides->Size(); ++i)
   {
     const CFileItemPtr item = m_slides->Get(i);
-    if (item->m_strPath == strPicture)
+    if (item->GetPath() == strPicture)
     {
       m_iDirection = 1;
       if (IsActive())
@@ -313,7 +313,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     CLog::Log(LOGDEBUG, "We have an error loading a picture!");
     if (m_Image[m_iCurrentPic].IsLoaded())
     { // Yes.  Let's let it transistion out, wait for it to be released, then try loading again.
-      CLog::Log(LOGERROR, "Error loading the next image %s", m_slides->Get(m_iNextSlide)->m_strPath.c_str());
+      CLog::Log(LOGERROR, "Error loading the next image %s", m_slides->Get(m_iNextSlide)->GetPath().c_str());
       if (!bSlideShow)
       { // tell the pic to start transistioning out now
         m_Image[m_iCurrentPic].StartTransistion();
@@ -327,7 +327,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
       // change to next image
       if (bSlideShow)
       {
-        CLog::Log(LOGERROR, "Error loading the current image %s", m_slides->Get(m_iCurrentSlide)->m_strPath.c_str());
+        CLog::Log(LOGERROR, "Error loading the current image %s", m_slides->Get(m_iCurrentSlide)->GetPath().c_str());
         m_iCurrentSlide = m_iNextSlide;
         m_iNextSlide    = GetNextSlide();
         ShowNext();
@@ -351,7 +351,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
 
   if (!m_Image[m_iCurrentPic].IsLoaded() && !m_pBackgroundLoader->IsLoading())
   { // load first image
-    CLog::Log(LOGDEBUG, "Loading the current image %s", m_slides->Get(m_iCurrentSlide)->m_strPath.c_str());
+    CLog::Log(LOGDEBUG, "Loading the current image %s", m_slides->Get(m_iCurrentSlide)->GetPath().c_str());
     m_bWaitForNextPic = false;
     m_bLoadNextPic = false;
     // load using the background loader
@@ -360,7 +360,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
                     (float)g_settings.m_ResInfo[m_Resolution].iHeight * zoomamount[m_iZoomFactor - 1],
                     maxWidth, maxHeight);
     if (!m_slides->Get(m_iCurrentSlide)->IsVideo())
-      m_pBackgroundLoader->LoadPic(m_iCurrentPic, m_iCurrentSlide, m_slides->Get(m_iCurrentSlide)->m_strPath, maxWidth, maxHeight);
+      m_pBackgroundLoader->LoadPic(m_iCurrentPic, m_iCurrentSlide, m_slides->Get(m_iCurrentSlide)->GetPath(), maxWidth, maxHeight);
   }
 
   // check if we should discard an already loaded next slide
@@ -378,7 +378,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   {
     if (m_Image[m_iCurrentPic].IsLoaded() && !m_Image[1 - m_iCurrentPic].IsLoaded() && !m_pBackgroundLoader->IsLoading() && !m_bWaitForNextPic)
     { // reload the image if we need to
-      CLog::Log(LOGDEBUG, "Reloading the current image %s at zoom level %i", m_slides->Get(m_iCurrentSlide)->m_strPath.c_str(), m_iZoomFactor);
+      CLog::Log(LOGDEBUG, "Reloading the current image %s at zoom level %i", m_slides->Get(m_iCurrentSlide)->GetPath().c_str(), m_iZoomFactor);
       // first, our maximal size for this zoom level
       int maxWidth = (int)((float)g_settings.m_ResInfo[m_Resolution].iWidth * zoomamount[m_iZoomFactor - 1]);
       int maxHeight = (int)((float)g_settings.m_ResInfo[m_Resolution].iWidth * zoomamount[m_iZoomFactor - 1]);
@@ -391,20 +391,20 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
       if (maxWidth < width) width = maxWidth;
       if (maxHeight < height) height = maxHeight;
 
-      m_pBackgroundLoader->LoadPic(m_iCurrentPic, m_iCurrentSlide, m_slides->Get(m_iCurrentSlide)->m_strPath, width, height);
+      m_pBackgroundLoader->LoadPic(m_iCurrentPic, m_iCurrentSlide, m_slides->Get(m_iCurrentSlide)->GetPath(), width, height);
     }
   }
   else
   {
     if (m_iNextSlide != m_iCurrentSlide && m_Image[m_iCurrentPic].IsLoaded() && !m_Image[1 - m_iCurrentPic].IsLoaded() && !m_pBackgroundLoader->IsLoading() && !m_bWaitForNextPic)
     { // load the next image
-      CLog::Log(LOGDEBUG, "Loading the next image %s", m_slides->Get(m_iNextSlide)->m_strPath.c_str());
+      CLog::Log(LOGDEBUG, "Loading the next image %s", m_slides->Get(m_iNextSlide)->GetPath().c_str());
       int maxWidth, maxHeight;
       GetCheckedSize((float)g_settings.m_ResInfo[m_Resolution].iWidth * zoomamount[m_iZoomFactor - 1],
                      (float)g_settings.m_ResInfo[m_Resolution].iHeight * zoomamount[m_iZoomFactor - 1],
                      maxWidth, maxHeight);
       if (!m_slides->Get(m_iNextSlide)->IsVideo())
-        m_pBackgroundLoader->LoadPic(1 - m_iCurrentPic, m_iNextSlide, m_slides->Get(m_iNextSlide)->m_strPath, maxWidth, maxHeight);
+        m_pBackgroundLoader->LoadPic(1 - m_iCurrentPic, m_iNextSlide, m_slides->Get(m_iNextSlide)->GetPath(), maxWidth, maxHeight);
     }
   }
 
@@ -418,7 +418,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
 
   if (m_slides->Get(m_iCurrentSlide)->IsVideo() && bSlideShow)
   { 
-    CLog::Log(LOGDEBUG, "Playing slide %s as video", m_slides->Get(m_iCurrentSlide)->m_strPath.c_str());
+    CLog::Log(LOGDEBUG, "Playing slide %s as video", m_slides->Get(m_iCurrentSlide)->GetPath().c_str());
     m_bPlayingVideo = true;
     g_application.getApplicationMessenger().PlayFile(*m_slides->Get(m_iCurrentSlide));
     m_iCurrentSlide = m_iNextSlide;
@@ -427,7 +427,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   // Check if we should be transistioning immediately
   if (m_bLoadNextPic)
   {
-    CLog::Log(LOGDEBUG, "Starting immediate transistion due to user wanting slide %s", m_slides->Get(m_iNextSlide)->m_strPath.c_str());
+    CLog::Log(LOGDEBUG, "Starting immediate transistion due to user wanting slide %s", m_slides->Get(m_iNextSlide)->GetPath().c_str());
     if (m_Image[m_iCurrentPic].StartTransistion())
     {
       m_Image[m_iCurrentPic].SetTransistionTime(1, IMMEDIATE_TRANSISTION_TIME); // only 20 frames for the transistion
@@ -458,7 +458,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   // check if we should swap images now
   if (m_Image[m_iCurrentPic].IsFinished())
   {
-    CLog::Log(LOGDEBUG, "Image %s is finished rendering, switching to %s", m_slides->Get(m_iCurrentSlide)->m_strPath.c_str(), m_slides->Get(m_iNextSlide)->m_strPath.c_str());
+    CLog::Log(LOGDEBUG, "Image %s is finished rendering, switching to %s", m_slides->Get(m_iCurrentSlide)->GetPath().c_str(), m_slides->Get(m_iNextSlide)->GetPath().c_str());
     m_Image[m_iCurrentPic].Close();
     if (m_Image[1 - m_iCurrentPic].IsLoaded())
       m_iCurrentPic = 1 - m_iCurrentPic;
@@ -782,7 +782,7 @@ void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, CBaseTexture* pT
       delete pTexture;
       return;
     }
-    CLog::Log(LOGDEBUG, "Finished background loading %s", m_slides->Get(iSlideNumber)->m_strPath.c_str());
+    CLog::Log(LOGDEBUG, "Finished background loading %s", m_slides->Get(iSlideNumber)->GetPath().c_str());
     if (m_bReloadImage)
     {
       if (m_Image[m_iCurrentPic].IsLoaded() && m_Image[m_iCurrentPic].SlideNumber() != iSlideNumber)
@@ -804,9 +804,9 @@ void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, CBaseTexture* pT
       m_Image[iPic].Zoom(m_iZoomFactor, true);
 
       m_Image[iPic].m_bIsComic = false;
-      if (URIUtils::IsInRAR(m_slides->Get(m_iCurrentSlide)->m_strPath) || URIUtils::IsInZIP(m_slides->Get(m_iCurrentSlide)->m_strPath)) // move to top for cbr/cbz
+      if (URIUtils::IsInRAR(m_slides->Get(m_iCurrentSlide)->GetPath()) || URIUtils::IsInZIP(m_slides->Get(m_iCurrentSlide)->GetPath())) // move to top for cbr/cbz
       {
-        CURL url(m_slides->Get(m_iCurrentSlide)->m_strPath);
+        CURL url(m_slides->Get(m_iCurrentSlide)->GetPath());
         CStdString strHostName = url.GetHostName();
         if (URIUtils::GetExtension(strHostName).Equals(".cbr", false) || URIUtils::GetExtension(strHostName).Equals(".cbz", false))
         {
@@ -910,9 +910,9 @@ void CGUIWindowSlideShow::AddItems(const CStdString &strPath, path_set *recursiv
     CFileItemPtr item = items[i];
     if (item->m_bIsFolder && recursivePaths)
     {
-      AddItems(item->m_strPath, recursivePaths);
+      AddItems(item->GetPath(), recursivePaths);
     }
-    else if (!item->m_bIsFolder && !URIUtils::IsRAR(item->m_strPath) && !URIUtils::IsZIP(item->m_strPath))
+    else if (!item->m_bIsFolder && !URIUtils::IsRAR(item->GetPath()) && !URIUtils::IsZIP(item->GetPath()))
     { // add to the slideshow
       Add(item.get());
     }

--- a/xbmc/pictures/PictureInfoLoader.cpp
+++ b/xbmc/pictures/PictureInfoLoader.cpp
@@ -38,7 +38,7 @@ CPictureInfoLoader::~CPictureInfoLoader()
 void CPictureInfoLoader::OnLoaderStart()
 {
   // Load previously cached items from HD
-  m_mapFileItems->m_strPath=m_pVecItems->m_strPath;
+  m_mapFileItems->SetPath(m_pVecItems->GetPath());
   m_mapFileItems->Load();
   m_mapFileItems->SetFastLookup(true);
 
@@ -61,7 +61,7 @@ bool CPictureInfoLoader::LoadItem(CFileItem* pItem)
     return true;
 
   // first check the cached item
-  CFileItemPtr mapItem = (*m_mapFileItems)[pItem->m_strPath];
+  CFileItemPtr mapItem = (*m_mapFileItems)[pItem->GetPath()];
   if (mapItem && mapItem->m_dateTime==pItem->m_dateTime && mapItem->HasPictureInfoTag())
   { // Query map if we previously cached the file on HD
     *pItem->GetPictureInfoTag() = *mapItem->GetPictureInfoTag();
@@ -71,7 +71,7 @@ bool CPictureInfoLoader::LoadItem(CFileItem* pItem)
 
   if (m_loadTags)
   { // Nothing found, load tag from file
-    pItem->GetPictureInfoTag()->Load(pItem->m_strPath);
+    pItem->GetPictureInfoTag()->Load(pItem->GetPath());
     m_tagReads++;
   }
 

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -63,7 +63,7 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
   CStdString thumb;
   if (pItem->IsPicture() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
   { // load the thumb from the image file
-    CStdString image = pItem->HasThumbnail() ? pItem->GetThumbnailImage() : CTextureCache::GetWrappedThumbURL(pItem->m_strPath);
+    CStdString image = pItem->HasThumbnail() ? pItem->GetThumbnailImage() : CTextureCache::GetWrappedThumbURL(pItem->GetPath());
     thumb = CTextureCache::Get().CheckAndCacheImage(image);
   }
   else if (pItem->IsVideo() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
@@ -92,7 +92,7 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
       else if (g_guiSettings.GetBool("myvideos.extractthumb") && g_guiSettings.GetBool("myvideos.extractflags"))
       {
         CFileItem item(*pItem);
-        CThumbExtractor* extract = new CThumbExtractor(item, pItem->m_strPath, true, thumb);
+        CThumbExtractor* extract = new CThumbExtractor(item, pItem->GetPath(), true, thumb);
         AddJob(extract);
       }
     }
@@ -114,7 +114,7 @@ void CPictureThumbLoader::OnJobComplete(unsigned int jobID, bool success, CJob* 
   if (success)
   {
     CThumbExtractor* loader = (CThumbExtractor*)job;
-    loader->m_item.m_strPath = loader->m_listpath;
+    loader->m_item.SetPath(loader->m_listpath);
     CFileItemPtr pItem(new CFileItem(loader->m_item));
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, pItem);
     g_windowManager.SendThreadMessage(msg);
@@ -137,10 +137,10 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
   db.Open();
   if (pItem->IsCBR() || pItem->IsCBZ())
   {
-    CStdString strTBN(URIUtils::ReplaceExtension(pItem->m_strPath,".tbn"));
+    CStdString strTBN(URIUtils::ReplaceExtension(pItem->GetPath(),".tbn"));
     if (CFile::Exists(strTBN))
     {
-      db.SetTextureForPath(pItem->m_strPath, strTBN);
+      db.SetTextureForPath(pItem->GetPath(), strTBN);
       pItem->SetThumbnailImage(CTextureCache::Get().CheckAndCacheImage(strTBN));
       return;
     }
@@ -149,23 +149,23 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
   {
     // first check for a folder.jpg
     CStdString thumb = "folder.jpg";
-    CStdString strPath = pItem->m_strPath;
+    CStdString strPath = pItem->GetPath();
     if (pItem->IsCBR())
     {
-      URIUtils::CreateArchivePath(strPath,"rar",pItem->m_strPath,"");
+      URIUtils::CreateArchivePath(strPath,"rar",pItem->GetPath(),"");
       thumb = "cover.jpg";
     }
     if (pItem->IsCBZ())
     {
-      URIUtils::CreateArchivePath(strPath,"zip",pItem->m_strPath,"");
+      URIUtils::CreateArchivePath(strPath,"zip",pItem->GetPath(),"");
       thumb = "cover.jpg";
     }
     if (pItem->IsMultiPath())
-      strPath = CMultiPathDirectory::GetFirstPath(pItem->m_strPath);
+      strPath = CMultiPathDirectory::GetFirstPath(pItem->GetPath());
     thumb = URIUtils::AddFileToFolder(strPath, thumb);
     if (CFile::Exists(thumb))
     {
-      db.SetTextureForPath(pItem->m_strPath, thumb);
+      db.SetTextureForPath(pItem->GetPath(), thumb);
       pItem->SetThumbnailImage(CTextureCache::Get().CheckAndCacheImage(thumb));
       return;
     }
@@ -217,8 +217,8 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       if (items.Size() < 4 || pItem->IsCBR() || pItem->IsCBZ())
       { // less than 4 items, so just grab the first thumb
         items.Sort(SORT_METHOD_LABEL, SORT_ORDER_ASC);
-        CStdString thumb = CTextureCache::GetWrappedThumbURL(items[0]->m_strPath);
-        db.SetTextureForPath(pItem->m_strPath, thumb);
+        CStdString thumb = CTextureCache::GetWrappedThumbURL(items[0]->GetPath());
+        db.SetTextureForPath(pItem->GetPath(), thumb);
         thumb = CTextureCache::Get().CheckAndCacheImage(thumb);
         pItem->SetThumbnailImage(thumb);
       }
@@ -228,10 +228,10 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
         // we basically load the 4 thumbs, resample to 62x62 pixels, and add them
         CStdString strFiles[4];
         for (int thumb = 0; thumb < 4; thumb++)
-          strFiles[thumb] = CTextureCache::Get().CheckAndCacheImage(CTextureCache::GetWrappedThumbURL(items[thumb]->m_strPath), false);
-        CStdString thumb = CTextureCache::GetUniqueImage(pItem->m_strPath, ".png");
+          strFiles[thumb] = CTextureCache::Get().CheckAndCacheImage(CTextureCache::GetWrappedThumbURL(items[thumb]->GetPath()), false);
+        CStdString thumb = CTextureCache::GetUniqueImage(pItem->GetPath(), ".png");
         CPicture::CreateFolderThumb(strFiles, thumb);
-        db.SetTextureForPath(pItem->m_strPath, thumb);
+        db.SetTextureForPath(pItem->GetPath(), thumb);
         pItem->SetThumbnailImage(thumb);
       }
     }

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -58,7 +58,7 @@ void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)
 
   // videodb files are not supported by the filesystem as yet
   if (item->IsVideoDb())
-    item->m_strPath = item->GetVideoInfoTag()->m_strFileNameAndPath;
+    item->SetPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
 
   // increment the playable counter
   item->ClearProperty("unplayable");
@@ -67,7 +67,7 @@ void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)
   else
     m_iPlayableItems++;
 
-  //CLog::Log(LOGDEBUG,"%s item:(%02i/%02i)[%s]", __FUNCTION__, iPosition, item->m_iprogramCount, item->m_strPath.c_str());
+  //CLog::Log(LOGDEBUG,"%s item:(%02i/%02i)[%s]", __FUNCTION__, iPosition, item->m_iprogramCount, item->GetPath().c_str());
   if (iPosition == iOldSize)
     m_vecItems.push_back(item);
   else
@@ -265,7 +265,7 @@ void CPlayList::Remove(const CStdString& strFileName)
   while (it != m_vecItems.end() )
   {
     CFileItemPtr item = *it;
-    if (item->m_strPath == strFileName)
+    if (item->GetPath() == strFileName)
     {
       iOrder = item->m_iprogramCount;
       it = m_vecItems.erase(it);
@@ -311,7 +311,7 @@ int CPlayList::RemoveDVDItems()
     CFileItemPtr item = *it;
     if ( item->IsCDDA() || item->IsOnDVD() )
     {
-      vecFilenames.push_back( item->m_strPath );
+      vecFilenames.push_back( item->GetPath() );
     }
     it++;
   }
@@ -418,13 +418,13 @@ bool CPlayList::Expand(int position)
   if ( NULL == playlist.get())
     return false;
 
-  if(!playlist->Load(item->m_strPath))
+  if(!playlist->Load(item->GetPath()))
     return false;
 
   // remove any item that points back to itself
   for(int i = 0;i<playlist->size();i++)
   {
-    if( (*playlist)[i]->m_strPath.Equals( item->m_strPath ) )
+    if( (*playlist)[i]->GetPath().Equals( item->GetPath() ) )
     {
       playlist->Remove(i);
       i--;
@@ -446,7 +446,7 @@ void CPlayList::UpdateItem(const CFileItem *item)
   for (ivecItems it = m_vecItems.begin(); it != m_vecItems.end(); ++it)
   {
     CFileItemPtr playlistItem = *it;
-    if (playlistItem->m_strPath == item->m_strPath)
+    if (playlistItem->GetPath() == item->GetPath())
     {
       *playlistItem = *item;
       break;
@@ -459,5 +459,5 @@ const CStdString& CPlayList::ResolveURL(const CFileItemPtr &item ) const
   if (item->IsMusicDb() && item->HasMusicInfoTag())
     return item->GetMusicInfoTag()->GetURL();
   else
-    return item->m_strPath;
+    return item->GetPath();
 }

--- a/xbmc/playlists/PlayListB4S.cpp
+++ b/xbmc/playlists/PlayListB4S.cpp
@@ -102,7 +102,7 @@ bool CPlayListB4S::LoadData(istream& stream)
           strFileName = CUtil::SubstitutePath(strFileName);
         CUtil::GetQualifiedFilename(m_strBasePath, strFileName);
         CFileItemPtr newItem(new CFileItem(strInfo));
-        newItem->m_strPath = strFileName;
+        newItem->SetPath(strFileName);
         newItem->GetMusicInfoTag()->SetDuration(lDuration);
         Add(newItem);
       }
@@ -130,7 +130,7 @@ void CPlayListB4S::Save(const CStdString& strFileName) const
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
     const CFileItemPtr item = m_vecItems[i];
-    write.AppendFormat("    <entry Playstring=%cfile:%s%c>\n", 34, item->m_strPath.c_str(), 34 );
+    write.AppendFormat("    <entry Playstring=%cfile:%s%c>\n", 34, item->GetPath().c_str(), 34 );
     write.AppendFormat("      <Name>%s</Name>\n", item->GetLabel().c_str());
     write.AppendFormat("      <Length>%u</Length>\n", item->GetMusicInfoTag()->GetDuration());
   }

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -70,7 +70,7 @@ CPlayList* CPlayListFactory::Create(const CFileItem& item)
       return new CPlayListWPL();
   }
 
-  CStdString extension = URIUtils::GetExtension(item.m_strPath);
+  CStdString extension = URIUtils::GetExtension(item.GetPath());
   extension.MakeLower();
 
   if (extension == ".m3u" || extension == ".strm")
@@ -123,7 +123,7 @@ bool CPlayListFactory::IsPlaylist(const CFileItem& item)
   || strMimeType == "audio/x-mpegurl")
     return true;
 
-  return IsPlaylist(item.m_strPath);
+  return IsPlaylist(item.GetPath());
 }
 
 bool CPlayListFactory::IsPlaylist(const CStdString& filename)

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -126,7 +126,7 @@ bool CPlayListM3U::Load(const CStdString& strFileName)
         // Get the full path file name and add it to the the play list
         CUtil::GetQualifiedFilename(m_strBasePath, strFileName);
         CFileItemPtr newItem(new CFileItem(strInfo));
-        newItem->m_strPath = strFileName;
+        newItem->SetPath(strFileName);
         if (lDuration && newItem->IsAudio())
           newItem->GetMusicInfoTag()->SetDuration(lDuration);
         Add(newItem);

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -153,7 +153,7 @@ bool CPlayListPLS::Load(const CStdString &strFile)
           strValue = CUtil::SubstitutePath(strValue);
         CUtil::GetQualifiedFilename(m_strBasePath, strValue);
         g_charsetConverter.unknownToUTF8(strValue);
-        m_vecItems[idx - 1]->m_strPath = strValue;
+        m_vecItems[idx - 1]->SetPath(strValue);
       }
       else if (strLeft.Left(5) == "title")
       {
@@ -195,7 +195,7 @@ bool CPlayListPLS::Load(const CStdString &strFile)
   ivecItems p = m_vecItems.begin();
   while ( p != m_vecItems.end())
   {
-    if ((*p)->m_strPath.empty())
+    if ((*p)->GetPath().empty())
     {
       p = m_vecItems.erase(p);
     }
@@ -227,7 +227,7 @@ void CPlayListPLS::Save(const CStdString& strFileName) const
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
     CFileItemPtr item = m_vecItems[i];
-    CStdString strFileName=item->m_strPath;
+    CStdString strFileName=item->GetPath();
     g_charsetConverter.utf8ToStringCharset(strFileName);
     CStdString strDescription=item->GetLabel();
     g_charsetConverter.utf8ToStringCharset(strDescription);
@@ -277,7 +277,7 @@ bool CPlayListASX::LoadAsxIniInfo(istream &stream)
 
     CLog::Log(LOGINFO, "Adding element %s=%s", name.c_str(), value.c_str());
     CFileItemPtr newItem(new CFileItem(value));
-    newItem->m_strPath = value;
+    newItem->SetPath(value);
     Add(newItem);
   }
 
@@ -371,7 +371,7 @@ bool CPlayListASX::LoadData(istream& stream)
 
             CLog::Log(LOGINFO, "Adding element %s, %s", title.c_str(), value.c_str());
             CFileItemPtr newItem(new CFileItem(title));
-            newItem->m_strPath = value;
+            newItem->SetPath(value);
             Add(newItem);
           }
           pRef = pRef->NextSiblingElement("ref");
@@ -406,7 +406,7 @@ bool CPlayListRAM::LoadData(istream& stream)
 
   CLog::Log(LOGINFO, "Adding element %s", strMMS.c_str());
   CFileItemPtr newItem(new CFileItem(strMMS));
-  newItem->m_strPath = strMMS;
+  newItem->SetPath(strMMS);
   Add(newItem);
   return true;
 }

--- a/xbmc/playlists/PlayListWPL.cpp
+++ b/xbmc/playlists/PlayListWPL.cpp
@@ -98,7 +98,7 @@ bool CPlayListWPL::LoadData(istream& stream)
       CUtil::GetQualifiedFilename(m_strBasePath, strFileName);
       CStdString strDescription = URIUtils::GetFileName(strFileName);
       CFileItemPtr newItem(new CFileItem(strDescription));
-      newItem->m_strPath = strFileName;
+      newItem->SetPath(strFileName);
       Add(newItem);
     }
     pMediaElement = pMediaElement->NextSiblingElement();
@@ -129,7 +129,7 @@ void CPlayListWPL::Save(const CStdString& strFileName) const
   for (int i = 0; i < (int)m_vecItems.size(); ++i)
   {
     CFileItemPtr item = m_vecItems[i];
-    write.AppendFormat("            <media src=%c%s%c/>", 34, item->m_strPath.c_str(), 34);
+    write.AppendFormat("            <media src=%c%s%c/>", 34, item->GetPath().c_str(), 34);
   }
   write.AppendFormat("        </seq>\n");
   write.AppendFormat("    </body>\n");

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -132,7 +132,7 @@ bool CPlayListXML::Load( const CStdString& strFileName )
 
        CStdString info = name;
        CFileItemPtr newItem( new CFileItem(info) );
-       newItem->m_strPath = url;
+       newItem->SetPath(url);
 
        // Set language as metadata
        if ( !lang.IsEmpty() )
@@ -185,7 +185,7 @@ void CPlayListXML::Save(const CStdString& strFileName) const
   {
     CFileItemPtr item = m_vecItems[i];
     write.AppendFormat("  <stream>\n" );
-    write.AppendFormat("    <url>%s</url>", item->m_strPath.c_str() );
+    write.AppendFormat("    <url>%s</url>", item->GetPath().c_str() );
     write.AppendFormat("    <name>%s</name>", item->GetLabel().c_str() );
 
     if ( !item->GetProperty("language").IsEmpty() )

--- a/xbmc/programs/GUIViewStatePrograms.cpp
+++ b/xbmc/programs/GUIViewStatePrograms.cpp
@@ -43,12 +43,12 @@ CGUIViewStateWindowPrograms::CGUIViewStateWindowPrograms(const CFileItemList& it
   SetViewAsControl(g_settings.m_viewStatePrograms.m_viewMode);
   SetSortOrder(g_settings.m_viewStatePrograms.m_sortOrder);
 
-  LoadViewState(items.m_strPath, WINDOW_PROGRAMS);
+  LoadViewState(items.GetPath(), WINDOW_PROGRAMS);
 }
 
 void CGUIViewStateWindowPrograms::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_PROGRAMS, &g_settings.m_viewStatePrograms);
+  SaveViewToDb(m_items.GetPath(), WINDOW_PROGRAMS, &g_settings.m_viewStatePrograms);
 }
 
 CStdString CGUIViewStateWindowPrograms::GetLockType()

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -78,7 +78,7 @@ bool CGUIWindowPrograms::OnMessage(CGUIMessage& message)
       m_dlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
 
       // is this the first time accessing this window?
-      if (m_vecItems->m_strPath == "?" && message.GetStringParam().IsEmpty())
+      if (m_vecItems->GetPath() == "?" && message.GetStringParam().IsEmpty())
         message.SetStringParam(g_settings.m_defaultProgramSource);
 
       m_database.Open();
@@ -179,7 +179,7 @@ bool CGUIWindowPrograms::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CShortcut cut;
       if (item->IsShortCut())
       {
-        cut.Create(item->m_strPath);
+        cut.Create(item->GetPath());
         strDescription = cut.m_strLabel;
       }
       else
@@ -190,15 +190,15 @@ bool CGUIWindowPrograms::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         if (item->IsShortCut())
         {
           cut.m_strLabel = strDescription;
-          cut.Save(item->m_strPath);
+          cut.Save(item->GetPath());
         }
         else
         {
           // SetXBEDescription will truncate to 40 characters.
-          //CUtil::SetXBEDescription(item->m_strPath,strDescription);
-          //m_database.SetDescription(item->m_strPath,strDescription);
+          //CUtil::SetXBEDescription(item->GetPath(),strDescription);
+          //m_database.SetDescription(item->GetPath(),strDescription);
         }
-        Update(m_vecItems->m_strPath);
+        Update(m_vecItems->GetPath());
       }
       return true;
     }

--- a/xbmc/programs/ProgramDatabase.cpp
+++ b/xbmc/programs/ProgramDatabase.cpp
@@ -186,7 +186,7 @@ uint32_t CProgramDatabase::GetProgramInfo(CFileItem *item)
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
-    CStdString strSQL = PrepareSQL("select xbedescription,iTimesPlayed,lastAccessed,titleId,iSize from files where strFileName like '%s'", item->m_strPath.c_str());
+    CStdString strSQL = PrepareSQL("select xbedescription,iTimesPlayed,lastAccessed,titleId,iSize from files where strFileName like '%s'", item->GetPath().c_str());
     m_pDS->query(strSQL.c_str());
     if (!m_pDS->eof())
     { // get info - only set the label if not preformatted
@@ -200,9 +200,9 @@ uint32_t CProgramDatabase::GetProgramInfo(CFileItem *item)
       if (item->m_dwSize == -1)
       {
         CStdString strPath;
-        URIUtils::GetDirectory(item->m_strPath,strPath);
+        URIUtils::GetDirectory(item->GetPath(),strPath);
         int64_t iSize = CGUIWindowFileManager::CalculateFolderSize(strPath);
-        CStdString strSQL=PrepareSQL("update files set iSize=%I64u where strFileName like '%s'",iSize,item->m_strPath.c_str());
+        CStdString strSQL=PrepareSQL("update files set iSize=%I64u where strFileName like '%s'",iSize,item->GetPath().c_str());
         m_pDS->exec(strSQL.c_str());
       }
     }
@@ -210,7 +210,7 @@ uint32_t CProgramDatabase::GetProgramInfo(CFileItem *item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CProgramDatabase::GetProgramInfo(%s) failed", item->m_strPath.c_str());
+    CLog::Log(LOGERROR, "CProgramDatabase::GetProgramInfo(%s) failed", item->GetPath().c_str());
   }
   return titleID;
 }
@@ -236,7 +236,7 @@ bool CProgramDatabase::AddProgramInfo(CFileItem *item, unsigned int titleID)
     lastAccessed.u.HighPart = time.dwHighDateTime;
 
     CStdString strPath;
-    URIUtils::GetDirectory(item->m_strPath,strPath);
+    URIUtils::GetDirectory(item->GetPath(),strPath);
     // special case - programs in root of sources
     bool bIsShare=false;
     CUtil::GetMatchingSource(strPath,g_settings.m_programSources,bIsShare);
@@ -244,20 +244,20 @@ bool CProgramDatabase::AddProgramInfo(CFileItem *item, unsigned int titleID)
     if (bIsShare)
     {
       struct __stat64 stat;
-      if (CFile::Stat(item->m_strPath,&stat) == 0)
+      if (CFile::Stat(item->GetPath(),&stat) == 0)
         iSize = stat.st_size;
     }
     else
       iSize = CGUIWindowFileManager::CalculateFolderSize(strPath);
     if (titleID == 0)
       titleID = (unsigned int) -1;
-    CStdString strSQL=PrepareSQL("insert into files (idFile, strFileName, titleId, xbedescription, iTimesPlayed, lastAccessed, iRegion, iSize) values(NULL, '%s', %u, '%s', %i, %I64u, %i, %I64u)", item->m_strPath.c_str(), titleID, item->GetLabel().c_str(), 0, lastAccessed.QuadPart, iRegion, iSize);
+    CStdString strSQL=PrepareSQL("insert into files (idFile, strFileName, titleId, xbedescription, iTimesPlayed, lastAccessed, iRegion, iSize) values(NULL, '%s', %u, '%s', %i, %I64u, %i, %I64u)", item->GetPath().c_str(), titleID, item->GetLabel().c_str(), 0, lastAccessed.QuadPart, iRegion, iSize);
     m_pDS->exec(strSQL.c_str());
     item->m_dwSize = iSize;
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CProgramDatabase::AddProgramInfo(%s) failed", item->m_strPath.c_str());
+    CLog::Log(LOGERROR, "CProgramDatabase::AddProgramInfo(%s) failed", item->GetPath().c_str());
   }
   return true;
 }

--- a/xbmc/settings/AppParamParser.cpp
+++ b/xbmc/settings/AppParamParser.cpp
@@ -142,7 +142,7 @@ void CAppParamParser::ParseArg(const CStdString &arg)
     if (m_testmode)
       g_application.SetEnableTestMode(true);
     CFileItemPtr pItem(new CFileItem(arg));
-    pItem->m_strPath = arg;
+    pItem->SetPath(arg);
     m_playlist.Add(pItem);
   }
 }

--- a/xbmc/settings/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/GUIDialogContentSettings.cpp
@@ -85,8 +85,8 @@ bool CGUIDialogContentSettings::OnMessage(CGUIMessage &message)
       { // Get More... item.
         // This is tricky - ideally we want to completely save the state of this dialog,
         // close it while linking to the addon manager, then reopen it on return.
-        // For now, we just close the dialog + send the message to open the addons window
-        CStdString content = m_vecItems->Get(iSelected)->m_strPath.Mid(14);
+        // For now, we just close the dialog + send the GetPath() to open the addons window
+        CStdString content = m_vecItems->Get(iSelected)->GetPath().Mid(14);
         OnCancel();
         Close();
         CBuiltins::Execute("ActivateWindow(AddonBrowser,addons://all/xbmc.metadata.scraper." + content + ",return)");
@@ -325,7 +325,7 @@ void CGUIDialogContentSettings::FillListControl()
   for (IVECADDONS iter=m_scrapers.find(m_content)->second.begin();iter!=m_scrapers.find(m_content)->second.end();++iter)
   {
     CFileItemPtr item(new CFileItem((*iter)->Name()));
-    item->m_strPath = (*iter)->ID();
+    item->SetPath((*iter)->ID());
     item->SetThumbnailImage((*iter)->Icon());
     if (m_scraper && (*iter)->ID() == m_scraper->ID())
     {

--- a/xbmc/settings/GUIWindowSettingsProfile.cpp
+++ b/xbmc/settings/GUIWindowSettingsProfile.cpp
@@ -183,7 +183,6 @@ void CGUIWindowSettingsProfile::LoadList()
   {
     const CProfile *profile = g_settings.GetProfile(i);
     CFileItemPtr item(new CFileItem(profile->getName()));
-    item->m_strPath.Empty();
     item->SetLabel2(profile->getDate());
     item->SetThumbnailImage(profile->getThumb());
     item->SetOverlayImage(profile->getLockMode() == LOCK_MODE_EVERYONE ? CGUIListItem::ICON_OVERLAY_NONE : CGUIListItem::ICON_OVERLAY_LOCKED);
@@ -191,7 +190,6 @@ void CGUIWindowSettingsProfile::LoadList()
   }
   {
     CFileItemPtr item(new CFileItem(g_localizeStrings.Get(20058)));
-    item->m_strPath.Empty();
     m_listItems->Add(item);
   }
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_PROFILES, 0, 0, m_listItems);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -995,7 +995,7 @@ bool CSettings::DeleteProfile(unsigned int index)
       }
 
       CFileItemPtr item = CFileItemPtr(new CFileItem(URIUtils::AddFileToFolder(GetUserDataFolder(), strDirectory)));
-      item->m_strPath = URIUtils::AddFileToFolder(GetUserDataFolder(), strDirectory + "\\");
+      item->SetPath(URIUtils::AddFileToFolder(GetUserDataFolder(), strDirectory + "/"));
       item->m_bIsFolder = true;
       item->Select(true);
       CFileUtils::DeleteItem(item);

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -109,7 +109,7 @@ bool CFileOperationJob::DoProcessFolder(FileAction action, const CStdString& str
   {
     CFileItemPtr pItem = items[i];
     pItem->Select(true);
-    CLog::Log(LOGDEBUG,"  -- %s",pItem->m_strPath.c_str());
+    CLog::Log(LOGDEBUG,"  -- %s",pItem->GetPath().c_str());
   }
 
   if (!DoProcess(action, items, strDestFile, fileOperations, totalTime)) return false;
@@ -130,12 +130,12 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
     CFileItemPtr pItem = items[iItem];
     if (pItem->IsSelected())
     {
-      CStdString strNoSlash = pItem->m_strPath;
+      CStdString strNoSlash = pItem->GetPath();
       URIUtils::RemoveSlashAtEnd(strNoSlash);
       CStdString strFileName = URIUtils::GetFileName(strNoSlash);
 
       // special case for upnp
-      if (URIUtils::IsUPnP(items.m_strPath) || URIUtils::IsUPnP(pItem->m_strPath))
+      if (URIUtils::IsUPnP(items.GetPath()) || URIUtils::IsUPnP(pItem->GetPath()))
       {
         // get filename from label instead of path
         strFileName = pItem->GetLabel();
@@ -144,7 +144,7 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
         {
           // FIXME: for now we only work well if the url has the extension
           // we should map the content type to the extension otherwise
-          strFileName += URIUtils::GetExtension(pItem->m_strPath);
+          strFileName += URIUtils::GetExtension(pItem->GetPath());
         }
 
         strFileName = CUtil::MakeLegalFileName(strFileName);
@@ -165,13 +165,13 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
           DoProcessFile(ActionCreateFolder, strnewDestFile, "", fileOperations, totalTime);
         if (action == ActionReplace && CDirectory::Exists(strnewDestFile))
           DoProcessFolder(ActionDelete, strnewDestFile, "", fileOperations, totalTime);
-        if (!DoProcessFolder(subdirAction, pItem->m_strPath, strnewDestFile, fileOperations, totalTime))
+        if (!DoProcessFolder(subdirAction, pItem->GetPath(), strnewDestFile, fileOperations, totalTime))
           return false;
         if (action == ActionDelete)
-          DoProcessFile(ActionDeleteFolder, pItem->m_strPath, "", fileOperations, totalTime);
+          DoProcessFile(ActionDeleteFolder, pItem->GetPath(), "", fileOperations, totalTime);
       }
       else
-        DoProcessFile(action, pItem->m_strPath, strnewDestFile, fileOperations, totalTime);
+        DoProcessFile(action, pItem->GetPath(), strnewDestFile, fileOperations, totalTime);
     }
   }
   return true;

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -23,7 +23,7 @@ bool CFileUtils::DeleteItem(const CFileItemPtr &item, bool force)
   {
     pDialog->SetHeading(122);
     pDialog->SetLine(0, 125);
-    pDialog->SetLine(1, URIUtils::GetFileName(item->m_strPath));
+    pDialog->SetLine(1, URIUtils::GetFileName(item->GetPath()));
     pDialog->SetLine(2, "");
     pDialog->DoModal();
     if (!pDialog->IsConfirmed()) return false;

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -203,14 +203,14 @@ CStdString CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFileI
     }
     break;
   case 'F': // filename
-    value = CUtil::GetTitleFromPath(item->m_strPath, item->m_bIsFolder && !item->IsFileFolder());
+    value = CUtil::GetTitleFromPath(item->GetPath(), item->m_bIsFolder && !item->IsFileFolder());
     break;
   case 'L':
     value = item->GetLabel();
     // is the label the actual file or folder name?
-    if (value == URIUtils::GetFileName(item->m_strPath))
+    if (value == URIUtils::GetFileName(item->GetPath()))
     { // label is the same as filename, clean it up as appropriate
-      value = CUtil::GetTitleFromPath(item->m_strPath, item->m_bIsFolder && !item->IsFileFolder());
+      value = CUtil::GetTitleFromPath(item->GetPath(), item->m_bIsFolder && !item->IsFileFolder());
     }
     break;
   case 'D':

--- a/xbmc/utils/SaveFileStateJob.h
+++ b/xbmc/utils/SaveFileStateJob.h
@@ -23,7 +23,7 @@ public:
 
 bool CSaveFileStateJob::DoWork()
 {
-  CStdString progressTrackingFile = m_item.m_strPath;
+  CStdString progressTrackingFile = m_item.GetPath();
 
   if (m_item.IsDVD()) 
     progressTrackingFile = m_item.GetVideoInfoTag()->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label
@@ -84,7 +84,7 @@ bool CSaveFileStateJob::DoWork()
           CUtil::DeleteVideoDatabaseDirectoryCache();
           CFileItemPtr msgItem(new CFileItem(m_item));
           if (m_item.HasProperty("original_listitem_url"))
-            msgItem->m_strPath = m_item.GetProperty("original_listitem_url");
+            msgItem->SetPath(m_item.GetProperty("original_listitem_url"));
           CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 1, msgItem); // 1 to update the listing as well
           g_windowManager.SendThreadMessage(message);
         }

--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -97,7 +97,7 @@ void CTuxBoxService::Process()
 
   while(!CThread::m_bStop && g_application.IsPlaying())
   {
-    strURL = g_application.CurrentFileItem().m_strPath;
+    strURL = g_application.CurrentFileItem().GetPath();
     if(!URIUtils::IsTuxBox(strURL))
       break;
 
@@ -135,10 +135,10 @@ bool CTuxBoxUtil::CreateNewItem(const CFileItem& item, CFileItem& item_new)
 {
   //Build new Item
   item_new.SetLabel(item.GetLabel());
-  item_new.m_strPath = item.m_strPath;
+  item_new.SetPath(item.GetPath());
   item_new.SetThumbnailImage(item.GetThumbnailImage());
 
-  if(g_tuxbox.GetZapUrl(item.m_strPath, item_new))
+  if(g_tuxbox.GetZapUrl(item.GetPath(), item_new))
   {
     if(vVideoSubChannel.mode)
       vVideoSubChannel.current_name = item_new.GetLabel()+" ("+vVideoSubChannel.current_name+")";
@@ -202,11 +202,11 @@ bool CTuxBoxUtil::ParseBouquets(TiXmlElement *root, CFileItemList &items, CURL &
             pItem->m_bIsFolder = true;
             pItem->SetLabel(strItemName);
             url.SetOptions("/"+strOptions+"&reference="+strItemPath);
-            pItem->m_strPath = "tuxbox://"+url.GetUserName()+":"+url.GetPassWord()+"@"+url.GetHostName()+strPort+url.GetOptions();
+            pItem->SetPath("tuxbox://"+url.GetUserName()+":"+url.GetPassWord()+"@"+url.GetHostName()+strPort+url.GetOptions());
             items.Add(pItem);
             //DEBUG Log
             CLog::Log(LOGDEBUG, "%s - Name:    %s", __FUNCTION__,strItemName.c_str());
-            CLog::Log(LOGDEBUG, "%s - Adress:  %s", __FUNCTION__,pItem->m_strPath.c_str());
+            CLog::Log(LOGDEBUG, "%s - Adress:  %s", __FUNCTION__,pItem->GetPath().c_str());
           }
         }
         pNode = pNode->NextSibling(strChild.c_str());
@@ -250,7 +250,7 @@ bool CTuxBoxUtil::ParseBouquetsEnigma2(TiXmlElement *root, CFileItemList &items,
       CStdString strItemName = pIt->FirstChild()->Value();
       pItem->m_bIsFolder = true;
       pItem->SetLabel(strItemName);
-      pItem->m_strPath = "tuxbox://"+url.GetHostName()+strPort+"/"+strItemName+"/";
+      pItem->SetPath("tuxbox://"+url.GetHostName()+strPort+"/"+strItemName+"/");
       items.Add(pItem);
       pNode = pNode->NextSiblingElement("e2bouquet");
     }
@@ -317,12 +317,12 @@ bool CTuxBoxUtil::ParseChannels(TiXmlElement *root, CFileItemList &items, CURL &
                     pbItem->m_bIsFolder = false;
                     pbItem->SetLabel(strItemName);
                     pbItem->SetLabelPreformated(true);
-                    pbItem->m_strPath = "tuxbox://"+url.GetUserName()+":"+url.GetPassWord()+"@"+url.GetHostName()+strPort+"/cgi-bin/zapTo?path="+strItemPath+".ts";
+                    pbItem->SetPath("tuxbox://"+url.GetUserName()+":"+url.GetPassWord()+"@"+url.GetHostName()+strPort+"/cgi-bin/zapTo?path="+strItemPath+".ts");
                     pbItem->SetThumbnailImage(GetPicon(strItemName)); //Set Picon Image
 
                     //DEBUG Log
                     CLog::Log(LOGDEBUG, "%s - Name:    %s", __FUNCTION__,strItemName.c_str());
-                    CLog::Log(LOGDEBUG, "%s - Adress:  %s", __FUNCTION__,pbItem->m_strPath.c_str());
+                    CLog::Log(LOGDEBUG, "%s - Adress:  %s", __FUNCTION__,pbItem->GetPath().c_str());
 
                     //add to the list
                     items.Add(pbItem);
@@ -378,11 +378,11 @@ bool CTuxBoxUtil::ParseChannelsEnigma2(TiXmlElement *root, CFileItemList &items,
           CFileItemPtr pbItem(new CFileItem);
           pbItem->m_bIsFolder = false;
           pbItem->SetLabel(strItemName);
-          pbItem->m_strPath = "http://"+url.GetHostName()+":8001/"+strItemPath;
+          pbItem->SetPath("http://"+url.GetHostName()+":8001/"+strItemPath);
           pbItem->SetMimeType("video/mpeg2");
           items.Add(pbItem);
           CLog::Log(LOGDEBUG, "%s - Name:    %s", __FUNCTION__,strItemName.c_str());
-          CLog::Log(LOGDEBUG, "%s - Adress:  %s", __FUNCTION__,pbItem->m_strPath.c_str());
+          CLog::Log(LOGDEBUG, "%s - Adress:  %s", __FUNCTION__,pbItem->GetPath().c_str());
         }
         pIta = pIta->NextSiblingElement("e2service");
       }
@@ -594,7 +594,7 @@ bool CTuxBoxUtil::GetZapUrl(const CStdString& strPath, CFileItem &items )
       items.GetVideoInfoTag()->m_strTitle = strTitle; // VIDEOPLAYER_TITLE: current_event_details     (Film beschreibung)
       items.GetVideoInfoTag()->m_strRuntime = StringUtils::SecondsToTimeString(iDuration); //VIDEOPLAYER_DURATION: current_event_duration (laufzeit in sec.)
 
-      items.m_strPath = strStreamURL;
+      items.SetPath(strStreamURL);
       items.m_iDriveType = url.GetPort(); // Dirty Hack! But i need to hold the Port ;)
       items.SetLabel(items.GetLabel()); // VIDEOPLAYER_DIRECTOR: service_name (Program Name)
       items.SetLabel2(sCurSrvData.current_event_description); // current_event_description (Film Name)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -250,20 +250,20 @@ bool URIUtils::GetParentPath(const CStdString& strPath, CStdString& strParent)
     CStackDirectory dir;
     CFileItemList items;
     dir.GetDirectory(strPath,items);
-    GetDirectory(items[0]->m_strPath,items[0]->m_strDVDLabel);
+    GetDirectory(items[0]->GetPath(),items[0]->m_strDVDLabel);
     if (items[0]->m_strDVDLabel.Mid(0,6).Equals("rar://") || items[0]->m_strDVDLabel.Mid(0,6).Equals("zip://"))
       GetParentPath(items[0]->m_strDVDLabel, strParent);
     else
       strParent = items[0]->m_strDVDLabel;
     for( int i=1;i<items.Size();++i)
     {
-      GetDirectory(items[i]->m_strPath,items[i]->m_strDVDLabel);
+      GetDirectory(items[i]->GetPath(),items[i]->m_strDVDLabel);
       if (items[0]->m_strDVDLabel.Mid(0,6).Equals("rar://") || items[0]->m_strDVDLabel.Mid(0,6).Equals("zip://"))
-        GetParentPath(items[i]->m_strDVDLabel, items[i]->m_strPath);
+        items[i]->SetPath(GetParentPath(items[i]->m_strDVDLabel));
       else
-        items[i]->m_strPath = items[i]->m_strDVDLabel;
+        items[i]->SetPath(items[i]->m_strDVDLabel);
 
-      GetCommonPath(strParent,items[i]->m_strPath);
+      GetCommonPath(strParent,items[i]->GetPath());
     }
     return true;
   }

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -84,12 +84,12 @@ CGUIViewStateWindowVideoFiles::CGUIViewStateWindowVideoFiles(const CFileItemList
     SetViewAsControl(g_settings.m_viewStateVideoFiles.m_viewMode);
     SetSortOrder(g_settings.m_viewStateVideoFiles.m_sortOrder);
   }
-  LoadViewState(items.m_strPath, WINDOW_VIDEO_FILES);
+  LoadViewState(items.GetPath(), WINDOW_VIDEO_FILES);
 }
 
 void CGUIViewStateWindowVideoFiles::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_FILES, &g_settings.m_viewStateVideoFiles);
+  SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_FILES, &g_settings.m_viewStateVideoFiles);
 }
 
 VECSOURCES& CGUIViewStateWindowVideoFiles::GetSources()
@@ -111,9 +111,9 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
   }
   else if (items.IsVideoDb())
   {
-    NODE_TYPE NodeType=CVideoDatabaseDirectory::GetDirectoryChildType(items.m_strPath);
+    NODE_TYPE NodeType=CVideoDatabaseDirectory::GetDirectoryChildType(items.GetPath());
     CQueryParams params;
-    CVideoDatabaseDirectory::GetQueryParams(items.m_strPath,params);
+    CVideoDatabaseDirectory::GetQueryParams(items.GetPath(),params);
 
     switch (NodeType)
     {
@@ -356,47 +356,47 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
     SetViewAsControl(g_settings.m_viewStateVideoFiles.m_viewMode);
     SetSortOrder(g_settings.m_viewStateVideoFiles.m_sortOrder);
   }
-  LoadViewState(items.m_strPath, WINDOW_VIDEO_NAV);
+  LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
 }
 
 void CGUIViewStateWindowVideoNav::SaveViewState()
 {
   if (m_items.IsVideoDb())
   {
-    NODE_TYPE NodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_items.m_strPath);
+    NODE_TYPE NodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_items.GetPath());
     switch (NodeType)
     {
     case NODE_TYPE_ACTOR:
-      SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavActors);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavActors);
       break;
     case NODE_TYPE_YEAR:
-      SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavYears);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavYears);
       break;
     case NODE_TYPE_GENRE:
-      SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavGenres);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavGenres);
       break;
     case NODE_TYPE_TITLE_MOVIES:
-      SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTitles);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTitles);
       break;
     case NODE_TYPE_EPISODES:
-      SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavEpisodes);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavEpisodes);
       break;
     case NODE_TYPE_TITLE_TVSHOWS:
-      SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTvShows);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTvShows);
       break;
     case NODE_TYPE_SEASONS:
-      SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavSeasons);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavSeasons);
       break;
     case NODE_TYPE_TITLE_MUSICVIDEOS:
-      SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavMusicVideos);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavMusicVideos);
     default:
-      SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV);
       break;
     }
   }
   else
   {
-    SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoFiles);
+    SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoFiles);
   }
 }
 
@@ -412,7 +412,7 @@ VECSOURCES& CGUIViewStateWindowVideoNav::GetSources()
     CFileItemPtr item=items[i];
     CMediaSource share;
     share.strName=item->GetLabel();
-    share.strPath = item->m_strPath;
+    share.strPath = item->GetPath();
     share.m_strThumbnailImage= item->GetIconImage();
     share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
     m_sources.push_back(share);
@@ -452,7 +452,7 @@ VECSOURCES& CGUIViewStateWindowVideoNav::GetSources()
 bool CGUIViewStateWindowVideoNav::AutoPlayNextItem()
 {
   CQueryParams params;
-  CVideoDatabaseDirectory::GetQueryParams(m_items.m_strPath,params);
+  CVideoDatabaseDirectory::GetQueryParams(m_items.GetPath(),params);
   if (params.GetContentType() == VIDEODB_CONTENT_MUSICVIDEOS || params.GetContentType() == 6) // recently added musicvideos
     return g_guiSettings.GetBool("musicplayer.autoplaynextitem");
 
@@ -468,12 +468,12 @@ CGUIViewStateWindowVideoPlaylist::CGUIViewStateWindowVideoPlaylist(const CFileIt
 
   SetSortOrder(SORT_ORDER_NONE);
 
-  LoadViewState(items.m_strPath, WINDOW_VIDEO_PLAYLIST);
+  LoadViewState(items.GetPath(), WINDOW_VIDEO_PLAYLIST);
 }
 
 void CGUIViewStateWindowVideoPlaylist::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_PLAYLIST);
+  SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_PLAYLIST);
 }
 
 bool CGUIViewStateWindowVideoPlaylist::HideExtensions()
@@ -522,12 +522,12 @@ CGUIViewStateVideoMovies::CGUIViewStateVideoMovies(const CFileItemList& items) :
 
   SetSortOrder(g_settings.m_viewStateVideoNavTitles.m_sortOrder);
 
-  LoadViewState(items.m_strPath, WINDOW_VIDEO_NAV);
+  LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
 }
 
 void CGUIViewStateVideoMovies::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTitles);
+  SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTitles);
 }
 
 
@@ -561,12 +561,12 @@ CGUIViewStateVideoMusicVideos::CGUIViewStateVideoMusicVideos(const CFileItemList
 
   SetSortOrder(g_settings.m_viewStateVideoNavMusicVideos.m_sortOrder);
 
-  LoadViewState(items.m_strPath, WINDOW_VIDEO_NAV);
+  LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
 }
 
 void CGUIViewStateVideoMusicVideos::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavMusicVideos);
+  SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavMusicVideos);
 }
 
 
@@ -591,12 +591,12 @@ CGUIViewStateVideoTVShows::CGUIViewStateVideoTVShows(const CFileItemList& items)
 
   SetSortOrder(g_settings.m_viewStateVideoNavTvShows.m_sortOrder);
 
-  LoadViewState(items.m_strPath, WINDOW_VIDEO_NAV);
+  LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
 }
 
 void CGUIViewStateVideoTVShows::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTvShows);
+  SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTvShows);
 }
 
 
@@ -635,11 +635,11 @@ CGUIViewStateVideoEpisodes::CGUIViewStateVideoEpisodes(const CFileItemList& item
 
   SetSortOrder(g_settings.m_viewStateVideoNavEpisodes.m_sortOrder);
 
-  LoadViewState(items.m_strPath, WINDOW_VIDEO_NAV);
+  LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
 }
 
 void CGUIViewStateVideoEpisodes::SaveViewState()
 {
-  SaveViewToDb(m_items.m_strPath, WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavEpisodes);
+  SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavEpisodes);
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -625,7 +625,7 @@ int CVideoDatabase::AddFile(const CFileItem& item)
 {
   if (item.IsVideoDb() && item.HasVideoInfoTag())
     return AddFile(item.GetVideoInfoTag()->m_strFileNameAndPath);
-  return AddFile(item.m_strPath);
+  return AddFile(item.GetPath());
 }
 
 bool CVideoDatabase::SetPathHash(const CStdString &path, const CStdString &hash)
@@ -772,7 +772,7 @@ int CVideoDatabase::GetFileId(const CFileItem &item)
 {
   if (item.IsVideoDb() && item.HasVideoInfoTag())
     return GetFileId(item.GetVideoInfoTag()->m_strFileNameAndPath);
-  return GetFileId(item.m_strPath);
+  return GetFileId(item.GetPath());
 }
 
 //********************************************************************************************************************************
@@ -3703,7 +3703,7 @@ void CVideoDatabase::UpdateFanart(const CFileItem &item, VIDEODB_CONTENT_TYPE ty
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s - error updating fanart for %s", __FUNCTION__, item.m_strPath.c_str());
+    CLog::Log(LOGERROR, "%s - error updating fanart for %s", __FUNCTION__, item.GetPath().c_str());
   }
 }
 
@@ -3912,11 +3912,11 @@ bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& i
         CFileItemPtr pItem(new CFileItem(it->second.first));
         CStdString strDir;
         strDir.Format("%ld/", it->first);
-        pItem->m_strPath = strBaseDir + strDir;
+        pItem->SetPath(strBaseDir + strDir);
         pItem->m_bIsFolder = true;
         if (idContent == VIDEODB_CONTENT_MOVIES || idContent == VIDEODB_CONTENT_MUSICVIDEOS)
           pItem->GetVideoInfoTag()->m_playCount = it->second.second;
-        if (!items.Contains(pItem->m_strPath))
+        if (!items.Contains(pItem->GetPath()))
         {
           pItem->SetLabelPreformated(true);
           items.Add(pItem);
@@ -3930,7 +3930,7 @@ bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& i
         CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
         CStdString strDir;
         strDir.Format("%ld/", m_pDS->fv(0).get_asInt());
-        pItem->m_strPath = strBaseDir + strDir;
+        pItem->SetPath(strBaseDir + strDir);
         pItem->m_bIsFolder = true;
         pItem->SetLabelPreformated(true);
         if (idContent == VIDEODB_CONTENT_MOVIES || idContent == VIDEODB_CONTENT_MUSICVIDEOS)
@@ -4014,15 +4014,15 @@ bool CVideoDatabase::GetSetsNav(const CStdString& strBaseDir, CFileItemList& ite
         pItem->GetVideoInfoTag()->m_iDbId = it->first;
         CStdString strDir;
         strDir.Format("%ld/", it->first);
-        pItem->m_strPath=strBaseDir + strDir;
+        pItem->SetPath(strBaseDir + strDir);
         pItem->m_bIsFolder=true;
-        pItem->GetVideoInfoTag()->m_strPath = pItem->m_strPath;
+        pItem->GetVideoInfoTag()->m_strPath = pItem->GetPath();
         if (idContent == VIDEODB_CONTENT_MOVIES || idContent == VIDEODB_CONTENT_MUSICVIDEOS)
         {
           pItem->GetVideoInfoTag()->m_playCount = it->second.second;
           pItem->GetVideoInfoTag()->m_strTitle = pItem->GetLabel();
         }
-        if (!items.Contains(pItem->m_strPath))
+        if (!items.Contains(pItem->GetPath()))
         {
           pItem->SetLabelPreformated(true);
           items.Add(pItem);
@@ -4037,9 +4037,9 @@ bool CVideoDatabase::GetSetsNav(const CStdString& strBaseDir, CFileItemList& ite
         pItem->GetVideoInfoTag()->m_iDbId = m_pDS->fv("sets.idSet").get_asInt();
         CStdString strDir;
         strDir.Format("%ld/", m_pDS->fv("sets.idSet").get_asInt());
-        pItem->m_strPath=strBaseDir + strDir;
+        pItem->SetPath(strBaseDir + strDir);
         pItem->m_bIsFolder=true;
-        pItem->GetVideoInfoTag()->m_strPath = pItem->m_strPath;
+        pItem->GetVideoInfoTag()->m_strPath = pItem->GetPath();
         pItem->SetLabelPreformated(true);
         if (idContent == VIDEODB_CONTENT_MOVIES || idContent==VIDEODB_CONTENT_MUSICVIDEOS)
         {
@@ -4143,10 +4143,10 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
           CFileItemPtr pItem(new CFileItem(it->second.first));
           CStdString strDir;
           strDir.Format("%ld/", it->first);
-          pItem->m_strPath=strBaseDir + strDir;
+          pItem->SetPath(strBaseDir + strDir);
           pItem->m_bIsFolder=true;
           pItem->SetLabelPreformated(true);
-          if (!items.Contains(pItem->m_strPath))
+          if (!items.Contains(pItem->GetPath()))
           {
             pItem->GetVideoInfoTag()->m_strArtist = m_pDS->fv(2).get_asString();
             CStdString strThumb = CThumbnailCache::GetAlbumThumb(*pItem);
@@ -4166,10 +4166,10 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
           CFileItemPtr pItem(new CFileItem(m_pDS->fv(0).get_asString()));
           CStdString strDir;
           strDir.Format("%ld/", m_pDS->fv(1).get_asInt());
-          pItem->m_strPath=strBaseDir + strDir;
+          pItem->SetPath(strBaseDir + strDir);
           pItem->m_bIsFolder=true;
           pItem->SetLabelPreformated(true);
-          if (!items.Contains(pItem->m_strPath))
+          if (!items.Contains(pItem->GetPath()))
           {
             pItem->GetVideoInfoTag()->m_strArtist = m_pDS->fv(2).get_asString();
             CStdString strThumb = CThumbnailCache::GetAlbumThumb(pItem->GetLabel(), m_pDS->fv(2).get_asString());
@@ -4317,7 +4317,7 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
         CFileItemPtr pItem(new CFileItem(it->second.name));
         CStdString strDir;
         strDir.Format("%ld/", it->first);
-        pItem->m_strPath=strBaseDir + strDir;
+        pItem->SetPath(strBaseDir + strDir);
         pItem->m_bIsFolder=true;
         pItem->GetVideoInfoTag()->m_playCount = it->second.playcount;
         pItem->GetVideoInfoTag()->m_strPictureURL.ParseString(it->second.thumb);
@@ -4333,7 +4333,7 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
           CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
           CStdString strDir;
           strDir.Format("%ld/", m_pDS->fv(0).get_asInt());
-          pItem->m_strPath=strBaseDir + strDir;
+          pItem->SetPath(strBaseDir + strDir);
           pItem->m_bIsFolder=true;
           pItem->GetVideoInfoTag()->m_strPictureURL.ParseString(m_pDS->fv(2).get_asString());
           if (idContent != VIDEODB_CONTENT_TVSHOWS)
@@ -4450,7 +4450,7 @@ bool CVideoDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
         CFileItemPtr pItem(new CFileItem(it->second.first));
         CStdString strDir;
         strDir.Format("%ld/", it->first);
-        pItem->m_strPath=strBaseDir + strDir;
+        pItem->SetPath(strBaseDir + strDir);
         pItem->m_bIsFolder=true;
         if (idContent == VIDEODB_CONTENT_MOVIES || idContent == VIDEODB_CONTENT_MUSICVIDEOS)
           pItem->GetVideoInfoTag()->m_playCount = it->second.second;
@@ -4483,7 +4483,7 @@ bool CVideoDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
         CFileItemPtr pItem(new CFileItem(strLabel));
         CStdString strDir;
         strDir.Format("%ld/", lYear);
-        pItem->m_strPath=strBaseDir + strDir;
+        pItem->SetPath(strBaseDir + strDir);
         pItem->m_bIsFolder=true;
         if (idContent == VIDEODB_CONTENT_MOVIES || idContent == VIDEODB_CONTENT_MUSICVIDEOS)
         {
@@ -4493,7 +4493,7 @@ bool CVideoDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
         }
 
         // take care of dupes ..
-        if (!items.Contains(pItem->m_strPath))
+        if (!items.Contains(pItem->GetPath()))
           items.Add(pItem);
 
         m_pDS->next();
@@ -4626,7 +4626,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         CFileItemPtr pItem(new CFileItem(strLabel));
         CStdString strDir;
         strDir.Format("%ld/", it->first);
-        pItem->m_strPath=strBaseDir + strDir;
+        pItem->SetPath(strBaseDir + strDir);
         pItem->m_bIsFolder=true;
         pItem->GetVideoInfoTag()->m_strTitle = strLabel;
         pItem->GetVideoInfoTag()->m_iSeason = iSeason;
@@ -4661,7 +4661,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         CFileItemPtr pItem(new CFileItem(strLabel));
         CStdString strDir;
         strDir.Format("%ld/", iSeason);
-        pItem->m_strPath=strBaseDir + strDir;
+        pItem->SetPath(strBaseDir + strDir);
         pItem->m_bIsFolder=true;
         pItem->GetVideoInfoTag()->m_strTitle = strLabel;
         pItem->GetVideoInfoTag()->m_iSeason = iSeason;
@@ -4763,7 +4763,8 @@ bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const CStdSt
           g_passwordManager.IsDatabasePathUnlocked(movie.m_strPath, g_settings.m_videoSources))
       {
         CFileItemPtr pItem(new CFileItem(movie));
-        pItem->m_strPath.Format("%s%ld", strBaseDir.c_str(), movie.m_iDbId);
+        CStdString path; path.Format("%s%ld", strBaseDir.c_str(), movie.m_iDbId);
+        pItem->SetPath(path);
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED,movie.m_playCount > 0);
         items.Add(pItem);
       }
@@ -4826,7 +4827,8 @@ bool CVideoDatabase::GetTvShowsByWhere(const CStdString& strBaseDir, const CStdS
           (!g_advancedSettings.m_bVideoLibraryHideEmptySeries || movie.m_iEpisode > 0))
       {
         CFileItemPtr pItem(new CFileItem(movie));
-        pItem->m_strPath.Format("%s%ld/", strBaseDir.c_str(), idShow);
+        CStdString path; path.Format("%s%ld/", strBaseDir.c_str(), idShow);
+        pItem->SetPath(path);
         pItem->m_dateTime.SetFromDateString(movie.m_strPremiered);
         pItem->GetVideoInfoTag()->m_iYear = pItem->m_dateTime.GetYear();
         pItem->SetProperty("totalseasons", numSeasons);
@@ -5104,10 +5106,12 @@ bool CVideoDatabase::GetEpisodesByWhere(const CStdString& strBaseDir, const CStd
           g_passwordManager.IsDatabasePathUnlocked(movie.m_strPath, g_settings.m_videoSources))
       {
         CFileItemPtr pItem(new CFileItem(movie));
+        CStdString path;
         if (appendFullShowPath)
-          pItem->m_strPath.Format("%s%ld/%ld/%ld",strBaseDir.c_str(), idShow, movie.m_iSeason,idEpisode);
+          path.Format("%s%ld/%ld/%ld",strBaseDir.c_str(), idShow, movie.m_iSeason,idEpisode);
         else
-          pItem->m_strPath.Format("%s%ld",strBaseDir.c_str(), idEpisode);
+          path.Format("%s%ld",strBaseDir.c_str(), idEpisode);
+        pItem->SetPath(path);
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED,movie.m_playCount > 0);
         pItem->m_dateTime.SetFromDateString(movie.m_strFirstAired);
         pItem->GetVideoInfoTag()->m_iYear = pItem->m_dateTime.GetYear();
@@ -5517,7 +5521,7 @@ void CVideoDatabase::GetMovieGenresByName(const CStdString& strSearch, CFileItem
       CFileItemPtr pItem(new CFileItem(m_pDS->fv("genre.strGenre").get_asString()));
       CStdString strDir;
       strDir.Format("%ld/", m_pDS->fv("genre.idGenre").get_asInt());
-      pItem->m_strPath="videodb://1/1/"+ strDir;
+      pItem->SetPath("videodb://1/1/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -5558,7 +5562,7 @@ void CVideoDatabase::GetMovieCountriesByName(const CStdString& strSearch, CFileI
       CFileItemPtr pItem(new CFileItem(m_pDS->fv("country.strCountry").get_asString()));
       CStdString strDir;
       strDir.Format("%ld/", m_pDS->fv("country.idCountry").get_asInt());
-      pItem->m_strPath="videodb://1/1/"+ strDir;
+      pItem->SetPath("videodb://1/1/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -5598,7 +5602,7 @@ void CVideoDatabase::GetTvShowGenresByName(const CStdString& strSearch, CFileIte
       CFileItemPtr pItem(new CFileItem(m_pDS->fv("genre.strGenre").get_asString()));
       CStdString strDir;
       strDir.Format("%ld/", m_pDS->fv("genre.idGenre").get_asInt());
-      pItem->m_strPath="videodb://2/1/"+ strDir;
+      pItem->SetPath("videodb://2/1/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -5638,7 +5642,7 @@ void CVideoDatabase::GetMovieActorsByName(const CStdString& strSearch, CFileItem
       CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
       CStdString strDir;
       strDir.Format("%ld/", m_pDS->fv("actors.idActor").get_asInt());
-      pItem->m_strPath="videodb://1/4/"+ strDir;
+      pItem->SetPath("videodb://1/4/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -5678,7 +5682,7 @@ void CVideoDatabase::GetTvShowsActorsByName(const CStdString& strSearch, CFileIt
       CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
       CStdString strDir;
       strDir.Format("%ld/", m_pDS->fv("actors.idActor").get_asInt());
-      pItem->m_strPath="videodb://2/4/"+ strDir;
+      pItem->SetPath("videodb://2/4/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -5721,7 +5725,7 @@ void CVideoDatabase::GetMusicVideoArtistsByName(const CStdString& strSearch, CFi
       CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
       CStdString strDir;
       strDir.Format("%ld/", m_pDS->fv("actors.idActor").get_asInt());
-      pItem->m_strPath="videodb://3/4/"+ strDir;
+      pItem->SetPath("videodb://3/4/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -5761,7 +5765,7 @@ void CVideoDatabase::GetMusicVideoGenresByName(const CStdString& strSearch, CFil
       CFileItemPtr pItem(new CFileItem(m_pDS->fv("genre.strGenre").get_asString()));
       CStdString strDir;
       strDir.Format("%ld/", m_pDS->fv("genre.idGenre").get_asInt());
-      pItem->m_strPath="videodb://3/1/"+ strDir;
+      pItem->SetPath("videodb://3/1/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -5817,7 +5821,7 @@ void CVideoDatabase::GetMusicVideoAlbumsByName(const CStdString& strSearch, CFil
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(0).get_asString()));
       CStdString strDir;
       strDir.Format("%ld", m_pDS->fv(1).get_asInt());
-      pItem->m_strPath="videodb://3/2/"+ strDir;
+      pItem->SetPath("videodb://3/2/"+ strDir);
       pItem->m_bIsFolder=false;
       items.Add(pItem);
       m_pDS->next();
@@ -5858,7 +5862,7 @@ void CVideoDatabase::GetMusicVideosByAlbum(const CStdString& strSearch, CFileIte
       CStdString strDir;
       strDir.Format("3/2/%ld",m_pDS->fv("musicvideo.idMVideo").get_asInt());
 
-      pItem->m_strPath="videodb://"+ strDir;
+      pItem->SetPath("videodb://"+ strDir);
       pItem->m_bIsFolder=false;
       items.Add(pItem);
       m_pDS->next();
@@ -5909,7 +5913,8 @@ bool CVideoDatabase::GetMusicVideosByWhere(const CStdString &baseDir, const CStd
           g_passwordManager.IsDatabasePathUnlocked(musicvideo.m_strPath,g_settings.m_videoSources))
       {
         CFileItemPtr item(new CFileItem(musicvideo));
-        item->m_strPath.Format("%s%ld",baseDir,idMVideo);
+        CStdString path; path.Format("%s%ld",baseDir,idMVideo);
+        item->SetPath(path);
         item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED,musicvideo.m_playCount > 0);
         items.Add(item);
       }
@@ -5988,7 +5993,8 @@ bool CVideoDatabase::GetRandomMusicVideo(CFileItem* item, int& idSong, const CSt
       return false;
     }
     *item->GetVideoInfoTag() = GetDetailsForMusicVideo(m_pDS);
-    item->m_strPath.Format("videodb://3/2/%ld",item->GetVideoInfoTag()->m_iDbId);
+    CStdString path; path.Format("videodb://3/2/%ld",item->GetVideoInfoTag()->m_iDbId);
+    item->SetPath(path);
     idSong = m_pDS->fv("idMVideo").get_asInt();
     item->SetLabel(item->GetVideoInfoTag()->m_strTitle);
     m_pDS->close();
@@ -6074,11 +6080,12 @@ void CVideoDatabase::GetMoviesByName(const CStdString& strSearch, CFileItemList&
       CStdString strSQL2 = PrepareSQL("select idSet from setlinkmovie where idMovie=%i",movieId); 
       m_pDS2->query(strSQL2.c_str());
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
+      CStdString path;
       if (m_pDS2->eof())
-        pItem->m_strPath.Format("videodb://1/2/%i",movieId);
+        path.Format("videodb://1/2/%i",movieId);
       else
-        pItem->m_strPath.Format("videodb://1/7/%i/%i",m_pDS2->fv(0).get_asInt(),movieId);
-
+        path.Format("videodb://1/7/%i/%i",m_pDS2->fv(0).get_asInt(),movieId);
+      pItem->SetPath(path);
       pItem->m_bIsFolder=false;
       items.Add(pItem);
       m_pDS2->close();
@@ -6120,7 +6127,7 @@ void CVideoDatabase::GetTvShowsByName(const CStdString& strSearch, CFileItemList
       CStdString strDir;
       strDir.Format("2/2/%ld/", m_pDS->fv("tvshow.idShow").get_asInt());
 
-      pItem->m_strPath="videodb://"+ strDir;
+      pItem->SetPath("videodb://"+ strDir);
       pItem->m_bIsFolder=true;
       pItem->GetVideoInfoTag()->m_iDbId = m_pDS->fv("tvshow.idShow").get_asInt();
       items.Add(pItem);
@@ -6159,7 +6166,8 @@ void CVideoDatabase::GetEpisodesByName(const CStdString& strSearch, CFileItemLis
         }
 
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()+" ("+m_pDS->fv(4).get_asString()+")"));
-      pItem->m_strPath.Format("videodb://2/2/%ld/%ld/%ld",m_pDS->fv("tvshowlinkepisode.idShow").get_asInt(),m_pDS->fv(2).get_asInt(),m_pDS->fv(0).get_asInt());
+      CStdString path; path.Format("videodb://2/2/%ld/%ld/%ld",m_pDS->fv("tvshowlinkepisode.idShow").get_asInt(),m_pDS->fv(2).get_asInt(),m_pDS->fv(0).get_asInt());
+      pItem->SetPath(path);
       pItem->m_bIsFolder=false;
       items.Add(pItem);
       m_pDS->next();
@@ -6204,7 +6212,7 @@ void CVideoDatabase::GetMusicVideosByName(const CStdString& strSearch, CFileItem
       CStdString strDir;
       strDir.Format("3/2/%ld",m_pDS->fv("musicvideo.idMVideo").get_asInt());
 
-      pItem->m_strPath="videodb://"+ strDir;
+      pItem->SetPath("videodb://"+ strDir);
       pItem->m_bIsFolder=false;
       items.Add(pItem);
       m_pDS->next();
@@ -6248,7 +6256,8 @@ void CVideoDatabase::GetEpisodesByPlot(const CStdString& strSearch, CFileItemLis
         }
 
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()+" ("+m_pDS->fv(4).get_asString()+")"));
-      pItem->m_strPath.Format("videodb://2/2/%ld/%ld/%ld",m_pDS->fv("tvshowlinkepisode.idShow").get_asInt(),m_pDS->fv(2).get_asInt(),m_pDS->fv(0).get_asInt());
+      CStdString path; path.Format("videodb://2/2/%ld/%ld/%ld",m_pDS->fv("tvshowlinkepisode.idShow").get_asInt(),m_pDS->fv(2).get_asInt(),m_pDS->fv(0).get_asInt());
+      pItem->SetPath(path);
       pItem->m_bIsFolder=false;
       items.Add(pItem);
       m_pDS->next();
@@ -6287,7 +6296,8 @@ void CVideoDatabase::GetMoviesByPlot(const CStdString& strSearch, CFileItemList&
         }
 
       CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
-      pItem->m_strPath.Format("videodb://1/2/%ld", m_pDS->fv(0).get_asInt());
+      CStdString path; path.Format("videodb://1/2/%ld", m_pDS->fv(0).get_asInt());
+      pItem->SetPath(path);
       pItem->m_bIsFolder=false;
 
       items.Add(pItem);
@@ -6331,7 +6341,7 @@ void CVideoDatabase::GetMovieDirectorsByName(const CStdString& strSearch, CFileI
       strDir.Format("%ld/", m_pDS->fv("directorlinkmovie.idDirector").get_asInt());
       CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
 
-      pItem->m_strPath="videodb://1/5/"+ strDir;
+      pItem->SetPath("videodb://1/5/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -6373,7 +6383,7 @@ void CVideoDatabase::GetTvShowsDirectorsByName(const CStdString& strSearch, CFil
       strDir.Format("%ld/", m_pDS->fv("directorlinktvshow.idDirector").get_asInt());
       CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
 
-      pItem->m_strPath="videodb://2/5/"+ strDir;
+      pItem->SetPath("videodb://2/5/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -6415,7 +6425,7 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const CStdString& strSearch, C
       strDir.Format("%ld/", m_pDS->fv("directorlinkmusicvideo.idDirector").get_asInt());
       CFileItemPtr pItem(new CFileItem(m_pDS->fv("actors.strActor").get_asString()));
 
-      pItem->m_strPath="videodb://3/5/"+ strDir;
+      pItem->SetPath("videodb://3/5/"+ strDir);
       pItem->m_bIsFolder=true;
       items.Add(pItem);
       m_pDS->next();
@@ -7278,7 +7288,7 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
       // now save the episodes from this show
       sql = PrepareSQL("select * from episodeview where idShow=%i order by strFileName, idEpisode",tvshow.m_iDbId);
       pDS->query(sql.c_str());
-      CStdString showDir(saveItem.m_strPath);
+      CStdString showDir(saveItem.GetPath());
 
       while (!pDS->eof())
       {
@@ -7549,7 +7559,7 @@ void CVideoDatabase::ImportFromXML(const CStdString &path)
       {
         info.Load(movie);
         CFileItem item(info);
-        bool useFolders = info.m_basePath.IsEmpty() ? LookupByFolders(item.m_strPath) : false;
+        bool useFolders = info.m_basePath.IsEmpty() ? LookupByFolders(item.GetPath()) : false;
         scanner.AddVideo(&item, CONTENT_MOVIES, useFolders);
         SetPlayCount(item, info.m_playCount, info.m_lastPlayed);
         CStdString strFileName(info.m_strTitle);
@@ -7566,7 +7576,7 @@ void CVideoDatabase::ImportFromXML(const CStdString &path)
       {
         info.Load(movie);
         CFileItem item(info);
-        bool useFolders = info.m_basePath.IsEmpty() ? LookupByFolders(item.m_strPath) : false;
+        bool useFolders = info.m_basePath.IsEmpty() ? LookupByFolders(item.GetPath()) : false;
         scanner.AddVideo(&item, CONTENT_MUSICVIDEOS, useFolders);
         SetPlayCount(item, info.m_playCount, info.m_lastPlayed);
         CStdString strFileName(info.m_strArtist + "." + info.m_strTitle);
@@ -7584,7 +7594,7 @@ void CVideoDatabase::ImportFromXML(const CStdString &path)
         URIUtils::AddSlashAtEnd(info.m_strPath);
         DeleteTvShow(info.m_strPath);
         CFileItem item(info);
-        bool useFolders = info.m_basePath.IsEmpty() ? LookupByFolders(item.m_strPath, true) : false;
+        bool useFolders = info.m_basePath.IsEmpty() ? LookupByFolders(item.GetPath(), true) : false;
         int showID = scanner.AddVideo(&item, CONTENT_TVSHOWS, useFolders);
         current++;
         CStdString showDir(GetSafeFile(tvshowsDir, info.m_strTitle));
@@ -7763,7 +7773,7 @@ void CVideoDatabase::DeleteThumbForItem(const CStdString& strPath, bool bFolder,
   CFileItem item(strPath,bFolder);
   if (idEpisode > 0)
   {
-    item.m_strPath = item.GetVideoInfoTag()->m_strFileNameAndPath;
+    item.SetPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
     if (CFile::Exists(item.GetCachedEpisodeThumb()))
       CTextureCache::Get().ClearCachedImage(item.GetCachedEpisodeThumb(), true);
     else
@@ -7882,6 +7892,6 @@ bool CVideoDatabase::GetItemsForPath(const CStdString &content, const CStdString
     GetMusicVideosByWhere("", where, items);
   }
   for (int i = 0; i < items.Size(); i++)
-    items[i]->m_strPath = items[i]->GetVideoInfoTag()->m_basePath;
+    items[i]->SetPath(items[i]->GetVideoInfoTag()->m_basePath);
   return items.Size() > 0;
 }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -268,7 +268,7 @@ namespace VIDEO
       if (foundDirectly && !settings.parent_name_root)
       {
         CDirectory::GetDirectory(strDirectory, items, g_settings.m_videoExtensions);
-        items.m_strPath = strDirectory;
+        items.SetPath(strDirectory);
         GetPathHash(items, hash);
         bSkip = true;
         if (!m_database.GetPathHash(strDirectory, dbHash) || dbHash != hash)
@@ -282,10 +282,10 @@ namespace VIDEO
       else
       {
         CFileItemPtr item(new CFileItem(URIUtils::GetFileName(strDirectory)));
-        item->m_strPath = strDirectory;
+        item->SetPath(strDirectory);
         item->m_bIsFolder = true;
         items.Add(item);
-        URIUtils::GetParentPath(item->m_strPath, items.m_strPath);
+        items.SetPath(URIUtils::GetParentPath(item->GetPath()));
       }
     }
 
@@ -325,7 +325,7 @@ namespace VIDEO
       // do not recurse for tv shows - we have already looked recursively for episodes
       if (pItem->m_bIsFolder && !pItem->IsParentFolder() && !pItem->IsPlayList() && settings.recurse > 0 && content != CONTENT_TVSHOWS)
       {
-        if (!DoScan(pItem->m_strPath))
+        if (!DoScan(pItem->GetPath()))
         {
           m_bStop = true;
         }
@@ -359,12 +359,12 @@ namespace VIDEO
       CFileItemPtr pItem = items[i];
 
       // we do this since we may have a override per dir
-      ScraperPtr info2 = m_database.GetScraperForPath(pItem->m_bIsFolder ? pItem->m_strPath : items.m_strPath);
+      ScraperPtr info2 = m_database.GetScraperForPath(pItem->m_bIsFolder ? pItem->GetPath() : items.GetPath());
       if (!info2) // skip
         continue;
 
       // Discard all exclude files defined by regExExclude
-      if (CUtil::ExcludeFileOrFolder(pItem->m_strPath, (content == CONTENT_TVSHOWS) ? g_advancedSettings.m_tvshowExcludeFromScanRegExps
+      if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), (content == CONTENT_TVSHOWS) ? g_advancedSettings.m_tvshowExcludeFromScanRegExps
                                                                                     : g_advancedSettings.m_moviesExcludeFromScanRegExps))
         continue;
 
@@ -391,7 +391,7 @@ namespace VIDEO
         ret = RetrieveInfoForMusicVideo(pItem, bDirNames, info2, useLocal, pURL, pDlgProgress);
       else
       {
-        CLog::Log(LOGERROR, "VideoInfoScanner: Unknown content type %d (%s)", info2->Content(), pItem->m_strPath.c_str());
+        CLog::Log(LOGERROR, "VideoInfoScanner: Unknown content type %d (%s)", info2->Content(), pItem->GetPath().c_str());
         FoundSomeInfo = false;
         break;
       }
@@ -407,13 +407,13 @@ namespace VIDEO
 
       // Keep track of directories we've seen
       if (pItem->m_bIsFolder)
-        seenPaths.push_back(m_database.GetPathId(pItem->m_strPath));
+        seenPaths.push_back(m_database.GetPathId(pItem->GetPath()));
     }
 
     if (content == CONTENT_TVSHOWS && ! seenPaths.empty())
     {
       vector<int> libPaths;
-      m_database.GetSubPaths(items.m_strPath, libPaths);
+      m_database.GetSubPaths(items.GetPath(), libPaths);
       for (vector<int>::iterator i = libPaths.begin(); i < libPaths.end(); ++i)
       {
         if (find(seenPaths.begin(), seenPaths.end(), *i) == seenPaths.end())
@@ -432,18 +432,18 @@ namespace VIDEO
   {
     long idTvShow = -1;
     if (pItem->m_bIsFolder)
-      idTvShow = m_database.GetTvShowId(pItem->m_strPath);
+      idTvShow = m_database.GetTvShowId(pItem->GetPath());
     else
     {
       CStdString strPath;
-      URIUtils::GetDirectory(pItem->m_strPath,strPath);
+      URIUtils::GetDirectory(pItem->GetPath(),strPath);
       idTvShow = m_database.GetTvShowId(strPath);
     }
     if (idTvShow > -1 && (fetchEpisodes || !pItem->m_bIsFolder))
     {
       INFO_RET ret = RetrieveInfoForEpisodes(pItem, idTvShow, info2, useLocal, pDlgProgress);
       if (ret == INFO_ADDED)
-        m_database.SetPathHash(pItem->m_strPath, pItem->GetProperty("hash"));
+        m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash"));
       return ret;
     }
 
@@ -459,8 +459,8 @@ namespace VIDEO
     { // check for preconfigured scraper; if found, overwrite with interpreted scraper (from Nfofile)
       // but keep current scan settings
       SScanSettings settings;
-      if (m_database.GetScraperForPath(pItem->m_strPath, settings))
-        m_database.SetScraperForPath(pItem->m_strPath, info2, settings);
+      if (m_database.GetScraperForPath(pItem->GetPath(), settings))
+        m_database.SetScraperForPath(pItem->GetPath(), info2, settings);
     }
     if (result == CNfoFile::FULL_NFO)
     {
@@ -479,7 +479,7 @@ namespace VIDEO
       {
         INFO_RET ret = RetrieveInfoForEpisodes(pItem, lResult, info2, useLocal, pDlgProgress);
         if (ret == INFO_ADDED)
-          m_database.SetPathHash(pItem->m_strPath, pItem->GetProperty("hash"));
+          m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash"));
         return ret;
       }
       return INFO_ADDED;
@@ -508,7 +508,7 @@ namespace VIDEO
     {
       INFO_RET ret = RetrieveInfoForEpisodes(pItem, lResult, info2, useLocal, pDlgProgress);
       if (ret == INFO_ADDED)
-        m_database.SetPathHash(pItem->m_strPath, pItem->GetProperty("hash"));
+        m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash"));
     }
     else
       if (g_guiSettings.GetBool("videolibrary.seasonthumbs"))
@@ -524,7 +524,7 @@ namespace VIDEO
     if (ProgressCancelled(pDlgProgress, 198, pItem->GetLabel()))
       return INFO_CANCELLED;
 
-    if (m_database.HasMovieInfo(pItem->m_strPath))
+    if (m_database.HasMovieInfo(pItem->GetPath()))
       return INFO_HAVE_ALREADY;
 
     CNfoFile::NFOResult result=CNfoFile::NO_NFO;
@@ -576,7 +576,7 @@ namespace VIDEO
     if (ProgressCancelled(pDlgProgress, 20394, pItem->GetLabel()))
       return INFO_CANCELLED;
 
-    if (m_database.HasMusicVideoInfo(pItem->m_strPath))
+    if (m_database.HasMusicVideoInfo(pItem->GetPath()))
       return INFO_HAVE_ALREADY;
 
     CNfoFile::NFOResult result=CNfoFile::NO_NFO;
@@ -632,7 +632,7 @@ namespace VIDEO
 
     // fetch episode guide
     CVideoInfoTag details;
-    m_database.GetTvShowInfo(item->m_strPath, details, showID);
+    m_database.GetTvShowInfo(item->GetPath(), details, showID);
     if (!details.m_strEpisodeGuide.IsEmpty()) // assume local-only series if no episode guide url
     {
       CScraperUrl url;
@@ -659,7 +659,7 @@ namespace VIDEO
       return INFO_CANCELLED;
 
     if (m_pObserver)
-      m_pObserver->OnDirectoryChanged(item->m_strPath);
+      m_pObserver->OnDirectoryChanged(item->GetPath());
 
     return OnProcessSeriesFolder(episodes, files, scraper, useLocal, showID, details.m_strTitle, progress);
   }
@@ -670,11 +670,11 @@ namespace VIDEO
 
     if (item->m_bIsFolder)
     {
-      CUtil::GetRecursiveListing(item->m_strPath, items, g_settings.m_videoExtensions, true);
+      CUtil::GetRecursiveListing(item->GetPath(), items, g_settings.m_videoExtensions, true);
       CStdString hash, dbHash;
       int numFilesInFolder = GetPathHash(items, hash);
 
-      if (m_database.GetPathHash(item->m_strPath, dbHash) && dbHash == hash)
+      if (m_database.GetPathHash(item->GetPath(), dbHash) && dbHash == hash)
       {
         m_currentItem += numFilesInFolder;
 
@@ -686,12 +686,12 @@ namespace VIDEO
             m_pObserver->OnSetProgress(m_currentItem, m_itemCount);
             m_pObserver->OnSetCurrentProgress(numFilesInFolder, numFilesInFolder);
           }
-          m_pObserver->OnDirectoryScanned(item->m_strPath);
+          m_pObserver->OnDirectoryScanned(item->GetPath());
         }
         return;
       }
-      m_pathsToClean.push_back(m_database.GetPathId(item->m_strPath));
-      m_database.GetPathsForTvShow(m_database.GetTvShowId(item->m_strPath), m_pathsToClean);
+      m_pathsToClean.push_back(m_database.GetPathId(item->GetPath()));
+      m_database.GetPathsForTvShow(m_database.GetTvShowId(item->GetPath()), m_pathsToClean);
       item->SetProperty("hash", hash);
     }
     else
@@ -720,7 +720,7 @@ namespace VIDEO
 
 
       CStdString strPathX, strFileX;
-      URIUtils::Split(items[x]->m_strPath, strPathX, strFileX);
+      URIUtils::Split(items[x]->GetPath(), strPathX, strFileX);
       //CLog::Log(LOGDEBUG,"%i:%s:%s", x, strPathX.c_str(), strFileX.c_str());
 
       int y = x + 1;
@@ -729,7 +729,7 @@ namespace VIDEO
         while (y < items.Size())
         {
           CStdString strPathY, strFileY;
-          URIUtils::Split(items[y]->m_strPath, strPathY, strFileY);
+          URIUtils::Split(items[y]->GetPath(), strPathY, strFileY);
           //CLog::Log(LOGDEBUG," %i:%s:%s", y, strPathY.c_str(), strFileY.c_str());
 
           if (strPathY.Equals(strPathX))
@@ -755,14 +755,14 @@ namespace VIDEO
       if (items[i]->m_bIsFolder)
         continue;
       CStdString strPath;
-      URIUtils::GetDirectory(items[i]->m_strPath, strPath);
+      URIUtils::GetDirectory(items[i]->GetPath(), strPath);
       URIUtils::RemoveSlashAtEnd(strPath); // want no slash for the test that follows
 
       if (URIUtils::GetFileName(strPath).Equals("sample"))
         continue;
 
       // Discard all exclude files defined by regExExcludes
-      if (CUtil::ExcludeFileOrFolder(items[i]->m_strPath, regexps))
+      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
         continue;
 
       /*
@@ -775,7 +775,7 @@ namespace VIDEO
 
       if (!EnumerateEpisodeItem(items[i], episodeList))
       {
-        CStdString decode(items[i]->m_strPath);
+        CStdString decode(items[i]->GetPath());
         CURL::Decode(decode);
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Could not enumerate file %s", decode.c_str());
       }
@@ -795,7 +795,7 @@ namespace VIDEO
     if (tag->m_iSeason > -1 && tag->m_iEpisode > 0)
     {
       SEpisode episode;
-      episode.strPath = item->m_strPath;
+      episode.strPath = item->GetPath();
       episode.iSeason = tag->m_iSeason;
       episode.iEpisode = tag->m_iEpisode;
       episode.isFolder = false;
@@ -812,7 +812,7 @@ namespace VIDEO
     if (!tag->m_strFirstAired.IsEmpty())
     {
       SEpisode episode;
-      episode.strPath = item->m_strPath;
+      episode.strPath = item->GetPath();
       episode.strTitle = tag->m_strTitle;
       episode.isFolder = false;
       /*
@@ -838,7 +838,7 @@ namespace VIDEO
     if (!tag->m_strTitle.IsEmpty())
     {
       SEpisode episode;
-      episode.strPath = item->m_strPath;
+      episode.strPath = item->GetPath();
       episode.strTitle = tag->m_strTitle;
       episode.isFolder = false;
       /*
@@ -860,7 +860,7 @@ namespace VIDEO
     if (tag->m_iSeason == 0 && tag->m_iEpisode == 0)
     {
       CLog::Log(LOGDEBUG,"%s - found exclusion match for: %s. Both Season and Episode are 0. Item will be ignored for scanning.",
-                __FUNCTION__, item->m_strPath.c_str());
+                __FUNCTION__, item->GetPath().c_str());
       return true;
     }
 
@@ -871,7 +871,7 @@ namespace VIDEO
   {
     SETTINGS_TVSHOWLIST expression = g_advancedSettings.m_tvshowEnumRegExps;
 
-    CStdString strLabel=item->m_strPath;
+    CStdString strLabel=item->GetPath();
     // URLDecode in case an episode is on a http/https/dav/davs:// source and URL-encoded like foo%201x01%20bar.avi
     CURL::Decode(strLabel);
     strLabel.MakeLower();
@@ -888,7 +888,7 @@ namespace VIDEO
         continue;
 
       SEpisode episode;
-      episode.strPath = item->m_strPath;
+      episode.strPath = item->GetPath();
       episode.iSeason = -1;
       episode.iEpisode = -1;
       episode.cDate.SetValid(false);
@@ -1054,7 +1054,7 @@ namespace VIDEO
     if (!m_database.Open())
       return -1;
 
-    CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to %s:%s", TranslateContent(content).c_str(), pItem->m_strPath.c_str());
+    CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to %s:%s", TranslateContent(content).c_str(), pItem->GetPath().c_str());
     long lResult = -1;
 
     CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
@@ -1069,7 +1069,7 @@ namespace VIDEO
       if (!strTrailer.IsEmpty())
         movieDetails.m_strTrailer = strTrailer;
 
-      lResult = m_database.SetDetailsForMovie(pItem->m_strPath, movieDetails);
+      lResult = m_database.SetDetailsForMovie(pItem->GetPath(), movieDetails);
       movieDetails.m_iDbId = lResult;
 
       // setup links to shows if the linked shows are in the db
@@ -1092,19 +1092,19 @@ namespace VIDEO
     {
       if (pItem->m_bIsFolder)
       {
-        lResult = m_database.SetDetailsForTvShow(pItem->m_strPath, movieDetails);
+        lResult = m_database.SetDetailsForTvShow(pItem->GetPath(), movieDetails);
         movieDetails.m_iDbId = lResult;
       }
       else
       {
         // we add episode then set details, as otherwise set details will delete the
         // episode then add, which breaks multi-episode files.
-        int idEpisode = m_database.AddEpisode(idShow, pItem->m_strPath);
-        lResult = m_database.SetDetailsForEpisode(pItem->m_strPath, movieDetails, idShow, idEpisode);
+        int idEpisode = m_database.AddEpisode(idShow, pItem->GetPath());
+        lResult = m_database.SetDetailsForEpisode(pItem->GetPath(), movieDetails, idShow, idEpisode);
         movieDetails.m_iDbId = lResult;
         if (movieDetails.m_fEpBookmark > 0)
         {
-          movieDetails.m_strFileNameAndPath = pItem->m_strPath;
+          movieDetails.m_strFileNameAndPath = pItem->GetPath();
           CBookmark bookmark;
           bookmark.timeInSeconds = movieDetails.m_fEpBookmark;
           bookmark.seasonNumber = movieDetails.m_iSeason;
@@ -1115,7 +1115,7 @@ namespace VIDEO
     }
     else if (content == CONTENT_MUSICVIDEOS)
     {
-      lResult = m_database.SetDetailsForMusicVideo(pItem->m_strPath, movieDetails);
+      lResult = m_database.SetDetailsForMusicVideo(pItem->GetPath(), movieDetails);
       movieDetails.m_iDbId = lResult;
     }
 
@@ -1141,7 +1141,7 @@ namespace VIDEO
     CStdString cachedThumb = pItem->GetCachedVideoThumb();
     if (isEpisode && CFile::Exists(cachedThumb))
     { // have an episode (??? and also a normal "cached" thumb that we're going to override now???)
-      movieDetails.m_strFileNameAndPath = pItem->m_strPath;
+      movieDetails.m_strFileNameAndPath = pItem->GetPath();
       CFileItem item(movieDetails);
       cachedThumb = item.GetCachedEpisodeThumb();
     }
@@ -1153,9 +1153,9 @@ namespace VIDEO
       if (bApplyToDir && localThumb.IsEmpty())
       {
         CStdString strParent;
-        URIUtils::GetParentPath(pItem->m_strPath, strParent);
+        URIUtils::GetParentPath(pItem->GetPath(), strParent);
         CFileItem item(*pItem);
-        item.m_strPath = strParent;
+        item.SetPath(strParent);
         item.m_bIsFolder = true;
         localThumb = item.GetUserVideoThumb();
       }
@@ -1176,7 +1176,7 @@ namespace VIDEO
             onlineThumb.Find("\\") < 0)
         {
           CStdString strPath;
-          URIUtils::GetDirectory(pItem->m_strPath, strPath);
+          URIUtils::GetDirectory(pItem->GetPath(), strPath);
           onlineThumb = URIUtils::AddFileToFolder(strPath, onlineThumb);
         }
         DownloadImage(onlineThumb, cachedThumb, true, pDialog);
@@ -1245,7 +1245,7 @@ namespace VIDEO
       }
 
       CFileItem item;
-      item.m_strPath = file->strPath;
+      item.SetPath(file->strPath);
 
       // handle .nfo files
       CNfoFile::NFOResult result=CNfoFile::NO_NFO;
@@ -1349,7 +1349,7 @@ namespace VIDEO
       {
         CVideoInfoDownloader imdb(scraper);
         CFileItem item;
-        item.m_strPath = file->strPath;
+        item.SetPath(file->strPath);
         if (!imdb.GetEpisodeDetails(guide->cScraperUrl, *item.GetVideoInfoTag(), pDlgProgress))
           return INFO_NOT_FOUND; // TODO: should we just skip to the next episode?
         item.GetVideoInfoTag()->m_iSeason = guide->key.first;
@@ -1384,21 +1384,21 @@ namespace VIDEO
     {
       // file
       CStdString strExtension;
-      URIUtils::GetExtension(item->m_strPath, strExtension);
+      URIUtils::GetExtension(item->GetPath(), strExtension);
 
-      if (URIUtils::IsInRAR(item->m_strPath)) // we have a rarred item - we want to check outside the rars
+      if (URIUtils::IsInRAR(item->GetPath())) // we have a rarred item - we want to check outside the rars
       {
         CFileItem item2(*item);
-        CURL url(item->m_strPath);
+        CURL url(item->GetPath());
         CStdString strPath;
         URIUtils::GetDirectory(url.GetHostName(), strPath);
-        URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(item->m_strPath),item2.m_strPath);
+        item2.SetPath(URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(item->GetPath())));
         return GetnfoFile(&item2, bGrabAny);
       }
 
       // grab the folder path
       CStdString strPath;
-      URIUtils::GetDirectory(item->m_strPath, strPath);
+      URIUtils::GetDirectory(item->GetPath(), strPath);
 
       if (bGrabAny)
       { // looking up by folder name - movie.nfo takes priority
@@ -1412,15 +1412,15 @@ namespace VIDEO
       {
         // first try .nfo file matching first file in stack
         CStackDirectory dir;
-        CStdString firstFile = dir.GetFirstStackedFile(item->m_strPath);
+        CStdString firstFile = dir.GetFirstStackedFile(item->GetPath());
         CFileItem item2;
-        item2.m_strPath = firstFile;
+        item2.SetPath(firstFile);
         nfoFile = GetnfoFile(&item2, bGrabAny);
         // else try .nfo file matching stacked title
         if (nfoFile.IsEmpty())
         {
-          CStdString stackedTitlePath = dir.GetStackedTitlePath(item->m_strPath);
-          item2.m_strPath = stackedTitlePath;
+          CStdString stackedTitlePath = dir.GetStackedTitlePath(item->GetPath());
+          item2.SetPath(stackedTitlePath);
           nfoFile = GetnfoFile(&item2, bGrabAny);
         }
       }
@@ -1428,10 +1428,10 @@ namespace VIDEO
       {
         // already an .nfo file?
         if ( strcmpi(strExtension.c_str(), ".nfo") == 0 )
-          nfoFile = item->m_strPath;
+          nfoFile = item->GetPath();
         // no, create .nfo file
         else
-          nfoFile = URIUtils::ReplaceExtension(item->m_strPath, ".nfo");
+          nfoFile = URIUtils::ReplaceExtension(item->GetPath(), ".nfo");
       }
 
       // test file existence
@@ -1445,14 +1445,14 @@ namespace VIDEO
         if (strPath.Mid(strPath.size()-3).Equals("cd1"))
         {
           strPath = strPath.Mid(0,strPath.size()-3);
-          URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(item->m_strPath),item2.m_strPath);
+          item2.SetPath(URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(item->GetPath())));
           return GetnfoFile(&item2, bGrabAny);
         }
       }
 
       if (!nfoFile.IsEmpty() && item->IsOpticalMediaFile())
       {
-        CStdString parent(URIUtils::GetParentPath(item->m_strPath));
+        CStdString parent(URIUtils::GetParentPath(item->GetPath()));
         CStdString parentFolder(parent);
         URIUtils::RemoveSlashAtEnd(parentFolder);
         if (parentFolder == "VIDEO_TS" || parentFolder == "BDMV")
@@ -1469,9 +1469,9 @@ namespace VIDEO
       // see if there is a unique nfo file in this folder, and if so, use that
       CFileItemList items;
       CDirectory dir;
-      CStdString strPath = item->m_strPath;
+      CStdString strPath = item->GetPath();
       if (!item->m_bIsFolder)
-        URIUtils::GetDirectory(item->m_strPath, strPath);
+        URIUtils::GetDirectory(item->GetPath(), strPath);
       if (dir.GetDirectory(strPath, items, ".nfo") && items.Size())
       {
         int numNFO = -1;
@@ -1489,7 +1489,7 @@ namespace VIDEO
           }
         }
         if (numNFO > -1)
-          return items[numNFO]->m_strPath;
+          return items[numNFO]->GetPath();
       }
     }
 
@@ -1499,7 +1499,7 @@ namespace VIDEO
   bool CVideoInfoScanner::GetDetails(CFileItem *pItem, CScraperUrl &url, const ScraperPtr& scraper, CNfoFile *nfoFile, CGUIDialogProgress* pDialog /* = NULL */)
   {
     CVideoInfoTag movieDetails;
-    movieDetails.m_strFileNameAndPath = pItem->m_strPath;
+    movieDetails.m_strFileNameAndPath = pItem->GetPath();
 
     CVideoInfoDownloader imdb(scraper);
     if ( imdb.GetDetails(url, movieDetails, pDialog) )
@@ -1542,7 +1542,7 @@ namespace VIDEO
     for (int i = 0; i < items.Size(); ++i)
     {
       const CFileItemPtr pItem = items[i];
-      md5state.append(pItem->m_strPath);
+      md5state.append(pItem->GetPath());
       md5state.append((unsigned char *)&pItem->m_dwSize, sizeof(pItem->m_dwSize));
       FILETIME time = pItem->m_dateTime;
       md5state.append((unsigned char *)&time, sizeof(FILETIME));
@@ -1596,7 +1596,8 @@ namespace VIDEO
     m_database.GetSeasonsNav(strPath, items, -1, -1, -1, -1, idTvShow);
     CFileItemPtr pItem;
     pItem.reset(new CFileItem(g_localizeStrings.Get(20366)));  // "All Seasons"
-    pItem->m_strPath.Format("%s/-1/", strPath.c_str());
+    CStdString path; path.Format("%s/-1/", strPath.c_str());
+    pItem->SetPath(path);
     pItem->GetVideoInfoTag()->m_iSeason = -1;
     pItem->GetVideoInfoTag()->m_strPath = movie.m_strPath;
     if (overwrite || !XFILE::CFile::Exists(pItem->GetCachedSeasonThumb()))
@@ -1623,11 +1624,11 @@ namespace VIDEO
         {
           for (int j=0;j<tbnItems.Size();++j)
           {
-            CStdString strCheck = URIUtils::GetFileName(tbnItems[j]->m_strPath);
+            CStdString strCheck = URIUtils::GetFileName(tbnItems[j]->GetPath());
             strCheck.ToLower();
             if (reg.RegFind(strCheck.c_str()) > -1)
             {
-              CPicture::CreateThumbnail(tbnItems[j]->m_strPath, items[i]->GetCachedSeasonThumb());
+              CPicture::CreateThumbnail(tbnItems[j]->GetPath(), items[i]->GetCachedSeasonThumb());
               bDownload=false;
               break;
             }
@@ -1668,7 +1669,7 @@ namespace VIDEO
         || (info->Content() == CONTENT_TVSHOWS && !pItem->m_bIsFolder))
       strNfoFile = GetnfoFile(pItem, bGrabAny);
     if (info->Content() == CONTENT_TVSHOWS && pItem->m_bIsFolder)
-      URIUtils::AddFileToFolder(pItem->m_strPath, "tvshow.nfo", strNfoFile);
+      URIUtils::AddFileToFolder(pItem->GetPath(), "tvshow.nfo", strNfoFile);
 
     CNfoFile::NFOResult result=CNfoFile::NO_NFO;
     if (!strNfoFile.IsEmpty() && CFile::Exists(strNfoFile))
@@ -1713,7 +1714,7 @@ namespace VIDEO
       }
     }
     else
-      CLog::Log(LOGDEBUG, "VideoInfoScanner: No NFO file found. Using title search for '%s'", pItem->m_strPath.c_str());
+      CLog::Log(LOGDEBUG, "VideoInfoScanner: No NFO file found. Using title search for '%s'", pItem->GetPath().c_str());
 
     return result;
   }
@@ -1764,9 +1765,9 @@ namespace VIDEO
 
   CStdString CVideoInfoScanner::GetParentDir(const CFileItem &item) const
   {
-    CStdString strCheck = item.m_strPath;
+    CStdString strCheck = item.GetPath();
     if (item.IsStack())
-      strCheck = CStackDirectory::GetFirstStackedFile(item.m_strPath);
+      strCheck = CStackDirectory::GetFirstStackedFile(item.GetPath());
 
     CStdString strDirectory;
     URIUtils::GetDirectory(strCheck, strDirectory);

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -284,13 +284,13 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
   else if (setting.id == SUBTITLE_SETTINGS_BROWSER)
   {
     CStdString strPath;
-    if (URIUtils::IsInRAR(g_application.CurrentFileItem().m_strPath) || URIUtils::IsInZIP(g_application.CurrentFileItem().m_strPath))
+    if (URIUtils::IsInRAR(g_application.CurrentFileItem().GetPath()) || URIUtils::IsInZIP(g_application.CurrentFileItem().GetPath()))
     {
-      CURL url(g_application.CurrentFileItem().m_strPath);
+      CURL url(g_application.CurrentFileItem().GetPath());
       strPath = url.GetHostName();
     }
     else
-      strPath = g_application.CurrentFileItem().m_strPath;
+      strPath = g_application.CurrentFileItem().GetPath();
 
     CStdString strMask = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.aqt|.jss|.ass|.idx|.rar|.zip";
     if (g_application.GetCurrentPlayer() == EPC_DVDPLAYER)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -193,7 +193,7 @@ bool CGUIDialogVideoInfo::OnMessage(CGUIMessage& message)
       if (IsActive() && message.GetParam1() == GUI_MSG_UPDATE_ITEM && message.GetItem())
       {
         CFileItemPtr item = boost::static_pointer_cast<CFileItem>(message.GetItem());
-        if (item && m_movieItem->m_strPath.Equals(item->m_strPath))
+        if (item && m_movieItem->GetPath().Equals(item->GetPath()))
         { // Just copy over the stream details and the thumb if we don't already have one
           if (!m_movieItem->HasThumbnail())
             m_movieItem->SetThumbnailImage(item->GetThumbnailImage());
@@ -556,13 +556,13 @@ void CGUIDialogVideoInfo::OnSearchItemFound(const CFileItem* pItem)
 
   CVideoInfoTag movieDetails;
   if (type == VIDEODB_CONTENT_MOVIES)
-    db.GetMovieInfo(pItem->m_strPath, movieDetails, pItem->GetVideoInfoTag()->m_iDbId);
+    db.GetMovieInfo(pItem->GetPath(), movieDetails, pItem->GetVideoInfoTag()->m_iDbId);
   if (type == VIDEODB_CONTENT_EPISODES)
-    db.GetEpisodeInfo(pItem->m_strPath, movieDetails, pItem->GetVideoInfoTag()->m_iDbId);
+    db.GetEpisodeInfo(pItem->GetPath(), movieDetails, pItem->GetVideoInfoTag()->m_iDbId);
   if (type == VIDEODB_CONTENT_TVSHOWS)
-    db.GetTvShowInfo(pItem->m_strPath, movieDetails, pItem->GetVideoInfoTag()->m_iDbId);
+    db.GetTvShowInfo(pItem->GetPath(), movieDetails, pItem->GetVideoInfoTag()->m_iDbId);
   if (type == VIDEODB_CONTENT_MUSICVIDEOS)
-    db.GetMusicVideoInfo(pItem->m_strPath, movieDetails, pItem->GetVideoInfoTag()->m_iDbId);
+    db.GetMusicVideoInfo(pItem->GetPath(), movieDetails, pItem->GetVideoInfoTag()->m_iDbId);
   db.Close();
 
   CFileItem item(*pItem);
@@ -593,7 +593,7 @@ void CGUIDialogVideoInfo::Play(bool resume)
 
   CFileItem movie(*m_movieItem->GetVideoInfoTag());
   if (m_movieItem->GetVideoInfoTag()->m_strFileNameAndPath.IsEmpty())
-    movie.m_strPath = m_movieItem->m_strPath;
+    movie.SetPath(m_movieItem->GetPath());
   CGUIWindowVideoNav* pWindow = (CGUIWindowVideoNav*)g_windowManager.GetWindow(WINDOW_VIDEO_NAV);
   if (pWindow)
   {
@@ -829,7 +829,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
 void CGUIDialogVideoInfo::PlayTrailer()
 {
   CFileItem item;
-  item.m_strPath = m_movieItem->GetVideoInfoTag()->m_strTrailer;
+  item.SetPath(m_movieItem->GetVideoInfoTag()->m_strTrailer);
   *item.GetVideoInfoTag() = *m_movieItem->GetVideoInfoTag();
   item.GetVideoInfoTag()->m_streamDetails.Reset();
   item.GetVideoInfoTag()->m_strTitle.Format("%s (%s)",m_movieItem->GetVideoInfoTag()->m_strTitle.c_str(),g_localizeStrings.Get(20410));

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -137,7 +137,7 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
         g_settings.m_videoStacking = !g_settings.m_videoStacking;
         g_settings.Save();
         UpdateButtons();
-        Update( m_vecItems->m_strPath );
+        Update( m_vecItems->GetPath() );
       }
       else if (iControl == CONTROL_PLAY_DVD)
       {
@@ -206,7 +206,7 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
               OnDeleteItem(iItem);
 
             // or be at the video playlists location
-            else if (m_vecItems->m_strPath.Equals("special://videoplaylists/"))
+            else if (m_vecItems->GetPath().Equals("special://videoplaylists/"))
               OnDeleteItem(iItem);
             else
               return false;
@@ -255,7 +255,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
   if (!pItem)
     return;
 
-  if (pItem->IsParentFolder() || pItem->m_bIsShareOrDrive || pItem->m_strPath.Equals("add"))
+  if (pItem->IsParentFolder() || pItem->m_bIsShareOrDrive || pItem->GetPath().Equals("add"))
     return;
 
   // ShowIMDB can kill the item as this window can be closed while we do it,
@@ -264,16 +264,16 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
   if (item.IsVideoDb() && item.HasVideoInfoTag())
   {
     if (item.GetVideoInfoTag()->m_strFileNameAndPath.IsEmpty())
-      item.m_strPath = item.GetVideoInfoTag()->m_strPath;
+      item.SetPath(item.GetVideoInfoTag()->m_strPath);
     else
-      item.m_strPath = item.GetVideoInfoTag()->m_strFileNameAndPath;
+      item.SetPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
   }
   else
   {
     if (item.m_bIsFolder && scraper && scraper->Content() != CONTENT_TVSHOWS)
     {
       CFileItemList items;
-      CDirectory::GetDirectory(item.m_strPath, items,"",true,false,DIR_CACHE_ONCE,true,true);
+      CDirectory::GetDirectory(item.GetPath(), items,"",true,false,DIR_CACHE_ONCE,true,true);
       items.Stack();
 
       // check for media files
@@ -283,9 +283,9 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
         CFileItemPtr item2 = items[i];
 
         if (item2->IsVideo() && !item2->IsPlayList() &&
-            !CUtil::ExcludeFileOrFolder(item2->m_strPath, g_advancedSettings.m_moviesExcludeFromScanRegExps))
+            !CUtil::ExcludeFileOrFolder(item2->GetPath(), g_advancedSettings.m_moviesExcludeFromScanRegExps))
         {
-          item.m_strPath = item2->m_strPath;
+          item.SetPath(item2->GetPath());
           item.m_bIsFolder = false;
           bFoundFile = true;
           break;
@@ -303,7 +303,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
 
   // we need to also request any thumbs be applied to the folder item
   if (pItem->m_bIsFolder)
-    item.SetProperty("set_folder_thumb", pItem->m_strPath);
+    item.SetProperty("set_folder_thumb", pItem->GetPath());
 
   bool modified = ShowIMDB(&item, scraper);
   if (modified &&
@@ -311,7 +311,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
       g_windowManager.GetActiveWindow() == WINDOW_VIDEO_NAV)) // since we can be called from the music library we need this check
   {
     int itemNumber = m_viewControl.GetSelectedItem();
-    Update(m_vecItems->m_strPath);
+    Update(m_vecItems->GetPath());
     m_viewControl.SetSelectedItem(itemNumber);
   }
 }
@@ -369,20 +369,20 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
 
     if (info->Content() == CONTENT_MOVIES)
     {
-      if (m_database.HasMovieInfo(item->m_strPath))
+      if (m_database.HasMovieInfo(item->GetPath()))
       {
         bHasInfo = true;
-        m_database.GetMovieInfo(item->m_strPath, movieDetails);
+        m_database.GetMovieInfo(item->GetPath(), movieDetails);
       }
     }
     if (info->Content() == CONTENT_TVSHOWS)
     {
       if (item->m_bIsFolder)
       {
-        if (m_database.HasTvShowInfo(item->m_strPath))
+        if (m_database.HasTvShowInfo(item->GetPath()))
         {
           bHasInfo = true;
-          m_database.GetTvShowInfo(item->m_strPath, movieDetails);
+          m_database.GetTvShowInfo(item->GetPath(), movieDetails);
         }
       }
       else
@@ -391,10 +391,10 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
         if (item->HasVideoInfoTag())
           EpisodeHint = item->GetVideoInfoTag()->m_iEpisode;
         int idEpisode=-1;
-        if ((idEpisode = m_database.GetEpisodeId(item->m_strPath,EpisodeHint)) > -1)
+        if ((idEpisode = m_database.GetEpisodeId(item->GetPath(),EpisodeHint)) > -1)
         {
           bHasInfo = true;
-          m_database.GetEpisodeInfo(item->m_strPath, movieDetails, idEpisode);
+          m_database.GetEpisodeInfo(item->GetPath(), movieDetails, idEpisode);
         }
         else
         {
@@ -407,10 +407,10 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
           //       database.  Possible solutions are to store the paths in the db separately and rely on the show
           //       stacking stuff, or to modify GetTvShowId to do support multipath:// shares
           CStdString strParentDirectory;
-          URIUtils::GetParentPath(item->m_strPath, strParentDirectory);
+          URIUtils::GetParentPath(item->GetPath(), strParentDirectory);
           if (m_database.GetTvShowId(strParentDirectory) < 0)
           {
-            CLog::Log(LOGERROR,"%s: could not add episode [%s]. tvshow does not exist yet..", __FUNCTION__, item->m_strPath.c_str());
+            CLog::Log(LOGERROR,"%s: could not add episode [%s]. tvshow does not exist yet..", __FUNCTION__, item->GetPath().c_str());
             return false;
           }
         }
@@ -418,10 +418,10 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
     }
     if (info->Content() == CONTENT_MUSICVIDEOS)
     {
-      if (m_database.HasMusicVideoInfo(item->m_strPath))
+      if (m_database.HasMusicVideoInfo(item->GetPath()))
       {
         bHasInfo = true;
-        m_database.GetMusicVideoInfo(item->m_strPath, movieDetails);
+        m_database.GetMusicVideoInfo(item->GetPath(), movieDetails);
       }
     }
     m_database.Close();
@@ -462,7 +462,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
   m_database.Open();
   // 2. Look for a nfo File to get the search URL
   SScanSettings settings;
-  info = m_database.GetScraperForPath(item->m_strPath,settings);
+  info = m_database.GetScraperForPath(item->GetPath(),settings);
 
   if (!info)
     return false;
@@ -590,7 +590,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
       // 5. Download the movie information
       // show dialog that we're downloading the movie info
       CFileItemList list;
-      CStdString strPath=item->m_strPath;
+      CStdString strPath=item->GetPath();
       if (item->IsVideoDb())
       {
         CFileItemPtr newItem(new CFileItem(*item->GetVideoInfoTag()));
@@ -604,9 +604,13 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
       }
 
       if (item->m_bIsFolder)
-        URIUtils::GetParentPath(strPath,list.m_strPath);
+        list.SetPath(URIUtils::GetParentPath(strPath));
       else
-        URIUtils::GetDirectory(strPath,list.m_strPath);
+      {
+        CStdString path;
+        URIUtils::GetDirectory(strPath, path);
+        list.SetPath(path);
+      }
 
       int iString=198;
       if (info->Content() == CONTENT_TVSHOWS)
@@ -627,32 +631,32 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
       if (bHasInfo)
       {
         if (info->Content() == CONTENT_MOVIES)
-          m_database.DeleteMovie(item->m_strPath);
+          m_database.DeleteMovie(item->GetPath());
         if (info->Content() == CONTENT_TVSHOWS && !item->m_bIsFolder)
-          m_database.DeleteEpisode(item->m_strPath,movieDetails.m_iDbId);
+          m_database.DeleteEpisode(item->GetPath(),movieDetails.m_iDbId);
         if (info->Content() == CONTENT_MUSICVIDEOS)
-          m_database.DeleteMusicVideo(item->m_strPath);
+          m_database.DeleteMusicVideo(item->GetPath());
         if (info->Content() == CONTENT_TVSHOWS && item->m_bIsFolder)
         {
           if (pDlgInfo->RefreshAll())
-            m_database.DeleteTvShow(item->m_strPath);
+            m_database.DeleteTvShow(item->GetPath());
           else
-            m_database.DeleteDetailsForTvShow(item->m_strPath);
+            m_database.DeleteDetailsForTvShow(item->GetPath());
         }
       }
       if (scanner.RetrieveVideoInfo(list,settings.parent_name_root,info->Content(),!ignoreNfo,&scrUrl,pDlgInfo->RefreshAll(),pDlgProgress))
       {
         if (info->Content() == CONTENT_MOVIES)
-          m_database.GetMovieInfo(item->m_strPath,movieDetails);
+          m_database.GetMovieInfo(item->GetPath(),movieDetails);
         if (info->Content() == CONTENT_MUSICVIDEOS)
-          m_database.GetMusicVideoInfo(item->m_strPath,movieDetails);
+          m_database.GetMusicVideoInfo(item->GetPath(),movieDetails);
         if (info->Content() == CONTENT_TVSHOWS)
         {
           // update tvshow info to get updated episode numbers
           if (item->m_bIsFolder)
-            m_database.GetTvShowInfo(item->m_strPath,movieDetails);
+            m_database.GetTvShowInfo(item->GetPath(),movieDetails);
           else
-            m_database.GetEpisodeInfo(item->m_strPath,movieDetails);
+            m_database.GetEpisodeInfo(item->GetPath(),movieDetails);
         }
 
         // got all movie details :-)
@@ -741,7 +745,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
 
     // recursive
     CFileItemList items;
-    GetDirectory(pItem->m_strPath, items);
+    GetDirectory(pItem->GetPath(), items);
     FormatAndSort(items);
 
     int watchedMode = g_settings.GetWatchMode(m_vecItems->GetContent());
@@ -751,7 +755,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
     {
       if (items[i]->m_bIsFolder)
       {
-        CStdString strPath = items[i]->m_strPath;
+        CStdString strPath = items[i]->GetPath();
         URIUtils::RemoveSlashAtEnd(strPath);
         strPath.ToLower();
         if (strPath.size() > 6)
@@ -778,7 +782,7 @@ void CGUIWindowVideoBase::AddItemToPlayList(const CFileItemPtr &pItem, CFileItem
       if (pPlayList.get())
       {
         // load it
-        if (!pPlayList->Load(pItem->m_strPath))
+        if (!pPlayList->Load(pItem->GetPath()))
         {
           CGUIDialogOK::ShowAndGetInput(6, 0, 477, 0);
           return; //hmmm unable to load playlist?
@@ -824,11 +828,11 @@ int  CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item)
   long startoffset = 0;
 
   if (item->IsStack() && (!g_guiSettings.GetBool("myvideos.treatstackasfile") ||
-                          CFileItem(CStackDirectory::GetFirstStackedFile(item->m_strPath),false).IsDVDImage()) )
+                          CFileItem(CStackDirectory::GetFirstStackedFile(item->GetPath()),false).IsDVDImage()) )
   {
 
     CStdStringArray movies;
-    GetStackedFiles(item->m_strPath, movies);
+    GetStackedFiles(item->GetPath(), movies);
 
     /* check if any of the stacked files have a resume bookmark */
     for (unsigned i = 0; i<movies.size();i++)
@@ -849,7 +853,7 @@ int  CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item)
     else
     {
       CBookmark bookmark;
-      CStdString strPath = item->m_strPath;
+      CStdString strPath = item->GetPath();
       if ((item->IsVideoDb() || item->IsDVD()) && item->HasVideoInfoTag())
         strPath = item->GetVideoInfoTag()->m_strFileNameAndPath;
 
@@ -874,7 +878,7 @@ bool CGUIWindowVideoBase::OnSelect(int iItem)
 
   CFileItemPtr item = m_vecItems->Get(iItem);
 
-  if (!item->m_bIsFolder && item->m_strPath != "add")
+  if (!item->m_bIsFolder && item->GetPath() != "add")
     return OnFileAction(iItem, g_guiSettings.GetInt("myvideos.selectaction"));
 
   return CGUIMediaWindow::OnSelect(iItem);
@@ -939,7 +943,7 @@ bool CGUIWindowVideoBase::OnInfo(int iItem)
 
   CFileItemPtr item = m_vecItems->Get(iItem);
 
-  if (item->m_strPath.Equals("add") || item->IsParentFolder())
+  if (item->GetPath().Equals("add") || item->IsParentFolder())
     return false;
 
   ADDON::ScraperPtr scraper;
@@ -953,16 +957,16 @@ bool CGUIWindowVideoBase::OnInfo(int iItem)
       strDir = item->GetVideoInfoTag()->m_strPath;
     }
     else
-      URIUtils::GetDirectory(item->m_strPath,strDir);
+      URIUtils::GetDirectory(item->GetPath(),strDir);
 
     SScanSettings settings;
     bool foundDirectly = false;
     scraper = m_database.GetScraperForPath(strDir, settings, foundDirectly);
 
     if (!scraper &&
-        !(m_database.HasMovieInfo(item->m_strPath) ||
+        !(m_database.HasMovieInfo(item->GetPath()) ||
           m_database.HasTvShowInfo(strDir)           ||
-          m_database.HasEpisodeInfo(item->m_strPath)))
+          m_database.HasEpisodeInfo(item->GetPath())))
     {
       return false;
     }
@@ -988,7 +992,7 @@ CStdString CGUIWindowVideoBase::GetResumeString(CFileItem item)
   if (db.Open())
   {
     CBookmark bookmark;
-    CStdString itemPath(item.m_strPath);
+    CStdString itemPath(item.GetPath());
     if (item.IsVideoDb() || item.IsDVD())
       itemPath = item.GetVideoInfoTag()->m_strFileNameAndPath;
     if (db.GetResumeBookMark(itemPath, bookmark) )
@@ -1071,7 +1075,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
   {
     if (!item->IsParentFolder())
     {
-      CStdString path(item->m_strPath);
+      CStdString path(item->GetPath());
       if (item->IsVideoDb() && item->HasVideoInfoTag())
         path = item->GetVideoInfoTag()->m_strFileNameAndPath;
 
@@ -1084,8 +1088,8 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
             buttons.Add(CONTEXT_BUTTON_PLAY_PART, 20324);
         }
 
-        if (!m_vecItems->m_strPath.IsEmpty() && !item->m_strPath.Left(19).Equals("newsmartplaylist://")
-            && !m_vecItems->m_strPath.Left(10).Equals("sources://"))
+        if (!m_vecItems->GetPath().IsEmpty() && !item->GetPath().Left(19).Equals("newsmartplaylist://")
+            && !m_vecItems->GetPath().Left(10).Equals("sources://"))
         {
           buttons.Add(CONTEXT_BUTTON_QUEUE_ITEM, 13347);      // Add to Playlist
         }
@@ -1102,8 +1106,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
         VECPLAYERCORES vecCores;
         if (item->IsVideoDb())
         {
-          CFileItem item2;
-          item2.m_strPath = item->GetVideoInfoTag()->m_strFileNameAndPath;
+          CFileItem item2(item->GetVideoInfoTag()->m_strFileNameAndPath, false);
           CPlayerCoreFactory::GetPlayers(item2, vecCores);
         }
         else
@@ -1150,14 +1153,14 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_SET_CONTENT:
     {
       SScanSettings settings;
-      ADDON::ScraperPtr info = m_database.GetScraperForPath(item->HasVideoInfoTag() ? item->GetVideoInfoTag()->m_strPath : item->m_strPath, settings);
-      OnAssignContent(item->m_strPath,0, info, settings);
+      ADDON::ScraperPtr info = m_database.GetScraperForPath(item->HasVideoInfoTag() ? item->GetVideoInfoTag()->m_strPath : item->GetPath(), settings);
+      OnAssignContent(item->GetPath(),0, info, settings);
       return true;
     }
   case CONTEXT_BUTTON_PLAY_PART:
     {
       CFileItemList items;
-      CStdString path(item->m_strPath);
+      CStdString path(item->GetPath());
       if (item->IsVideoDb())
         path = item->GetVideoInfoTag()->m_strFileNameAndPath;
 
@@ -1208,7 +1211,7 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     }
 
   case CONTEXT_BUTTON_PLAY_PARTYMODE:
-    g_partyModeManager.Enable(PARTYMODECONTEXT_VIDEO, m_vecItems->Get(itemNumber)->m_strPath);
+    g_partyModeManager.Enable(PARTYMODECONTEXT_VIDEO, m_vecItems->Get(itemNumber)->GetPath());
     return true;
 
   case CONTEXT_BUTTON_RESTART_ITEM:
@@ -1241,7 +1244,7 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       ADDON::ScraperPtr info;
       SScanSettings settings;
       GetScraperForItem(item.get(), info, settings);
-      CStdString strPath = item->m_strPath;
+      CStdString strPath = item->GetPath();
       if (item->IsVideoDb() && (!item->m_bIsFolder || item->GetVideoInfoTag()->m_strPath.IsEmpty()))
         return false;
 
@@ -1266,11 +1269,11 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     return true;
   case CONTEXT_BUTTON_EDIT_SMART_PLAYLIST:
     {
-      CStdString playlist = m_vecItems->Get(itemNumber)->IsSmartPlayList() ? m_vecItems->Get(itemNumber)->m_strPath : m_vecItems->m_strPath; // save path as activatewindow will destroy our items
+      CStdString playlist = m_vecItems->Get(itemNumber)->IsSmartPlayList() ? m_vecItems->Get(itemNumber)->GetPath() : m_vecItems->GetPath(); // save path as activatewindow will destroy our items
       if (CGUIDialogSmartPlaylistEditor::EditPlaylist(playlist, "video"))
       { // need to update
         m_vecItems->RemoveDiscCache(GetID());
-        Update(m_vecItems->m_strPath);
+        Update(m_vecItems->GetPath());
       }
       return true;
     }
@@ -1284,13 +1287,13 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       m_viewControl.SetSelectedItem(newSelection);
 
       CUtil::DeleteVideoDatabaseDirectoryCache();
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
       return true;
     }
   case CONTEXT_BUTTON_MARK_UNWATCHED:
     MarkWatched(item,false);
     CUtil::DeleteVideoDatabaseDirectoryCache();
-    Update(m_vecItems->m_strPath);
+    Update(m_vecItems->GetPath());
     return true;
   case CONTEXT_BUTTON_PLAY_AND_QUEUE:
     return OnPlayAndQueueMedia(item);
@@ -1313,7 +1316,7 @@ void CGUIWindowVideoBase::GetStackedFiles(const CStdString &strFilePath1, vector
     CFileItemList items;
     dir.GetDirectory(strFilePath, items);
     for (int i = 0; i < items.Size(); ++i)
-      movies.push_back(items[i]->m_strPath);
+      movies.push_back(items[i]->GetPath());
   }
   if (movies.empty())
     movies.push_back(strFilePath);
@@ -1343,8 +1346,8 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem)
   CFileItem item(*pItem);
   if (pItem->IsVideoDb())
   {
-    item.m_strPath = pItem->GetVideoInfoTag()->m_strFileNameAndPath;
-    item.SetProperty("original_listitem_url", pItem->m_strPath);
+    item.SetPath(pItem->GetVideoInfoTag()->m_strFileNameAndPath);
+    item.SetProperty("original_listitem_url", pItem->GetPath());
   }
 
   PlayMovie(&item);
@@ -1371,10 +1374,10 @@ void CGUIWindowVideoBase::PlayMovie(const CFileItem *item)
   long startoffset = item->m_lStartOffset;
 
   if (item->IsStack() && (!g_guiSettings.GetBool("myvideos.treatstackasfile") ||
-                          CFileItem(CStackDirectory::GetFirstStackedFile(item->m_strPath),false).IsDVDImage()) )
+                          CFileItem(CStackDirectory::GetFirstStackedFile(item->GetPath()),false).IsDVDImage()) )
   {
     CStdStringArray movies;
-    GetStackedFiles(item->m_strPath, movies);
+    GetStackedFiles(item->GetPath(), movies);
 
     if (item->m_lStartOffset == STARTOFFSET_RESUME)
     {
@@ -1395,7 +1398,7 @@ void CGUIWindowVideoBase::PlayMovie(const CFileItem *item)
 
         /* figure out what file this time offset is */
         vector<int> times;
-        m_database.GetStackTimes(item->m_strPath, times);
+        m_database.GetStackTimes(item->GetPath(), times);
         long totaltime = 0;
         for (unsigned i = 0; i < times.size(); i++)
         {
@@ -1463,7 +1466,7 @@ void CGUIWindowVideoBase::OnDeleteItem(int iItem)
 
   OnDeleteItem(m_vecItems->Get(iItem));
 
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
   m_viewControl.SetSelectedItem(iItem);
 }
 
@@ -1480,7 +1483,7 @@ void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
   }
 
   if (g_guiSettings.GetBool("filelists.allowfiledeletion") &&
-      CUtil::SupportsFileOperations(item->m_strPath))
+      CUtil::SupportsFileOperations(item->GetPath()))
     CFileUtils::DeleteItem(item);
 }
 
@@ -1502,7 +1505,7 @@ void CGUIWindowVideoBase::MarkWatched(const CFileItemPtr &item, bool bMark)
     CFileItemList items;
     if (item->m_bIsFolder)
     {
-      CStdString strPath = item->m_strPath;
+      CStdString strPath = item->GetPath();
       CDirectory::GetDirectory(strPath, items);
     }
     else
@@ -1524,7 +1527,7 @@ void CGUIWindowVideoBase::MarkWatched(const CFileItemPtr &item, bool bMark)
 
       // Clear resume bookmark
       if (bMark)
-        database.ClearBookMarksOfFile(pItem->m_strPath, CBookmark::RESUME);
+        database.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
 
       database.SetPlayCount(*pItem, bMark ? 1 : 0);
     }
@@ -1549,7 +1552,7 @@ void CGUIWindowVideoBase::UpdateVideoTitle(const CFileItem* pItem)
   database.Open();
   CVideoDatabaseDirectory dir;
   CQueryParams params;
-  dir.GetQueryParams(pItem->m_strPath,params);
+  dir.GetQueryParams(pItem->GetPath(),params);
   int iDbId = pItem->GetVideoInfoTag()->m_iDbId;
 
   VIDEODB_CONTENT_TYPE iType=VIDEODB_CONTENT_MOVIES;
@@ -1569,7 +1572,7 @@ void CGUIWindowVideoBase::UpdateVideoTitle(const CFileItem* pItem)
   if (iType == VIDEODB_CONTENT_MOVIE_SETS)
     database.GetSetInfo(params.GetSetId(), detail);
   if (iType == VIDEODB_CONTENT_EPISODES)
-    database.GetEpisodeInfo(pItem->m_strPath,detail,pItem->GetVideoInfoTag()->m_iDbId);
+    database.GetEpisodeInfo(pItem->GetPath(),detail,pItem->GetVideoInfoTag()->m_iDbId);
   if (iType == VIDEODB_CONTENT_TVSHOWS)
     database.GetTvShowInfo(pItem->GetVideoInfoTag()->m_strFileNameAndPath,detail,pItem->GetVideoInfoTag()->m_iDbId);
   if (iType == VIDEODB_CONTENT_MUSICVIDEOS)
@@ -1646,7 +1649,7 @@ void CGUIWindowVideoBase::PlayItem(int iItem)
   else if (pItem->IsPlayList())
   {
     // load the playlist the old way
-    LoadPlayList(pItem->m_strPath, PLAYLIST_VIDEO);
+    LoadPlayList(pItem->GetPath(), PLAYLIST_VIDEO);
   }
   else
   {
@@ -1673,7 +1676,7 @@ bool CGUIWindowVideoBase::GetDirectory(const CStdString &strDirectory, CFileItem
   bool bResult = CGUIMediaWindow::GetDirectory(strDirectory,items);
 
   // add in the "New Playlist" item if we're in the playlists folder
-  if ((items.m_strPath == "special://videoplaylists/") && !items.Contains("newplaylist://"))
+  if ((items.GetPath() == "special://videoplaylists/") && !items.Contains("newplaylist://"))
   {
     CFileItemPtr newPlaylist(new CFileItem(g_settings.GetUserDataItem("PartyMode-Video.xsp"),false));
     newPlaylist->SetLabel(g_localizeStrings.Get(16035));
@@ -1710,7 +1713,7 @@ bool CGUIWindowVideoBase::GetDirectory(const CStdString &strDirectory, CFileItem
 
 void CGUIWindowVideoBase::OnPrepareFileItems(CFileItemList &items)
 {
-  if (!items.m_strPath.Equals("plugin://video/"))
+  if (!items.GetPath().Equals("plugin://video/"))
     items.SetCachedVideoThumbs();
 
   if (items.GetContent() != "episodes")
@@ -1782,9 +1785,9 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
 
   // everything is ok, so add to database
   m_database.Open();
-  int idMovie = m_database.AddMovie(pItem->m_strPath);
+  int idMovie = m_database.AddMovie(pItem->GetPath());
   movie.m_strIMDBNumber.Format("xx%08i", idMovie);
-  m_database.SetDetailsForMovie(pItem->m_strPath, movie);
+  m_database.SetDetailsForMovie(pItem->GetPath(), movie);
   m_database.Close();
 
   // done...
@@ -1851,7 +1854,7 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
 {
   if (pSelItem->m_bIsFolder)
   {
-    CStdString strPath = pSelItem->m_strPath;
+    CStdString strPath = pSelItem->GetPath();
     CStdString strParentPath;
     URIUtils::GetParentPath(strPath, strParentPath);
 
@@ -1862,7 +1865,7 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
     else
       SetHistoryForPath(strParentPath);
 
-    strPath = pSelItem->m_strPath;
+    strPath = pSelItem->GetPath();
     CURL url(strPath);
     if (pSelItem->IsSmb() && !URIUtils::HasSlashAtEnd(strPath))
       strPath += "/";
@@ -1870,7 +1873,7 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
     for (int i = 0; i < m_vecItems->Size(); i++)
     {
       CFileItemPtr pItem = m_vecItems->Get(i);
-      if (pItem->m_strPath == strPath)
+      if (pItem->GetPath() == strPath)
       {
         m_viewControl.SetSelectedItem(i);
         break;
@@ -1880,7 +1883,7 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
   else
   {
     CStdString strPath;
-    URIUtils::GetDirectory(pSelItem->m_strPath, strPath);
+    URIUtils::GetDirectory(pSelItem->GetPath(), strPath);
 
     Update(strPath);
 
@@ -1892,7 +1895,7 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
     for (int i = 0; i < (int)m_vecItems->Size(); i++)
     {
       CFileItemPtr pItem = m_vecItems->Get(i);
-      if (pItem->m_strPath == pSelItem->m_strPath)
+      if (pItem->GetPath() == pSelItem->GetPath())
       {
         m_viewControl.SetSelectedItem(i);
         break;
@@ -1919,7 +1922,7 @@ int CGUIWindowVideoBase::GetScraperForItem(CFileItem *item, ADDON::ScraperPtr &i
   }
 
   bool foundDirectly = false;
-  info = m_database.GetScraperForPath(item->HasVideoInfoTag() ? item->GetVideoInfoTag()->m_strPath : item->m_strPath, settings, foundDirectly);
+  info = m_database.GetScraperForPath(item->HasVideoInfoTag() ? item->GetVideoInfoTag()->m_strPath : item->GetPath(), settings, foundDirectly);
   return foundDirectly ? 1 : 0;
 }
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -103,7 +103,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
   switch (message.GetMessage())
   {
   case GUI_MSG_WINDOW_RESET:
-    m_vecItems->m_strPath.clear();
+    m_vecItems->SetPath("");
     break;
   case GUI_MSG_WINDOW_DEINIT:
     if (m_thumbLoader.IsLoading())
@@ -124,7 +124,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
 
       if (!m_database.HasContent() && m_vecItems->IsVideoDb())
       { // no library - make sure we default to the root.
-        m_vecItems->m_strPath = "";
+        m_vecItems->SetPath("");
         SetHistoryForPath("");
         Update("");
       }
@@ -169,7 +169,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
         // TODO: Can we perhaps filter this directly?  Probably not for some of the more complicated views,
         //       but for those perhaps we can just display them all, and only filter when we get a list
         //       of actual videos?
-        Update(m_vecItems->m_strPath);
+        Update(m_vecItems->GetPath());
         return true;
       }
       else if (iControl == CONTROL_BTNFLATTEN)
@@ -192,7 +192,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
         // TODO: Can we perhaps filter this directly?  Probably not for some of the more complicated views,
         //       but for those perhaps we can just display them all, and only filter when we get a list
         //       of actual videos?
-        Update(m_vecItems->m_strPath);
+        Update(m_vecItems->GetPath());
         return true;
       }
     }
@@ -201,7 +201,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
     case GUI_MSG_SCAN_FINISHED:
     case GUI_MSG_REFRESH_THUMBS:
     {
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
     }
     break;
   }
@@ -287,8 +287,8 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
     {
       XFILE::CVideoDatabaseDirectory dir;
       CQueryParams params;
-      dir.GetQueryParams(items.m_strPath,params);
-      VIDEODATABASEDIRECTORY::NODE_TYPE node = dir.GetDirectoryChildType(items.m_strPath);
+      dir.GetQueryParams(items.GetPath(),params);
+      VIDEODATABASEDIRECTORY::NODE_TYPE node = dir.GetDirectoryChildType(items.GetPath());
 
       items.SetThumbnailImage("");
       if (node == VIDEODATABASEDIRECTORY::NODE_TYPE_EPISODES ||
@@ -297,13 +297,14 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
       {
         CLog::Log(LOGDEBUG, "WindowVideoNav::GetDirectory");
         // grab the show thumb
-        CFileItem showItem;
-        m_database.GetFilePathById(params.GetTvShowId(),showItem.m_strPath,VIDEODB_CONTENT_TVSHOWS);
+        CStdString path;
+        m_database.GetFilePathById(params.GetTvShowId(),path,VIDEODB_CONTENT_TVSHOWS);
+        CFileItem showItem(path, true);
         showItem.SetVideoThumb();
         items.SetProperty("tvshowthumb", showItem.GetThumbnailImage());
         // Grab fanart data
         CVideoInfoTag details;
-        m_database.GetTvShowInfo(showItem.m_strPath, details, params.GetTvShowId());
+        m_database.GetTvShowInfo(showItem.GetPath(), details, params.GetTvShowId());
         items.SetProperty("fanart_color1", details.m_fanart.GetColor(0));
         items.SetProperty("fanart_color2", details.m_fanart.GetColor(1));
         items.SetProperty("fanart_color3", details.m_fanart.GetColor(2));
@@ -321,7 +322,7 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
           strLabel.Format(g_localizeStrings.Get(20358), params.GetSeason());
 
         CFileItem item(strLabel);
-        URIUtils::GetParentPath(items.m_strPath,item.m_strPath);
+        item.SetPath(URIUtils::GetParentPath(items.GetPath()));
         item.m_bIsFolder = true;
         item.SetCachedSeasonThumb();
         if (item.HasThumbnail())
@@ -337,9 +338,9 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
           if (params.GetSeason() == -1 && items.Size() > 0)
           {
             CQueryParams params2;
-            dir.GetQueryParams(items[0]->m_strPath,params2);
+            dir.GetQueryParams(items[0]->GetPath(),params2);
             strLabel.Format(g_localizeStrings.Get(20358), params2.GetSeason());
-            URIUtils::GetParentPath(items.m_strPath,strPath);
+            strPath = URIUtils::GetParentPath(items.GetPath());
           }
           else
           {
@@ -347,13 +348,12 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
               strLabel = g_localizeStrings.Get(20381);
             else
               strLabel.Format(g_localizeStrings.Get(20358), params.GetSeason());
-            strPath = items.m_strPath;
+            strPath = items.GetPath();
           }
 
-          CFileItem item(strLabel);
-          item.m_strPath = strPath;
-          item.m_bIsFolder = true;
-          item.GetVideoInfoTag()->m_strPath = showItem.m_strPath;
+          CFileItem item(strPath, true);
+          item.SetLabel(strLabel);
+          item.GetVideoInfoTag()->m_strPath = showItem.GetPath();
           item.SetCachedSeasonThumb();
 
           items.SetThumbnailImage(item.GetThumbnailImage());
@@ -398,7 +398,7 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
     else
     { // load info from the database
       CStdString label;
-      if (items.GetLabel().IsEmpty() && m_rootDir.IsSource(items.m_strPath, g_settings.GetSourcesFromType("video"), &label)) 
+      if (items.GetLabel().IsEmpty() && m_rootDir.IsSource(items.GetPath(), g_settings.GetSourcesFromType("video"), &label)) 
         items.SetLabel(label);
       LoadVideoInfo(items);
     }
@@ -413,7 +413,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
   if (!items.GetContent().IsEmpty())
     return; // don't load for listings that have content set
 
-  CStdString content = m_database.GetContentForPath(items.m_strPath);
+  CStdString content = m_database.GetContentForPath(items.GetPath());
   items.SetContent(content.IsEmpty() ? "files" : content);
 
   bool fileMetaData = (g_guiSettings.GetBool("myvideos.filemetadata") &&
@@ -425,7 +425,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
   bool fetchedPlayCounts = false;
   if (!content.IsEmpty())
   {
-    m_database.GetItemsForPath(content, items.m_strPath, dbItems);
+    m_database.GetItemsForPath(content, items.GetPath(), dbItems);
     dbItems.SetFastLookup(true);
   }
 
@@ -434,7 +434,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
     CFileItemPtr pItem = items[i];
     CFileItemPtr match;
     if (!content.IsEmpty())
-      match = dbItems.Get(pItem->m_strPath);
+      match = dbItems.Get(pItem->GetPath());
     if (match)
     {
       CStdString label (pItem->GetLabel ());
@@ -444,9 +444,9 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
       if (fileMetaData)
       {
         if (match->m_bIsFolder)
-          pItem->m_strPath = match->GetVideoInfoTag()->m_strPath;
+          pItem->SetPath(match->GetVideoInfoTag()->m_strPath);
         else
-          pItem->m_strPath = match->GetVideoInfoTag()->m_strFileNameAndPath;
+          pItem->SetPath(match->GetVideoInfoTag()->m_strFileNameAndPath);
         // if we switch from a file to a folder item it means we really shouldn't be sorting files and
         // folders separately
         if (pItem->m_bIsFolder != match->m_bIsFolder)
@@ -471,7 +471,7 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
                 This code can be removed once the content tables are always filled */
       if (!pItem->m_bIsFolder && !fetchedPlayCounts)
       {
-        m_database.GetPlayCounts(items.m_strPath, items);
+        m_database.GetPlayCounts(items.GetPath(), items);
         fetchedPlayCounts = true;
       }
       
@@ -500,11 +500,11 @@ void CGUIWindowVideoNav::UpdateButtons()
     {
       CFileItemPtr pItem = m_vecItems->Get(i);
       if (pItem->IsParentFolder()) iItems--;
-      if (pItem->m_strPath.Left(4).Equals("/-1/")) iItems--;
+      if (pItem->GetPath().Left(4).Equals("/-1/")) iItems--;
     }
     // or the last item
     if (m_vecItems->Size() > 2 &&
-      m_vecItems->Get(m_vecItems->Size()-1)->m_strPath.Left(4).Equals("/-1/"))
+      m_vecItems->Get(m_vecItems->Size()-1)->GetPath().Left(4).Equals("/-1/"))
       iItems--;
   }
   CStdString items;
@@ -515,25 +515,25 @@ void CGUIWindowVideoNav::UpdateButtons()
   CStdString strLabel;
 
   // "Playlists"
-  if (m_vecItems->m_strPath.Equals("special://videoplaylists/"))
+  if (m_vecItems->GetPath().Equals("special://videoplaylists/"))
     strLabel = g_localizeStrings.Get(136);
   // "{Playlist Name}"
   else if (m_vecItems->IsPlayList())
   {
     // get playlist name from path
     CStdString strDummy;
-    URIUtils::Split(m_vecItems->m_strPath, strDummy, strLabel);
+    URIUtils::Split(m_vecItems->GetPath(), strDummy, strLabel);
   }
-  else if (m_vecItems->m_strPath.Equals("sources://video/"))
+  else if (m_vecItems->GetPath().Equals("sources://video/"))
     strLabel = g_localizeStrings.Get(744);
   // everything else is from a videodb:// path
   else if (m_vecItems->IsVideoDb())
   {
     CVideoDatabaseDirectory dir;
-    dir.GetLabel(m_vecItems->m_strPath, strLabel);
+    dir.GetLabel(m_vecItems->GetPath(), strLabel);
   }
   else
-    strLabel = URIUtils::GetFileName(m_vecItems->m_strPath);
+    strLabel = URIUtils::GetFileName(m_vecItems->GetPath());
 
   SET_CONTROL_LABEL(CONTROL_FILTER, strLabel);
 
@@ -634,7 +634,7 @@ void CGUIWindowVideoNav::OnInfo(CFileItem* pItem, ADDON::ScraperPtr& scraper)
   else
   {
     CStdString strPath,strFile;
-    URIUtils::Split(pItem->m_strPath,strPath,strFile);
+    URIUtils::Split(pItem->GetPath(),strPath,strFile);
     scraper = m_database.GetScraperForPath(strPath);
   }
   m_database.Close();
@@ -663,13 +663,13 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
 
   if (!m_vecItems->IsVideoDb())
   {
-    if (!pItem->m_strPath.Equals("newsmartplaylist://video") &&
-        !pItem->m_strPath.Equals("special://videoplaylists/") &&
-        !pItem->m_strPath.Equals("sources://video/"))
+    if (!pItem->GetPath().Equals("newsmartplaylist://video") &&
+        !pItem->GetPath().Equals("special://videoplaylists/") &&
+        !pItem->GetPath().Equals("sources://video/"))
       CGUIWindowVideoBase::OnDeleteItem(pItem);
   }
-  else if (pItem->m_strPath.Left(14).Equals("videodb://1/7/") &&
-           pItem->m_strPath.size() > 14 && pItem->m_bIsFolder)
+  else if (pItem->GetPath().Left(14).Equals("videodb://1/7/") &&
+           pItem->GetPath().size() > 14 && pItem->m_bIsFolder)
   {
     CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*)g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
     pDialog->SetLine(0, g_localizeStrings.Get(432));
@@ -681,13 +681,13 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
     if (pDialog->IsConfirmed())
     {
       CFileItemList items;
-      CDirectory::GetDirectory(pItem->m_strPath,items,"",false,false,DIR_CACHE_ONCE,true,true);
+      CDirectory::GetDirectory(pItem->GetPath(),items,"",false,false,DIR_CACHE_ONCE,true,true);
       for (int i=0;i<items.Size();++i)
         OnDeleteItem(items[i]);
 
        CVideoDatabaseDirectory dir;
        CQueryParams params;
-       dir.GetQueryParams(pItem->m_strPath,params);
+       dir.GetQueryParams(pItem->GetPath(),params);
        m_database.DeleteSet(params.GetSetId());
     }
   }
@@ -717,7 +717,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
     if (g_guiSettings.GetBool("filelists.allowfiledeletion") &&
         CUtil::SupportsFileOperations(strDeletePath))
     {
-      pItem->m_strPath = strDeletePath;
+      pItem->SetPath(strDeletePath);
       CGUIWindowVideoBase::OnDeleteItem(pItem);
     }
   }
@@ -727,7 +727,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
 
 bool CGUIWindowVideoNav::DeleteItem(CFileItem* pItem, bool bUnavailable /* = false */)
 {
-  if (!pItem->HasVideoInfoTag() || !CanDelete(pItem->m_strPath))
+  if (!pItem->HasVideoInfoTag() || !CanDelete(pItem->GetPath()))
     return false;
 
   VIDEODB_CONTENT_TYPE iType=VIDEODB_CONTENT_MOVIES;
@@ -814,11 +814,11 @@ void CGUIWindowVideoNav::OnPrepareFileItems(CFileItemList &items)
   // set fanart
   CQueryParams params;
   CVideoDatabaseDirectory dir;
-  dir.GetQueryParams(items.m_strPath,params);
+  dir.GetQueryParams(items.GetPath(),params);
   if (params.GetContentType() == VIDEODB_CONTENT_MUSICVIDEOS)
     CGUIWindowMusicNav::SetupFanart(items);
 
-  NODE_TYPE node = dir.GetDirectoryChildType(items.m_strPath);
+  NODE_TYPE node = dir.GetDirectoryChildType(items.GetPath());
 
   // now filter as necessary
   bool filterWatched=false;
@@ -874,7 +874,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
     return;
 
   CVideoDatabaseDirectory dir;
-  NODE_TYPE node = dir.GetDirectoryChildType(m_vecItems->m_strPath);
+  NODE_TYPE node = dir.GetDirectoryChildType(m_vecItems->GetPath());
 
   if (!item)
   {
@@ -884,7 +884,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
     else
       buttons.Add(CONTEXT_BUTTON_UPDATE_LIBRARY, 653);
   }
-  else if (m_vecItems->m_strPath.Equals("sources://video/"))
+  else if (m_vecItems->GetPath().Equals("sources://video/"))
   {
     // get the usual shares
     CGUIDialogContextMenu::GetContextButtons("video", item, buttons);
@@ -892,12 +892,12 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
     CGUIDialogVideoScan *pScanDlg = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
     if (pScanDlg && pScanDlg->IsScanning())
       buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353);  // Stop Scanning
-    if (!item->IsDVD() && item->m_strPath != "add" &&
+    if (!item->IsDVD() && item->GetPath() != "add" &&
         (g_settings.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
     {
       CVideoDatabase database;
       database.Open();
-      ADDON::ScraperPtr info = database.GetScraperForPath(item->m_strPath);
+      ADDON::ScraperPtr info = database.GetScraperForPath(item->GetPath());
 
       if (!pScanDlg || (pScanDlg && !pScanDlg->IsScanning()))
       {
@@ -969,7 +969,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
             buttons.Add(CONTEXT_BUTTON_UPDATE_TVSHOW, 13349);
         }
         if (!item->IsPlugin() && !item->IsScript() && !item->IsLiveTV() && !item->IsAddonsPath() &&
-             item->m_strPath != "sources://video/" && item->m_strPath != "special://videoplaylists/")
+             item->GetPath() != "sources://video/" && item->GetPath() != "special://videoplaylists/")
         {
           if (item->m_bIsFolder)
           {
@@ -1002,7 +1002,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         if (node == NODE_TYPE_SEASONS && item->m_bIsFolder)
           buttons.Add(CONTEXT_BUTTON_SET_SEASON_THUMB, 20371);
 
-        if (item->m_strPath.Left(14).Equals("videodb://1/7/") && item->m_strPath.size() > 14 && item->m_bIsFolder) // sets
+        if (item->GetPath().Left(14).Equals("videodb://1/7/") && item->GetPath().size() > 14 && item->m_bIsFolder) // sets
         {
           buttons.Add(CONTEXT_BUTTON_EDIT, 16105);
           buttons.Add(CONTEXT_BUTTON_SET_MOVIESET_THUMB, 20435);
@@ -1010,9 +1010,9 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
           buttons.Add(CONTEXT_BUTTON_DELETE, 646);
         }
 
-        if (node == NODE_TYPE_ACTOR && !dir.IsAllItem(item->m_strPath) && item->m_bIsFolder)
+        if (node == NODE_TYPE_ACTOR && !dir.IsAllItem(item->GetPath()) && item->m_bIsFolder)
         {
-          if (m_vecItems->m_strPath.Left(11).Equals("videodb://3")) // mvids
+          if (m_vecItems->GetPath().Left(11).Equals("videodb://3")) // mvids
             buttons.Add(CONTEXT_BUTTON_SET_ARTIST_THUMB, 13359);
           else
             buttons.Add(CONTEXT_BUTTON_SET_ACTOR_THUMB, 20403);
@@ -1045,7 +1045,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       if (!m_vecItems->IsVideoDb() && !m_vecItems->IsVirtualDirectoryRoot())
       { // non-video db items, file operations are allowed
         if (g_guiSettings.GetBool("filelists.allowfiledeletion") &&
-            CUtil::SupportsFileOperations(item->m_strPath))
+            CUtil::SupportsFileOperations(item->GetPath()))
         {
           buttons.Add(CONTEXT_BUTTON_DELETE, 117);
           buttons.Add(CONTEXT_BUTTON_RENAME, 118);
@@ -1081,9 +1081,9 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     if (button == CONTEXT_BUTTON_REMOVE_SOURCE && !item->IsPlugin()
         && !item->IsLiveTV() &&!item->IsRSS())
     {
-      OnUnAssignContent(item->m_strPath,20375,20340,20341);
+      OnUnAssignContent(item->GetPath(),20375,20340,20341);
     }
-    Update(m_vecItems->m_strPath);
+    Update(m_vecItems->GetPath());
     return true;
   }
   switch (button)
@@ -1091,7 +1091,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_EDIT:
     UpdateVideoTitle(item.get());
     CUtil::DeleteVideoDatabaseDirectoryCache();
-    Update(m_vecItems->m_strPath);
+    Update(m_vecItems->GetPath());
     return true;
 
   case CONTEXT_BUTTON_SET_SEASON_THUMB:
@@ -1157,7 +1157,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       {
         CStdString picturePath;
 
-        CStdString strPath = m_vecItems->Get(itemNumber)->m_strPath;
+        CStdString strPath = m_vecItems->Get(itemNumber)->GetPath();
         URIUtils::RemoveSlashAtEnd(strPath);
 
         int nPos=strPath.ReverseFind("/");
@@ -1236,7 +1236,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CUtil::DeleteVideoDatabaseDirectoryCache();
       CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
       g_windowManager.SendMessage(msg);
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
 
       return true;
     }
@@ -1298,7 +1298,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       else
         item->ClearProperty("fanart_image");
 
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
       return true;
     }
   case CONTEXT_BUTTON_UPDATE_LIBRARY:
@@ -1309,7 +1309,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_UNLINK_MOVIE:
     {
       OnLinkMovieToTvShow(itemNumber, true);
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
       return true;
     }
   case CONTEXT_BUTTON_LINK_MOVIE:
@@ -1355,7 +1355,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       m_database.DeleteBookMarkForEpisode(*m_vecItems->Get(itemNumber)->GetVideoInfoTag());
       m_database.Close();
       CUtil::DeleteVideoDatabaseDirectoryCache();
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
       return true;
     }
 
@@ -1433,7 +1433,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem)
 
     // update list
     m_vecItems->RemoveDiscCache(GetID());
-    Update(m_vecItems->m_strPath);
+    Update(m_vecItems->GetPath());
     m_viewControl.SetSelectedItem(iItem);
     return true;
   }

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -79,7 +79,7 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
       // global playlist changed outside playlist window
       m_vecItems->RemoveDiscCache(GetID());
       UpdateButtons();
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
 
       if (m_viewControl.HasControl(m_iLastControl) && m_vecItems->Size() <= 0)
       {
@@ -98,7 +98,7 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
 
   case GUI_MSG_WINDOW_INIT:
     {
-      m_vecItems->m_strPath="playlistvideo://";
+      m_vecItems->SetPath("playlistvideo://");
 
       if (!CGUIWindowVideoBase::OnMessage(message))
         return false;
@@ -131,7 +131,7 @@ bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
           g_settings.m_bMyVideoPlaylistShuffle = g_playlistPlayer.IsShuffled(PLAYLIST_VIDEO);
           g_settings.Save();
           UpdateButtons();
-          Update(m_vecItems->m_strPath);
+          Update(m_vecItems->GetPath());
         }
       }
       else if (iControl == CONTROL_BTNSAVE)
@@ -246,7 +246,7 @@ bool CGUIWindowVideoPlaylist::MoveCurrentPlayListItem(int iItem, int iAction, bo
     }
 
     if (bUpdate)
-      Update(m_vecItems->m_strPath);
+      Update(m_vecItems->GetPath());
     return true;
   }
 
@@ -323,7 +323,7 @@ bool CGUIWindowVideoPlaylist::OnPlayMedia(int iItem)
   else
   {
     CFileItemPtr pItem = m_vecItems->Get(iItem);
-    CStdString strPath = pItem->m_strPath;
+    CStdString strPath = pItem->GetPath();
     g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
     g_playlistPlayer.Play( iItem );
   }
@@ -350,7 +350,7 @@ void CGUIWindowVideoPlaylist::RemovePlayListItem(int iItem)
     }
   }
 
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
 
   if (m_vecItems->Size() <= 0)
   {
@@ -510,7 +510,7 @@ void CGUIWindowVideoPlaylist::MoveItem(int iStart, int iDest)
     else
       break;
   }
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
 }
 
 void CGUIWindowVideoPlaylist::MarkPlaying()

--- a/xbmc/win32/WINSMBDirectory.cpp
+++ b/xbmc/win32/WINSMBDirectory.cpp
@@ -141,11 +141,10 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
           if (strLabel != "." && strLabel != "..")
           {
             CFileItemPtr pItem(new CFileItem(strLabel));
-            pItem->m_strPath = strPath;
-            URIUtils::AddSlashAtEnd(pItem->m_strPath);
-            pItem->m_strPath += strLabel;
+            CStdString path = URIUtils::AddFileToFolder(strPath, strLabel);
+            URIUtils::AddSlashAtEnd(path);
+            pItem->SetPath(path);
             pItem->m_bIsFolder = true;
-            URIUtils::AddSlashAtEnd(pItem->m_strPath);
             FileTimeToLocalFileTime(&wfd.ftLastWriteTime, &localTime);
             pItem->m_dateTime=localTime;
 
@@ -158,9 +157,7 @@ bool CWINSMBDirectory::GetDirectory(const CStdString& strPath1, CFileItemList &i
         else
         {
           CFileItemPtr pItem(new CFileItem(strLabel));
-          pItem->m_strPath = strPath;
-          URIUtils::AddSlashAtEnd(pItem->m_strPath);
-          pItem->m_strPath += strLabel;
+          pItem->SetPath(URIUtils::AddFileToFolder(strPath, strLabel));
           pItem->m_bIsFolder = false;
           pItem->m_dwSize = CUtil::ToInt64(wfd.nFileSizeHigh, wfd.nFileSizeLow);
           FileTimeToLocalFileTime(&wfd.ftLastWriteTime, &localTime);
@@ -302,10 +299,10 @@ bool CWINSMBDirectory::EnumerateFunc(LPNETRESOURCEW lpnr, CFileItemList &items)
             strName = rooturl.GetHostName();
 
           strName.Replace("\\","");
-          
+
+          URIUtils::AddSlashAtEnd(strurl);
           CFileItemPtr pItem(new CFileItem(strName));
-          pItem->m_strPath = strurl;
-          URIUtils::AddSlashAtEnd(pItem->m_strPath);
+          pItem->SetPath(strurl);
           pItem->m_bIsFolder = true;
           items.Add(pItem);
         }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -78,7 +78,7 @@ CGUIMediaWindow::CGUIMediaWindow(int id, const char *xmlFile)
 {
   m_vecItems = new CFileItemList;
   m_unfilteredItems = new CFileItemList;
-  m_vecItems->m_strPath = "?";
+  m_vecItems->SetPath("?");
   m_iLastControl = -1;
   m_iSelectedItem = -1;
 
@@ -154,7 +154,7 @@ CFileItemPtr CGUIMediaWindow::GetCurrentListItem(int offset)
 bool CGUIMediaWindow::OnAction(const CAction &action)
 {
   if (action.GetID() == ACTION_PARENT_DIR ||
-     (action.GetID() == ACTION_NAV_BACK && !(m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->m_strPath == m_startDirectory)))
+     (action.GetID() == ACTION_NAV_BACK && !(m_vecItems->IsVirtualDirectoryRoot() || m_vecItems->GetPath() == m_startDirectory)))
   {
     GoParentFolder();
     return true;
@@ -303,7 +303,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
     { // Message is received even if this window is inactive
       if (message.GetParam1() == GUI_MSG_WINDOW_RESET)
       {
-        m_vecItems->m_strPath = "?";
+        m_vecItems->SetPath("?");
         return true;
       }
       else if ( message.GetParam1() == GUI_MSG_REFRESH_THUMBS )
@@ -315,21 +315,21 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       else if (message.GetParam1() == GUI_MSG_REMOVED_MEDIA)
       {
         if ((m_vecItems->IsVirtualDirectoryRoot() ||
-             m_vecItems->m_strPath.Left(10).Equals("sources://")) && IsActive())
+             m_vecItems->GetPath().Left(10).Equals("sources://")) && IsActive())
         {
           int iItem = m_viewControl.GetSelectedItem();
-          Update(m_vecItems->m_strPath);
+          Update(m_vecItems->GetPath());
           m_viewControl.SetSelectedItem(iItem);
         }
         else if (m_vecItems->IsRemovable())
         { // check that we have this removable share still
-          if (!m_rootDir.IsInSource(m_vecItems->m_strPath))
+          if (!m_rootDir.IsInSource(m_vecItems->GetPath()))
           { // don't have this share any more
             if (IsActive()) Update("");
             else
             {
               m_history.ClearPathHistory();
-              m_vecItems->m_strPath="";
+              m_vecItems->SetPath("");
             }
           }
         }
@@ -339,10 +339,10 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       else if (message.GetParam1()==GUI_MSG_UPDATE_SOURCES)
       { // State of the sources changed, so update our view
         if ((m_vecItems->IsVirtualDirectoryRoot() ||
-             m_vecItems->m_strPath.Left(10).Equals("sources://")) && IsActive())
+             m_vecItems->GetPath().Left(10).Equals("sources://")) && IsActive())
         {
           int iItem = m_viewControl.GetSelectedItem();
-          Update(m_vecItems->m_strPath);
+          Update(m_vecItems->GetPath());
           m_viewControl.SetSelectedItem(iItem);
         }
         return true;
@@ -351,13 +351,13 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       {
         if (message.GetNumStringParams())
         {
-          m_vecItems->m_strPath = message.GetStringParam();
+          m_vecItems->SetPath(message.GetStringParam());
           if (message.GetParam2()) // param2 is used for resetting the history
-            SetHistoryForPath(m_vecItems->m_strPath);
+            SetHistoryForPath(m_vecItems->GetPath());
         }
         // clear any cached listing
         m_vecItems->RemoveDiscCache(GetID());
-        Update(m_vecItems->m_strPath);
+        Update(m_vecItems->GetPath());
       }
       else if (message.GetParam1()==GUI_MSG_UPDATE_ITEM && message.GetItem())
       {
@@ -372,7 +372,9 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         else if (newItem)
         { // need to remove the disc cache
           CFileItemList items;
-          URIUtils::GetDirectory(newItem->m_strPath, items.m_strPath);
+          CStdString path;
+          URIUtils::GetDirectory(newItem->GetPath(), path);
+          items.SetPath(path);
           items.RemoveDiscCache(GetID());
         }
       }
@@ -380,10 +382,10 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       {
         if (IsActive())
         {
-          if((message.GetStringParam() == m_vecItems->m_strPath) ||
-             (m_vecItems->IsMultiPath() && XFILE::CMultiPathDirectory::HasPath(m_vecItems->m_strPath, message.GetStringParam())))
+          if((message.GetStringParam() == m_vecItems->GetPath()) ||
+             (m_vecItems->IsMultiPath() && XFILE::CMultiPathDirectory::HasPath(m_vecItems->GetPath(), message.GetStringParam())))
           {
-            Update(m_vecItems->m_strPath);
+            Update(m_vecItems->GetPath());
           }
         }
       }
@@ -457,8 +459,8 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
     break;
   case GUI_MSG_WINDOW_INIT:
     {
-      if (m_vecItems->m_strPath == "?")
-        m_vecItems->m_strPath.Empty();
+      if (m_vecItems->GetPath() == "?")
+        m_vecItems->SetPath("");
       CStdString dir = message.GetStringParam(0);
       const CStdString &ret = message.GetStringParam(1);
       bool returning = ret.CompareNoCase("return") == 0;
@@ -467,14 +469,14 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         m_history.ClearPathHistory();
         // ensure our directory is valid
         dir = GetStartFolder(dir);
-        if (!returning || m_vecItems->m_strPath.Left(dir.GetLength()) != dir)
+        if (!returning || m_vecItems->GetPath().Left(dir.GetLength()) != dir)
         { // we're not returning to the same path, so set our directory to the requested path
-          m_vecItems->m_strPath = dir;
+          m_vecItems->SetPath(dir);
         }
         // check for network up
-        if (URIUtils::IsRemote(m_vecItems->m_strPath) && !WaitForNetwork())
-          m_vecItems->m_strPath.Empty();
-        SetHistoryForPath(m_vecItems->m_strPath);
+        if (URIUtils::IsRemote(m_vecItems->GetPath()) && !WaitForNetwork())
+          m_vecItems->SetPath("");
+        SetHistoryForPath(m_vecItems->GetPath());
       }
       if (message.GetParam1() != WINDOW_INVALID)
       { // first time to this window - make sure we set the root path
@@ -641,10 +643,10 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
       m_history.RemoveParentPath();
   }
 
-  if (m_guiState.get() && !m_guiState->HideParentDirItems() && !items.m_strPath.IsEmpty())
+  if (m_guiState.get() && !m_guiState->HideParentDirItems() && !items.GetPath().IsEmpty())
   {
     CFileItemPtr pItem(new CFileItem(".."));
-    pItem->m_strPath = strParentPath;
+    pItem->SetPath(strParentPath);
     pItem->m_bIsFolder = true;
     pItem->m_bIsShareOrDrive = false;
     items.AddFront(pItem, 0);
@@ -664,7 +666,7 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
   {
     for (int i=0; i < items.Size();)
     {
-      if (CUtil::ExcludeFileOrFolder(items[i]->m_strPath, regexps))
+      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
         items.Remove(i);
       else
         i++;
@@ -697,7 +699,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory)
     }
   }
 
-  CStdString strOldDirectory = m_vecItems->m_strPath;
+  CStdString strOldDirectory = m_vecItems->GetPath();
 
   m_history.SetSelectedItem(strSelectedItem, strOldDirectory);
 
@@ -721,7 +723,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory)
   }
 
   if (items.GetLabel().IsEmpty())
-    items.SetLabel(CUtil::GetTitleFromPath(items.m_strPath, true));
+    items.SetLabel(CUtil::GetTitleFromPath(items.GetPath(), true));
 
   ClearFileItems();
   m_vecItems->Copy(items);
@@ -744,7 +746,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory)
   {
     CStdString strLabel = g_localizeStrings.Get(showLabel);
     CFileItemPtr pItem(new CFileItem(strLabel));
-    pItem->m_strPath = "add";
+    pItem->SetPath("add");
     pItem->SetIconImage("DefaultAddSource.png");
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformated(true);
@@ -772,7 +774,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory)
 
   m_viewControl.SetItems(*m_vecItems);
 
-  strSelectedItem = m_history.GetSelectedItem(m_vecItems->m_strPath);
+  strSelectedItem = m_history.GetSelectedItem(m_vecItems->GetPath());
 
   bool bSelectedFound = false;
   //int iSongInDirectory = -1;
@@ -797,7 +799,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory)
   if (!bSelectedFound)
     m_viewControl.SetSelectedItem(0);
 
-  m_history.AddPath(m_vecItems->m_strPath);
+  m_history.AddPath(m_vecItems->GetPath());
 
   //m_history.DumpPathHistory();
 
@@ -833,7 +835,7 @@ void CGUIMediaWindow::OnFinalizeFileItems(CFileItemList &items)
   if (items.IsEmpty())
   {
     CFileItemPtr pItem(new CFileItem(".."));
-    pItem->m_strPath=m_history.GetParentPath();
+    pItem->SetPath(m_history.GetParentPath());
     pItem->m_bIsFolder = true;
     pItem->m_bIsShareOrDrive = false;
     items.AddFront(pItem, 0);
@@ -853,7 +855,7 @@ bool CGUIMediaWindow::OnClick(int iItem)
     GoParentFolder();
     return true;
   }
-  if (pItem->m_strPath == "add" || pItem->m_strPath == "sources://add/") // 'add source button' in empty root
+  if (pItem->GetPath() == "add" || pItem->GetPath() == "sources://add/") // 'add source button' in empty root
   {
     OnContextButton(iItem, CONTEXT_BUTTON_ADD_SOURCE);
     return true;
@@ -862,7 +864,7 @@ bool CGUIMediaWindow::OnClick(int iItem)
   if (!pItem->m_bIsFolder && pItem->IsFileFolder())
   {
     XFILE::IFileDirectory *pFileDirectory = NULL;
-    pFileDirectory = XFILE::CFactoryFileDirectory::Create(pItem->m_strPath, pItem.get(), "");
+    pFileDirectory = XFILE::CFactoryFileDirectory::Create(pItem->GetPath(), pItem.get(), "");
     if(pFileDirectory)
       pItem->m_bIsFolder = true;
     else if(pItem->m_bIsFolder)
@@ -873,7 +875,7 @@ bool CGUIMediaWindow::OnClick(int iItem)
   if (pItem->IsScript())
   {
     // execute the script
-    CURL url(pItem->m_strPath);
+    CURL url(pItem->GetPath());
     AddonPtr addon;
     if (CAddonMgr::Get().GetAddon(url.GetHostName(), addon))
     {
@@ -894,59 +896,59 @@ bool CGUIMediaWindow::OnClick(int iItem)
         if (!strLockType.IsEmpty() && !g_passwordManager.IsItemUnlocked(pItem.get(), strLockType))
             return true;
 
-      if (!HaveDiscOrConnection(pItem->m_strPath, pItem->m_iDriveType))
+      if (!HaveDiscOrConnection(pItem->m_iDriveType))
         return true;
     }
 
     // check for the partymode playlist items - they may not exist yet
-    if ((pItem->m_strPath == g_settings.GetUserDataItem("PartyMode.xsp")) ||
-        (pItem->m_strPath == g_settings.GetUserDataItem("PartyMode-Video.xsp")))
+    if ((pItem->GetPath() == g_settings.GetUserDataItem("PartyMode.xsp")) ||
+        (pItem->GetPath() == g_settings.GetUserDataItem("PartyMode-Video.xsp")))
     {
       // party mode playlist item - if it doesn't exist, prompt for user to define it
-      if (!XFILE::CFile::Exists(pItem->m_strPath))
+      if (!XFILE::CFile::Exists(pItem->GetPath()))
       {
         m_vecItems->RemoveDiscCache(GetID());
-        if (CGUIDialogSmartPlaylistEditor::EditPlaylist(pItem->m_strPath))
-          Update(m_vecItems->m_strPath);
+        if (CGUIDialogSmartPlaylistEditor::EditPlaylist(pItem->GetPath()))
+          Update(m_vecItems->GetPath());
         return true;
       }
     }
 
     // remove the directory cache if the folder is not normally cached
-    CFileItemList items(pItem->m_strPath);
+    CFileItemList items(pItem->GetPath());
     if (!items.AlwaysCache())
       items.RemoveDiscCache(GetID());
 
     CFileItem directory(*pItem);
-    if (!Update(directory.m_strPath))
+    if (!Update(directory.GetPath()))
       ShowShareErrorMessage(&directory);
 
     return true;
   }
   else if (pItem->IsPlugin() && pItem->GetProperty("isplayable") != "true")
   {
-    return XFILE::CPluginDirectory::RunScriptWithParams(pItem->m_strPath);
+    return XFILE::CPluginDirectory::RunScriptWithParams(pItem->GetPath());
   }
   else
   {
     m_iSelectedItem = m_viewControl.GetSelectedItem();
 
-    if (pItem->m_strPath == "newplaylist://")
+    if (pItem->GetPath() == "newplaylist://")
     {
       m_vecItems->RemoveDiscCache(GetID());
       g_windowManager.ActivateWindow(WINDOW_MUSIC_PLAYLIST_EDITOR,"newplaylist://");
       return true;
     }
-    else if (pItem->m_strPath.Left(19).Equals("newsmartplaylist://"))
+    else if (pItem->GetPath().Left(19).Equals("newsmartplaylist://"))
     {
       m_vecItems->RemoveDiscCache(GetID());
-      if (CGUIDialogSmartPlaylistEditor::NewPlaylist(pItem->m_strPath.Mid(19)))
-        Update(m_vecItems->m_strPath);
+      if (CGUIDialogSmartPlaylistEditor::NewPlaylist(pItem->GetPath().Mid(19)))
+        Update(m_vecItems->GetPath());
       return true;
     }
-    else if (pItem->m_strPath.Left(14).Equals("addons://more/"))
+    else if (pItem->GetPath().Left(14).Equals("addons://more/"))
     {
-      CBuiltins::Execute("ActivateWindow(AddonBrowser,addons://all/xbmc.addon." + pItem->m_strPath.Mid(14) + ",return)");
+      CBuiltins::Execute("ActivateWindow(AddonBrowser,addons://all/xbmc.addon." + pItem->GetPath().Mid(14) + ",return)");
       return true;
     }
 
@@ -958,7 +960,7 @@ bool CGUIMediaWindow::OnClick(int iItem)
 
     if (pItem->IsPlugin())
     {
-      CURL url(pItem->m_strPath);
+      CURL url(pItem->GetPath());
       AddonPtr addon;
       if (CAddonMgr::Get().GetAddon(url.GetHostName(),addon))
       {
@@ -992,7 +994,7 @@ bool CGUIMediaWindow::OnSelect(int item)
 
 // \brief Checks if there is a disc in the dvd drive and whether the
 // network is connected or not.
-bool CGUIMediaWindow::HaveDiscOrConnection(CStdString& strPath, int iDriveType)
+bool CGUIMediaWindow::HaveDiscOrConnection(int iDriveType)
 {
   if (iDriveType==CMediaSource::SOURCE_TYPE_DVD)
   {
@@ -1043,7 +1045,7 @@ void CGUIMediaWindow::GoParentFolder()
   // remove current directory if its on the stack
   // there were some issues due some folders having a trailing slash and some not
   // so just add a trailing slash to all of them for comparison.
-  CStdString strPath = m_vecItems->m_strPath;
+  CStdString strPath = m_vecItems->GetPath();
   URIUtils::AddSlashAtEnd(strPath);
   CStdString strParent = m_history.GetParentPath();
   // in case the path history is messed up and the current folder is on
@@ -1061,7 +1063,7 @@ void CGUIMediaWindow::GoParentFolder()
 
   // if vector is not empty, pop parent
   // if vector is empty, parent is root source listing
-  CStdString strOldPath(m_vecItems->m_strPath);
+  CStdString strOldPath(m_vecItems->GetPath());
   strParent = m_history.RemoveParentPath();
   Update(strParent);
 }
@@ -1095,7 +1097,7 @@ void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, CStdStri
     else
     {
       // Other items in virual directory
-      CStdString strPath = pItem->m_strPath;
+      CStdString strPath = pItem->GetPath();
       URIUtils::RemoveSlashAtEnd(strPath);
 
       strHistoryString = pItem->GetLabel() + strPath;
@@ -1106,12 +1108,12 @@ void CGUIMediaWindow::GetDirectoryHistoryString(const CFileItem* pItem, CStdStri
     // Could be a cue item, all items of a cue share the same filename
     // so add the offsets to build the history string
     strHistoryString.Format("%ld%ld", pItem->m_lStartOffset, pItem->m_lEndOffset);
-    strHistoryString += pItem->m_strPath;
+    strHistoryString += pItem->GetPath();
   }
   else
   {
     // Normal directory items
-    strHistoryString = pItem->m_strPath;
+    strHistoryString = pItem->GetPath();
   }
   URIUtils::RemoveSlashAtEnd(strHistoryString);
   strHistoryString.ToLower();
@@ -1140,8 +1142,9 @@ void CGUIMediaWindow::SetHistoryForPath(const CStdString& strDirectory)
       for (int i = 0; i < (int)items.Size(); ++i)
       {
         CFileItemPtr pItem = items[i];
-        URIUtils::RemoveSlashAtEnd(pItem->m_strPath);
-        if (pItem->m_strPath == strPath)
+        CStdString path(pItem->GetPath());
+        URIUtils::RemoveSlashAtEnd(path);
+        if (path == strPath)
         {
           CStdString strHistory;
           GetDirectoryHistoryString(pItem.get(), strHistory);
@@ -1223,7 +1226,7 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr &item)
 
     // Save current window and directory to know where the selected item was
     if (m_guiState.get())
-      m_guiState->SetPlaylistDirectory(m_vecItems->m_strPath);
+      m_guiState->SetPlaylistDirectory(m_vecItems->GetPath());
 
     // figure out where we start playback
     if (g_playlistPlayer.IsShuffled(iPlaylist))
@@ -1248,7 +1251,7 @@ void CGUIMediaWindow::UpdateFileList()
   int nItem = m_viewControl.GetSelectedItem();
   CStdString strSelected;
   if (nItem >= 0)
-    strSelected = m_vecItems->Get(nItem)->m_strPath;
+    strSelected = m_vecItems->Get(nItem)->GetPath();
 
   FormatAndSort(*m_vecItems);
   UpdateButtons();
@@ -1257,7 +1260,7 @@ void CGUIMediaWindow::UpdateFileList()
   m_viewControl.SetSelectedItem(strSelected);
 
   //  set the currently playing item as selected, if its in this directory
-  if (m_guiState.get() && m_guiState->IsCurrentPlaylistDirectory(m_vecItems->m_strPath))
+  if (m_guiState.get() && m_guiState->IsCurrentPlaylistDirectory(m_vecItems->GetPath()))
   {
     int iPlaylist=m_guiState->GetPlaylist();
     int nSong = g_playlistPlayer.GetCurrentSong();
@@ -1277,7 +1280,7 @@ void CGUIMediaWindow::UpdateFileList()
       if (!pItem->IsPlayList() && !pItem->IsZIP() && !pItem->IsRAR())
         g_playlistPlayer.Add(iPlaylist, pItem);
 
-      if (pItem->m_strPath == playlistItem.m_strPath &&
+      if (pItem->GetPath() == playlistItem.GetPath() &&
           pItem->m_lStartOffset == playlistItem.m_lStartOffset)
         g_playlistPlayer.SetCurrentSong(g_playlistPlayer.GetPlaylist(iPlaylist).size() - 1);
     }
@@ -1299,7 +1302,7 @@ void CGUIMediaWindow::OnDeleteItem(int iItem)
   if (!CFileUtils::DeleteItem(item))
     return;
   m_vecItems->RemoveDiscCache(GetID());
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
   m_viewControl.SetSelectedItem(iItem);
 }
 
@@ -1311,10 +1314,10 @@ void CGUIMediaWindow::OnRenameItem(int iItem)
     if (!g_passwordManager.IsMasterLockUnlocked(true))
       return;
 
-  if (!CFileUtils::RenameFile(m_vecItems->Get(iItem)->m_strPath))
+  if (!CFileUtils::RenameFile(m_vecItems->Get(iItem)->GetPath()))
     return;
   m_vecItems->RemoveDiscCache(GetID());
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
   m_viewControl.SetSelectedItem(iItem);
 }
 
@@ -1322,7 +1325,7 @@ void CGUIMediaWindow::OnInitWindow()
 {
   // initial fetch is done unthreaded to ensure the items are setup prior to skin animations kicking off
   m_rootDir.SetAllowThreads(false);
-  Update(m_vecItems->m_strPath);
+  Update(m_vecItems->GetPath());
   m_rootDir.SetAllowThreads(true);
 
   if (m_iSelectedItem > -1)
@@ -1403,8 +1406,8 @@ void CGUIMediaWindow::GetContextButtons(int itemNumber, CContextButtons &buttons
     return;
 
   // TODO: FAVOURITES Conditions on masterlock and localisation
-  if (!item->IsParentFolder() && !item->m_strPath.Equals("add") && !item->m_strPath.Equals("newplaylist://") &&
-      !item->m_strPath.Left(19).Equals("newsmartplaylist://") && !item->IsAddonsPath())
+  if (!item->IsParentFolder() && !item->GetPath().Equals("add") && !item->GetPath().Equals("newplaylist://") &&
+      !item->GetPath().Left(19).Equals("newsmartplaylist://") && !item->IsAddonsPath())
   {
     if (CFavourites::IsFavourite(item.get(), GetID()))
       buttons.Add(CONTEXT_BUTTON_ADD_FAVOURITE, 14077);     // Remove Favourite
@@ -1425,11 +1428,11 @@ bool CGUIMediaWindow::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     }
   case CONTEXT_BUTTON_PLUGIN_SETTINGS:
     {
-      CURL plugin(m_vecItems->Get(itemNumber)->m_strPath);
+      CURL plugin(m_vecItems->Get(itemNumber)->GetPath());
       ADDON::AddonPtr addon;
       if (CAddonMgr::Get().GetAddon(plugin.GetHostName(), addon, ADDON_PLUGIN))
         if (CGUIDialogAddonSettings::ShowAndGetInput(addon))
-          Update(m_vecItems->m_strPath);
+          Update(m_vecItems->GetPath());
       return true;
     }
   case CONTEXT_BUTTON_USER1:
@@ -1473,7 +1476,7 @@ bool CGUIMediaWindow::WaitForNetwork() const
   if (!progress)
     return true;
 
-  CURL url(m_vecItems->m_strPath);
+  CURL url(m_vecItems->GetPath());
   progress->SetHeading(1040); // Loading Directory
   progress->SetLine(1, url.GetWithoutUserDetails());
   progress->ShowProgressBar(false);
@@ -1496,7 +1499,7 @@ void CGUIMediaWindow::OnFilterItems(const CStdString &filter)
   CStdString currentItem;
   int item = m_viewControl.GetSelectedItem();
   if (item >= 0)
-    currentItem = m_vecItems->Get(item)->m_strPath;
+    currentItem = m_vecItems->Get(item)->GetPath();
   
   m_viewControl.Clear();
   

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -88,7 +88,7 @@ protected:
   void GetFilteredItems(const CStdString &filter, CFileItemList &items);
 
   // check for a disc or connection
-  virtual bool HaveDiscOrConnection(CStdString& strPath, int iDriveType);
+  virtual bool HaveDiscOrConnection(int iDriveType);
   void ShowShareErrorMessage(CFileItem* pItem);
 
   void GetDirectoryHistoryString(const CFileItem* pItem, CStdString& strHistoryString);

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -96,8 +96,8 @@ CGUIWindowFileManager::CGUIWindowFileManager(void)
   m_Directory[1] = new CFileItem;
   m_vecItems[0] = new CFileItemList;
   m_vecItems[1] = new CFileItemList;
-  m_Directory[0]->m_strPath = "?";
-  m_Directory[1]->m_strPath = "?";
+  m_Directory[0]->SetPath("?");
+  m_Directory[1]->SetPath("?");
   m_Directory[0]->m_bIsFolder = true;
   m_Directory[1]->m_bIsFolder = true;
   bCheckShareConnectivity = true;
@@ -189,8 +189,8 @@ bool CGUIWindowFileManager::OnMessage(CGUIMessage& message)
     { // Message is received even if window is inactive
       if (message.GetParam1() == GUI_MSG_WINDOW_RESET)
       {
-        m_Directory[0]->m_strPath = "?";
-        m_Directory[1]->m_strPath = "?";
+        m_Directory[0]->SetPath("?");
+        m_Directory[1]->SetPath("?");
         m_Directory[0]->m_bIsFolder = true;
         m_Directory[1]->m_bIsFolder = true;
         return true;
@@ -204,15 +204,15 @@ bool CGUIWindowFileManager::OnMessage(CGUIMessage& message)
           if (m_Directory[i]->IsVirtualDirectoryRoot() && IsActive())
           {
             int iItem = GetSelectedItem(i);
-            Update(i, m_Directory[i]->m_strPath);
+            Update(i, m_Directory[i]->GetPath());
             CONTROL_SELECT_ITEM(CONTROL_LEFT_LIST + i, iItem);
           }
-          else if (m_Directory[i]->IsRemovable() && !m_rootDir.IsInSource(m_Directory[i]->m_strPath))
+          else if (m_Directory[i]->IsRemovable() && !m_rootDir.IsInSource(m_Directory[i]->GetPath()))
           { //
             if (IsActive())
               Update(i, "");
             else
-              m_Directory[i]->m_strPath="";
+              m_Directory[i]->SetPath("");
           }
         }
         return true;
@@ -224,7 +224,7 @@ bool CGUIWindowFileManager::OnMessage(CGUIMessage& message)
           if (m_Directory[i]->IsVirtualDirectoryRoot() && IsActive())
           {
             int iItem = GetSelectedItem(i);
-            Update(i, m_Directory[i]->m_strPath);
+            Update(i, m_Directory[i]->GetPath());
             CONTROL_SELECT_ITEM(CONTROL_LEFT_LIST + i, iItem);
           }
         }
@@ -304,7 +304,7 @@ void CGUIWindowFileManager::OnSort(int iList)
   for (int i = 0; i < m_vecItems[iList]->Size(); i++)
   {
     CFileItemPtr pItem = m_vecItems[iList]->Get(i);
-    if (pItem->m_bIsFolder && (!pItem->m_dwSize || pItem->m_strPath.Equals("add")))
+    if (pItem->m_bIsFolder && (!pItem->m_dwSize || pItem->GetPath().Equals("add")))
       pItem->SetLabel2("");
     else
       pItem->SetFileSizeLabel();
@@ -315,7 +315,7 @@ void CGUIWindowFileManager::OnSort(int iList)
       if (pItem->IsHD())
       {
         ULARGE_INTEGER ulBytesFree;
-        if (GetDiskFreeSpaceEx(pItem->m_strPath.c_str(), &ulBytesFree, NULL, NULL))
+        if (GetDiskFreeSpaceEx(pItem->GetPath().c_str(), &ulBytesFree, NULL, NULL))
         {
           pItem->m_dwSize = ulBytesFree.QuadPart;
           pItem->SetFileSizeLabel();
@@ -324,7 +324,7 @@ void CGUIWindowFileManager::OnSort(int iList)
       else if (pItem->IsDVD() && g_mediaManager.IsDiscInDrive())
       {
         ULARGE_INTEGER ulBytesTotal;
-        if (GetDiskFreeSpaceEx(pItem->m_strPath.c_str(), NULL, &ulBytesTotal, NULL))
+        if (GetDiskFreeSpaceEx(pItem->GetPath().c_str(), NULL, &ulBytesTotal, NULL))
         {
           pItem->m_dwSize = ulBytesTotal.QuadPart;
           pItem->SetFileSizeLabel();
@@ -379,7 +379,7 @@ void CGUIWindowFileManager::UpdateButtons()
 
   */
   // update our current directory labels
-  CStdString strDir = CURL(m_Directory[0]->m_strPath).GetWithoutUserDetails();
+  CStdString strDir = CURL(m_Directory[0]->GetPath()).GetWithoutUserDetails();
   if (strDir.IsEmpty())
   {
     SET_CONTROL_LABEL(CONTROL_CURRENTDIRLABEL_LEFT,g_localizeStrings.Get(20108));
@@ -388,7 +388,7 @@ void CGUIWindowFileManager::UpdateButtons()
   {
     SET_CONTROL_LABEL(CONTROL_CURRENTDIRLABEL_LEFT, strDir);
   }
-  strDir = CURL(m_Directory[1]->m_strPath).GetWithoutUserDetails();
+  strDir = CURL(m_Directory[1]->GetPath()).GetWithoutUserDetails();
   if (strDir.IsEmpty())
   {
     SET_CONTROL_LABEL(CONTROL_CURRENTDIRLABEL_RIGHT,g_localizeStrings.Get(20108));
@@ -443,17 +443,17 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
     if (!pItem->IsParentFolder())
     {
       GetDirectoryHistoryString(pItem.get(), strSelectedItem);
-      m_history[iList].SetSelectedItem(strSelectedItem, m_Directory[iList]->m_strPath);
+      m_history[iList].SetSelectedItem(strSelectedItem, m_Directory[iList]->GetPath());
     }
   }
 
-  CStdString strOldDirectory=m_Directory[iList]->m_strPath;
-  m_Directory[iList]->m_strPath = strDirectory;
+  CStdString strOldDirectory=m_Directory[iList]->GetPath();
+  m_Directory[iList]->SetPath(strDirectory);
 
   CFileItemList items;
-  if (!GetDirectory(iList, m_Directory[iList]->m_strPath, items))
+  if (!GetDirectory(iList, m_Directory[iList]->GetPath(), items))
   {
-    m_Directory[iList]->m_strPath = strOldDirectory;
+    m_Directory[iList]->SetPath(strOldDirectory);
     return false;
   }
 
@@ -462,7 +462,7 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
   ClearFileItems(iList);
 
   m_vecItems[iList]->Append(items);
-  m_vecItems[iList]->m_strPath = items.m_strPath;
+  m_vecItems[iList]->SetPath(items.GetPath());
 
   CStdString strParentPath;
   URIUtils::GetParentPath(strDirectory, strParentPath);
@@ -470,7 +470,7 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
   { // add 'add source button'
     CStdString strLabel = g_localizeStrings.Get(1026);
     CFileItemPtr pItem(new CFileItem(strLabel));
-    pItem->m_strPath = "add";
+    pItem->SetPath("add");
     pItem->SetIconImage("DefaultAddSource.png");
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformated(true);
@@ -481,7 +481,7 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
   else if (items.IsEmpty() || g_guiSettings.GetBool("filelists.showparentdiritems"))
   {
     CFileItemPtr pItem(new CFileItem(".."));
-    pItem->m_strPath = (m_rootDir.IsSource(strDirectory) ? "" : strParentPath);
+    pItem->SetPath(m_rootDir.IsSource(strDirectory) ? "" : strParentPath);
     pItem->m_bIsFolder = true;
     pItem->m_bIsShareOrDrive = false;
     m_vecItems[iList]->AddFront(pItem, 0);
@@ -503,10 +503,10 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
   {
     CFileItemPtr pItem = m_vecItems[iList]->Get(i);
     CStdString strExtension;
-    URIUtils::GetExtension(pItem->m_strPath, strExtension);
+    URIUtils::GetExtension(pItem->GetPath(), strExtension);
     if (pItem->IsHD() && strExtension == ".tbn")
     {
-      pItem->SetThumbnailImage(pItem->m_strPath);
+      pItem->SetThumbnailImage(pItem->GetPath());
     }
   }
   m_vecItems[iList]->FillInDefaultIcons();
@@ -515,7 +515,7 @@ bool CGUIWindowFileManager::Update(int iList, const CStdString &strDirectory)
   UpdateButtons();
 
   int item = 0;
-  strSelectedItem = m_history[iList].GetSelectedItem(m_Directory[iList]->m_strPath);
+  strSelectedItem = m_history[iList].GetSelectedItem(m_Directory[iList]->GetPath());
   for (int i = 0; i < m_vecItems[iList]->Size(); ++i)
   {
     CFileItemPtr pItem = m_vecItems[iList]->Get(i);
@@ -538,13 +538,13 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
   if ( iItem < 0 || iItem >= m_vecItems[iList]->Size() ) return ;
 
   CFileItemPtr pItem = m_vecItems[iList]->Get(iItem);
-  if (pItem->m_strPath == "add" && pItem->GetLabel() == g_localizeStrings.Get(1026)) // 'add source button' in empty root
+  if (pItem->GetPath() == "add" && pItem->GetLabel() == g_localizeStrings.Get(1026)) // 'add source button' in empty root
   {
     if (CGUIDialogMediaSource::ShowAndAddMediaSource("files"))
     {
       m_rootDir.SetSources(g_settings.m_fileSources);
-      Update(0,m_Directory[0]->m_strPath);
-      Update(1,m_Directory[1]->m_strPath);
+      Update(0,m_Directory[0]->GetPath());
+      Update(1,m_Directory[1]->GetPath());
     }
     return;
   }
@@ -552,7 +552,7 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
   if (pItem->m_bIsFolder)
   {
     // save path + drive type because of the possible refresh
-    CStdString strPath = pItem->m_strPath;
+    CStdString strPath = pItem->GetPath();
     int iDriveType = pItem->m_iDriveType;
     if ( pItem->m_bIsShareOrDrive )
     {
@@ -571,13 +571,13 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
   else if (pItem->IsZIP() || pItem->IsCBZ()) // mount zip archive
   {
     CStdString strArcivedPath;
-    URIUtils::CreateArchivePath(strArcivedPath, "zip", pItem->m_strPath, "");
+    URIUtils::CreateArchivePath(strArcivedPath, "zip", pItem->GetPath(), "");
     Update(iList, strArcivedPath);
   }
   else if (pItem->IsRAR() || pItem->IsCBR())
   {
     CStdString strArcivedPath;
-    URIUtils::CreateArchivePath(strArcivedPath, "rar", pItem->m_strPath, "");
+    URIUtils::CreateArchivePath(strArcivedPath, "rar", pItem->GetPath(), "");
     Update(iList, strArcivedPath);
   }
   else
@@ -595,7 +595,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem)
   // start playlists from file manager
   if (pItem->IsPlayList())
   {
-    CStdString strPlayList = pItem->m_strPath;
+    CStdString strPlayList = pItem->GetPath();
     auto_ptr<CPlayList> pPlayList (CPlayListFactory::Create(strPlayList));
     if (NULL != pPlayList.get())
     {
@@ -616,12 +616,12 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem)
 #ifdef HAS_PYTHON
   if (pItem->IsPythonScript())
   {
-    g_pythonParser.evalFile(pItem->m_strPath.c_str(),ADDON::AddonPtr());
+    g_pythonParser.evalFile(pItem->GetPath().c_str(),ADDON::AddonPtr());
     return ;
   }
 #endif
   if (pItem->IsShortCut())
-    CUtil::RunShortcut(pItem->m_strPath);
+    CUtil::RunShortcut(pItem->GetPath());
   if (pItem->IsPicture())
   {
     CGUIWindowSlideShow *pSlideShow = (CGUIWindowSlideShow *)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
@@ -632,7 +632,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem)
 
     pSlideShow->Reset();
     pSlideShow->Add(pItem);
-    pSlideShow->Select(pItem->m_strPath);
+    pSlideShow->Select(pItem->GetPath());
 
     g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
   }
@@ -699,7 +699,7 @@ void CGUIWindowFileManager::OnCopy(int iList)
   m_errorHeading = 16201;
   m_errorLine    = 16202;
 
-  CJobManager::GetInstance().AddJob(new CFileOperationJob(CFileOperationJob::ActionCopy, *m_vecItems[iList], m_Directory[1 - iList]->m_strPath), this);
+  CJobManager::GetInstance().AddJob(new CFileOperationJob(CFileOperationJob::ActionCopy, *m_vecItems[iList], m_Directory[1 - iList]->GetPath()), this);
 }
 
 void CGUIWindowFileManager::OnMove(int iList)
@@ -712,7 +712,7 @@ void CGUIWindowFileManager::OnMove(int iList)
   m_errorHeading = 16203;
   m_errorLine    = 16204;
 
-  CJobManager::GetInstance().AddJob(new CFileOperationJob(CFileOperationJob::ActionMove, *m_vecItems[iList], m_Directory[1 - iList]->m_strPath), this);
+  CJobManager::GetInstance().AddJob(new CFileOperationJob(CFileOperationJob::ActionMove, *m_vecItems[iList], m_Directory[1 - iList]->GetPath()), this);
 }
 
 void CGUIWindowFileManager::OnDelete(int iList)
@@ -725,7 +725,7 @@ void CGUIWindowFileManager::OnDelete(int iList)
   m_errorHeading = 16205;
   m_errorLine    = 16206;
 
-  CJobManager::GetInstance().AddJob(new CFileOperationJob(CFileOperationJob::ActionDelete, *m_vecItems[iList], m_Directory[iList]->m_strPath), this);
+  CJobManager::GetInstance().AddJob(new CFileOperationJob(CFileOperationJob::ActionDelete, *m_vecItems[iList], m_Directory[iList]->GetPath()), this);
 }
 
 void CGUIWindowFileManager::OnRename(int iList)
@@ -736,7 +736,7 @@ void CGUIWindowFileManager::OnRename(int iList)
     CFileItemPtr pItem = m_vecItems[iList]->Get(i);
     if (pItem->IsSelected())
     {
-      strFile = pItem->m_strPath;
+      strFile = pItem->GetPath();
       break;
     }
   }
@@ -763,7 +763,7 @@ void CGUIWindowFileManager::OnNewFolder(int iList)
   CStdString strNewFolder = "";
   if (CGUIDialogKeyboard::ShowAndGetInput(strNewFolder, g_localizeStrings.Get(16014), false))
   {
-    CStdString strNewPath = m_Directory[iList]->m_strPath;
+    CStdString strNewPath = m_Directory[iList]->GetPath();
     URIUtils::AddSlashAtEnd(strNewPath);
     strNewPath += strNewFolder;
     CDirectory::Create(strNewPath);
@@ -773,7 +773,7 @@ void CGUIWindowFileManager::OnNewFolder(int iList)
     for (int i=0; i<m_vecItems[iList]->Size(); ++i)
     {
       CFileItemPtr pItem=m_vecItems[iList]->Get(i);
-      CStdString strPath=pItem->m_strPath;
+      CStdString strPath=pItem->GetPath();
       URIUtils::RemoveSlashAtEnd(strPath);
       if (strPath==strNewPath)
       {
@@ -788,7 +788,7 @@ void CGUIWindowFileManager::Refresh(int iList)
 {
   int nSel = GetSelectedItem(iList);
   // update the list views
-  Update(iList, m_Directory[iList]->m_strPath);
+  Update(iList, m_Directory[iList]->GetPath());
 
   while (nSel > m_vecItems[iList]->Size())
     nSel--;
@@ -802,8 +802,8 @@ void CGUIWindowFileManager::Refresh()
   int iList = GetFocusedList();
   int nSel = GetSelectedItem(iList);
   // update the list views
-  Update(0, m_Directory[0]->m_strPath);
-  Update(1, m_Directory[1]->m_strPath);
+  Update(0, m_Directory[0]->GetPath());
+  Update(1, m_Directory[1]->GetPath());
 
   while (nSel > (int)m_vecItems[iList]->Size())
     nSel--;
@@ -821,16 +821,16 @@ int CGUIWindowFileManager::GetSelectedItem(int iControl)
 
 void CGUIWindowFileManager::GoParentFolder(int iList)
 {
-  CURL url(m_Directory[iList]->m_strPath);
+  CURL url(m_Directory[iList]->GetPath());
   if ((url.GetProtocol() == "rar") || (url.GetProtocol() == "zip"))
   {
     // check for step-below, if, unmount rar
     if (url.GetFileName().IsEmpty())
       if (url.GetProtocol() == "zip")
-        g_ZipManager.release(m_Directory[iList]->m_strPath); // release resources
+        g_ZipManager.release(m_Directory[iList]->GetPath()); // release resources
   }
 
-  CStdString strPath(m_strParentPath[iList]), strOldPath(m_Directory[iList]->m_strPath);
+  CStdString strPath(m_strParentPath[iList]), strOldPath(m_Directory[iList]->GetPath());
   Update(iList, strPath);
 }
 
@@ -878,14 +878,14 @@ void CGUIWindowFileManager::GetDirectoryHistoryString(const CFileItem* pItem, CS
     else
     {
       // Other items in virtual directory
-      strHistoryString = pItem->GetLabel() + pItem->m_strPath;
+      strHistoryString = pItem->GetLabel() + pItem->GetPath();
       URIUtils::RemoveSlashAtEnd(strHistoryString);
     }
   }
   else
   {
     // Normal directory items
-    strHistoryString = pItem->m_strPath;
+    strHistoryString = pItem->GetPath();
     URIUtils::RemoveSlashAtEnd(strHistoryString);
   }
 }
@@ -1075,7 +1075,7 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
       CFileItemPtr pItem2=m_vecItems[list]->Get(i);
       if (pItem2->m_bIsFolder && pItem2->IsSelected())
       {
-        int64_t folderSize = CalculateFolderSize(pItem2->m_strPath, progress);
+        int64_t folderSize = CalculateFolderSize(pItem2->GetPath(), progress);
         if (folderSize >= 0)
         {
           pItem2->m_dwSize = folderSize;
@@ -1101,7 +1101,7 @@ void CGUIWindowFileManager::OnPopupMenu(int list, int item, bool bContextDriven 
   }
   if (btnid == 12)
   {
-    CGUIDialogContextMenu::SwitchMedia("files", m_vecItems[list]->m_strPath);
+    CGUIDialogContextMenu::SwitchMedia("files", m_vecItems[list]->GetPath());
     return;
   }
 
@@ -1147,7 +1147,7 @@ int64_t CGUIWindowFileManager::CalculateFolderSize(const CStdString &strDirector
   {
     if (items[i]->m_bIsFolder && !items[i]->IsParentFolder()) // folder
     {
-      int64_t folderSize = CalculateFolderSize(items[i]->m_strPath, pProgress);
+      int64_t folderSize = CalculateFolderSize(items[i]->GetPath(), pProgress);
       if (folderSize < 0) return -1;
       totalSize += folderSize;
     }
@@ -1199,7 +1199,7 @@ void CGUIWindowFileManager::ShowShareErrorMessage(CFileItem* pItem)
   if (pItem->m_bIsShareOrDrive)
   {
     int idMessageText=0;
-    CURL url(pItem->m_strPath);
+    CURL url(pItem->GetPath());
     const CStdString& strHostName=url.GetHostName();
 
     if (pItem->m_iDriveType!=CMediaSource::SOURCE_TYPE_REMOTE) //  Local shares incl. dvd drive
@@ -1220,15 +1220,14 @@ void CGUIWindowFileManager::OnInitWindow()
 
   for (int i = 0; i < 2; i++)
   {
-    Update(i, m_Directory[i]->m_strPath);
+    Update(i, m_Directory[i]->GetPath());
   }
   CGUIWindow::OnInitWindow();
 
   if (!bCheckShareConnectivity)
   {
     bCheckShareConnectivity = true; //reset
-    CFileItem pItem;
-    pItem.m_strPath=strCheckSharePath;
+    CFileItem pItem(strCheckSharePath, true);
     pItem.m_bIsShareOrDrive = true;
     if (URIUtils::IsHD(strCheckSharePath))
       pItem.m_iDriveType=CMediaSource::SOURCE_TYPE_LOCAL;
@@ -1249,9 +1248,9 @@ void CGUIWindowFileManager::SetInitialPath(const CStdString &path)
     CLog::Log(LOGINFO, "Attempting to quickpath to: %s", strDestination.c_str());
   }
   // otherwise, is this the first time accessing this window?
-  else if (m_Directory[0]->m_strPath == "?")
+  else if (m_Directory[0]->GetPath() == "?")
   {
-    m_Directory[0]->m_strPath = strDestination = g_settings.m_defaultFileSource;
+    m_Directory[0]->SetPath(strDestination = g_settings.m_defaultFileSource);
     CLog::Log(LOGINFO, "Attempting to default to: %s", strDestination.c_str());
   }
   // try to open the destination path
@@ -1260,13 +1259,13 @@ void CGUIWindowFileManager::SetInitialPath(const CStdString &path)
     // open root
     if (strDestination.Equals("$ROOT"))
     {
-      m_Directory[0]->m_strPath = "";
+      m_Directory[0]->SetPath("");
       CLog::Log(LOGINFO, "  Success! Opening root listing.");
     }
     else
     {
       // default parameters if the jump fails
-      m_Directory[0]->m_strPath = "";
+      m_Directory[0]->SetPath("");
 
       bool bIsSourceName = false;
       VECSOURCES shares;
@@ -1275,17 +1274,19 @@ void CGUIWindowFileManager::SetInitialPath(const CStdString &path)
       if (iIndex > -1)
       {
         // set current directory to matching share
+        CStdString path;
         if (bIsSourceName && iIndex < (int)shares.size())
-          m_Directory[0]->m_strPath = shares[iIndex].strPath;
+          path = shares[iIndex].strPath;
         else
-          m_Directory[0]->m_strPath = strDestination;
-        URIUtils::RemoveSlashAtEnd(m_Directory[0]->m_strPath);
+          path = strDestination;
+        URIUtils::RemoveSlashAtEnd(path);
+        m_Directory[0]->SetPath(path);
         CLog::Log(LOGINFO, "  Success! Opened destination path: %s", strDestination.c_str());
 
         // outside call: check the share for connectivity
-        bCheckShareConnectivity = Update(0, m_Directory[0]->m_strPath);
+        bCheckShareConnectivity = Update(0, m_Directory[0]->GetPath());
         if(!bCheckShareConnectivity)
-          strCheckSharePath = m_Directory[0]->m_strPath;
+          strCheckSharePath = m_Directory[0]->GetPath();
       }
       else
       {
@@ -1294,7 +1295,7 @@ void CGUIWindowFileManager::SetInitialPath(const CStdString &path)
     }
   }
 
-  if (m_Directory[1]->m_strPath == "?") m_Directory[1]->m_strPath = "";
+  if (m_Directory[1]->GetPath() == "?") m_Directory[1]->SetPath("");
 }
 
 void CGUIWindowFileManager::ResetProgressBar(bool showProgress /*= true */)


### PR DESCRIPTION
At one point we were wanting to move CFileItem::m_strPath to a CURL rather than leaving it as a string.

This does the initial monkey work by moving the member private and adding accessors.

Do we still want to attempt this?

Builds on win32+osx.  A build test on linux would be good.
