### PR TITLE
fix missing pts values after decoding using vaapi

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -205,6 +205,7 @@ int CDecoder::GetBuffer(AVCodecContext *avctx, AVFrame *pic)
   pic->linesize[1]    = 0;
   pic->linesize[2]    = 0;
   pic->linesize[3]    = 0;
+  pic->reordered_opaque= avctx->reordered_opaque;
   return 0;
 }
 


### PR DESCRIPTION
pictures got no pts values after decoding with vaapi. might have been a reason for a/v sync issues
