### PR TITLE
Add virtual addon type combining plugins and scripts 

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -80,6 +80,7 @@ static const TypeMapping types[] =
    {"xbmc.addon.audio",                  ADDON_AUDIO,                1038, "DefaultAddonMusic.png" },
    {"xbmc.addon.image",                  ADDON_IMAGE,                1039, "DefaultAddonPicture.png" },
    {"xbmc.addon.executable",             ADDON_EXECUTABLE,           1043, "DefaultAddonProgram.png" },
+   {"xbmc.addon.media",                  ADDON_MEDIA,               24001, ""},
    {"xbmc.service",                      ADDON_SERVICE,             24018, "DefaultAddonService.png" }};
 
 const CStdString TranslateType(const ADDON::TYPE &type, bool pretty/*=false*/)

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -338,6 +338,8 @@ int CGUIWindowAddonBrowser::SelectAddonID(TYPE type, CStdString &addonID, bool s
     CAddonsDirectory::GetScriptsAndPlugins("image",addons);
   else if (type == ADDON_VIDEO)
     CAddonsDirectory::GetScriptsAndPlugins("video",addons);
+  else if (type == ADDON_MEDIA)
+    CAddonsDirectory::GetScriptsAndPlugins("media",addons);
   else
     CAddonMgr::Get().GetAddons(type, addons);
 

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -55,6 +55,7 @@ namespace ADDON
     ADDON_AUDIO,
     ADDON_IMAGE,
     ADDON_EXECUTABLE,
+    ADDON_MEDIA, // combined ADDON_VIDEO, ADDON_AUDIO, ADDON_IMAGE and ADDON_EXECUTABLE
     ADDON_VIZ_LIBRARY, // add noninstallable after this and installable before
     ADDON_SCRAPER_LIBRARY,
     ADDON_SCRIPT_LIBRARY,

--- a/xbmc/addons/PluginSource.cpp
+++ b/xbmc/addons/PluginSource.cpp
@@ -77,6 +77,8 @@ CPluginSource::Content CPluginSource::Translate(const CStdString &content)
     return CPluginSource::EXECUTABLE;
   else if (content.Equals("video"))
     return CPluginSource::VIDEO;
+  else if (content.Equals("media"))
+    return CPluginSource::MEDIA;
   else
     return CPluginSource::UNKNOWN;
 }
@@ -86,7 +88,8 @@ bool CPluginSource::IsType(TYPE type) const
   return ((type == ADDON_VIDEO && Provides(VIDEO))
        || (type == ADDON_AUDIO && Provides(AUDIO))
        || (type == ADDON_IMAGE && Provides(IMAGE))
-       || (type == ADDON_EXECUTABLE && Provides(EXECUTABLE)));
+       || (type == ADDON_EXECUTABLE && Provides(EXECUTABLE))
+       || (type == ADDON_MEDIA && Provides(MEDIA)));
 }
 
 } /*namespace ADDON*/

--- a/xbmc/addons/PluginSource.h
+++ b/xbmc/addons/PluginSource.h
@@ -29,14 +29,14 @@ class CPluginSource : public CAddon
 {
 public:
 
-  enum Content { UNKNOWN, AUDIO, IMAGE, EXECUTABLE, VIDEO };
+  enum Content { UNKNOWN, AUDIO, IMAGE, EXECUTABLE, VIDEO, MEDIA };
 
   CPluginSource(const cp_extension_t *ext);
   CPluginSource(const AddonProps &props);
   virtual ~CPluginSource() {}
   virtual bool IsType(TYPE type) const;
   bool Provides(const Content& content) const {
-    return content == UNKNOWN ? false : m_providedContent.count(content) > 0; }
+    return content == UNKNOWN ? false : content == MEDIA ? m_providedContent.size() > 0 : m_providedContent.count(content) > 0; }
 
   static Content Translate(const CStdString &content);
 private:


### PR DESCRIPTION
This allow popping up addon selector (skin.setaddon) with combined list of scripts and plugins to ease adding addon shortcuts on home screen (will be needed in skin.touched). Virtual addon type in commit: xbmc.addon.media doesn't sound realy right for me (too generic) but neither me nor Jeez_X could find name that would properly describe plugins+scripts - I will gladly change it something better.
