### PR TITLE
fix info manager to display more accurate fps

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3630,7 +3630,7 @@ void CGUIInfoManager::Clear()
 void CGUIInfoManager::UpdateFPS()
 {
   m_frameCounter++;
-  unsigned int curTime = CTimeUtils::GetFrameTime();
+  unsigned int curTime = XbmcThreads::SystemClockMillis();
 
   float fTimeSpan = (float)(curTime - m_lastFPSTime);
   if (fTimeSpan >= 1000.0f)


### PR DESCRIPTION
Since the frame time smoother was recently introduced end of July, the fps value in the info manager (press "o") is inaccurate, as it uses an "estimated second" instead of real one.
