### PR TITLE
Add dvdid support for uniqueness of DVD label storage re. resume

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -713,6 +713,7 @@ case TMSG_POWERDOWN:
       {
         CMediaSource share;
         share.strStatus = g_mediaManager.GetDiskLabel(share.strPath);
+        share.strDiskUniqueId = g_mediaManager.GetDiskUniqueId(share.strPath);
         share.strPath = pMsg->strParam;
         if(g_mediaManager.IsAudio(share.strPath))
           share.strStatus = "Audio-CD";

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -53,7 +53,7 @@ CAutorun::CAutorun()
 CAutorun::~CAutorun()
 {}
 
-void CAutorun::ExecuteAutorun( bool bypassSettings, bool ignoreplaying, bool restart )
+void CAutorun::ExecuteAutorun( bool bypassSettings, bool ignoreplaying, bool startFromBeginning )
 {
   if ((!ignoreplaying && (g_application.IsPlayingAudio() || g_application.IsPlayingVideo() || g_windowManager.HasModalDialog())) || g_windowManager.GetActiveWindow() == WINDOW_LOGIN_SCREEN)
     return ;
@@ -79,7 +79,7 @@ void CAutorun::ExecuteAutorun( bool bypassSettings, bool ignoreplaying, bool res
   }
   else
   {
-    RunMedia(bypassSettings, restart);
+    RunMedia(bypassSettings, startFromBeginning);
   }
 }
 
@@ -100,7 +100,7 @@ void CAutorun::RunCdda()
   g_playlistPlayer.Play();
 }
 
