### PR TITLE
Fix bug playing local URLs

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -636,7 +636,7 @@ CStdString CURL::GetWithoutFilename() const
 
 bool CURL::IsLocal() const
 {
-  return m_strProtocol.IsEmpty();
+  return (IsLocalHost() || m_strProtocol.IsEmpty());
 }
 
 bool CURL::IsLocalHost() const

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -636,7 +636,7 @@ CStdString CURL::GetWithoutFilename() const
 
 bool CURL::IsLocal() const
 {
-  return (IsLocalHost() || m_strProtocol.IsEmpty());
+  return m_strProtocol.IsEmpty();
 }
 
 bool CURL::IsLocalHost() const

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -402,20 +402,19 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
 
 void CUtil::GetQualifiedFilename(const CStdString &strBasePath, CStdString &strFilename)
 {
-  //Make sure you have a full path in the filename, otherwise adds the base path before.
+  // If this is a URL like http://whatever just return as no change is needed
   CURL plItemUrl(strFilename);
+  if (!plItemUrl.GetProtocol().IsEmpty())
+    return;
 
-  if (!plItemUrl.IsLocal())
-    return; // non-local path, don't do anything
-  else if (strFilename.size() > 1)
-  { // local path - see if it's fully qualified
+  // If the filename starts "x:" or "/" it's already fully qualified so return
+  if (strFilename.size() > 1)
 #ifdef _LINUX
     if ( (strFilename[1] == ':') || (strFilename[0] == '/') )
 #else
     if ( strFilename[1] == ':' )
 #endif
       return;
-  }
 
   // add to base path and then clean
   strFilename = URIUtils::AddFileToFolder(strBasePath, strFilename);


### PR DESCRIPTION
If you try to play a stream like http://localhost/stream or http://127.0.0.1/stream from a .strm file the stream gets converted to C:\somedirectory\http:\localhost\stream i.e. XBMC is treating it as a file name and is attempting to construct a fully qualified file name.

This is happening in CUtil::GetQualifiedFilename because plItemUrl.IsLocal() is returning true. In turn, this is happening because CURL::IsLocal() has been changed to return true if the host is localhost or 127.0.0.1. My pull simply reverts the change to CURL::IsLocal().

It looks as if the change to utils.cpp was made in https://github.com/xbmc/xbmc/commit/563f4d1afc3651b16502cc005e76401d6b9657ce and the change to url.cpp in https://github.com/xbmc/xbmc/commit/abe8bf2e36262d515f17f7622457c456830877a4 but it isn't clear to me what the reasons for this were and what consequences reverting the changes will have.
