### PR TITLE
Unnecessary refresh changes for DVD stills because of incorrect fps report

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -46,6 +46,7 @@ CBaseRenderer::~CBaseRenderer()
 
 void CBaseRenderer::ChooseBestResolution(float fps)
 {
+  if (fps == 0.0) return;
   m_resolution = g_guiSettings.m_LookAndFeelResolution;
   if ( m_resolution == RES_WINDOW )
     m_resolution = RES_DESKTOP;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -998,6 +998,12 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
         {
           st->iFpsRate = pStream->r_frame_rate.num;
           st->iFpsScale = pStream->r_frame_rate.den;
+          if (pStream->codec_info_nb_frames <= 2 && pStream->codec_info_nb_frames > 0)
+          {
+            CLog::Log(LOGDEBUG, "%s - fps may be unreliable since ffmpeg decoded only %d frame(s)", __FUNCTION__, pStream->codec_info_nb_frames);
+            st->iFpsRate  = 0;
+            st->iFpsScale = 0;
+          }
         }
         else
         {

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -143,6 +143,8 @@ protected:
   int    m_iFrameRateLength; //how many seconds we should measure the framerate
                              //this is increased exponentially from CDVDPlayerVideo::CalcFrameRate()
 
+  bool   m_bFpsInvalid;      // needed to ignore fps (e.g. dvd stills)
+
   struct SOutputConfiguration
   {
     unsigned int width;


### PR DESCRIPTION
I have encountered several DVDs that report incorrect frame rates when entering a still stream (probably FFMpeg is to blame here). 
For example hint.fpsrate = 91 and hint.fpsscale = 3. The resulting framerate is then 30.33 and this tries to switch to 60Hz when auto-refresh is turned on. You can imagine how annoying this is when playing PAL dvds, that each time for a still it switches to 60Hz and for video back to 50Hz...

I have developed a simple patch that ignores these values if hint.stills is true, and takes the "last known" fps from the DVD. For example, in case we arrive at a still from a video fragment (e.g. going back to the menu, or first a little video intro, followed by a still menu). The last known fps is of course "unknown" when the very first stream is a still. So there we need to assume something, and I hard coded the default to 25. However we could change that to a configurable (i.e. settings) value e.g. preferred DVD video format (PAL | NTSC)
