### PR TITLE
Allow selecting addon in addon settings

### DIFF
--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -45,6 +45,7 @@
 #include "settings/Settings.h"
 #include "GUIInfoManager.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "GUIWindowAddonBrowser.h"
 #include "utils/log.h"
 
 using namespace std;
@@ -399,6 +400,30 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
             ((CGUIButtonControl*) control)->SetLabel2(value);
           }
         }
+        else if (strcmp(type, "addon") == 0)
+        {
+          const char *strType = setting->Attribute("addontype");
+          TYPE type = strType ? TranslateType(strType) : ADDON_UNKNOWN;
+          if (type != ADDON_UNKNOWN)
+          {
+            const char *strMultiselect = setting->Attribute("multiselect");
+            bool multiSelect = strMultiselect && strcmpi(strMultiselect, "true") == 0;
+            if (multiSelect)
+            {
+              // construct vector of addon IDs (IDs are comma seperated in single string)
+              CStdStringArray addonIDs;
+              StringUtils::SplitString(value, ",", addonIDs);
+              if (CGUIWindowAddonBrowser::SelectAddonID(type, addonIDs, false) == 1)
+              {
+                StringUtils::JoinString(addonIDs, ",", value);
+                ((CGUIButtonControl*) control)->SetLabel2(GetAddonNames(value));
+              }
+            }
+            else // no need of string splitting/joining if we select only 1 addon
+              if (CGUIWindowAddonBrowser::SelectAddonID(type, value, false) == 1)
+                ((CGUIButtonControl*) control)->SetLabel2(GetAddonNames(value));
+          }
+        }
         m_buttonValues[id] = value;
         break;
       }
@@ -593,13 +618,14 @@ void CGUIDialogAddonSettings::CreateControls()
 
     if (type)
     {
+      bool isAddonSetting = false;
       if (strcmpi(type, "text") == 0 || strcmpi(type, "ipaddress") == 0 ||
         strcmpi(type, "number") == 0 ||strcmpi(type, "video") == 0 ||
         strcmpi(type, "audio") == 0 || strcmpi(type, "image") == 0 ||
         strcmpi(type, "folder") == 0 || strcmpi(type, "executable") == 0 ||
         strcmpi(type, "file") == 0 || strcmpi(type, "action") == 0 ||
         strcmpi(type, "date") == 0 || strcmpi(type, "time") == 0 ||
-        strcmpi(type, "select") == 0)
+        strcmpi(type, "select") == 0 || (isAddonSetting = strcmpi(type, "addon") == 0))
       {
         pControl = new CGUIButtonControl(*pOriginalButton);
         if (!pControl) return;
@@ -620,7 +646,12 @@ void CGUIDialogAddonSettings::CreateControls()
             ((CGUIButtonControl *)pControl)->SetLabel2(hiddenText);
           }
           else
-            ((CGUIButtonControl *)pControl)->SetLabel2(value);
+          {
+            if (isAddonSetting)
+              ((CGUIButtonControl *)pControl)->SetLabel2(GetAddonNames(value));
+            else
+              ((CGUIButtonControl *)pControl)->SetLabel2(value);
+          }
         }
         else
           ((CGUIButtonControl *)pControl)->SetLabel2(defaultValue);
@@ -800,6 +831,24 @@ void CGUIDialogAddonSettings::CreateControls()
     }
   }
   EnableControls();
+}
+
+CStdString CGUIDialogAddonSettings::GetAddonNames(const CStdString& addonIDslist) const
+{
+  CStdString retVal;
+  CStdStringArray addons;
+  StringUtils::SplitString(addonIDslist, ",", addons);
+  for (CStdStringArray::const_iterator it = addons.begin(); it != addons.end() ; it ++)
+  {
+    if (!retVal.IsEmpty())
+      retVal += ", ";
+    AddonPtr addon;
+    if (CAddonMgr::Get().GetAddon(*it ,addon))
+      retVal += addon->Name();
+    else
+      retVal += *it;
+  }
+  return retVal;
 }
 
 vector<CStdString> CGUIDialogAddonSettings::GetFileEnumValues(const CStdString &path, const CStdString &mask, const CStdString &options) const

