### PR TITLE
Master slave control relations

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -747,6 +747,13 @@ void CGUIBaseContainer::SetPageControl(int id)
   m_pageControl = id;
 }
 
+const void CGUIBaseContainer::GetSlaveControlsIDs(vector<int>& controlIDs) const
+{
+  if (m_pageControl)
+    controlIDs.push_back(m_pageControl);
+  CGUIControl::GetSlaveControlsIDs(controlIDs);
+}
+
 void CGUIBaseContainer::ValidateOffset()
 {
 }

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -56,6 +56,7 @@ public:
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
+  virtual const void GetSlaveControlsIDs(std::vector<int>& controlIDs) const;
 
   virtual unsigned int GetRows() const;
 

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -52,6 +52,8 @@ CGUIControl::CGUIControl()
   m_bInvalidated = true;
   m_bAllocated=false;
   m_parentControl = NULL;
+  m_slaveControls = NULL;
+  m_masterControl = NULL;
   m_hasCamera = false;
   m_pushedUpdates = false;
   m_pulseOnSelect = false;
@@ -80,6 +82,8 @@ CGUIControl::CGUIControl(int parentID, int controlID, float posX, float posY, fl
   m_bAllocated=false;
   m_hasRendered = false;
   m_parentControl = NULL;
+  m_slaveControls = NULL;
+  m_masterControl = NULL;
   m_hasCamera = false;
   m_pushedUpdates = false;
   m_pulseOnSelect = false;
@@ -88,7 +92,7 @@ CGUIControl::CGUIControl(int parentID, int controlID, float posX, float posY, fl
 
 CGUIControl::~CGUIControl(void)
 {
-
+  delete m_slaveControls;
 }
 
 void CGUIControl::AllocResources()
@@ -930,4 +934,26 @@ CPoint CGUIControl::GetRenderPosition() const
   if (m_parentControl)
     point += m_parentControl->GetRenderPosition();
   return point;
+}
+
+void CGUIControl::AddSlaveControl(CGUIControl *control)
+{
+  if (!control) return;
+  if (!m_slaveControls)
+    m_slaveControls = new vector<CGUIControl*>(); // lazy initialization
+
+  if (find(m_slaveControls->begin(), m_slaveControls->end(), control) == m_slaveControls->end())
+    m_slaveControls->push_back(control);
+
+  control->m_masterControl = this;
+}
+
+bool CGUIControl::IsSlaveControl() const
+{
+  return m_masterControl != NULL;
+}
+
+const vector<CGUIControl*>* CGUIControl::GetSlaveControls() const
+{
+  return m_slaveControls;
 }

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -233,6 +233,20 @@ public:
   CGUIControl *GetParentControl(void) const { return m_parentControl; };
   virtual void SaveStates(std::vector<CControlState> &states);
 
+  /*! \brief Set master-slave relation.
+   \param control Control that will be added as slave to current object, this automaticly set current object as master for param
+   */
+  void AddSlaveControl(CGUIControl *control);
+
+  // True if control has defined master control
+  bool IsSlaveControl() const;
+
+  // Get vector of slave controls
+  const std::vector<CGUIControl*>* GetSlaveControls() const;
+
+  // Method used to generate vector of slave controls IDs that is used to build master-slave relations during window loading
+  virtual const void GetSlaveControlsIDs(std::vector<int>& controlIDs) const {};
+
   enum GUICONTROLTYPES {
     GUICONTROL_UNKNOWN,
     GUICONTROL_BUTTON,
@@ -351,6 +365,9 @@ protected:
 
   bool  m_controlIsDirty;
   CRect m_renderRegion;         // In screen coordinates
+private:
+  std::vector<CGUIControl*>* m_slaveControls;
+  CGUIControl* m_masterControl;
 };
 
 #endif

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -101,18 +101,28 @@ void CGUIControlGroup::Process(unsigned int currentTime, CDirtyRegionList &dirty
 
   CRect rect;
   for (iControls it = m_children.begin(); it != m_children.end(); ++it)
-  {
-    CGUIControl *control = *it;
-    control->UpdateVisibility();
-    unsigned int oldDirty = dirtyregions.size();
-    control->DoProcess(currentTime, dirtyregions);
-    if (control->IsVisible() || (oldDirty != dirtyregions.size())) // visible or dirty (was visible?)
-      rect.Union(control->GetRenderRegion());
-  }
+    if (!(*it)->IsSlaveControl())
+      ProcessItem(currentTime, dirtyregions, *it, rect);
 
   g_graphicsContext.RestoreOrigin();
   CGUIControl::Process(currentTime, dirtyregions);
   m_renderRegion = rect;
+}
+
+void CGUIControlGroup::ProcessItem(unsigned int currentTime, CDirtyRegionList &dirtyregions, CGUIControl* control, CRect& rect)
+{
+  control->UpdateVisibility();
+  unsigned int oldDirty = dirtyregions.size();
+  control->DoProcess(currentTime, dirtyregions);
+  if (control->IsVisible() || (oldDirty != dirtyregions.size())) // visible or dirty (was visible?)
+    rect.Union(control->GetRenderRegion());
+
+  const vector<CGUIControl*>* slaves = control->GetSlaveControls();
+  if (slaves)
+  {
+    for (vector<CGUIControl*>::const_iterator it = slaves->begin() ; it != slaves->end() ; ++it)
+      ProcessItem(currentTime, dirtyregions, *it, rect);
+  }
 }
 
 void CGUIControlGroup::Render()

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -42,6 +42,7 @@ public:
   virtual CGUIControlGroup *Clone() const { return new CGUIControlGroup(*this); };
 
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
+  void ProcessItem(unsigned int currentTime, CDirtyRegionList &dirtyregions, CGUIControl* control, CRect& rect);
   virtual void Render();
   virtual bool OnAction(const CAction &action);
   virtual bool OnMessage(CGUIMessage& message);

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -207,6 +207,13 @@ bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
   return CGUIControlGroup::OnMessage(message);
 }
 
