### PR TITLE
Decoupling DXVA2 processor based renderer from CDecoder

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -50,6 +50,8 @@ enum ERENDERFEATURE
   RENDERFEATURE_NONLINSTRETCH
 };
 
+struct DVDVideoPicture;
+
 class CBaseRenderer
 {
 public:
@@ -60,6 +62,10 @@ public:
   RESOLUTION GetResolution() const;
   void GetVideoRect(CRect &source, CRect &dest);
   float GetAspectRatio() const;
+
+  virtual bool AddVideoPicture(DVDVideoPicture* picture) { return false; }
+
+  virtual unsigned int GetProcessorSize() { return 0; }
 
 protected:
   void       ChooseBestResolution(float fps);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -252,7 +252,7 @@ bool CLinuxRendererGL::ValidateRenderTarget()
   return false;
 }
 
-bool CLinuxRendererGL::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags)
+bool CLinuxRendererGL::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, unsigned int format)
 {
   m_sourceWidth = width;
   m_sourceHeight = height;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -132,7 +132,7 @@ public:
   bool RenderCapture(CRenderCapture* capture);
 
   // Player functions
-  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags);
+  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, unsigned int format);
   virtual bool IsConfigured() { return m_bConfigured; }
   virtual int          GetImage(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
   virtual void         ReleaseImage(int source, bool preserve = false);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -150,7 +150,7 @@ bool CLinuxRendererGLES::ValidateRenderTarget()
   return false;  
 }
 
-bool CLinuxRendererGLES::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags)
+bool CLinuxRendererGLES::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, unsigned int format)
 {
   m_sourceWidth = width;
   m_sourceHeight = height;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -134,7 +134,7 @@ public:
   bool RenderCapture(CRenderCapture* capture);
 
   // Player functions
-  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags);
+  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, unsigned int format);
   virtual bool IsConfigured() { return m_bConfigured; }
   virtual int          GetImage(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
   virtual void         ReleaseImage(int source, bool preserve = false);

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -210,7 +210,7 @@ CStdString CXBMCRenderManager::GetVSyncState()
   return state;
 }
 
-bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags)
+bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, unsigned int format)
 {
   /* make sure any queued frame was fully presented */
   double timeout = m_presenttime + 0.1;
@@ -230,7 +230,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
     return false;
   }
 
-  bool result = m_pRenderer->Configure(width, height, d_width, d_height, fps, flags);
+  bool result = m_pRenderer->Configure(width, height, d_width, d_height, fps, flags, format);
   if(result)
   {
     if( flags & CONF_FLAGS_FULLSCREEN )
@@ -694,10 +694,8 @@ int CXBMCRenderManager::AddVideoPicture(DVDVideoPicture& pic)
   if (!m_pRenderer)
     return -1;
 
-#ifdef HAS_DX
   if(m_pRenderer->AddVideoPicture(&pic))
     return 1;
-#endif
 
   YV12Image image;
   int index = m_pRenderer->GetImage(&image);
@@ -717,6 +715,10 @@ int CXBMCRenderManager::AddVideoPicture(DVDVideoPicture& pic)
        || pic.format == DVDVideoPicture::FMT_UYVY)
   {
     CDVDCodecUtils::CopyYUV422PackedPicture(&image, &pic);
+  }
+  else if(pic.format == DVDVideoPicture::FMT_DXVA)
+  {
+    CDVDCodecUtils::CopyDXVA2Picture(&image, &pic);
   }
 #ifdef HAVE_LIBVDPAU
   else if(pic.format == DVDVideoPicture::FMT_VDPAU)

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -68,7 +68,7 @@ public:
   void SetViewMode(int iViewMode) { CSharedLock lock(m_sharedSection); if (m_pRenderer) m_pRenderer->SetViewMode(iViewMode); };
 
   // Functions called from mplayer
-  bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags);
+  bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, unsigned int format);
   bool IsConfigured();
 
   int AddVideoPicture(DVDVideoPicture& picture);
