### PR TITLE
More gesture support

### DIFF
--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -61,8 +61,8 @@ enum EVENT_RESULT { EVENT_RESULT_UNHANDLED = 0,
                     EVENT_RESULT_HANDLED,
                     EVENT_RESULT_PAN_HORIZONTAL,
                     EVENT_RESULT_PAN_VERTICAL,
-                    EVENT_RESULT_PAN_VERTICAL_WITHOUT_INERTIAL,
-                    EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIAL,                    
+                    EVENT_RESULT_PAN_VERTICAL_WITHOUT_INERTIA,
+                    EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIA,                    
                     EVENT_RESULT_ROTATE,
                     EVENT_RESULT_ZOOM };
 

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -61,6 +61,8 @@ enum EVENT_RESULT { EVENT_RESULT_UNHANDLED = 0,
                     EVENT_RESULT_HANDLED,
                     EVENT_RESULT_PAN_HORIZONTAL,
                     EVENT_RESULT_PAN_VERTICAL,
+                    EVENT_RESULT_PAN_VERTICAL_WITHOUT_INERTIAL,
+                    EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIAL,                    
                     EVENT_RESULT_ROTATE,
                     EVENT_RESULT_ZOOM };
 

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -334,7 +334,29 @@ EVENT_RESULT CGUIScrollBar::OnMouseEvent(const CPoint &point, const CMouseEvent 
   {
     Move(1);
     return EVENT_RESULT_HANDLED;
+  }  
+  else if (event.m_id == ACTION_GESTURE_NOTIFY)
+  {
+    return (m_orientation == HORIZONTAL) ? EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIAL : EVENT_RESULT_PAN_VERTICAL_WITHOUT_INERTIAL;
+  }  
+  else if (event.m_id == ACTION_GESTURE_BEGIN)
+  { // grab exclusive access
+    CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, GetID(), GetParentID());
+    SendWindowMessage(msg);
+    return EVENT_RESULT_HANDLED;
   }
