### PR TITLE
Added: option to notify the user on PlayerControl(Random) and PlayerControl(Repeat)

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -481,7 +481,7 @@ bool CPlayListPlayer::IsShuffled(int iPlaylist) const
   return false;
 }
 
-void CPlayListPlayer::SetRepeat(int iPlaylist, REPEAT_STATE state)
+void CPlayListPlayer::SetRepeat(int iPlaylist, REPEAT_STATE state, bool bNotify /* = false */)
 {
   if (iPlaylist != PLAYLIST_MUSIC && iPlaylist != PLAYLIST_VIDEO)
     return;
@@ -489,6 +489,19 @@ void CPlayListPlayer::SetRepeat(int iPlaylist, REPEAT_STATE state)
   // disable repeat in party mode
   if (g_partyModeManager.IsEnabled() && iPlaylist == PLAYLIST_MUSIC)
     state = REPEAT_NONE;
+
+  // notify the user if there was a change in the repeat state
+  if (m_repeatState[iPlaylist] != state && bNotify)
+  {
+    int iLocalizedString;
+    if (state == REPEAT_NONE)
+      iLocalizedString = 595; // Repeat: Off
+    else if (state == REPEAT_ONE)
+      iLocalizedString = 596; // Repeat: One
+    else
+      iLocalizedString = 597; // Repeat: All
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(559), g_localizeStrings.Get(iLocalizedString));
+  }
 
   m_repeatState[iPlaylist] = state;
 }

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -426,7 +426,7 @@ bool CPlayListPlayer::RepeatedOne(int iPlaylist) const
   return false;
 }
 
-void CPlayListPlayer::SetShuffle(int iPlaylist, bool bYesNo)
+void CPlayListPlayer::SetShuffle(int iPlaylist, bool bYesNo, bool bNotify /* = false */)
 {
   if (iPlaylist != PLAYLIST_MUSIC && iPlaylist != PLAYLIST_VIDEO)
     return;
@@ -449,6 +449,13 @@ void CPlayListPlayer::SetShuffle(int iPlaylist, bool bYesNo)
       playlist.Shuffle();
     else
       playlist.UnShuffle();
+
+    if (bNotify)
+    {
+      CStdString shuffleStr;
+      shuffleStr.Format("%s: %s", g_localizeStrings.Get(191), g_localizeStrings.Get(bYesNo ? 593 : 591)); // Shuffle: All/Off
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(559),  shuffleStr);
+    }
 
     // find the previous order value and fix the current song marker
     if (iOrder >= 0)

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -126,9 +126,10 @@ public:
    Has no effect if Party Mode is enabled.
    \param playlist the playlist to (un)shuffle, PLAYLIST_MUSIC or PLAYLIST_VIDEO.
    \param shuffle set true to shuffle, false to unshuffle.
+   \param notify notify the user with a Toast notification (defaults to false)
    \sa IsShuffled
    */
-  void SetShuffle(int playlist, bool shuffle);
+  void SetShuffle(int playlist, bool shuffle, bool notify = false);
   
   /*! \brief Return whether a playlist is shuffled.
    If partymode is enabled, this always returns false.

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -144,7 +144,14 @@ public:
    */
   bool HasPlayedFirstFile() const;
 
-  void SetRepeat(int iPlaylist, REPEAT_STATE state);
+  /*! \brief Set repeat state of a playlist.
+   If called while in Party Mode, repeat is disabled.
+   \param playlist the playlist to set repeat state for, PLAYLIST_MUSIC or PLAYLIST_VIDEO.
+   \param state set to REPEAT_NONE, REPEAT_ONE or REPEAT_ALL
+   \param notify notify the user with a Toast notification
+   \sa GetRepeat
+   */
+  void SetRepeat(int iPlaylist, REPEAT_STATE state, bool notify = false);
   REPEAT_STATE GetRepeat(int iPlaylist) const;
 
   // add items via the playlist player

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -773,7 +773,10 @@ int CBuiltins::Execute(const CStdString& execString)
 
       if (state == previous_state)
         return 0;
-      g_playlistPlayer.SetRepeat(iPlaylist, state);
+
+      // check to see if we should notify the user
+      bool notify = (params.size() == 2 && params[1].Equals("notify"));
+      g_playlistPlayer.SetRepeat(iPlaylist, state, notify);
 
       // save settings for now playing windows
       switch (iPlaylist)

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -729,7 +729,10 @@ int CBuiltins::Execute(const CStdString& execString)
       bool shuffled = g_playlistPlayer.IsShuffled(iPlaylist);
       if ((shuffled && parameter.Equals("randomon")) || (!shuffled && parameter.Equals("randomoff")))
         return 0;
-      g_playlistPlayer.SetShuffle(iPlaylist, !shuffled);
+
+      // check to see if we should notify the user
+      bool notify = (params.size() == 2 && params[1].Equals("notify"));
+      g_playlistPlayer.SetShuffle(iPlaylist, !shuffled, notify);
 
       // save settings for now playing windows
       switch (iPlaylist)

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -752,21 +752,24 @@ int CBuiltins::Execute(const CStdString& execString)
     {
       // get current playlist
       int iPlaylist = g_playlistPlayer.GetCurrentPlaylist();
-      PLAYLIST::REPEAT_STATE state = g_playlistPlayer.GetRepeat(iPlaylist);
+      PLAYLIST::REPEAT_STATE previous_state = g_playlistPlayer.GetRepeat(iPlaylist);
 
+      PLAYLIST::REPEAT_STATE state;
       if (parameter.Equals("repeatall"))
         state = PLAYLIST::REPEAT_ALL;
       else if (parameter.Equals("repeatone"))
         state = PLAYLIST::REPEAT_ONE;
       else if (parameter.Equals("repeatoff"))
         state = PLAYLIST::REPEAT_NONE;
-      else if (state == PLAYLIST::REPEAT_NONE)
+      else if (previous_state == PLAYLIST::REPEAT_NONE)
         state = PLAYLIST::REPEAT_ALL;
-      else if (state == PLAYLIST::REPEAT_ALL)
+      else if (previous_state == PLAYLIST::REPEAT_ALL)
         state = PLAYLIST::REPEAT_ONE;
       else
         state = PLAYLIST::REPEAT_NONE;
 
+      if (state == previous_state)
+        return 0;
       g_playlistPlayer.SetRepeat(iPlaylist, state);
 
       // save settings for now playing windows


### PR DESCRIPTION
Problem: You've configured a keymap.xml to call PlayerControl(Random). You go to press the toggle shuffle key on your remote... "OMG DID I ENABLE OR DISABLE SHUFFLE I DONT KNOW OMG" you say to yourself.

Dramatization aside, when this bult-in is called from a skin's <onlick>, visual confirmation is given by toggling the shuffle button that was clicked. If called by any other technique (remote keypress, Eventghost, ExecBuiltIn(), etc) no confirmation is given when the button can't be seen.

The solution is an optional parameter called Notify that defaults to false for backwards compatibility, like so: PlayerControl(Random,Notify). This parameter isn't exposed to Python or JSON, only the built-ins interface. Now, when the key on the remote is pressed, the user gets a small status notification.

This issue was reported by kiboy6 [here](http://forum.xbmc.org/showthread.php?t=108436).