@@ -141,6 +141,14 @@ public:
   CStdString GetVSyncState();
 
   void UpdateResolution();
+
+  unsigned int GetProcessorSize()
+  {
+    CSharedLock lock(m_sharedSection);
+    if (m_pRenderer)
+      return m_pRenderer->GetProcessorSize();
+    return 0;
+  }
 
 #ifdef HAS_GL
   CLinuxRendererGL *m_pRenderer;

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -29,6 +29,7 @@
 #include "guilib/D3DResource.h"
 #include "RenderCapture.h"
 #include "settings/VideoSettings.h"
+#include "cores/dvdplayer/DVDCodecs/Video/DXVA.h"
 //#define MP_DIRECTRENDERING
 
 #ifdef MP_DIRECTRENDERING
@@ -79,7 +80,6 @@ class DllAvUtil;
 class DllAvCodec;
 class DllSwScale;
 
-namespace DXVA { class CProcessor; }
 struct DVDVideoPicture;
 
 struct DRAWRECT
@@ -171,14 +171,12 @@ struct DXVABuffer : SVideoBuffer
 {
   DXVABuffer()
   {
-    proc = NULL;
     id   = 0;
   }
   ~DXVABuffer();
   virtual void Release();
   virtual void StartDecode();
 
-  DXVA::CProcessor* proc;
   int64_t           id;
 };
 
@@ -194,7 +192,7 @@ public:
   bool RenderCapture(CRenderCapture* capture);
 
   // Player functions
-  virtual bool         Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags);
+  virtual bool         Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, unsigned int format);
   virtual int          GetImage(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
   virtual void         ReleaseImage(int source, bool preserve = false);
   virtual bool         AddVideoPicture(DVDVideoPicture* picture);
@@ -209,6 +207,8 @@ public:
   virtual bool         Supports(ESCALINGMETHOD method);
 
   void                 RenderUpdate(bool clear, DWORD flags = 0, DWORD alpha = 255);
+
+  virtual unsigned int GetProcessorSize() { return m_processor.Size(); }
 
   static void          CropSource(RECT& src, RECT& dst, const D3DSURFACE_DESC& desc);
 
@@ -242,7 +242,7 @@ protected:
   bool                 m_bConfigured;
   SVideoBuffer        *m_VideoBuffers[NUM_BUFFERS];
   RenderMethod         m_renderMethod;
-  DXVA::CProcessor*    m_processor;
+  DXVA::CProcessor     m_processor;
 
   // software scale libraries (fallback if required pixel shaders version is not available)
   DllAvUtil           *m_dllAvUtil;
@@ -268,9 +268,12 @@ protected:
 
   bool                 m_bFilterInitialized;
 
+  int                  m_iRequestedMethod;
+
   // clear colour for "black" bars
   DWORD                m_clearColour;
   unsigned int         m_flags;
+  unsigned int         m_format;
 
   // Width and height of the render target
   // the separable HQ scalers need this info, but could the m_destRect be used instead?

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDCodecUtils.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDCodecUtils.h
@@ -37,6 +37,7 @@ public:
   static DVDVideoPicture* ConvertToYUV422PackedPicture(DVDVideoPicture *pSrc, DVDVideoPicture::EFormat format);
   static bool CopyNV12Picture(YV12Image* pImage, DVDVideoPicture *pSrc);
   static bool CopyYUV422PackedPicture(YV12Image* pImage, DVDVideoPicture *pSrc);
+  static bool CopyDXVA2Picture(YV12Image* pImage, DVDVideoPicture *pSrc);
 
   static bool IsVP3CompatibleWidth(int width);
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -119,7 +119,7 @@ CDVDOverlayCodec* CDVDFactoryCodec::OpenCodec(CDVDOverlayCodec* pCodec, CDVDStre
 }
 
 
-CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec( CDVDStreamInfo &hint )
+CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, unsigned int surfaces)
 {
   CDVDVideoCodec* pCodec = NULL;
   CDVDCodecOptions options;
@@ -247,6 +247,9 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec( CDVDStreamInfo &hint )
   }
 #endif
 
