### PR TITLE
fix PresentBob - eliminate double wait till presentation time

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -599,7 +599,7 @@ void CXBMCRenderManager::Present()
   m_overlays.Render();
 
   /* wait for this present to be valid */
-  if(g_graphicsContext.IsFullScreenVideo())
+  if(g_graphicsContext.IsFullScreenVideo() && m_presentstep == PRESENT_IDLE)
     WaitPresentTime(m_presenttime);
 
   m_presentevent.Set();


### PR DESCRIPTION
When playing back interlaced material, the DVDPlayerVideo only outputs one frame with two fields. The renderer will use PresentBob two render two frames. The problem is that the DVDPlayerVideo sets the "end presentation" time to be the end of the full frame (i.e. the two fields). The renderer however did wait until that time for EACH field, which obviously causes stuttering. The attached fix is eliminating that problem by only waiting for the end present time when the render step is PRESENT_IDLE.
