### PR TITLE
build: fixed our soname version function to find libs outside of /usr/lib

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -20,10 +20,10 @@ AC_DEFUN([XB_FIND_SONAME],
 [
   if [[ "$host_vendor" != "apple" ]]; then
     AC_MSG_CHECKING([for lib$2 soname])
-    $1_SONAME=$( $CC -print-file-name=lib$2.so | \
-      while read output; do objdump -p $output | \
-        grep "SONAME" | \
-        sed -e 's/  *SONAME  *//'; done 2> /dev/null )
+    $1_FILENAME=$($LD $LDFLAGS -l$2 -M -o /dev/null 2>/dev/null | grep "^LOAD.*$2" | awk '{V=2; print $V}')
+    if [[ ! -z $$1_FILENAME ]]; then
+      $1_SONAME=$(objdump -p $$1_FILENAME | grep "SONAME.*$2" | awk '{V=2; print $V}')
+    fi
   else
     AC_MSG_CHECKING([for lib$2 dylib])
     gcc_lib_path=[`$CC -print-search-dirs 2>/dev/null | fgrep libraries: | sed 's/[^=]*=\(.*\)/\1/' | sed 's/:/ /g'`]


### PR DESCRIPTION
build: fixed our soname version function to find libs outside of /usr/lib

previously, we were only able to determine the sonames of libs in gcc's
default search paths. Instead, we should be using linker paths since it's
next to impossible to change where gcc looks. Use ld's paths instead for
consistency.

There are two primary reasons for this change:
1. Allow the use of libs in /usr/local, or anywhere else libs may be configured
2. Simplify cross builds where libs may be coming from a staging dir.

In the 2nd case, adding a path to LDFLAGS means that we'll be able to find the
SONAME.

This works by doing a dumb "link" on the libname, so it uses the same mechanism
as our dyloader.

@cptspiff @althekiller @davilla @fneufneu I would appreciate your thoughts before merging this.

It's a subtle change, but one that could impact many builders. I don't like the reliance on gnu ld's output, though I suppose it's a reasonable trade from gcc's. It also (ab)uses ld, but this is the only approach that I could come up with that doesn't make any assumptions other than a working ld itself.

A simple testcase to see what's going on more clearly:

```
$ ld -lX11 -M -o /dev/null
...
LOAD /usr/lib/x86_64-linux-gnu/libX11.so
...
```

The objdump is the same as before.