+  CStdString value;
+  value.Format("%d", surfaces);
+  options.push_back(CDVDCodecOption("surfaces", value));
   if( (pCodec = OpenCodec(new CDVDVideoCodecFFmpeg(), hint, options)) ) return pCodec;
 
   return NULL;

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.h
@@ -35,7 +35,7 @@ typedef std::vector<CDVDCodecOption> CDVDCodecOptions;
 class CDVDFactoryCodec
 {
 public:
-  static CDVDVideoCodec* CreateVideoCodec(CDVDStreamInfo &hint );
+  static CDVDVideoCodec* CreateVideoCodec(CDVDStreamInfo &hint, unsigned int surfaces = 0);
   static CDVDAudioCodec* CreateAudioCodec(CDVDStreamInfo &hint, bool passthrough = true );
   static CDVDOverlayCodec* CreateOverlayCodec(CDVDStreamInfo &hint );
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -32,7 +32,7 @@
 #define FRAME_TYPE_B 3
 #define FRAME_TYPE_D 4
 
-namespace DXVA { class CProcessor; }
+namespace DXVA { class CSurfaceContext; }
 namespace VAAPI { struct CHolder; }
 class CVDPAU;
 class COpenMax;
@@ -56,8 +56,7 @@ struct DVDVideoPicture
       int iLineSize[4];   // [4] = alpha channel, currently not used
     };
     struct {
-      DXVA::CProcessor* proc;
-      int64_t           proc_id;
+      DXVA::CSurfaceContext* context;
     };
     struct {
       CVDPAU* vdpau;
@@ -88,6 +87,7 @@ struct DVDVideoPicture
   unsigned int chroma_position;
   unsigned int color_primaries;
   unsigned int color_transfer;
+  unsigned int extended_format;
   int iGroupId;
 
   int8_t* qscale_table; // Quantization parameters, primarily used by filters

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -40,7 +40,7 @@ public:
     public:
              IHardwareDecoder() {}
     virtual ~IHardwareDecoder() {};
-    virtual bool Open      (AVCodecContext* avctx, const enum PixelFormat) = 0;
+    virtual bool Open      (AVCodecContext* avctx, const enum PixelFormat, unsigned int surfaces) = 0;
     virtual int  Decode    (AVCodecContext* avctx, AVFrame* frame) = 0;
     virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture) = 0;
     virtual int  Check     (AVCodecContext* avctx) = 0;
@@ -94,6 +94,8 @@ protected:
 
   int m_iScreenWidth;
   int m_iScreenHeight;
+
+  unsigned int m_uSurfacesCount;
 
   DllAvCodec m_dllAvCodec;
   DllAvUtil  m_dllAvUtil;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -724,16 +724,15 @@ bool CDecoder::OpenTarget(const GUID &guid)
   CHECK(m_service->GetDecoderRenderTargets(guid, &output_count, &output_list))
   SCOPE(D3DFORMAT, output_list);
 
