### PR TITLE
Optimization to libcmyth to help with slow seeking with Myth 0.24

### DIFF
--- a/lib/cmyth/libcmyth/commbreak.c
+++ b/lib/cmyth/libcmyth/commbreak.c
@@ -263,18 +263,12 @@ int cmyth_rcv_commbreaklist(cmyth_conn_t conn, int *err,
 					__FUNCTION__, type);
 		}
 	}
-	if (start >= 0) {
-		/*
-		 * The last entry may be a start without and end mark. We need to make the end_mark really big
-		 * (but not too big)
-		 */
-		commbreak = cmyth_commbreak_create();
-		commbreak->start_mark = start;
-		commbreak->end_mark = 1 << 30;
-		breaklist->commbreak_list = realloc(breaklist->commbreak_list,
-			(++breaklist->commbreak_count) * sizeof(cmyth_commbreak_t));
-		breaklist->commbreak_list[breaklist->commbreak_count - 1] = commbreak;
-	}
+
+	/*
+	 * If the last entry is a start marker then it doesn't have an associated end marker. In this
+	 * case we choose to simply ignore it. Another option is to put in a really large fake end marker
+	 * but that may cause strange seek behaviour in a client application.
+	 */
 
 	return total;
 

--- a/lib/cmyth/libcmyth/file.c
+++ b/lib/cmyth/libcmyth/file.c
@@ -618,7 +618,7 @@ int cmyth_file_read(cmyth_file_t file, char *buf, unsigned long len)
 			}
 			if (len64 >= 0x100000000LL || len64 < 0) {
 				/* -1 seems to be a common result, but isn't valid so use 0 instead. */
-				cmyth_dbg (CMYTH_DBG_DEBUG,
+				cmyth_dbg (CMYTH_DBG_WARN,
 				           "%s: cmyth_rcv_int64() returned out of bound value (%d). Using 0\n",
 				           __FUNCTION__, (long)len64);
 				len64 = 0;

--- a/lib/cmyth/libcmyth/file.c
+++ b/lib/cmyth/libcmyth/file.c
@@ -435,6 +435,9 @@ cmyth_file_seek(cmyth_file_t file, long long offset, int whence)
 	if ((offset == 0) && (whence == SEEK_CUR))
 		return file->file_pos;
 
+	if ((offset == file->file_pos) && (whence == SEEK_SET))
+		return file->file_pos;
+
 	while(file->file_pos < file->file_req) {
 		c = file->file_req - file->file_pos;
 		if(c > sizeof(msg))


### PR DESCRIPTION
@elupus, would you be able to cast your eye over this and make sure the seeking optimization is kosher. This fix helped with some slow seeking behavior experienced when I upgraded to Myth 0.24. XBMC logs listed seeking to pos 0 with whence 0 immediately after playback started through dvdplayer and then a long delay before the next log entry. Playback directly off disk was fine.
