### PR TITLE
enable hardware decoding for DVDs

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2732,7 +2732,7 @@ bool CDVDPlayer::OpenVideoStream(int iStream, int source)
     float aspect = static_cast<CDVDInputStreamNavigator*>(m_pInputStream)->GetVideoAspectRatio();
     if(aspect != 0.0)
       hint.aspect = aspect;
-    hint.software = true;
+    hint.software = static_cast<CDVDInputStreamNavigator*>(m_pInputStream)->IsInMenu();
     hint.stills   = static_cast<CDVDInputStreamNavigator*>(m_pInputStream)->IsInMenu();
   }
 


### PR DESCRIPTION
Currently, DVDs are "forced" to be software decoded. Probably because of an old ffmpeg, but with the most recent version in master this works perfectly fine. Have tested many DVDs with this, it seems ok at least on Windows/DXVA. Note that this is not very practical until DXVA deinterlacing is merged in... (very soon!)
