### PR TITLE
Update libcmyth to support protocol 57 for deletion of recordings

### DIFF
--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -558,13 +558,6 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		goto out;
 	}
 
-	/*
-	 * XXX: for some reason, this seems to return an error, even though
-	 *      it succeeds...
-	 */
-
-	ret = 0;
-
     out:
 	pthread_mutex_unlock(&mutex);
 
@@ -1410,13 +1403,6 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		ret = err;
 		goto out;
 	}
-
-	/*
-	 * XXX: for some reason, this seems to return an error, even though
-	 *      it succeeds...
-	 */
-
-	ret = 0;
 
     out:
 	return ret;

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -393,10 +393,10 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 	char rec_end_ts[CMYTH_TIMESTAMP_LEN + 1];
 	char originalairdate[CMYTH_TIMESTAMP_LEN + 1];
 	char lastmodified[CMYTH_TIMESTAMP_LEN + 1];
-	int err;
-	int count;
-	long r;
-	int ret;
+	int err = 0;
+	int count = 0;
+	long r = 0;
+	int ret = 0;
 
 	if (!prog) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no program info\n",
@@ -1243,8 +1243,8 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 	char rec_end_ts[CMYTH_TIMESTAMP_LEN + 1];
 	char originalairdate[CMYTH_TIMESTAMP_LEN + 1];
 	char lastmodified[CMYTH_TIMESTAMP_LEN + 1];
-	int err;
-	int ret;
+	int err = 0;
+	int ret = 0;
 	char *host = "mediamvp";
 
 	if (!prog) {

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -465,7 +465,7 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_chanId);
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanstr));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chansign));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanicon));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_channame));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_url));
 		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length >> 32));
 		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length & 0xffffffff));
@@ -1312,7 +1312,7 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_chanId);
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanstr));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chansign));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanicon));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_channame));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_url));
 		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length >> 32));
 		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length & 0xffffffff));

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -497,34 +497,27 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
 		sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
 		if (control->conn_version >= 15) {
-		    sprintf(buf + strlen(buf), "%ld[]:[]",
-		    		prog->proginfo_hasairdate);
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_hasairdate);
 		}
 		if (control->conn_version >= 18) {
-		    sprintf(buf + strlen(buf), "%s[]:[]",
-			    S(prog->proginfo_playgroup));
+			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_playgroup));
 		}
-		if (control->conn_version >= 25){
-		    sprintf(buf + strlen(buf), "%s[]:[]",
-			    S(prog->proginfo_recpriority_2));
+		if (control->conn_version >= 25) {
+			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_recpriority_2));
 		}
 		if (control->conn_version >= 31) {
-		    sprintf(buf + strlen(buf), "%ld[]:[]",
-		    		prog->proginfo_parentid);
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_parentid);
 		}
 		if (control->conn_version >= 32) {
-		    sprintf(buf + strlen(buf), "%s[]:[]",
-			    S(prog->proginfo_storagegroup));
+			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_storagegroup));
 		}
 		if (control->conn_version >= 35) {
-		    sprintf(buf + strlen(buf), "%ld[]:[]%ld[]:[]%ld[]:[]",
-		    		prog->proginfo_audioproperties,
-				prog->proginfo_videoproperties,
-				prog->proginfo_subtitletype);
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_audioproperties);
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_videoproperties);
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_subtitletype);
 		}
 		if (control->conn_version >= 41) {
-		    sprintf(buf + strlen(buf), "%s[]:[]",
-			    S(prog->proginfo_prodyear));
+			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_prodyear));
 		}
 	}
 #undef S
