### PR TITLE
fix: honor the aspect ratio of splash screen(and possibly other images)

### DIFF
--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -397,8 +397,8 @@ bool CGUITextureBase::CalculateSize()
     }
     if (m_aspect.ratio == CAspectRatio::AR_CENTER)
     { // keep original size + center
-      newWidth = m_frameWidth;
-      newHeight = m_frameHeight;
+      newWidth = m_frameWidth / sqrt(pixelRatio);
+      newHeight = m_frameHeight * sqrt(pixelRatio);
     }
 
     if (m_aspect.align & ASPECT_ALIGN_LEFT)


### PR DESCRIPTION
this is fix suggested by @jmarshallnz on IRC. I have tested that the splash image is no longer distorted on iPad and it looks as it did before on OSX.

if no one has any objection I will push this in in few days

Cheers,
amet
