### PR TITLE
Ability to auto-resume DVD discs improved

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3474,7 +3474,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
 #ifdef HAS_DVD_DRIVE
     // Display the Play Eject dialog
     if (CGUIDialogPlayEject::ShowAndGetInput(item))
-      return MEDIA_DETECT::CAutorun::PlayDisc();
+      return MEDIA_DETECT::CAutorun::PlayDisc(!MEDIA_DETECT::CAutorun::CanResumePlayDVD() || CGUIDialogYesNo::ShowAndGetInput(341, -1, -1, -1, 13404, 12021));
 #endif
     return true;
   }

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -38,6 +38,7 @@
 #include "playlists/PlayList.h"
 #include "guilib/GUIWindowManager.h"
 #include "storage/MediaManager.h"
+#include "video/VideoDatabase.h"
 
 using namespace std;
 using namespace XFILE;
@@ -369,6 +370,18 @@ bool CAutorun::PlayDisc(bool restart)
 {
   ExecuteAutorun(true,true, restart);
   return true;
+}
+
+bool CAutorun::CanResumePlayDVD()
+{
+  CStdString strPath = "removable://"; // need to put volume label for resume point in videoInfoTag
+  strPath += g_mediaManager.GetDiskLabel();
+  CVideoDatabase dbs;
+  dbs.Open();
+  CBookmark bookmark;
+  if (dbs.GetResumeBookMark(strPath, bookmark))
+    return true;
+  return false;
 }
 
 #endif

--- a/xbmc/Autorun.h
+++ b/xbmc/Autorun.h
@@ -47,7 +47,8 @@ class CAutorun
 public:
   CAutorun();
   virtual ~CAutorun();
-  static bool PlayDisc(bool restart = false);
+  static bool CanResumePlayDVD();
+  static bool PlayDisc(bool restart);
   bool IsEnabled() const;
   void Enable();
   void Disable();

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -323,7 +323,7 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
     return MEDIA_DETECT::CAutorun::PlayDisc(true); // restart
 
   case CONTEXT_BUTTON_RESUME_DISC:
-    return MEDIA_DETECT::CAutorun::PlayDisc();
+    return MEDIA_DETECT::CAutorun::PlayDisc(false);// resume
 
   case CONTEXT_BUTTON_EJECT_DISC:
 #ifdef _WIN32

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -914,7 +914,10 @@ int CBuiltins::Execute(const CStdString& execString)
   else if (execute.Equals("playdvd"))
   {
 #ifdef HAS_DVD_DRIVE
-    CAutorun::PlayDisc();
+    bool restart = false;
+    if (params.size() > 0 && params[0].CompareNoCase("restart") == 0)
+      restart = true;
+    CAutorun::PlayDisc(restart);
 #endif
   }
   else if (execute.Equals("ripcd"))

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -32,6 +32,7 @@
 #include "playlists/PlayListM3U.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogKeyboard.h"
+#include "dialogs/GUIDialogYesNo.h"
 #include "FileItem.h"
 #include "settings/GUISettings.h"
 #include "GUIUserMessages.h"
@@ -199,7 +200,7 @@ void CGUIWindowMusicPlaylistEditor::PlayItem(int iItem)
 
 #ifdef HAS_DVD_DRIVE
   if (m_vecItems->Get(iItem)->IsDVD())
-    MEDIA_DETECT::CAutorun::PlayDisc();
+    MEDIA_DETECT::CAutorun::PlayDisc(!MEDIA_DETECT::CAutorun::CanResumePlayDVD() || CGUIDialogYesNo::ShowAndGetInput(341, -1, -1, -1, 13404, 12021));
   else
 #endif
     CGUIWindowMusicBase::PlayItem(iItem);

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -453,7 +453,7 @@ void CGUIWindowMusicSongs::PlayItem(int iItem)
 
 #ifdef HAS_DVD_DRIVE
   if (m_vecItems->Get(iItem)->IsDVD())
-    MEDIA_DETECT::CAutorun::PlayDisc();
+    MEDIA_DETECT::CAutorun::PlayDisc(!MEDIA_DETECT::CAutorun::CanResumePlayDVD() || CGUIDialogYesNo::ShowAndGetInput(341, -1, -1, -1, 13404, 12021));
   else
 #endif
     CGUIWindowMusicBase::PlayItem(iItem);

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -33,6 +33,7 @@
 #include "PictureInfoLoader.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogOK.h"
+#include "dialogs/GUIDialogYesNo.h"
 #include "playlists/PlayList.h"
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"
@@ -300,7 +301,7 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
 
 #ifdef HAS_DVD_DRIVE
   if (pItem->IsDVD())
-    return MEDIA_DETECT::CAutorun::PlayDisc();
+    return MEDIA_DETECT::CAutorun::PlayDisc(!MEDIA_DETECT::CAutorun::CanResumePlayDVD() || CGUIDialogYesNo::ShowAndGetInput(341, -1, -1, -1, 13404, 12021));
 #endif
 
   if (pItem->m_bIsShareOrDrive)

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -236,7 +236,7 @@ bool CGUIWindowPrograms::OnPlayMedia(int iItem)
 
 #ifdef HAS_DVD_DRIVE
   if (pItem->IsDVD())
-    return MEDIA_DETECT::CAutorun::PlayDisc();
+    return MEDIA_DETECT::CAutorun::PlayDisc(!MEDIA_DETECT::CAutorun::CanResumePlayDVD() || CGUIDialogYesNo::ShowAndGetInput(341, -1, -1, -1, 13404, 12021));
 #endif
 
   if (pItem->m_bIsFolder) return false;

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -173,7 +173,7 @@ bool CGUIWindowFileManager::OnAction(const CAction &action)
     {
 #ifdef HAS_DVD_DRIVE
       if (m_vecItems[list]->Get(GetSelectedItem(list))->IsDVD())
-        return MEDIA_DETECT::CAutorun::PlayDisc();
+        return MEDIA_DETECT::CAutorun::PlayDisc(!MEDIA_DETECT::CAutorun::CanResumePlayDVD() || CGUIDialogYesNo::ShowAndGetInput(341, -1, -1, -1, 13404, 12021));
 #endif
     }
   }


### PR DESCRIPTION
as a follow-up to pull-request 93 (see https://github.com/xbmc/xbmc/pull/93), I have improved the resume function of (removable) DVD discs. The following new feature is now available:

The previous default behaviour of preferring "resume" is now changed in favor of presenting the user a choice between resume and restart, in case a a resume point is available from the video database.

Situations:
- if playing a DVD through the selection of a "disc stub"
- any other instance in the GUI that would trigger the playback of a dvd disc

Exception (skinner's opportunity):
- Built-In interface function still defaults to "resume" i.e. PlayDVD without any parameter. This is used when called from the Home screen (skin) but now also accepts a parameter to potentially make the skin restart the disc from the beginning, by passing "restart" (as in "PlayDVD(restart)").