-  for(unsigned k = 0; k < output_count; k++)
-  {
-    if(output_list[k] == MAKEFOURCC('Y','V','1','2')
-    || output_list[k] == MAKEFOURCC('N','V','1','2'))
-    {
-      m_input         = guid;
-      m_format.Format = output_list[k];
-      return true;
-    }
-  }
+  for (unsigned i = 0; render_targets[i] != D3DFMT_UNKNOWN; i++)
+      for(unsigned k = 0; k < output_count; k++)
+          if (output_list[k] == render_targets[i])
+          {
+              m_input = guid;
+              m_format.Format = output_list[k];
+              return true;
+          }
+
   return false;
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -31,7 +31,18 @@
 
 namespace DXVA {
 
-class CProcessor;
+class CSurfaceContext
+  : public IDVDResourceCounted<CSurfaceContext>
+{
+public:
+  CSurfaceContext();
+  ~CSurfaceContext();
+
+   void HoldSurface(IDirect3DSurface9* surface);
+
+protected:
+  std::vector<IDirect3DSurface9*> m_heldsurfaces;
+};
 
 class CDecoder
   : public CDVDVideoCodecFFmpeg::IHardwareDecoder
@@ -40,14 +51,13 @@ class CDecoder
 public:
   CDecoder();
  ~CDecoder();
-  virtual bool Open      (AVCodecContext* avctx, const enum PixelFormat);
+  virtual bool Open      (AVCodecContext* avctx, const enum PixelFormat, unsigned int surfaces);
   virtual int  Decode    (AVCodecContext* avctx, AVFrame* frame);
   virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture);
   virtual int  Check     (AVCodecContext* avctx);
   virtual void Close();
   virtual const std::string Name() { return "dxva2"; }
 
-  bool  OpenProcessor();
   bool  OpenTarget(const GUID &guid);
   bool  OpenDecoder();
   int   GetBuffer(AVCodecContext *avctx, AVFrame *pic);
@@ -92,7 +102,9 @@ protected:
 
   struct dxva_context*         m_context;
 
-  CProcessor*                  m_processor;
+  CSurfaceContext*             m_surface_context;
+
+  unsigned int                 m_shared;
 
   CCriticalSection             m_section;
   CEvent                       m_event;
@@ -100,21 +112,19 @@ protected:
 
 class CProcessor
   : public ID3DResource
-  , public IDVDResourceCounted<CProcessor>
 {
 public:
   CProcessor();
  ~CProcessor();
 
-  bool           Open(UINT width, UINT height, unsigned int flags);
-  bool           Open(const DXVA2_VideoDesc& dsc);
-  bool           CreateSurfaces();
+  bool           PreInit();
+  void           UnInit();
+  bool           Open(UINT width, UINT height, unsigned int flags, unsigned int format);
   void           Close();
-  void           HoldSurface(IDirect3DSurface9* surface);
-  REFERENCE_TIME Add(IDirect3DSurface9* source);
+  REFERENCE_TIME Add(IDirect3DSurface9* source, CSurfaceContext* context);
   REFERENCE_TIME Add(DVDVideoPicture* picture);
   bool           Render(const RECT& src, const RECT& dst, IDirect3DSurface9* target, const REFERENCE_TIME time);
-  int            Size() { return m_size; }
+  unsigned       Size() { if (m_service) return m_size; return 0; }
 
   virtual void OnCreateDevice()  {}
   virtual void OnDestroyDevice() { CSingleLock lock(m_section); Close(); }
@@ -122,7 +132,8 @@ public:
   virtual void OnResetDevice()   { CSingleLock lock(m_section); Close(); }
 
 protected:
-  bool           Open(UINT width, UINT height, unsigned int flags, D3DFORMAT format);
+  bool UpdateSize(const DXVA2_VideoDesc& dsc);
+  bool CreateSurfaces();
 
   IDirectXVideoProcessorService* m_service;
   IDirectXVideoProcessor*        m_process;
@@ -139,14 +150,20 @@ protected:
   unsigned         m_size;
 
   unsigned         m_index;
-  typedef std::deque<DXVA2_VideoSample> SSamples;
+
+  struct SVideoSample
+  {
+    DXVA2_VideoSample sample;
+    CSurfaceContext* context;
+  };
+
+  typedef std::deque<SVideoSample> SSamples;
   SSamples          m_sample;
 
   CCriticalSection  m_section;
 
-  std::vector<IDirect3DSurface9*> m_heldsurfaces;
   LPDIRECT3DSURFACE9* m_surfaces;
-  unsigned            m_surfaces_count;
+  CSurfaceContext* m_context;
 };
 
 };

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -121,7 +121,6 @@ public:
   void           UnInit();
   bool           Open(UINT width, UINT height, unsigned int flags, unsigned int format);
   void           Close();
