### PR TITLE
Allow using grouplist in DialogContextMenu

### DIFF
--- a/addons/skin.confluence/720p/DialogContextMenu.xml
+++ b/addons/skin.confluence/720p/DialogContextMenu.xml
@@ -7,18 +7,26 @@
 		<posy>0</posy>
 	</coordinates>
 	<controls>
-		<control type="image" id="997">
-			<description>background top image</description>
+		<control type="image" id="999">
+			<description>background image</description>
 			<posx>0</posx>
-			<posy>-30</posy>
+			<posy>0</posy>
 			<width>340</width>
-			<height>30</height>
-			<texture border="20,19,20,0">DialogContextTop.png</texture>
+			<height>200</height>
+			<texture border="20,19,20,19">DialogBack.png</texture>
+		</control>
+		<control type="grouplist" id="996">
+			<description>grouplist for context buttons</description>
+			<posx>20</posx>
+			<posy>30</posy>
+			<width>300</width>
+			<height>145</height>
+			<itemgap>2</itemgap>
 		</control>
 		<control type="button">
 			<description>Close Window button</description>
 			<posx>260</posx>
-			<posy>-25</posy>
+			<posy>5</posy>
 			<width>64</width>
 			<height>32</height>
 			<label>-</label>
@@ -32,23 +40,9 @@
 			<ondown>2</ondown>
 			<visible>system.getbool(input.enablemouse)</visible>
 		</control>
-		<control type="image" id="999">
-			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
-			<width>340</width>
-			<texture border="20,0,20,0">DialogContextMiddle.png</texture>
-		</control>
-		<control type="image" id="998">
-			<description>background bottom image</description>
-			<posx>0</posx>
-			<width>340</width>
-			<height>25</height>
-			<texture border="20,0,19,20">DialogContextBottom.png</texture>
-		</control>
 		<control type="button" id="1000">
 			<description>button template</description>
-			<posx>20</posx>
+			<posx>-</posx>
 			<posy>-</posy>
 			<width>300</width>
 			<height>38</height>

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -53,13 +53,15 @@
 using namespace std;
 
 #define BACKGROUND_IMAGE       999
+#if PRE_SKIN_VERSION_11_COMPATIBILITY
 #define BACKGROUND_BOTTOM      998
 #define BACKGROUND_TOP         997
+#define SPACE_BETWEEN_BUTTONS    2
+#endif
 #define GROUP_LIST             996
 #define BUTTON_TEMPLATE       1000
 #define BUTTON_START          1001
 #define BUTTON_END            (BUTTON_START + (int)m_buttons.size() - 1)
-#define SPACE_BETWEEN_BUTTONS    2
 
 void CContextButtons::Add(unsigned int button, const CStdString &label)
 {
@@ -134,16 +136,19 @@ void CGUIDialogContextMenu::SetupButtons()
         pButton->SetPosition(pButtonTemplate->GetXPosition(), pButtonTemplate->GetYPosition());
         pGroupList->AddControl(pButton);
       }
+#if PRE_SKIN_VERSION_11_COMPATIBILITY
       else
       {
         pButton->SetPosition(pButtonTemplate->GetXPosition(), i*(pButtonTemplate->GetHeight() + SPACE_BETWEEN_BUTTONS));
         pButton->SetNavigation(id - 1, id + 1, id, id);
         AddControl(pButton);
       }
+#endif
     }
   }
 
   CGUIControl *pControl = NULL;
+#if PRE_SKIN_VERSION_11_COMPATIBILITY
   if (!pGroupList)
   {
     // if we don't have grouplist update the navigation of the first and last buttons
@@ -154,6 +159,7 @@ void CGUIDialogContextMenu::SetupButtons()
     if (pControl)
       pControl->SetNavigation(pControl->GetControlIdUp(), BUTTON_START, pControl->GetControlIdLeft(), pControl->GetControlIdRight());
   }
+#endif
 
   // fix up background images placement and size
   pControl = (CGUIControl *)GetControl(BACKGROUND_IMAGE);
@@ -177,6 +183,7 @@ void CGUIDialogContextMenu::SetupButtons()
         pControl->SetWidth(diff + pGroupList->GetWidth());
       }
     }
+#if PRE_SKIN_VERSION_11_COMPATIBILITY
     else
       pControl->SetHeight(m_buttons.size() * (pButtonTemplate->GetHeight() + SPACE_BETWEEN_BUTTONS));
 
@@ -198,6 +205,7 @@ void CGUIDialogContextMenu::SetupButtons()
       if (pControl2)
         pControl2->SetPosition(pControl2->GetXPosition(), pControl->GetYPosition() + pControl->GetHeight());
     }
+#endif
   }
 
   // update our default control
@@ -215,12 +223,14 @@ void CGUIDialogContextMenu::SetPosition(float posX, float posY)
   if (posX + GetWidth() > m_coordsRes.iWidth)
     posX = m_coordsRes.iWidth - GetWidth();
   if (posX < 0) posX = 0;
+#if PRE_SKIN_VERSION_11_COMPATIBILITY
   // we currently hack the positioning of the buttons from y position 0, which
   // forces skinners to place the top image at a negative y value.  Thus, we offset
   // the y coordinate by the height of the top image.
   const CGUIControl *top = GetControl(BACKGROUND_TOP);
   if (top)
     posY += top->GetHeight();