+  else if (event.m_id == ACTION_GESTURE_PAN)
+  { // do the drag 
+    SetFromPosition(point);
+    return EVENT_RESULT_HANDLED;
+  }
+  else if (event.m_id == ACTION_GESTURE_END)
+  { // release exclusive access
+    CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, 0, GetParentID());
+    SendWindowMessage(msg);
+    return EVENT_RESULT_HANDLED;
+  }
+  
   return EVENT_RESULT_UNHANDLED;
 }
 

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -337,7 +337,7 @@ EVENT_RESULT CGUIScrollBar::OnMouseEvent(const CPoint &point, const CMouseEvent 
   }  
   else if (event.m_id == ACTION_GESTURE_NOTIFY)
   {
-    return (m_orientation == HORIZONTAL) ? EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIAL : EVENT_RESULT_PAN_VERTICAL_WITHOUT_INERTIAL;
+    return (m_orientation == HORIZONTAL) ? EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIA : EVENT_RESULT_PAN_VERTICAL_WITHOUT_INERTIA;
   }  
   else if (event.m_id == ACTION_GESTURE_BEGIN)
   { // grab exclusive access

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -377,6 +377,27 @@ EVENT_RESULT CGUISliderControl::OnMouseEvent(const CPoint &point, const CMouseEv
     Move(-10);
     return EVENT_RESULT_HANDLED;
   }
+  else if (event.m_id == ACTION_GESTURE_NOTIFY)
+  {
+    return EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIAL;
+  }  
+  else if (event.m_id == ACTION_GESTURE_BEGIN)
+  { // grab exclusive access
+    CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, GetID(), GetParentID());
+    SendWindowMessage(msg);
+    return EVENT_RESULT_HANDLED;
+  }
+  else if (event.m_id == ACTION_GESTURE_PAN)
+  { // do the drag 
+    SetFromPosition(point);
+    return EVENT_RESULT_HANDLED;
+  }
+  else if (event.m_id == ACTION_GESTURE_END)
+  { // release exclusive access
+    CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, 0, GetParentID());
+    SendWindowMessage(msg);
+    return EVENT_RESULT_HANDLED;
+  }
   return EVENT_RESULT_UNHANDLED;
 }
 

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -379,7 +379,7 @@ EVENT_RESULT CGUISliderControl::OnMouseEvent(const CPoint &point, const CMouseEv
   }
   else if (event.m_id == ACTION_GESTURE_NOTIFY)
   {
-    return EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIAL;
+    return EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIA;
   }  
   else if (event.m_id == ACTION_GESTURE_BEGIN)
   { // grab exclusive access

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -287,7 +287,7 @@
 
 #define ACTION_GESTURE_NOTIFY         221
 #define ACTION_GESTURE_BEGIN          222
-#define ACTION_GESTURE_ZOOM           223
+#define ACTION_GESTURE_ZOOM           223 //sendaction with point and currentPinchScale (fingers together < 1.0 -> fingers apart > 1.0)
 #define ACTION_GESTURE_ROTATE         224
 #define ACTION_GESTURE_PAN            225
 #define ACTION_GESTURE_END            226

--- a/xbmc/input/InertialScrollingHandler.cpp
+++ b/xbmc/input/InertialScrollingHandler.cpp
@@ -25,6 +25,7 @@
 #include "Application.h"
 #include "utils/TimeUtils.h"
 #include "guilib/Key.h"
+#include "guilib/GUIWindowManager.h"
 
 #include <cmath>
 
@@ -77,21 +78,37 @@ bool CInertialScrollingHandler::CheckForInertialScrolling(const CAction* action)
   {
     if (action->GetID() == ACTION_GESTURE_END && ( fabs(action->GetAmount(0)) > MINIMUM_SPEED_FOR_INERTIA || fabs(action->GetAmount(1)) > MINIMUM_SPEED_FOR_INERTIA ) )
     {
-      m_iFlickVelocity.x = action->GetAmount(0)/2;//in pixels per sec
-      m_iFlickVelocity.y = action->GetAmount(1)/2;//in pixels per sec     
-      m_iLastGesturePoint.x = action->GetAmount(2);//last gesture point x
-      m_iLastGesturePoint.y = action->GetAmount(3);//last gesture point y
+      bool inertialRequested = false;
+      CGUIMessage message(GUI_MSG_GESTURE_NOTIFY, 0, 0, action->GetAmount(2), action->GetAmount(3));    
       
-      //calc deacceleration for fullstop in TIME_TO_ZERO_SPEED secs
-      //v = a*t + v0 -> set v = 0 because we want to stop scrolling
-      //a = -v0 / t
-      m_inertialDeacceleration.x = -1*m_iFlickVelocity.x/TIME_TO_ZERO_SPEED;    
-      m_inertialDeacceleration.y = -1*m_iFlickVelocity.y/TIME_TO_ZERO_SPEED;
+      //ask if the control wants inertial scrolling
+      if(g_windowManager.SendMessage(message))
+      {
+        if( message.GetParam1() == EVENT_RESULT_PAN_HORIZONTAL ||
+            message.GetParam1() == EVENT_RESULT_PAN_VERTICAL)
+        {
+          inertialRequested = true;
+        }
+      }
+
+      if( inertialRequested )                                                                                                             
+      {        
+        m_iFlickVelocity.x = action->GetAmount(0)/2;//in pixels per sec
+        m_iFlickVelocity.y = action->GetAmount(1)/2;//in pixels per sec     
+        m_iLastGesturePoint.x = action->GetAmount(2);//last gesture point x
+        m_iLastGesturePoint.y = action->GetAmount(3);//last gesture point y
       
-      //CLog::Log(LOGDEBUG, "initial vel: %f dec: %f", m_iFlickVelocity.y, m_inertialDeacceleration.y);
-      m_inertialStartTime = CTimeUtils::GetFrameTime();//start time of inertial scrolling
-      ret = true;
-      m_bScrolling = true;//activate the inertial scrolling animation
+        //calc deacceleration for fullstop in TIME_TO_ZERO_SPEED secs
+        //v = a*t + v0 -> set v = 0 because we want to stop scrolling
+        //a = -v0 / t
+        m_inertialDeacceleration.x = -1*m_iFlickVelocity.x/TIME_TO_ZERO_SPEED;    
+        m_inertialDeacceleration.y = -1*m_iFlickVelocity.y/TIME_TO_ZERO_SPEED;
+      
+        //CLog::Log(LOGDEBUG, "initial vel: %f dec: %f", m_iFlickVelocity.y, m_inertialDeacceleration.y);
+        m_inertialStartTime = CTimeUtils::GetFrameTime();//start time of inertial scrolling
+        ret = true;
+        m_bScrolling = true;//activate the inertial scrolling animation
+      }
     }
   }
   return ret;

--- a/xbmc/input/InertialScrollingHandler.cpp
+++ b/xbmc/input/InertialScrollingHandler.cpp
@@ -26,6 +26,7 @@
 #include "utils/TimeUtils.h"
 #include "guilib/Key.h"
 #include "guilib/GUIWindowManager.h"
+#include "windowing/WindowingFactory.h"
 
 #include <cmath>
 
@@ -51,6 +52,11 @@ CInertialScrollingHandler::CInertialScrollingHandler()
 bool CInertialScrollingHandler::CheckForInertialScrolling(const CAction* action)
 {
   bool ret = false;//return value - false no inertial scrolling - true - inertial scrolling
+  
+  if(g_Windowing.HasInertialGestures())
+  {
+    return ret;//no need for emulating inertial scrolling - windowing does support it nativly.
+  }
   
   //reset screensaver during pan
   if( action->GetID() == ACTION_GESTURE_PAN )

--- a/xbmc/osx/ios/XBMCController.h
+++ b/xbmc/osx/ios/XBMCController.h
@@ -34,6 +34,8 @@
   /* Touch handling */
   CGSize screensize;
   CGPoint lastGesturePoint;
+  CGFloat lastPinchScale;
+  CGFloat currentPinchScale;  
   bool touchBeginSignaled;
 	
   UIInterfaceOrientation orientation;
@@ -42,6 +44,8 @@
 }
 @property (readonly, nonatomic, getter=isAnimating) BOOL animating;
 @property CGPoint lastGesturePoint;
+@property CGFloat lastPinchScale;
+@property CGFloat currentPinchScale;
 @property bool touchBeginSignaled;
 @property CGSize screensize;
 @property XBMC_Event lastEvent;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -53,6 +53,7 @@ using namespace XFILE;
 
 #define PICTURE_MOVE_AMOUNT              0.02f
 #define PICTURE_MOVE_AMOUNT_ANALOG       0.01f
+#define PICTURE_MOVE_AMOUNT_TOUCH        0.002f
 #define PICTURE_VIEW_BOX_COLOR      0xffffff00 // YELLOW
 #define PICTURE_VIEW_BOX_BACKGROUND 0xff000000 // BLACK
 
@@ -506,6 +507,67 @@ int CGUIWindowSlideShow::GetNextSlide()
     return (m_iCurrentSlide - 1 + m_slides->Size()) % m_slides->Size();
 }
 
+EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
+{
+  if (event.m_id == ACTION_GESTURE_NOTIFY)
+  {
+    if( m_iZoomFactor == 1)//zoomed out - no inertial scrolling
+    {
+      return EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIAL;
+    }
+    else//zoomed in - with inertia 
+    {
+      return EVENT_RESULT_PAN_HORIZONTAL;
+    }
+  }  
+  else if (event.m_id == ACTION_GESTURE_BEGIN)
+  {
+    m_firstGesturePoint = point;
+    return EVENT_RESULT_HANDLED;
+  }
+  else if (event.m_id == ACTION_GESTURE_PAN)
+  { // on zoomlevel 1 just detect swipe left and right
+    if( m_iZoomFactor == 1 )
+    {   
+      if( m_firstGesturePoint.x > 0 && fabs(point.x - m_firstGesturePoint.x) > 100 )
+      {
+        if( point.x < m_firstGesturePoint.x )
+        {
+          OnAction(CAction(ACTION_NEXT_PICTURE));
+        }
+        else 
+        {
+          OnAction(CAction(ACTION_PREV_PICTURE));
+        }
+        m_firstGesturePoint.x = 0;
+      }
+    }
+    else//zoomed in - free move mode
+    {
+      Move(PICTURE_MOVE_AMOUNT_TOUCH/m_iZoomFactor*(m_firstGesturePoint.x-point.x),PICTURE_MOVE_AMOUNT_TOUCH/m_iZoomFactor*(m_firstGesturePoint.y-point.y));
+      m_firstGesturePoint = point;
+    }
+    return EVENT_RESULT_HANDLED;
+  }
+  else if (event.m_id == ACTION_GESTURE_END)
+  {
+    return EVENT_RESULT_HANDLED;
+  }
+  else if (event.m_id == ACTION_GESTURE_ZOOM)
+  {
+    if( event.m_offsetX > 1)
+    {
+      Zoom((int)event.m_offsetX);
+    }
+    else 
+    {
+      Zoom(m_iZoomFactor - event.m_offsetX);
+    }
+    return EVENT_RESULT_HANDLED;    
+  }
+  return EVENT_RESULT_UNHANDLED;
+}
+
 bool CGUIWindowSlideShow::OnAction(const CAction &action)
 {
   if (m_bScreensaver)
@@ -532,11 +594,9 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
     g_windowManager.PreviousWindow();
     break;
   case ACTION_NEXT_PICTURE:
-//    if (m_iZoomFactor == 1)
       ShowNext();
     break;
   case ACTION_PREV_PICTURE:
-//    if (m_iZoomFactor == 1)
       ShowPrevious();
     break;
   case ACTION_MOVE_RIGHT:

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -513,7 +513,7 @@ EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouse
   {
     if( m_iZoomFactor == 1)//zoomed out - no inertial scrolling
     {
-      return EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIAL;
+      return EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIA;
     }
     else//zoomed in - with inertia 
     {

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -83,6 +83,7 @@ public:
   void StartSlideShow(bool screensaver=false);
   bool InSlideShow() const;
   virtual bool OnMessage(CGUIMessage& message);
+  virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);  
   virtual bool OnAction(const CAction &action);
   virtual void Render();
   virtual void Process(unsigned int currentTime, CDirtyRegionList &regions);
@@ -134,4 +135,5 @@ private:
   RESOLUTION m_Resolution;
   CCriticalSection m_slideSection;
   CStdString m_strExtensions;
+  CPoint m_firstGesturePoint;
 };

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -71,6 +71,8 @@ public:
   virtual void NotifyAppActiveChange(bool bActivated) {}
   virtual void ShowOSMouse(bool show) {};
   virtual bool HasCursor(){ return true; }
+  //some plattforms have api for gesture inertial scrolling - default to false and use the InertialScrollingHandler
+  virtual bool HasInertialGestures(){ return false; }
 
   virtual bool Minimize() { return false; }
   virtual bool Restore() { return false; }

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -737,8 +737,12 @@ void CWinEventsWin32::OnGestureNotify(HWND hWnd, LPARAM lParam)
       gc[1].dwWant |= GC_ROTATE;
     if (gestures == EVENT_RESULT_PAN_VERTICAL)
       gc[2].dwWant |= GC_PAN_WITH_SINGLE_FINGER_VERTICALLY | GC_PAN_WITH_GUTTER | GC_PAN_WITH_INERTIA;
+    if (gestures == EVENT_RESULT_PAN_VERTICAL_WITHOUT_INERTIAL)
+      gc[2].dwWant |= GC_PAN_WITH_SINGLE_FINGER_VERTICALLY;
     if (gestures == EVENT_RESULT_PAN_HORIZONTAL)
       gc[2].dwWant |= GC_PAN_WITH_SINGLE_FINGER_HORIZONTALLY | GC_PAN_WITH_GUTTER | GC_PAN_WITH_INERTIA;
+    if (gestures == EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIALL)
+      gc[2].dwWant |= GC_PAN_WITH_SINGLE_FINGER_HORIZONTALLY;
     gc[0].dwBlock = gc[0].dwWant ^ 1;
     gc[1].dwBlock = gc[1].dwWant ^ 1;
     gc[2].dwBlock = gc[2].dwWant ^ 30;

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -138,6 +138,7 @@ public:
   virtual int  GetNumScreens() { return m_MonitorsInfo.size(); };
   virtual void ShowOSMouse(bool show);
   virtual bool WindowedMode() { return true; }
+  virtual bool HasInertialGestures(){ return true; }//if win32 has touchscreen - it uses the win32 gesture api for inertial scrolling 
 
   virtual bool Minimize();
   virtual bool Restore();


### PR DESCRIPTION
This PR will add the following:
1. Add a method HasInertialGestures to the WindowSystem. This can be overwritten for each plattforms windowing for letting InertialScrollingHandler know if inertia is supported by plattform API or if the InertialScrollingHandler should emulate it (on Windows the API will be used because - it has inertia)
2. Add EVENT_RESULT_PAN_VERTICAL_WITHOUT_INERTIAL and EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIAL for letting controls decide if they want inertial scrolling or not
3. Make the scrollbar and slider gesture aware (without inertia)
4. Adding pinch gesture to ios gesture controller (for zooming)
5. Make slideshow gesture aware (until now it was uncontrollable on touch devices)
6. swipe left and right - next/prev slide
7. pinch - zoom (yeah this is still a bit twonky wonky)
8. when zoomed in - pan for moving inside the picture