-  REFERENCE_TIME Add(IDirect3DSurface9* source, CSurfaceContext* context);
   REFERENCE_TIME Add(DVDVideoPicture* picture);
   bool           Render(const RECT& src, const RECT& dst, IDirect3DSurface9* target, const REFERENCE_TIME time);
   unsigned       Size() { if (m_service) return m_size; return 0; }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -229,7 +229,7 @@ void CDecoder::Close()
   m_holder.surface.reset();
 }
 
-bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt)
+bool CDecoder::Open(AVCodecContext *avctx, enum PixelFormat fmt, unsigned int surfaces)
 {
   VAEntrypoint entrypoint = VAEntrypointVLD;
   VAProfile    profile;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.h
@@ -101,7 +101,7 @@ class CDecoder
 public:
   CDecoder();
  ~CDecoder();
-  virtual bool Open      (AVCodecContext* avctx, const enum PixelFormat);
+  virtual bool Open      (AVCodecContext* avctx, const enum PixelFormat, unsigned int surfaces);
   virtual int  Decode    (AVCodecContext* avctx, AVFrame* frame);
   virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture);
   virtual int  Check     (AVCodecContext* avctx);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -123,7 +123,7 @@ CVDPAU::CVDPAU()
   upScale = g_advancedSettings.m_videoVDPAUScaling;
 }
 
-bool CVDPAU::Open(AVCodecContext* avctx, const enum PixelFormat)
+bool CVDPAU::Open(AVCodecContext* avctx, const enum PixelFormat, unsigned int surfaces)
 {
   if(avctx->width  == 0
   || avctx->height == 0)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -63,7 +63,7 @@ public:
   CVDPAU();
   virtual ~CVDPAU();
   
-  virtual bool Open      (AVCodecContext* avctx, const enum PixelFormat);
+  virtual bool Open      (AVCodecContext* avctx, const enum PixelFormat, unsigned int surfaces);
   virtual int  Decode    (AVCodecContext* avctx, AVFrame* frame);
   virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture);
   virtual void Reset();

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -176,8 +176,18 @@ double CDVDPlayerVideo::GetOutputDelay()
 
 bool CDVDPlayerVideo::OpenStream( CDVDStreamInfo &hint )
 {
+  unsigned int surfaces = 0;
+#ifdef HAS_VIDEO_PLAYBACK
+  if(!m_output.inited)
+  {
+    g_renderManager.PreInit();
+    m_output.inited = true;
+  }
+  surfaces = g_renderManager.GetProcessorSize();
+#endif
+
   CLog::Log(LOGNOTICE, "Creating video codec with codec id: %i", hint.codec);
-  CDVDVideoCodec* codec = CDVDFactoryCodec::CreateVideoCodec( hint );
+  CDVDVideoCodec* codec = CDVDFactoryCodec::CreateVideoCodec(hint, surfaces);
   if(!codec)
   {
     CLog::Log(LOGERROR, "Unsupported video codec");
@@ -283,13 +293,6 @@ void CDVDPlayerVideo::OnStartup()
   m_iCurrentPts = DVD_NOPTS_VALUE;
   m_FlipTimeStamp = m_pClock->GetAbsoluteClock();
 
-#ifdef HAS_VIDEO_PLAYBACK
-  if(!m_output.inited)
-  {
-    g_renderManager.PreInit();
-    m_output.inited = true;
-  }
-#endif
   g_dvdPerformanceCounter.EnableVideoDecodePerformance(ThreadHandle());
 }
 
@@ -739,6 +742,8 @@ void CDVDPlayerVideo::OnExit()
     m_pOverlayCodecCC = NULL;
   }
 
+  m_output.inited = false;
+
   CLog::Log(LOGNOTICE, "thread end: video_thread");
 }
 
