### PR TITLE
default to library root on direct access to files and no sources are available

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -122,8 +122,8 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
       //  base class has opened the database, do our check
       m_database.Open();
 
-      if (!m_database.HasContent() && m_vecItems->IsVideoDb())
-      { // no library - make sure we default to the root.
+      if ((!m_database.HasContent() && m_vecItems->IsVideoDb()) || (m_vecItems->GetPath().Left(10).Equals("sources://") && !m_vecItems->Size()))
+      { // no library or no sources available - make sure we default to the root.
         m_vecItems->SetPath("");
         SetHistoryForPath("");
         Update("");


### PR DESCRIPTION
At the moment if no sources are setup and the user goes directly to Video->Files (Files submenu item on confluence for instance) then they're left in a blank screen.  This remedies this by going to root in this case.

Question is whether we should do this in general: i.e. if upon entering the video window the listing is completely empty (which will occur for instance if parent directory items aren't on and any listing returns empty) then should we go to root?

Only cases I can think of are perhaps when the listing is not always empty but may be in one instance (eg something like a smartplaylist is linked directly from home, and it so happens that the smartplaylist has no items in it at this particular point in time, whereas at other times it would have items available).  It may not be obvious to the user why it didn't enter the particular listing and instead went to the library root.
