### PR TITLE
Configure cleanup

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -136,7 +136,7 @@ LIB_DIRS=\
 	lib/xbmc-dll-symbols
 
 SS_DIRS=
-ifeq (@USE_OPENGL@,1)
+ifneq (@DISABLE_RSXS@,1)
   SS_DIRS+= xbmc/screensavers/rsxs-0.9/xbmc
 endif
 

--- a/configure.in
+++ b/configure.in
@@ -68,6 +68,8 @@ goom_enabled="== GOOM enabled. =="
 goom_disabled="== GOOM disabled. =="
 rsxs_enabled="== RSXS enabled. =="
 rsxs_disabled="== RSXS disabled. =="
+x11_enabled="== X11 enabled. =="
+x11_disabled="== X11 disabled. =="
 pulse_not_found="== Could not find libpulse. PulseAudio support disabled. =="
 pulse_disabled="== PulseAudio support manually disabled. =="
 dvdcss_enabled="== DVDCSS support enabled. =="
@@ -215,6 +217,12 @@ AC_ARG_ENABLE([rsxs],
   [enable really slick X screensavers (default is yes)])],
   [use_rsxs=$enableval],
   [use_rsxs=yes])
+
+AC_ARG_ENABLE([x11],
+  [AS_HELP_STRING([--enable-x11],
+  [enable x11 (default is yes) 'Linux Only'])],
+  [use_x11=$enableval],
+  [use_x11=yes])
 
 AC_ARG_ENABLE([ccache],
   [AS_HELP_STRING([--enable-ccache],
@@ -682,9 +690,6 @@ else
   PKG_CHECK_MODULES([ENCA],  [enca],
     [INCLUDES="$INCLUDES $ENCA_CFLAGS"; LIBS="$LIBS $ENCA_LIBS"],
     AC_MSG_ERROR($missing_library))
-  PKG_CHECK_MODULES([XEXT],  [xext],
-    [INCLUDES="$INCLUDES $XEXT_CFLAGS"; LIBS="$LIBS $XEXT_LIBS"],
-    AC_MSG_ERROR($missing_library))
   PKG_CHECK_MODULES([DBUS],  [dbus-1],
     [INCLUDES="$INCLUDES $DBUS_CFLAGS"; LIBS="$LIBS $DBUS_LIBS"],
     AC_MSG_ERROR($missing_library))
@@ -779,8 +784,22 @@ else
   fi
 fi
 
+# X11
+if test "$use_x11" = "yes" && test "$host_vendor" != "apple"; then
+  AC_MSG_NOTICE($x11_enabled)
+  PKG_CHECK_MODULES([X11],    [x11],
+    [INCLUDES="$INCLUDES $X11_CFLAGS"; LIBS="$LIBS $X11_LIBS"],
+    AC_MSG_ERROR($missing_library))
+  PKG_CHECK_MODULES([XEXT],  [xext],
+    [INCLUDES="$INCLUDES $XEXT_CFLAGS"; LIBS="$LIBS $XEXT_LIBS"],
+    AC_MSG_ERROR($missing_library))
+  AC_DEFINE([HAVE_X11], [1], [Define to 1 if you have X11 libs installed.])
+else
+  AC_MSG_RESULT($x11_disabled)
+fi
+
 # XRandR
-if test "$host_vendor" = "apple" ; then
+if test "$host_vendor" = "apple" || test "$use_x11" == "no"; then
   use_xrandr="no"
   AC_MSG_RESULT($xrandr_disabled)
 else
@@ -1290,6 +1309,11 @@ else
   final_message="$final_message\n  RSXS:\t\tNo"
 fi
 
+if test "$use_x11" = "yes"; then
+  final_message="$final_message\n  X11:\t\tYes"
+else
+  final_message="$final_message\n  X11:\t\tNo"
+fi
 
 if test "$use_libbluray" = "yes"; then
   final_message="$final_message\n  Bluray:\tYes"

--- a/configure.in
+++ b/configure.in
@@ -66,6 +66,8 @@ xrandr_not_found="== Could not find libXRandR. SDL will be used for resolution s
 xrandr_disabled="== XRandR support disabled. SDL will be used for resolution support. =="
 goom_enabled="== GOOM enabled. =="
 goom_disabled="== GOOM disabled. =="
+rsxs_enabled="== RSXS enabled. =="
+rsxs_disabled="== RSXS disabled. =="
 pulse_not_found="== Could not find libpulse. PulseAudio support disabled. =="
 pulse_disabled="== PulseAudio support manually disabled. =="
 dvdcss_enabled="== DVDCSS support enabled. =="
@@ -207,6 +209,12 @@ AC_ARG_ENABLE([goom],
   [enable GOOM visualisation (default is no)])],
   [use_goom=$enableval],
   [use_goom=no])
+
+AC_ARG_ENABLE([rsxs],
+  [AS_HELP_STRING([--enable-rsxs],
+  [enable really slick X screensavers (default is yes)])],
+  [use_rsxs=$enableval],
+  [use_rsxs=yes])
 
 AC_ARG_ENABLE([ccache],
   [AS_HELP_STRING([--enable-ccache],
@@ -674,14 +682,8 @@ else
   PKG_CHECK_MODULES([ENCA],  [enca],
     [INCLUDES="$INCLUDES $ENCA_CFLAGS"; LIBS="$LIBS $ENCA_LIBS"],
     AC_MSG_ERROR($missing_library))
-  PKG_CHECK_MODULES([XT],    [xt],
-    [INCLUDES="$INCLUDES $XT_CFLAGS"; LIBS="$LIBS $XT_LIBS"],
-    AC_MSG_ERROR($missing_library))
   PKG_CHECK_MODULES([XEXT],  [xext],
     [INCLUDES="$INCLUDES $XEXT_CFLAGS"; LIBS="$LIBS $XEXT_LIBS"],
-    AC_MSG_ERROR($missing_library))
-  PKG_CHECK_MODULES([XMU],   [xmu],
-    [INCLUDES="$INCLUDES $XMU_CFLAGS"; LIBS="$LIBS $XMU_LIBS"],
     AC_MSG_ERROR($missing_library))
   PKG_CHECK_MODULES([DBUS],  [dbus-1],
     [INCLUDES="$INCLUDES $DBUS_CFLAGS"; LIBS="$LIBS $DBUS_LIBS"],
@@ -802,6 +804,21 @@ else
     AC_MSG_NOTICE($goom_disabled)
     DISABLE_GOOM=1
   fi
+fi
+
+# RSXS
+if test "$use_rsxs" = "no" || test "$use_gl" == "no"; then
+  AC_MSG_NOTICE($rsxs_disabled)
+  DISABLE_RSXS=1
+else
+  AC_MSG_NOTICE($rsxs_enabled)
+  DISABLE_RSXS=0
+  PKG_CHECK_MODULES([XT],    [xt],
+    [INCLUDES="$INCLUDES $XT_CFLAGS"; LIBS="$LIBS $XT_LIBS"],
+    AC_MSG_ERROR($missing_library))
+  PKG_CHECK_MODULES([XMU],   [xmu],
+    [INCLUDES="$INCLUDES $XMU_CFLAGS"; LIBS="$LIBS $XMU_LIBS"],
+    AC_MSG_ERROR($missing_library))
 fi
 
 # libRTMP
@@ -1267,6 +1284,13 @@ else
   final_message="$final_message\n  GOOM:\t\tNo"
 fi
 
+if test "$use_rsxs" = "yes"; then
+  final_message="$final_message\n  RSXS:\t\tYes"
+else
+  final_message="$final_message\n  RSXS:\t\tNo"
+fi
+
+
 if test "$use_libbluray" = "yes"; then
   final_message="$final_message\n  Bluray:\tYes"
 else
@@ -1496,6 +1520,7 @@ AC_SUBST(LDFLAGS)
 AC_SUBST(SDL_DEFINES)
 AC_SUBST(BUILD_DVDCSS)
 AC_SUBST(DISABLE_GOOM)
+AC_SUBST(DISABLE_RSXS)
 AC_SUBST(USE_EXTERNAL_FFMPEG)
 AC_SUBST(PYTHON_VERSION)
 AC_SUBST(OUTPUT_FILES)
@@ -1756,7 +1781,6 @@ XB_CONFIG_MODULE([xbmc/visualizations/Goom/goom2k4-0],[
 ], [$DISABLE_GOOM])
 
 XB_CONFIG_MODULE([xbmc/screensavers/rsxs-0.9/], [
-if test "$use_gl" = "no"; then :; else
   ./configure \
     CC="$CC" \
     CXX="$CXX" \
@@ -1777,8 +1801,7 @@ if test "$use_gl" = "no"; then :; else
     --disable-hyperspace \
     --disable-lattice \
     --disable-skyrocket
-fi
-], [0])
+], [$DISABLE_RSXS])
 
 XB_CONFIG_MODULE([lib/libapetag], [
   ./configure \

--- a/configure.in
+++ b/configure.in
@@ -97,6 +97,7 @@ librtmp_disabled="== RTMP support disabled. =="
 libnfs_not_found="== Could not find libnfs. NFS support disabled. =="
 libnfs_disabled="== NFS support disabled. =="
 alsa_not_found="== Could not find ALSA. ALSA support disabled. =="
+dbus_not_found="== Could not find DBUS. DBUS support disabled. =="
 
 
 # External library message strings
@@ -687,9 +688,10 @@ else
   PKG_CHECK_MODULES([ALSA],  [alsa],
     [INCLUDES="$INCLUDES $ALSA_CFLAGS"; LIBS="$LIBS $ALSA_LIBS"; use_alsa=yes],
     AC_MSG_NOTICE($alsa_not_found); use_alsa=no)
-  PKG_CHECK_MODULES([DBUS],  [dbus-1],
-    [INCLUDES="$INCLUDES $DBUS_CFLAGS"; LIBS="$LIBS $DBUS_LIBS"],
-    AC_MSG_ERROR($missing_library))
+  PKG_CHECK_MODULES([DBUS],    [dbus-1],
+    [INCLUDES="$INCLUDES $DBUS_CFLAGS"; LIBS="$LIBS $DBUS_LIBS"; use_dbus=yes]; \
+    AC_DEFINE([HAVE_DBUS],[1],["Define to 1 if dbus is installed"]),
+    AC_MSG_NOTICE($missing_library); use_dbus=no)
   PKG_CHECK_MODULES([SDL],   [sdl],
     [INCLUDES="$INCLUDES $SDL_CFLAGS"; LIBS="$LIBS $SDL_LIBS"],
     AC_MSG_ERROR($missing_library))
@@ -1241,6 +1243,12 @@ if test "$use_alsa" = "yes"; then
 else
   USE_ALSA=0
   final_message="$final_message\n  ALSA:\t\tNo"
+fi
+
+if test "$use_dbus" = "yes"; then
+  final_message="$final_message\n  DBUS:\t\tYes"
+else
+  final_message="$final_message\n  DBUS:\t\tNo"
 fi
 
 if test "x$use_vdpau" != "xno"; then

--- a/configure.in
+++ b/configure.in
@@ -687,9 +687,6 @@ else
   PKG_CHECK_MODULES([ALSA],  [alsa],
     [INCLUDES="$INCLUDES $ALSA_CFLAGS"; LIBS="$LIBS $ALSA_LIBS"; use_alsa=yes],
     AC_MSG_NOTICE($alsa_not_found); use_alsa=no)
-  PKG_CHECK_MODULES([ENCA],  [enca],
-    [INCLUDES="$INCLUDES $ENCA_CFLAGS"; LIBS="$LIBS $ENCA_LIBS"],
-    AC_MSG_ERROR($missing_library))
   PKG_CHECK_MODULES([DBUS],  [dbus-1],
     [INCLUDES="$INCLUDES $DBUS_CFLAGS"; LIBS="$LIBS $DBUS_LIBS"],
     AC_MSG_ERROR($missing_library))

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -136,7 +136,9 @@
 #define HAS_DBUS
 #define HAS_DBUS_SERVER
 #define HAS_GL
+#ifdef HAVE_X11
 #define HAS_GLX
+#endif
 #define HAS_LINUX_NETWORK
 #define HAS_SDL_AUDIO
 #define HAS_LIRC

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -133,8 +133,10 @@
 #define HAS_AVAHI
 #endif
 #define HAS_LCD
+#ifdef HAVE_DBUS
 #define HAS_DBUS
 #define HAS_DBUS_SERVER
+#endif
 #define HAS_GL
 #ifdef HAVE_X11
 #define HAS_GLX


### PR DESCRIPTION
These should be pretty straightforward for the most part. Allow to build with libs that aren't strictly necessary. But would like some eyes on it before pushing.

DBUS (and recently ALSA) raise the question: should we be silently disabling functionality when libs aren't present? Or adding configure switches for everything we make optional?

My opinion: If it's a basic lib for the platform, like alsa or dbus for linux, no configure option is needed. Packagers can undef in system.h if the functionality is really not desired.

X is an exception here and really should be the same as the two above, except that in the future we'll have the ability to choose a window system at configure-time, so the option will be needed.