--- a/xbmc/addons/GUIDialogAddonSettings.h
+++ b/xbmc/addons/GUIDialogAddonSettings.h
@@ -56,6 +56,12 @@ private:
    */
   std::vector<CStdString> GetFileEnumValues(const CStdString &path, const CStdString &mask, const CStdString &options) const;
 
+  /*! \brief Translate list of addon IDs to list of addon names
+   \param addonIDslist comma seperated list of addon IDs
+   \return comma seperated list of addon names
+   */
+  CStdString GetAddonNames(const CStdString& addonIDslist) const;
+
   void CreateSections();
   void FreeSections();
   void CreateControls();

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -322,13 +322,25 @@ bool CGUIWindowAddonBrowser::Update(const CStdString &strDirectory)
   return true;
 }
 
-int CGUIWindowAddonBrowser::SelectAddonID(TYPE type, CStdString &addonID, bool showNone)
+int CGUIWindowAddonBrowser::SelectAddonID(TYPE type, CStdString &addonID, bool showNone /*= false*/)
+{
+  CStdStringArray addonIDs;
+  if (!addonID.IsEmpty())
+    addonIDs.push_back(addonID);
+  int retval = SelectAddonID(type, addonIDs, showNone, false);
+  if (addonIDs.size() > 0)
+    addonID = addonIDs.at(0);
+  else
+    addonID = "";
+  return retval;
+}
+
+int CGUIWindowAddonBrowser::SelectAddonID(ADDON::TYPE type, CStdStringArray &addonIDs, bool showNone /*= false*/, bool multipleSelection /*= true*/)
 {
   CGUIDialogSelect *dialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
   if (type == ADDON_UNKNOWN || !dialog)
     return 0;
 
-  int selectedIdx = 0;
   ADDON::VECADDONS addons;
   if (type == ADDON_AUDIO)
     CAddonsDirectory::GetScriptsAndPlugins("audio",addons);
@@ -348,7 +360,13 @@ int CGUIWindowAddonBrowser::SelectAddonID(TYPE type, CStdString &addonID, bool s
   dialog->SetHeading(TranslateType(type, true));
   dialog->Reset();
   dialog->SetUseDetails(true);
-  dialog->EnableButton(true, 21452);
+  if (multipleSelection)
+  {
+    showNone = false;
+    dialog->EnableButton(true, 186);
+  }
+  else
+    dialog->EnableButton(true, 21452);
   if (showNone)
   {
     CFileItemPtr item(new CFileItem("", false));
@@ -359,15 +377,20 @@ int CGUIWindowAddonBrowser::SelectAddonID(TYPE type, CStdString &addonID, bool s
     items.Add(item);
   }
   items.Sort(SORT_METHOD_LABEL, SORT_ORDER_ASC);
-  for (int i = 0; i < items.Size(); ++i)
+
+  if (addonIDs.size() > 0)
   {
-    if (addonID.Equals(items[i]->GetProperty("Addon.ID")))
-      selectedIdx = i;
+    for (CStdStringArray::const_iterator it = addonIDs.begin(); it != addonIDs.end() ; it++)
+    {
+      CFileItemPtr item = items.Get(*it);
+      if (item)
+        item->Select(true);
+    }
   }
   dialog->SetItems(&items);
-  dialog->SetSelected(selectedIdx);
+  dialog->SetMultiSelection(multipleSelection);
   dialog->DoModal();
-  if (dialog->IsButtonPressed())
+  if (!multipleSelection && dialog->IsButtonPressed())
   { // switch to the addons browser.
     vector<CStdString> params;
     params.push_back("addons://all/"+TranslateType(type,false)+"/");
@@ -375,12 +398,13 @@ int CGUIWindowAddonBrowser::SelectAddonID(TYPE type, CStdString &addonID, bool s
     g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
     return 2;
   }
-  if (dialog->GetSelectedLabel() >= 0)
-  {
-    addonID = dialog->GetSelectedItem()->GetPath();
-    return 1;
-  }
-  return 0;
+  if (!multipleSelection && dialog->GetSelectedLabel() == -1)
+    return 0;
+  addonIDs.clear();
+  const CFileItemList& list = dialog->GetSelectedItems();
+  for (int i = 0 ; i < list.Size() ; i++)
+    addonIDs.push_back(list.Get(i)->GetPath());
+  return 1;
 }
 
 CStdString CGUIWindowAddonBrowser::GetStartFolder(const CStdString &dir)

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -377,7 +377,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(TYPE type, CStdString &addonID, bool s
   }
   if (dialog->GetSelectedLabel() >= 0)
   {
-    addonID = dialog->GetSelectedItem().GetPath();
+    addonID = dialog->GetSelectedItem()->GetPath();
     return 1;
   }
   return 0;

--- a/xbmc/addons/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/GUIWindowAddonBrowser.h
@@ -42,7 +42,15 @@ public:
    \return 1 if an addon was selected, 2 if "Get More" was chosen, or 0 if an error occurred or if the selection process was cancelled
    */
   static int SelectAddonID(ADDON::TYPE type, CStdString &addonID, bool showNone = false);
-
+  /*! \brief Popup a selection dialog with a list of addons of the given type
+   \param type the type of addon wanted
+   \param addonIDs [out] array of selected addon IDs
+   \param showNone whether there should be a "None" item in the list (defaults to false)
+   \param multipleSelection allow selection of multiple addons, if set to true showNone will automaticly switch to false
+   \return 1 if an addon was selected or multiple selection was specified, 2 if "Get More" was chosen, or 0 if an error occurred or if the selection process was cancelled
+   */
+  static int SelectAddonID(ADDON::TYPE type, CStdStringArray &addonIDs, bool showNone = false, bool multipleSelection = true);
+  
 protected:
   /* \brief set label2 of an item based on the Addon.Status property
    \param item the item to update

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -36,7 +36,8 @@ CGUIDialogSelect::CGUIDialogSelect(void)
   m_bButtonEnabled = false;
   m_useDetails = false;
   m_vecListInternal = new CFileItemList;
-  m_selectedItem = new CFileItem;
+  m_selectedItems = new CFileItemList;
+  m_multiSelection = false;
   m_vecList = m_vecListInternal;
   m_iSelected = -1;
 }
@@ -44,7 +45,7 @@ CGUIDialogSelect::CGUIDialogSelect(void)
 CGUIDialogSelect::~CGUIDialogSelect(void)
 {
   delete m_vecListInternal;
-  delete m_selectedItem;
+  delete m_selectedItems;
 }
 
 bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
@@ -57,6 +58,22 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
       m_viewControl.Reset();
       m_bButtonEnabled = false;
       m_useDetails = false;
+      m_multiSelection = false;
+
+      // construct selected items list
+      m_selectedItems->Clear();
+      m_iSelected = -1;
+      for (int i = 0 ; i < m_vecList->Size() ; i++)
+      {
+        CFileItemPtr item = m_vecList->Get(i);
+        if (item->IsSelected())
+        {
+          m_selectedItems->Add(item);
+          if (m_iSelected == -1)
+            m_iSelected = i;
+        }
+      }
+
       m_vecListInternal->Clear();
       m_vecList = m_vecListInternal;
       return true;
@@ -67,8 +84,6 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
     {
       m_bButtonPressed = false;
       CGUIDialog::OnMessage(message);
-      m_iSelected = -1;
-
       return true;
     }
     break;
@@ -82,14 +97,20 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
         int iAction = message.GetParam1();
         if (ACTION_SELECT_ITEM == iAction || ACTION_MOUSE_LEFT_CLICK == iAction)
         {
-          m_iSelected = m_viewControl.GetSelectedItem();
-          if(m_iSelected >= 0 && m_iSelected < (int)m_vecList->Size())
+          int iSelected = m_viewControl.GetSelectedItem();
+          if(iSelected >= 0 && iSelected < (int)m_vecList->Size())
           {
-            *m_selectedItem = *m_vecList->Get(m_iSelected);
-            Close();
+            CFileItemPtr item(m_vecList->Get(iSelected));
+            if (m_multiSelection)
+              item->Select(!item->IsSelected());
+            else
+            {
+              for (int i = 0 ; i < m_vecList->Size() ; i++)
+                m_vecList->Get(i)->Select(false);
+              item->Select(true);
+              Close();
+            }
           }
-          else
-            m_iSelected = -1;
         }
       }
       if (CONTROL_BUTTON == iControl)
@@ -114,12 +135,20 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
   return CGUIDialog::OnMessage(message);
 }
 
+bool CGUIDialogSelect::OnBack(int actionID)
+{
+  m_iSelected = -1;
+  return CGUIDialog::OnBack(actionID);
+}
+
 void CGUIDialogSelect::Reset()
 {
   m_bButtonEnabled = false;
   m_useDetails = false;
+  m_multiSelection = false;
   m_iSelected = -1;
   m_vecListInternal->Clear();
+  m_selectedItems->Clear();
   m_vecList = m_vecListInternal;
 }
 
@@ -156,12 +185,17 @@ int CGUIDialogSelect::GetSelectedLabel() const
 
 const CFileItem& CGUIDialogSelect::GetSelectedItem()
 {
-  return *m_selectedItem;
+  return *m_selectedItems->Get(0);
 }
 
 const CStdString& CGUIDialogSelect::GetSelectedLabelText()
 {
-  return m_selectedItem->GetLabel();
+  return GetSelectedItem().GetLabel();
+}
+
+const CFileItemList& CGUIDialogSelect::GetSelectedItems() const
+{
+  return *m_selectedItems;
 }
 
 void CGUIDialogSelect::EnableButton(bool enable, int string)
@@ -212,6 +246,18 @@ void CGUIDialogSelect::OnWindowLoaded()
 void CGUIDialogSelect::OnInitWindow()
 {
   m_viewControl.SetItems(*m_vecList);
+  m_selectedItems->Clear();
+  if (m_iSelected == -1)
+  {
+    for(int i = 0 ; i < m_vecList->Size(); i++)
+    {
+      if (m_vecList->Get(i)->IsSelected())
+      {
+        m_iSelected = i;
+        break;
+      }
+    }
+  }
   m_viewControl.SetCurrentView(m_useDetails ? CONTROL_DETAILS : CONTROL_LIST);
 
   CStdString items;

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -183,14 +183,14 @@ int CGUIDialogSelect::GetSelectedLabel() const
   return m_iSelected;
 }
 
-const CFileItem& CGUIDialogSelect::GetSelectedItem()
+const CFileItemPtr CGUIDialogSelect::GetSelectedItem()
 {
-  return *m_selectedItems->Get(0);
+  return m_selectedItems->Size() > 0 ? m_selectedItems->Get(0) : CFileItemPtr(new CFileItem);
 }
 
 const CStdString& CGUIDialogSelect::GetSelectedLabelText()
 {
-  return GetSelectedItem().GetLabel();
+  return GetSelectedItem()->GetLabel();
 }
 
 const CFileItemList& CGUIDialogSelect::GetSelectedItems() const

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -44,7 +44,7 @@ public:
   void SetItems(CFileItemList* items);
   int GetSelectedLabel() const;
   const CStdString& GetSelectedLabelText();
-  const CFileItem& GetSelectedItem();
+  const CFileItemPtr GetSelectedItem();
   const CFileItemList& GetSelectedItems() const;
   void EnableButton(bool enable, int string);
   bool IsButtonPressed();

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -35,6 +35,7 @@ public:
   CGUIDialogSelect(void);
   virtual ~CGUIDialogSelect(void);
   virtual bool OnMessage(CGUIMessage& message);
+  virtual bool OnBack(int actionID);
 
   void Reset();
   void Add(const CStdString& strLabel);
@@ -44,11 +45,13 @@ public:
   int GetSelectedLabel() const;
   const CStdString& GetSelectedLabelText();
   const CFileItem& GetSelectedItem();
+  const CFileItemList& GetSelectedItems() const;
   void EnableButton(bool enable, int string);
   bool IsButtonPressed();
   void Sort(bool bSortOrder = true);
   void SetSelected(int iSelected);
   void SetUseDetails(bool useDetails);
+  void SetMultiSelection(bool multiSelection) { m_multiSelection = multiSelection; };
 protected:
   virtual CGUIControl *GetFirstFocusableControl(int id);
   virtual void OnWindowLoaded();
@@ -58,8 +61,9 @@ protected:
   bool m_bButtonPressed;
   int m_iSelected;
   bool m_useDetails;
+  bool m_multiSelection;
 
-  CFileItem* m_selectedItem;
+  CFileItemList* m_selectedItems;
   CFileItemList* m_vecListInternal;
   CFileItemList* m_vecList;
   CGUIViewControl m_viewControl;

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -117,10 +117,10 @@ void CGUIButtonControl::ProcessText(unsigned int currentTime)
 
   // render the second label if it exists
   CStdString label2(m_info2.GetLabel(m_parentID));
+  changed |= m_label2.SetMaxRect(m_posX, m_posY, m_width, m_height);
+  changed |= m_label2.SetText(label2);
   if (!label2.IsEmpty())
   {
-    changed |= m_label2.SetMaxRect(m_posX, m_posY, m_width, m_height);
-    changed |= m_label2.SetText(label2);
     changed |= m_label2.SetAlign(XBFONT_RIGHT | (m_label.GetLabelInfo().align & XBFONT_CENTER_Y) | XBFONT_TRUNCATED);
     changed |= m_label2.SetScrolling(HasFocus());
 

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -50,7 +50,8 @@ void CGUIListLabel::SetScrolling(bool scrolling)
 
 void CGUIListLabel::SetSelected(bool selected)
 {
-  m_label.SetColor(selected ? CGUILabel::COLOR_SELECTED : CGUILabel::COLOR_TEXT);
+  if(m_label.SetColor(selected ? CGUILabel::COLOR_SELECTED : CGUILabel::COLOR_TEXT))
+    SetInvalid();
 }
 
 void CGUIListLabel::SetFocus(bool focus)

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -971,7 +971,7 @@ bool CMusicInfoScanner::DownloadAlbumInfo(const CStdString& strPath, const CStdS
           m_musicDatabase.Close();
           return DownloadAlbumInfo(strPath,strNewArtist,strNewAlbum,bCanceled,albumInfo,pDialog);
         }
-        iSelectedAlbum = pDlg->GetSelectedItem().m_idepth;
+        iSelectedAlbum = pDlg->GetSelectedItem()->m_idepth;
       }
     }
 
@@ -1153,7 +1153,7 @@ bool CMusicInfoScanner::DownloadArtistInfo(const CStdString& strPath, const CStd
             m_musicDatabase.Close();
             return DownloadArtistInfo(strPath,strNewArtist,bCanceled,pDialog);
           }
-          iSelectedArtist = pDlg->GetSelectedItem().m_idepth;
+          iSelectedArtist = pDlg->GetSelectedItem()->m_idepth;
         }
       }
     }


### PR DESCRIPTION
This allow using

<pre>&lt;setting label="foo" id="bar" type="addon" addontype="blah" [multiselect="true/false"] /&gt; </pre>

in addon's setting.xml

If we want to use addon settings by skins this will be needed. On Amet request (so there is usecase for this) I added ability to select multiple addons.

Shots:
http://dl.dropbox.com/u/28792047/xbmc/screenshot035.png
http://dl.dropbox.com/u/28792047/xbmc/screenshot036.png
