### PR TITLE
Windows - Reduce CPU spikes when losing focus in D3D fullscreen mode

### DIFF
--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -81,7 +81,7 @@ public:
   DWORD   DefaultD3DUsage() { return m_defaultD3DUsage; }
   D3DPOOL DefaultD3DPool()  { return m_defaultD3DPool; }
   D3DADAPTER_IDENTIFIER9 GetAIdentifier() { return m_AIdentifier; }
-
+  bool    WindowedMode()    { return m_useWindowedDX; }
   bool    Interlaced()      { return m_interlaced; }
 
   /*!

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -404,9 +404,14 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         {
           WINDOWPLACEMENT lpwndpl;
           lpwndpl.length = sizeof(lpwndpl);
-          if (LOWORD(wParam) != WA_INACTIVE && GetWindowPlacement(hWnd, &lpwndpl))
+          if (LOWORD(wParam) != WA_INACTIVE)
           {
-            g_application.m_AppActive = lpwndpl.showCmd != SW_HIDE;
+            if (GetWindowPlacement(hWnd, &lpwndpl))
+              g_application.m_AppActive = lpwndpl.showCmd != SW_HIDE;
+          }
+          else
+          {
+            g_application.m_AppActive = g_Windowing.WindowedMode();
           }
         }
         if (g_application.m_AppActive != active)


### PR DESCRIPTION
CPU usage increases and there are significant spikes when XBMC loses the focus in D3D fullscreen mode. Part of this is because XBMC thinks it is still displayed on screen and keeps rendering.
This PR detects the situation and makes XBMC inactive. That reduces the spikes but CPU is still a bit higher. I don't know where that comes from.

Exporting the fullscreen mode from RenderSystemDX is the only way I found to detect the situation, as the parameters of WM_ACTIVATE and the values returned by GetWindowPlacement() are identical in windowed and fullscreen modes.

This PR doesn't help when milkdrop is active, the CPU still spikes.
