### PR TITLE
Improve mysql lookup with additional indexes

### DIFF
--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -214,7 +214,7 @@ protected:
   std::map<CStdString, CAlbumCache> m_albumCache;
 
   virtual bool CreateTables();
-  virtual int GetMinVersion() const { return 16; };
+  virtual int GetMinVersion() const { return 17; };
   const char *GetBaseDBName() const { return "MyMusic"; };
 
   int AddAlbum(const CStdString& strAlbum1, int idArtist, const CStdString &extraArtists, const CStdString &strArtist1, int idThumb, int idGenre, const CStdString &extraGenres, int year);
@@ -229,6 +229,10 @@ protected:
   bool SetAlbumInfoSongs(int idAlbumInfo, const VECSONGS& songs);
   bool GetAlbumInfoSongs(int idAlbumInfo, VECSONGS& songs);
 private:
+  /*! \brief (Re)Create the generic database views for songs and albums
+   */
+  void CreateViews();
+
   void SplitString(const CStdString &multiString, std::vector<CStdString> &vecStrings, CStdString &extraStrings);
   CSong GetSongFromDataset(bool bWithMusicDbPath=false);
   CArtist GetArtistFromDataset(dbiplus::Dataset* pDS, bool needThumb=true);


### PR DESCRIPTION
This PR provides additional indexes to some integer columns in the Music Database which have proven to speed up library cleanup considerably (see trac ticket #11850). In general these indexes will also contribute to improving general lookup speeds as well.

At the same time the database view creation was aligned with how video database views are handled as well. 