+const void CGUIControlGroupList::GetSlaveControlsIDs(std::vector<int>& controlIDs) const
+{
+  if (m_pageControl)
+    controlIDs.push_back(m_pageControl);
+  CGUIControl::GetSlaveControlsIDs(controlIDs);
+}
+
 void CGUIControlGroupList::ValidateOffset()
 {
   // calculate how many items we have on this page

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -46,6 +46,7 @@ public:
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnMessage(CGUIMessage& message);
+  virtual const void GetSlaveControlsIDs(std::vector<int>& controlIDs) const;
 
   virtual EVENT_RESULT SendMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual void UnfocusFromPoint(const CPoint &point);

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -282,6 +282,13 @@ void CGUITextBox::UpdatePageControl()
   }
 }
 
+const void CGUITextBox::GetSlaveControlsIDs(std::vector<int>& controlIDs) const
+{
+  if (m_pageControl)
+    controlIDs.push_back(m_pageControl);
+  CGUIControl::GetSlaveControlsIDs(controlIDs);
+}
+
 bool CGUITextBox::CanFocus() const
 {
   return false;

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -53,6 +53,7 @@ public:
   virtual void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
   virtual bool OnMessage(CGUIMessage& message);
+  virtual const void GetSlaveControlsIDs(std::vector<int>& controlIDs) const;
 
   void SetPageControl(int pageControl);
 

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -251,6 +251,7 @@ protected:
   MAPCONTROLSELECTEDEVENTS m_mapSelectedEvents;
 
   void LoadControl(TiXmlElement* pControl, CGUIControlGroup *pGroup);
+  void LoadControl(TiXmlElement* pControl, CGUIControlGroup *pGroup, std::map<int,CGUIControl*>& pendingSlavesMasterRelation);
 
 //#ifdef PRE_SKIN_VERSION_9_10_COMPATIBILITY
   void ChangeButtonToEdit(int id, bool singleLabel = false);


### PR DESCRIPTION
Issue: scrollbar A is never processed if in .xml it's placed before control, that uses A as page control. We can't reorder child list as this will affect render order too. Issue can be seen in confluence's filebrowser - scrolling through container doesn't trigger linked scrollbar to update nib position.

This adds master-slave relation in controls hierarchy. If control is slave to other control - it will be processed right after its master was processed.
