### PR TITLE
Trac 11876 - Infinite loop in CFileItem

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2510,10 +2510,13 @@ CStdString CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */) co
   {
     CStdString strFolder, strFile;
     URIUtils::Split(m_strPath, strFolder, strFile);
-    CFileItem folderItem(strFolder, true);
-    folderItem.SetMusicThumb(alwaysCheckRemote);
-    if (folderItem.HasThumbnail())
-      return folderItem.GetThumbnailImage();
+    if (!m_strPath.Equals(strFolder)) // any more parents to inherit from?
+    {
+      CFileItem folderItem(strFolder, true);
+      folderItem.SetMusicThumb(alwaysCheckRemote);
+      if (folderItem.HasThumbnail())
+        return folderItem.GetThumbnailImage();
+    }
   }
   // No thumb found
   return "";


### PR DESCRIPTION
This small patch closes http://trac.xbmc.org/ticket/11876.

In some cases, CFileItem can fall into an infinite loop. The solution is to add a stop case before things get really ugly. In this case, FileItem infinitely duplicates itself on a quest for the parent it never had.