+#endif
   CGUIDialog::SetPosition(posX, posY);
 }
 
@@ -228,6 +238,7 @@ float CGUIDialogContextMenu::GetHeight()
 {
   const CGUIControl *backMain = GetControl(BACKGROUND_IMAGE);
   if (backMain)
+#if PRE_SKIN_VERSION_11_COMPATIBILITY
   {
     float height = backMain->GetHeight();
     const CGUIControl *backBottom = GetControl(BACKGROUND_BOTTOM);
@@ -238,6 +249,9 @@ float CGUIDialogContextMenu::GetHeight()
       height += backTop->GetHeight();
     return height;
   }
+#else
+  return backMain->GetHeight();
+#endif
   else
     return CGUIDialog::GetHeight();
 }

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -146,13 +146,13 @@ void CGUIDialogContextMenu::SetupButtons()
   CGUIControl *pControl = NULL;
   if (!pGroupList)
   {
-  // if we don't have grouplist update the navigation of the first and last buttons
-  pControl = (CGUIControl *)GetControl(BUTTON_START);
-  if (pControl)
-    pControl->SetNavigation(BUTTON_END, pControl->GetControlIdDown(), pControl->GetControlIdLeft(), pControl->GetControlIdRight());
-  pControl = (CGUIControl *)GetControl(BUTTON_END);
-  if (pControl)
-    pControl->SetNavigation(pControl->GetControlIdUp(), BUTTON_START, pControl->GetControlIdLeft(), pControl->GetControlIdRight());
+    // if we don't have grouplist update the navigation of the first and last buttons
+    pControl = (CGUIControl *)GetControl(BUTTON_START);
+    if (pControl)
+      pControl->SetNavigation(BUTTON_END, pControl->GetControlIdDown(), pControl->GetControlIdLeft(), pControl->GetControlIdRight());
+    pControl = (CGUIControl *)GetControl(BUTTON_END);
+    if (pControl)
+      pControl->SetNavigation(pControl->GetControlIdUp(), BUTTON_START, pControl->GetControlIdLeft(), pControl->GetControlIdRight());
   }
 
   // fix up background images placement and size

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -223,14 +223,7 @@ bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
 void CGUIControlGroupList::ValidateOffset()
 {
   // calculate how many items we have on this page
-  m_totalSize = 0;
-  for (iControls it = m_children.begin(); it != m_children.end(); ++it)
-  {
-    CGUIControl *control = *it;
-    if (!control->IsVisible()) continue;
-    m_totalSize += Size(control) + m_itemGap;
-  }
-  if (m_totalSize > 0) m_totalSize -= m_itemGap;
+  m_totalSize = GetTotalSize();
   // check our m_offset range
   if (m_offset > m_totalSize - Size())
     m_offset = m_totalSize - Size();
@@ -471,4 +464,17 @@ EVENT_RESULT CGUIControlGroupList::OnMouseEvent(const CPoint &point, const CMous
     }
   }
   return EVENT_RESULT_UNHANDLED;
+}
+
+float CGUIControlGroupList::GetTotalSize() const
+{
+  float totalSize = 0;
+  for (ciControls it = m_children.begin(); it != m_children.end(); ++it)
+  {
+    CGUIControl *control = *it;
+    if (!control->IsVisible()) continue;
+    totalSize += Size(control) + m_itemGap;
+  }
+  if (totalSize > 0) totalSize -= m_itemGap;
+  return totalSize;
 }

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -50,6 +50,10 @@ public:
   virtual void ClearAll();
 
   virtual bool GetCondition(int condition, int data) const;
+  /**
+   * Calculate total size of child controls area (including gaps between controls)
+   */
+  float GetTotalSize() const;
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   bool IsFirstFocusableControl(const CGUIControl *control) const;

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -54,6 +54,7 @@ public:
    * Calculate total size of child controls area (including gaps between controls)
    */
   float GetTotalSize() const;
+  ORIENTATION GetOrientation() const { return m_orientation; }
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   bool IsFirstFocusableControl(const CGUIControl *control) const;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -21,6 +21,7 @@
  */
 
 #define PRE_SKIN_VERSION_9_10_COMPATIBILITY 1
+#define PRE_SKIN_VERSION_11_COMPATIBILITY 1
 
 #define DEFAULT_SKIN          "skin.confluence"
 #define DEFAULT_FANART_HEIGHT 0


### PR DESCRIPTION
This allow using grouplist (both vertical and horizontal) in dialogcontextmenu

If there is no grouplist specified by hard_coded id 996 then old behaviour is preserved

If there is grouplist it will stretch background images in appropiate dimension:
vertical will stretch "center" background image height and move bottom background on the bottom edge of "center" backround
horizontal will stretch all background images width

If grouplist is used - stretching background will preserve whatever gap skinner placed between grouplist and backgrounds

In "optional commit" I added way to limit max size of grouplist - skinner may use pagecontrol there (I'm not sure this is logical to do so in context menu - hence "optional"). 

This would tick off 1.3 point in http://forum.xbmc.org/showthread.php?t=94724
