### PR TITLE
Fix includes in VS project file for libcmyth

### DIFF
--- a/lib/cmyth/Win32/libcmyth.vcproj
+++ b/lib/cmyth/Win32/libcmyth.vcproj
@@ -42,7 +42,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="..;../include;include;../librefmem;../libcmyth;../../../win32"
+				AdditionalIncludeDirectories="..;../include;include;../librefmem;../libcmyth"
 				PreprocessorDefinitions="WIN32;DEBUG;_LIB;inline=__inline; _CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -120,7 +120,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalIncludeDirectories="..;../include;include;../librefmem;../libcmyth;../../../win32"
+				AdditionalIncludeDirectories="..;../include;include;../librefmem;../libcmyth"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;inline=__inline; _CRT_SECURE_NO_WARNINGS"
 				RuntimeLibrary="2"
 				UsePrecompiledHeader="0"

--- a/lib/cmyth/Win32/libcmyth.vcxproj
+++ b/lib/cmyth/Win32/libcmyth.vcxproj
@@ -53,7 +53,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..;../include;include;../librefmem;../libcmyth;../../../win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;../include;include;../librefmem;../libcmyth;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;DEBUG;_LIB;inline=__inline; _CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -93,7 +93,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..;../include;include;../librefmem;../libcmyth;../../../win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;../include;include;../librefmem;../libcmyth;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;inline=__inline; _CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>


### PR DESCRIPTION
Remove the reference to the XBMC win32 include folder since the required inttypes.h file is in the cmyth/win32/include directory now.

Can someone with Visual Studio test that this fix works. The required inttypes.h file is in a folder that was already in the includes path via the existing "include" reference. Nothing should be needed from the xbmc/win32 folder.
