### PR TITLE
Modify CUtil::GetQualifiedFilename to not process URLs

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -402,7 +402,7 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
 
 void CUtil::GetQualifiedFilename(const CStdString &strBasePath, CStdString &strFilename)
 {
-  // If this is a URL like http://whatever just return as no change is needed
+  // Check if the filename is a fully qualified URL such as protocol://path/to/file
   CURL plItemUrl(strFilename);
   if (!plItemUrl.GetProtocol().IsEmpty())
     return;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -402,20 +402,19 @@ void CUtil::CleanString(const CStdString& strFileName, CStdString& strTitle, CSt
 
 void CUtil::GetQualifiedFilename(const CStdString &strBasePath, CStdString &strFilename)
 {
-  //Make sure you have a full path in the filename, otherwise adds the base path before.
+  // If this is a URL like http://whatever just return as no change is needed
   CURL plItemUrl(strFilename);
+  if (!plItemUrl.GetProtocol().IsEmpty())
+    return;
 
-  if (!plItemUrl.IsLocal())
-    return; // non-local path, don't do anything
-  else if (strFilename.size() > 1)
-  { // local path - see if it's fully qualified
+  // If the filename starts "x:" or "/" it's already fully qualified so return
+  if (strFilename.size() > 1)
 #ifdef _LINUX
     if ( (strFilename[1] == ':') || (strFilename[0] == '/') )
 #else
     if ( strFilename[1] == ':' )
 #endif
       return;
-  }
 
   // add to base path and then clean
   strFilename = URIUtils::AddFileToFolder(strBasePath, strFilename);


### PR DESCRIPTION
At the moment trying to play a stream like http://localhost/whatever fails because the stream is treated like a file name and the path to the strm file is prepended. This pull modifies CUtil::GetQualifiedFilename so it checks if it's argument is a URL, and if so it does not modify the URL.
