### PR TITLE
Fixed: If selecting a subtitle stream, switch on subtitles as well.

### DIFF
--- a/xbmc/interfaces/python/xbmcmodule/player.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/player.cpp
@@ -647,7 +647,10 @@ namespace PYXBMC
     {
       int streamCount = g_application.m_pPlayer->GetSubtitleCount();
       if(iStream < streamCount)
+      {
         g_application.m_pPlayer->SetSubtitle(iStream);
+        g_application.m_pPlayer->SetSubtitleVisible(true);
+      }
     }
 
     Py_INCREF(Py_None);


### PR DESCRIPTION
Thanks for putting in the ability to select subtitle streams via addons, but I would like to suggest this tweak - as there is no way to actually turn on subtitles in an addon (although you _can_ disable them :) )

So, if we select a subtitle stream, we should also make subtitles visible.
