### PR TITLE
Bring up Search dialog in videos on NYXBoard flip

### DIFF
--- a/system/keymaps/keyboard.nyxboard.xml
+++ b/system/keymaps/keyboard.nyxboard.xml
@@ -347,6 +347,7 @@
       <delete>Delete</delete>
       <space>Playlist</space>
       <w>ToggleWatched</w>
+      <f7>VideoLibrary.Search</f7>
     </keyboard>
   </MyVideoLibrary>
   <MyVideoFiles>
@@ -354,6 +355,7 @@
       <space>Playlist</space>
       <q>Queue</q>
       <w>ToggleWatched</w>
+      <f7>VideoLibrary.Search</f7>
     </keyboard>
   </MyVideoFiles>
   <MyVideoPlaylist>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -392,6 +392,7 @@
       <delete>Delete</delete>
       <space>Playlist</space>
       <w>ToggleWatched</w>
+      <f7>VideoLibrary.Search</f7>
     </keyboard>
   </MyVideoLibrary>
   <MyVideoFiles>
@@ -399,6 +400,7 @@
       <space>Playlist</space>
       <q>Queue</q>
       <w>ToggleWatched</w>
+      <f7>VideoLibrary.Search</f7>
     </keyboard>
   </MyVideoFiles>
   <MyVideoPlaylist>

--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -124,3 +124,6 @@
 
 // Sent from filesystem if a path is known to have changed
 #define GUI_MSG_UPDATE_PATH           GUI_MSG_USER + 33
+
+// Sent to tell window to initiate a search dialog
+#define GUI_MSG_SEARCH                GUI_MSG_USER + 34

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -205,6 +205,7 @@ const BUILT_IN commands[] = {
   { "LCD.Suspend",                false,  "Suspends LCDproc" },
   { "LCD.Resume",                 false,  "Resumes LCDproc" },
 #endif
+  { "VideoLibrary.Search",        false,  "Brings up a search dialog which will search the library" },
 };
 
 bool CBuiltins::HasCommand(const CStdString& execString)
@@ -1523,6 +1524,11 @@ int CBuiltins::Execute(const CStdString& execString)
   {
     CGUIMessage msg(GUI_MSG_MOVE_OFFSET, 0, 0, 0);
     g_windowManager.SendMessage(msg, WINDOW_WEATHER);
+  }
+  else if (execute.Equals("videolibrary.search"))
+  {
+    CGUIMessage msg(GUI_MSG_SEARCH, 0, 0, 0);
+    g_windowManager.SendMessage(msg, WINDOW_VIDEO_NAV);
   }
   else
     return -1;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -62,7 +62,7 @@
 #include "utils/log.h"
 #include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
-
+#include "GUIUserMessages.h"
 #include "addons/Skin.h"
 
 using namespace std;
@@ -216,6 +216,9 @@ bool CGUIWindowVideoBase::OnMessage(CGUIMessage& message)
         }
       }
     }
+    break;
+  case GUI_MSG_SEARCH:
+    OnSearch();
     break;
   }
   return CGUIMediaWindow::OnMessage(message);


### PR DESCRIPTION
This patchchain makes XBMC pop up the search dialog in Videos when you flip the NYXBoard.

There are a couple of issues with the patches which I'd like to bring up, the action is possible to send if your in any window, this will bring up the search but it will not work (won't find anything). Second point of discussion is if the naming of the action is good "VideoLibrary.Search", other alternatives would be "Video.Search" or "XBMC.Search(video)", not sure which is preferred? XBMC.Search() has the added benefit that it would work on general searches (omit the content).

The Audio section needs patches aswell but the search works differently (its remembered and filtered instead), I guess we should a) unify searching (and allow general search on any content). b) make all contents searched behave consistently.