@@ -921,6 +926,7 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
    || m_output.dheight != pPicture->iDisplayHeight
    || m_output.framerate != m_fFrameRate
    || m_output.color_format != (unsigned int)pPicture->format
+   || m_output.extended_format != pPicture->extended_format
    || ( m_output.color_matrix != pPicture->color_matrix && pPicture->color_matrix != 0 ) // don't reconfigure on unspecified
    || ( m_output.chroma_position != pPicture->chroma_position && pPicture->chroma_position != 0 )
    || ( m_output.color_primaries != pPicture->color_primaries && pPicture->color_primaries != 0 )
@@ -1049,7 +1055,7 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
     }
 
     CLog::Log(LOGDEBUG,"%s - change configuration. %dx%d. framerate: %4.2f. format: %s",__FUNCTION__,pPicture->iWidth, pPicture->iHeight, m_bFpsInvalid ? 0.0 : m_fFrameRate, formatstr.c_str());
-    if(!g_renderManager.Configure(pPicture->iWidth, pPicture->iHeight, pPicture->iDisplayWidth, pPicture->iDisplayHeight, m_bFpsInvalid ? 0.0 : m_fFrameRate, flags))
+    if(!g_renderManager.Configure(pPicture->iWidth, pPicture->iHeight, pPicture->iDisplayWidth, pPicture->iDisplayHeight, m_bFpsInvalid ? 0.0 : m_fFrameRate, flags, pPicture->extended_format))
     {
       CLog::Log(LOGERROR, "%s - failed to configure renderer", __FUNCTION__);
       return EOS_ABORT;
@@ -1061,6 +1067,7 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
     m_output.dheight = pPicture->iDisplayHeight;
     m_output.framerate = m_fFrameRate;
     m_output.color_format = pPicture->format;
+    m_output.extended_format = pPicture->extended_format;
     m_output.color_matrix = pPicture->color_matrix;
     m_output.chroma_position = pPicture->chroma_position;
     m_output.color_primaries = pPicture->color_primaries;

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -152,6 +152,7 @@ protected:
     unsigned int dwidth;
     unsigned int dheight;
     unsigned int color_format;
+    unsigned int extended_format;
     unsigned int color_matrix : 4;
     unsigned int color_range  : 1;
     unsigned int chroma_position;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -91,6 +91,7 @@ void CAdvancedSettings::Initialize()
   m_videoAllowMpeg4VDPAU = false;
   m_DXVACheckCompatibility = false;
   m_DXVACheckCompatibilityPresent = false;
+  m_DXVAForceProcessorRenderer = true;
 
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
@@ -526,6 +527,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
 
     m_DXVACheckCompatibilityPresent = XMLUtils::GetBoolean(pElement,"checkdxvacompatibility", m_DXVACheckCompatibility);
 
+    XMLUtils::GetBoolean(pElement,"forcedxvarenderer", m_DXVAForceProcessorRenderer);
   }
 
   pElement = pRootElement->FirstChildElement("musiclibrary");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -123,6 +123,7 @@ class CAdvancedSettings
     std::vector<RefreshOverride> m_videoAdjustRefreshOverrides;
     bool m_DXVACheckCompatibility;
     bool m_DXVACheckCompatibilityPresent;
+    bool m_DXVAForceProcessorRenderer;
 
     CStdString m_videoDefaultPlayer;
     CStdString m_videoDefaultDVDPlayer;


### PR DESCRIPTION
This commit makes DXVA2 processor based renderer a class not linked with CDecoder anymore. Thus we only need to have an unique instance of CProcessor in WinRenderer to manage.
With these changes the code path is more homogeneous and the DXVA2 renderer is fully independent from decoded content. Any combination of ffmpeg/DXVA2 decoding and DXVA/Pixel Shader/Software renderers are allowed so as example the user now is never forced again to use DXVA2 renderer for DXVA2 accelerated content when he hasn't selected it as a renderer option in GUI.