@@ -1344,34 +1337,27 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
 		sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
 		if(control->conn_version >= 15) {
-		    sprintf(buf+strlen(buf),"%ld[]:[]",
-			    prog->proginfo_hasairdate);
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_hasairdate);
 		}
 		if(control->conn_version >= 18) {
-		    sprintf(buf+strlen(buf),"%s[]:[]",
-			    S(prog->proginfo_playgroup));
+			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_playgroup));
 		}
 		if(control->conn_version >= 25) {
-		    sprintf(buf+strlen(buf),"%s[]:[]",
-			    S(prog->proginfo_recpriority_2));
+			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_recpriority_2));
 		}
 		if(control->conn_version >= 31) {
-		    sprintf(buf+strlen(buf),"%ld[]:[]",
-			    prog->proginfo_parentid);
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_parentid);
 		}
 		if(control->conn_version >= 32) {
-		    sprintf(buf+strlen(buf),"%s[]:[]",
-			    S(prog->proginfo_storagegroup));
+			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_storagegroup));
 		}
 		if(control->conn_version >= 35) {
-		    sprintf(buf+strlen(buf),"%ld[]:[]%ld[]:[]%ld[]:[]",
-		    	    prog->proginfo_audioproperties,
-			    prog->proginfo_videoproperties,
-			    prog->proginfo_subtitletype);
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_audioproperties);
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_videoproperties);
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_subtitletype);
 		}
 		if(control->conn_version >= 41) {
-		    sprintf(buf+strlen(buf),"%s[]:[]",
-			    S(prog->proginfo_prodyear));
+			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_prodyear));
 		}
 	}
 #undef S

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -472,8 +472,8 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%s[]:[]",  start_ts);
 		sprintf(buf + strlen(buf), "%s[]:[]",  end_ts);
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_recording);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_override);
+		sprintf(buf + strlen(buf), "%ld[]:[]", 0); // "shareable"
+		sprintf(buf + strlen(buf), "%ld[]:[]", 0); // "findid"
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_hostname));
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_source_id);
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_card_id);
@@ -1319,8 +1319,8 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%s[]:[]",  start_ts);
 		sprintf(buf + strlen(buf), "%s[]:[]",  end_ts);
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_recording);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_override);
+		sprintf(buf + strlen(buf), "%ld[]:[]", 0); // "shareable"
+		sprintf(buf + strlen(buf), "%ld[]:[]", 0); // "findid"
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_hostname));
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_source_id);
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_card_id);

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -457,55 +457,45 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 			  __FUNCTION__, control->conn_version);
 		return -EINVAL;
 	} else {
-		sprintf(buf,
-			"%s 0[]:[]"
-			"%s[]:[]%s[]:[]%s[]:[]%s[]:[]%ld[]:[]"
-			"%s[]:[]%s[]:[]%s[]:[]%s[]:[]%d[]:[]%d[]:[]"
-			"%s[]:[]%s[]:[]%s[]:[]%ld[]:[]"
-			"%ld[]:[]%s[]:[]%ld[]:[]%ld[]:[]%ld[]:[]"
-			"%s[]:[]%ld[]:[]%ld[]:[]%ld[]:[]%ld[]:[]"
-			"%ld[]:[]%s[]:[]%s[]:[]%ld[]:[]%ld[]:[]"
-			"%s[]:[]%s[]:[]%s[]:[]%s[]:[]"
-			"%s[]:[]%s[]:[]%s[]:[]%s[]:[]",
-			cmd,
-			S(prog->proginfo_title),
-			S(prog->proginfo_subtitle),
-			S(prog->proginfo_description),
-			S(prog->proginfo_category),
-			prog->proginfo_chanId,
-			S(prog->proginfo_chanstr),
-			S(prog->proginfo_chansign),
-			S(prog->proginfo_chanicon),
-			S(prog->proginfo_url),
-			(int32_t)(prog->proginfo_Length >> 32),
-			(int32_t)(prog->proginfo_Length & 0xffffffff),
-			start_ts,
-			end_ts,
-			S(prog->proginfo_unknown_0),
-			prog->proginfo_recording,
-			prog->proginfo_override,
-			S(prog->proginfo_hostname),
-			prog->proginfo_source_id,
-			prog->proginfo_card_id,
-			prog->proginfo_input_id,
-			S(prog->proginfo_rec_priority),
-			prog->proginfo_rec_status,
-			prog->proginfo_record_id,
-			prog->proginfo_rec_type,
-			prog->proginfo_rec_dups,
-			prog->proginfo_unknown_1,
-			rec_start_ts,
-			rec_end_ts,
-			prog->proginfo_repeat,
-			prog->proginfo_program_flags,
-			S(prog->proginfo_recgroup),
-			S(prog->proginfo_chancommfree),
-			S(prog->proginfo_chan_output_filters),
-			S(prog->proginfo_seriesid),
-			S(prog->proginfo_programid),
-			lastmodified,
-			S(prog->proginfo_stars),
-			originalairdate);
+		sprintf(buf, "%s 0[]:[]", cmd);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_title));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_subtitle));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_description));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_category));
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_chanId);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanstr));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chansign));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanicon));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_url));
+		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length >> 32));
+		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length & 0xffffffff));
+		sprintf(buf + strlen(buf), "%s[]:[]",  start_ts);
+		sprintf(buf + strlen(buf), "%s[]:[]",  end_ts);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_recording);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_override);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_hostname));
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_source_id);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_card_id);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_input_id);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_rec_priority));
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_status);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_record_id);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_type);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_dups);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_unknown_1); // "dupmethod"
+		sprintf(buf + strlen(buf), "%s[]:[]",  rec_start_ts);
+		sprintf(buf + strlen(buf), "%s[]:[]",  rec_end_ts);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_repeat);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_program_flags);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_recgroup));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chancommfree));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chan_output_filters));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_seriesid));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_programid));
+		sprintf(buf + strlen(buf), "%s[]:[]",  lastmodified);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
+		sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
 		if (control->conn_version >= 15) {
 		    sprintf(buf + strlen(buf), "%ld[]:[]",
 		    		prog->proginfo_hasairdate);
@@ -1314,55 +1304,45 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 			  __FUNCTION__, control->conn_version);
 		return -EINVAL;
 	} else {
-		sprintf(buf,
-			"%s %s[]:[]0[]:[]"
-			"%s[]:[]%s[]:[]%s[]:[]%s[]:[]%ld[]:[]"
-			"%s[]:[]%s[]:[]%s[]:[]%s[]:[]%d[]:[]%d[]:[]"
-			"%s[]:[]%s[]:[]%s[]:[]%ld[]:[]"
-			"%ld[]:[]%s[]:[]%ld[]:[]%ld[]:[]%ld[]:[]"
-			"%s[]:[]%ld[]:[]%ld[]:[]%ld[]:[]%ld[]:[]"
-			"%ld[]:[]%s[]:[]%s[]:[]%ld[]:[]%ld[]:[]"
-			"%s[]:[]%s[]:[]%s[]:[]%s[]:[]"
-			"%s[]:[]%s[]:[]%s[]:[]%s[]:[]",
-			cmd, host,
-			S(prog->proginfo_title),
-			S(prog->proginfo_subtitle),
-			S(prog->proginfo_description),
-			S(prog->proginfo_category),
-			prog->proginfo_chanId,
-			S(prog->proginfo_chanstr),
-			S(prog->proginfo_chansign),
-			S(prog->proginfo_chanicon),
-			S(prog->proginfo_url),
-			(int32_t)(prog->proginfo_Length >> 32),
-			(int32_t)(prog->proginfo_Length & 0xffffffff),
-			start_ts,
-			end_ts,
-			S(prog->proginfo_unknown_0),
-			prog->proginfo_recording,
-			prog->proginfo_override,
-			S(prog->proginfo_hostname),
-			prog->proginfo_source_id,
-			prog->proginfo_card_id,
-			prog->proginfo_input_id,
-			S(prog->proginfo_rec_priority),
-			prog->proginfo_rec_status,
-			prog->proginfo_record_id,
-			prog->proginfo_rec_type,
-			prog->proginfo_rec_dups,
-			prog->proginfo_unknown_1,
-			rec_start_ts,
-			rec_end_ts,
-			prog->proginfo_repeat,
-			prog->proginfo_program_flags,
-			S(prog->proginfo_recgroup),
-			S(prog->proginfo_chancommfree),
-			S(prog->proginfo_chan_output_filters),
-			S(prog->proginfo_seriesid),
-			S(prog->proginfo_programid),
-			lastmodified,
-			S(prog->proginfo_stars),
-			originalairdate);
+		sprintf(buf, "%s %s[]:[]0[]:[]", cmd, host);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_title));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_subtitle));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_description));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_category));
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_chanId);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanstr));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chansign));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanicon));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_url));
+		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length >> 32));
+		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length & 0xffffffff));
+		sprintf(buf + strlen(buf), "%s[]:[]",  start_ts);
+		sprintf(buf + strlen(buf), "%s[]:[]",  end_ts);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_recording);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_override);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_hostname));
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_source_id);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_card_id);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_input_id);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_rec_priority));
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_status);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_record_id);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_type);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_dups);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_unknown_1); // "dupmethod"
+		sprintf(buf + strlen(buf), "%s[]:[]",  rec_start_ts);
+		sprintf(buf + strlen(buf), "%s[]:[]",  rec_end_ts);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_repeat);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_program_flags);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_recgroup));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chancommfree));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chan_output_filters));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_seriesid));
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_programid));
+		sprintf(buf + strlen(buf), "%s[]:[]",  lastmodified);
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
+		sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
 		if(control->conn_version >= 15) {
 		    sprintf(buf+strlen(buf),"%ld[]:[]",
 			    prog->proginfo_hasairdate);

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -1336,27 +1336,27 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%s[]:[]",  lastmodified);
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
 		sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
-		if(control->conn_version >= 15) {
+		if (control->conn_version >= 15) {
 			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_hasairdate);
 		}
-		if(control->conn_version >= 18) {
+		if (control->conn_version >= 18) {
 			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_playgroup));
 		}
