### PR TITLE
Close window fix

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -339,21 +339,22 @@ void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*
     return;
 
   forceClose |= (nextWindowID == WINDOW_FULLSCREEN_VIDEO);
-  if (!forceClose && m_active && !m_closing && HasAnimation(ANIM_TYPE_WINDOW_CLOSE))
+  if (!forceClose && HasAnimation(ANIM_TYPE_WINDOW_CLOSE))
   {
+    if (!m_closing)
+    {
     if (enableSound && IsSoundEnabled())
       g_audioManager.PlayWindowSound(GetID(), SOUND_DEINIT);
     
     // Perform the window out effect
     QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
     m_closing = true;
+    }
+    return;
   }
-  else if (forceClose)
-  {
     CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
     OnMessage(msg);
     m_closing = false;
-  }
 }
 
 void CGUIWindow::Close(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -343,18 +343,19 @@ void CGUIWindow::Close_Internal(bool forceClose /*= false*/, int nextWindowID /*
   {
     if (!m_closing)
     {
-    if (enableSound && IsSoundEnabled())
-      g_audioManager.PlayWindowSound(GetID(), SOUND_DEINIT);
-    
-    // Perform the window out effect
-    QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
-    m_closing = true;
+      if (enableSound && IsSoundEnabled())
+        g_audioManager.PlayWindowSound(GetID(), SOUND_DEINIT);
+
+      // Perform the window out effect
+      QueueAnimation(ANIM_TYPE_WINDOW_CLOSE);
+      m_closing = true;
     }
     return;
   }
-    CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
-    OnMessage(msg);
-    m_closing = false;
+
+  CGUIMessage msg(GUI_MSG_WINDOW_DEINIT, 0, 0);
+  OnMessage(msg);
+  m_closing = false;
 }
 
 void CGUIWindow::Close(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)


### PR DESCRIPTION
This should fix (once and for all?) the window closing shenanigans.  As a pull request for pieh to check over so we don't have to fix each others work again :)

The first commit sums up the cases, and brings it in line with how CGUIDialog::Close_Internal() used to operate.  Key point that was missing is if no window close anim exists we must close immediately.