-void CAutorun::RunMedia(bool bypassSettings, bool restart)
+void CAutorun::RunMedia(bool bypassSettings, bool startFromBeginning)
 {
   if ( !bypassSettings && !g_guiSettings.GetBool("audiocds.autorun") && !g_guiSettings.GetBool("dvds.autorun"))
     return ;
@@ -109,7 +109,7 @@ void CAutorun::RunMedia(bool bypassSettings, bool restart)
   int nAddedToPlaylist = 0;
 #ifdef _WIN32
   auto_ptr<IDirectory> pDir ( CFactoryDirectory::Create( g_mediaManager.TranslateDevicePath("") ));
-  bool bPlaying = RunDisc(pDir.get(), g_mediaManager.TranslateDevicePath(""), nAddedToPlaylist, true, bypassSettings, restart);
+  bool bPlaying = RunDisc(pDir.get(), g_mediaManager.TranslateDevicePath(""), nAddedToPlaylist, true, bypassSettings, startFromBeginning);
 #else
   CCdInfo* pInfo = g_mediaManager.GetCdInfo();
 
@@ -120,12 +120,12 @@ void CAutorun::RunMedia(bool bypassSettings, bool restart)
   if (pInfo->IsISOUDF(1) || pInfo->IsISOHFS(1) || pInfo->IsIso9660(1) || pInfo->IsIso9660Interactive(1))
   {
     auto_ptr<IDirectory> pDir ( CFactoryDirectory::Create( "iso9660://" ));
-    bPlaying = RunDisc(pDir.get(), "iso9660://", nAddedToPlaylist, true, bypassSettings, restart);
+    bPlaying = RunDisc(pDir.get(), "iso9660://", nAddedToPlaylist, true, bypassSettings, startFromBeginning);
   }
   else
   {
     auto_ptr<IDirectory> pDir ( CFactoryDirectory::Create( "D:\\" ) );
-    bPlaying = RunDisc(pDir.get(), "D:\\", nAddedToPlaylist, true, bypassSettings, restart);
+    bPlaying = RunDisc(pDir.get(), "D:\\", nAddedToPlaylist, true, bypassSettings, startFromBeginning);
   }
 #endif
   if ( !bPlaying && nAddedToPlaylist > 0 )
@@ -141,7 +141,7 @@ void CAutorun::RunMedia(bool bypassSettings, bool restart)
 /**
  * This method tries to determine what type of disc is located in the given drive and starts to play the content appropriately.
  */
-bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAddedToPlaylist, bool bRoot, bool bypassSettings /* = false */, bool restart /* = false */)
+bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAddedToPlaylist, bool bRoot, bool bypassSettings /* = false */, bool startFromBeginning /* = false */)
 {
   bool bPlaying(false);
   CFileItemList vecItems;
@@ -179,7 +179,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
         if (pItem->GetPath().Find( "VIDEO_TS" ) != -1 && bAllowVideo
         && (bypassSettings || g_guiSettings.GetBool("dvds.autorun")))
         {
-          CUtil::PlayDVD("dvd", restart);
+          CUtil::PlayDVD("dvd", startFromBeginning);
           bPlaying = true;
           return true;
         }
@@ -190,7 +190,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
         if (pItem->GetPath().Find( "BDMV" ) != -1 && bAllowVideo
         && (bypassSettings || g_guiSettings.GetBool("dvds.autorun")))
         {
-          CUtil::PlayDVD("bd", restart);
+          CUtil::PlayDVD("bd", startFromBeginning);
           bPlaying = true;
           return true;
         }
@@ -321,7 +321,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
       {
         if (pItem->GetPath() != "." && pItem->GetPath() != ".." )
         {
-          if (RunDisc(pDir, pItem->GetPath(), nAddedToPlaylist, false, bypassSettings, restart))
+          if (RunDisc(pDir, pItem->GetPath(), nAddedToPlaylist, false, bypassSettings, startFromBeginning))
           {
             bPlaying = true;
             break;
@@ -366,21 +366,23 @@ bool CAutorun::IsEnabled() const
   return m_bEnable;
 }
 
-bool CAutorun::PlayDisc(bool restart)
+bool CAutorun::PlayDisc(bool startFromBeginning)
 {
-  ExecuteAutorun(true,true, restart);
+  ExecuteAutorun(true,true, startFromBeginning);
   return true;
 }
 
 bool CAutorun::CanResumePlayDVD()
 {
-  CStdString strPath = "removable://"; // need to put volume label for resume point in videoInfoTag
-  strPath += g_mediaManager.GetDiskLabel();
-  CVideoDatabase dbs;
-  dbs.Open();
-  CBookmark bookmark;
-  if (dbs.GetResumeBookMark(strPath, bookmark))
-    return true;
+  CStdString strUniqueId = g_mediaManager.GetDiskUniqueId();
+  if (!strUniqueId.IsEmpty())
+  {
+    CVideoDatabase dbs;
+    dbs.Open();
+    CBookmark bookmark;
+    if (dbs.GetResumeBookMark(strUniqueId, bookmark))
+      return true;
+  }
   return false;
 }
 

--- a/xbmc/Autorun.h
+++ b/xbmc/Autorun.h
@@ -48,16 +48,16 @@ public:
   CAutorun();
   virtual ~CAutorun();
   static bool CanResumePlayDVD();
-  static bool PlayDisc(bool restart);
+  static bool PlayDisc(bool startFromBeginning);
   bool IsEnabled() const;
   void Enable();
   void Disable();
   void HandleAutorun();
-  static void ExecuteAutorun(bool bypassSettings = false, bool ignoreplaying = false, bool restart = false);
+  static void ExecuteAutorun(bool bypassSettings = false, bool ignoreplaying = false, bool startFromBeginning = false);
 protected:
   static void RunCdda();
-  static void RunMedia(bool bypassSettings, bool restart);
-  static bool RunDisc(XFILE::IDirectory* pDir, const CStdString& strDrive, int& nAddedToPlaylist, bool bRoot, bool bypassSettings, bool restart);
+  static void RunMedia(bool bypassSettings, bool startFromBeginning);
+  static bool RunDisc(XFILE::IDirectory* pDir, const CStdString& strDrive, int& nAddedToPlaylist, bool bRoot, bool bypassSettings, bool startFromBeginning);
   bool m_bEnable;
 };
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -218,10 +218,7 @@ CFileItem::CFileItem(const CMediaSource& share)
   m_strThumbnailImage = share.m_strThumbnailImage;
   SetLabelPreformated(true);
   if (IsDVD())
-  {
-    GetVideoInfoTag()->m_strFileNameAndPath = "removable://";
-    GetVideoInfoTag()->m_strFileNameAndPath += share.strStatus; // share.strStatus contains disc volume label
-  }
+    GetVideoInfoTag()->m_strFileNameAndPath = share.strDiskUniqueId; // share.strDiskUniqueId contains disc unique id
 }
 
 CFileItem::~CFileItem(void)

--- a/xbmc/MediaSource.h
+++ b/xbmc/MediaSource.h
@@ -51,6 +51,7 @@ public:
   bool IsWritable() const;
   CStdString strName; ///< Name of the share, can be choosen freely.
   CStdString strStatus; ///< Status of the share (eg has disk etc.)
+  CStdString strDiskUniqueId; ///< removable:// + DVD Label + DVD ID for resume point storage, if available
   CStdString strPath; ///< Path of the share, eg. iso9660:// or F:
 
   /*!

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -770,7 +770,7 @@ bool CUtil::ThumbCached(const CStdString& strFileName)
   return CThumbnailCache::GetThumbnailCache()->IsCached(strFileName);
 }
 
-void CUtil::PlayDVD(const CStdString& strProtocol, bool restart)
+void CUtil::PlayDVD(const CStdString& strProtocol, bool startFromBeginning)
 {
 #if defined(HAS_DVDPLAYER) && defined(HAS_DVD_DRIVE)
   CIoSupport::Dismount("Cdrom0");
@@ -779,10 +779,12 @@ void CUtil::PlayDVD(const CStdString& strProtocol, bool restart)
   strPath.Format("%s://1", strProtocol.c_str());
   CFileItem item(strPath, false);
   item.SetLabel(g_mediaManager.GetDiskLabel());
-  item.GetVideoInfoTag()->m_strFileNameAndPath = "removable://"; // need to put volume label for resume point in videoInfoTag
-  item.GetVideoInfoTag()->m_strFileNameAndPath += g_mediaManager.GetDiskLabel();
-  if (!restart) item.m_lStartOffset = STARTOFFSET_RESUME;
-  g_application.PlayFile(item, restart);
+  item.GetVideoInfoTag()->m_strFileNameAndPath = g_mediaManager.GetDiskUniqueId();
+
+  if (!startFromBeginning && !item.GetVideoInfoTag()->m_strFileNameAndPath.IsEmpty()) 
+    item.m_lStartOffset = STARTOFFSET_RESUME;
+
+  g_application.PlayFile(item, false);
 #endif
 }
 

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -90,7 +90,7 @@ public:
   static bool ThumbCached(const CStdString& strFileName);
   static void ThumbCacheAdd(const CStdString& strFileName, bool bFileExists);
   static void ThumbCacheClear();
-  static void PlayDVD(const CStdString& strProtocol = "dvd", bool restart = false);
+  static void PlayDVD(const CStdString& strProtocol = "dvd", bool startFromBeginning = false);
   static CStdString GetNextFilename(const CStdString &fn_template, int max);
   static CStdString GetNextPathname(const CStdString &path_template, int max);
   static void TakeScreenshot();

--- a/xbmc/filesystem/VirtualDirectory.cpp
+++ b/xbmc/filesystem/VirtualDirectory.cpp
@@ -182,10 +182,12 @@ void CVirtualDirectory::GetSources(VECSOURCES &shares) const
       {
         share.strStatus = "Audio-CD";
         share.strPath = "cdda://local/";
+        share.strDiskUniqueId = "";
       }
       else
       {
         share.strStatus = g_mediaManager.GetDiskLabel(share.strPath);
+        share.strDiskUniqueId = g_mediaManager.GetDiskUniqueId(share.strPath);
         if (!share.strPath.length()) // unmounted CD
         {
           if (g_mediaManager.GetDiscPath() == "iso9660://")

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -25,9 +25,9 @@
 #include "IoSupport.h"
 #include "URL.h"
 #include "Util.h"
+#include "utils/URIUtils.h"
 #ifdef _WIN32
 #include "WIN32Util.h"
-#include "utils/URIUtils.h"
 #endif
 #include "guilib/GUIWindowManager.h"
 #ifdef HAS_DVD_DRIVE
@@ -48,6 +48,12 @@
 #include "AutorunMediaJob.h"
 #include "settings/GUISettings.h"
 
+#include "FileItem.h"
+#include "filesystem/File.h"
+#include "filesystem/FactoryDirectory.h"
+#include "filesystem/Directory.h"
+#include "utils/Crc32.h"
+
 #ifdef __APPLE__
 #include "osx/DarwinStorageProvider.h"
 #elif defined(_LINUX)
@@ -57,6 +63,7 @@
 #endif
 
 using namespace std;
+using namespace XFILE;
 
 const char MEDIA_SOURCES_XML[] = { "special://profile/mediasources.xml" };
 
@@ -434,6 +441,111 @@ CStdString CMediaManager::GetDiskLabel(const CStdString& devicePath)
   return MEDIA_DETECT::CDetectDVDMedia::GetDVDLabel();
 #endif
 }
+
+CStdString CMediaManager::GetDiskUniqueId(const CStdString& devicePath)
+{
+  CStdString strDevice = devicePath;
+
+  if (strDevice.IsEmpty()) // if no value passed, use the current default disc path.
+    strDevice = GetDiscPath();    // in case of non-Windows we must obtain the disc path
+
+#ifdef _WIN32
+  if (!m_bhasoptical)
+    return "";
+  strDevice = TranslateDevicePath(strDevice);
+  URIUtils::AddSlashAtEnd(strDevice);
+#endif
+
+  CStdString strDrive = g_mediaManager.TranslateDevicePath(strDevice);
+
+#ifndef _WIN32
+  {
+    CSingleLock waitLock(m_muAutoSource);  
+    CCdInfo* pInfo = g_mediaManager.GetCdInfo();
+    if ( pInfo  )
+    {
+      if (pInfo->IsISOUDF(1) || pInfo->IsISOHFS(1) || pInfo->IsIso9660(1) || pInfo->IsIso9660Interactive(1))
+        strDrive = "iso9660://";
+      else
+        strDrive = "D:\\";
+    }
+    else
+    {
+      CLog::Log(LOGERROR, "GetDiskUniqueId: Failed getting CD info");
+      return "";
+    }
+  }
+#endif
+
+  CStdString pathVideoTS = URIUtils::AddFileToFolder(strDrive, "VIDEO_TS");
+  if(! CDirectory::Exists(pathVideoTS) )
+    return ""; // return empty
+
+  CLog::Log(LOGDEBUG, "GetDiskUniqueId: Trying to retrieve ID for path %s", pathVideoTS.c_str());
+  uint32_t dvdcrc = 0;
+  CStdString strID;
+
+  if (HashDVD(pathVideoTS, dvdcrc))
+  {
+    strID.Format("removable://%s_%08x", GetDiskLabel(devicePath), dvdcrc);
+    CLog::Log(LOGDEBUG, "GetDiskUniqueId: Got ID %s for DVD disk", strID.c_str());
+  }
+
+  return strID;
+}
+
+bool CMediaManager::HashDVD(const CStdString& dvdpath, uint32_t& crc)
+{
+  CFileItemList vecItemsTS;
+  bool success = false;
+
+  // first try to open the VIDEO_TS folder of the DVD
+  if (!CDirectory::GetDirectory( dvdpath, vecItemsTS, ".ifo" ))
+  {
+    CLog::Log(LOGERROR, "%s - Cannot open dvd VIDEO_TS folder -- ABORTING", __FUNCTION__);
+    return false;
+  }
+
+  Crc32 crc32;
+  bool dataRead = false;
+
+  vecItemsTS.Sort(SORT_METHOD_FILE, SORT_ORDER_ASC);
+  for (int i = 0; i < vecItemsTS.Size(); i++) 
+  {
+    CFileItemPtr videoTSItem = vecItemsTS[i];
+    success = true;
+
+    // get the file name for logging purposes
+    CStdString fileName = URIUtils::GetFileName(videoTSItem->GetPath());
+    CLog::Log(LOGDEBUG, "%s - Adding file content for dvd file: %s", __FUNCTION__, fileName.c_str());
+    CFile file;
+    if(!file.Open(videoTSItem->GetPath()))
+    {
+      CLog::Log(LOGERROR, "%s - Cannot open dvd file: %s -- ABORTING", __FUNCTION__, fileName.c_str());
+      return false;
+    }
+    int res;
+    char buf[2048];
+    while( (res = file.Read(buf, sizeof(buf))) > 0) 
+    {
+      dataRead = true;
+      crc32.Compute(buf, res);
+    }
+    file.Close();
+  }
+
+  if (!dataRead)
+  {
+    CLog::Log(LOGERROR, "%s - Did not read any data from the IFO files -- ABORTING", __FUNCTION__);
+    return false;
+  }
+
+  // put result back in reference parameter
+  crc = (uint32_t) crc32;
+
+  return success;
+}
+
 
 CStdString CMediaManager::GetDiscPath()
 {

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -72,6 +72,7 @@ public:
   CCdInfo* GetCdInfo(const CStdString& devicePath="");
   bool RemoveCdInfo(const CStdString& devicePath="");
   CStdString GetDiskLabel(const CStdString& devicePath="");
+  CStdString GetDiskUniqueId(const CStdString& devicePath="");
 #endif
   CStdString GetDiscPath();
   void SetHasOpticalDrive(bool bstatus);
@@ -93,6 +94,7 @@ protected:
   CCriticalSection m_muAutoSource, m_CritSecStorageProvider;
 #ifdef HAS_DVD_DRIVE
   std::map<CStdString,CCdInfo*> m_mapCdInfo;
+  bool HashDVD(const CStdString& dvdpath, uint32_t& crc);
 #endif
   bool m_bhasoptical;
 

--- a/xbmc/utils/SaveFileStateJob.h
+++ b/xbmc/utils/SaveFileStateJob.h
@@ -26,7 +26,7 @@ bool CSaveFileStateJob::DoWork()
   CStdString progressTrackingFile = m_item.GetPath();
 
   if (m_item.IsDVD()) 
-    progressTrackingFile = m_item.GetVideoInfoTag()->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label
+    progressTrackingFile = m_item.GetVideoInfoTag()->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label+uniqueid or is empty if label not uniquely identified
 
   if (progressTrackingFile != "")
   {


### PR DESCRIPTION
After resume functionality for external DVDs was pulled into xbmc code, it turned out that there's an issue with non-unique DVD volume labels.

For a full description, see : http://trac.xbmc.org/ticket/11833

The DVD unique hash ID is calculated using CRC32 on content of all VIDEO_TS*.IFO files.

Any comments are welcome.