-		if(control->conn_version >= 25) {
+		if (control->conn_version >= 25) {
 			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_recpriority_2));
 		}
-		if(control->conn_version >= 31) {
+		if (control->conn_version >= 31) {
 			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_parentid);
 		}
-		if(control->conn_version >= 32) {
+		if (control->conn_version >= 32) {
 			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_storagegroup));
 		}
-		if(control->conn_version >= 35) {
+		if (control->conn_version >= 35) {
 			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_audioproperties);
 			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_videoproperties);
 			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_subtitletype);
 		}
-		if(control->conn_version >= 41) {
+		if (control->conn_version >= 41) {
 			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_prodyear));
 		}
 	}

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <inttypes.h>
 #include <cmyth_local.h>
 
 /*
@@ -467,12 +468,18 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chansign));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_channame));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_url));
-		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length >> 32));
-		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length & 0xffffffff));
+		if (control->conn_version >= 57) {
+			sprintf(buf + strlen(buf), "%"PRId64"[]:[]", prog->proginfo_Length);
+		} else {
+			sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length >> 32));
+			sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length & 0xffffffff));
+		}
 		sprintf(buf + strlen(buf), "%s[]:[]",  start_ts);
 		sprintf(buf + strlen(buf), "%s[]:[]",  end_ts);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
-		sprintf(buf + strlen(buf), "%ld[]:[]", 0); // "shareable"
+		if (control->conn_version < 57) {
+			sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
+			sprintf(buf + strlen(buf), "%ld[]:[]", 0); // "shareable"
+		}
 		sprintf(buf + strlen(buf), "%ld[]:[]", 0); // "findid"
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_hostname));
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_source_id);
@@ -486,17 +493,21 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_unknown_1); // "dupmethod"
 		sprintf(buf + strlen(buf), "%s[]:[]",  rec_start_ts);
 		sprintf(buf + strlen(buf), "%s[]:[]",  rec_end_ts);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_repeat);
+		if (control->conn_version < 57) {
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_repeat);
+		}
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_program_flags);
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_recgroup));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chancommfree));
+		if (control->conn_version < 57) {
+			sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chancommfree));
+		}
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chan_output_filters));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_seriesid));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_programid));
 		sprintf(buf + strlen(buf), "%s[]:[]",  lastmodified);
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
 		sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
-		if (control->conn_version >= 15) {
+		if (control->conn_version >= 15 && control->conn_version < 57) {
 			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_hasairdate);
 		}
 		if (control->conn_version >= 18) {
@@ -1307,12 +1318,18 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chansign));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_channame));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_url));
-		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length >> 32));
-		sprintf(buf + strlen(buf), "%d[]:[]",  (int32_t)(prog->proginfo_Length & 0xffffffff));
+		if (control->conn_version >= 57) {
+			sprintf(buf + strlen(buf), "%"PRId64"[]:[]", prog->proginfo_Length);
+		} else {
+			sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length >> 32));
+			sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length & 0xffffffff));
+		}
 		sprintf(buf + strlen(buf), "%s[]:[]",  start_ts);
 		sprintf(buf + strlen(buf), "%s[]:[]",  end_ts);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
-		sprintf(buf + strlen(buf), "%ld[]:[]", 0); // "shareable"
+		if (control->conn_version < 57) {
+			sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
+			sprintf(buf + strlen(buf), "%ld[]:[]", 0); // "shareable"
+		}
 		sprintf(buf + strlen(buf), "%ld[]:[]", 0); // "findid"
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_hostname));
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_source_id);
@@ -1326,17 +1343,21 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_unknown_1); // "dupmethod"
 		sprintf(buf + strlen(buf), "%s[]:[]",  rec_start_ts);
 		sprintf(buf + strlen(buf), "%s[]:[]",  rec_end_ts);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_repeat);
+		if (control->conn_version < 57) {
+			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_repeat);
+		}
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_program_flags);
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_recgroup));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chancommfree));
+		if (control->conn_version < 57) {
+			sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chancommfree));
+		}
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chan_output_filters));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_seriesid));
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_programid));
 		sprintf(buf + strlen(buf), "%s[]:[]",  lastmodified);
 		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
 		sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
-		if (control->conn_version >= 15) {
+		if (control->conn_version >= 15 && control->conn_version < 57) {
 			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_hasairdate);
 		}
 		if (control->conn_version >= 18) {


### PR DESCRIPTION
The ProgramInfo object was changed in protocol 57. The code that receives a ProgramInfo was changed to support that, but not the place where the ProgramInfo is sent to the server, e.g. when deleting a recording.
