### PR TITLE
update current position in CPlayListPlayer on Remove() and Insert()

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -583,6 +583,8 @@ void CPlayListPlayer::Insert(int iPlaylist, CPlayList& playlist, int iIndex)
   list.Insert(playlist, iIndex);
   if (list.IsShuffled())
     ReShuffle(iPlaylist, iSize);
+  else if (m_iCurrentPlayList == iPlaylist && m_iCurrentSong >= iIndex)
+    m_iCurrentSong++;
 }
 
 void CPlayListPlayer::Insert(int iPlaylist, const CFileItemPtr &pItem, int iIndex)
@@ -594,6 +596,8 @@ void CPlayListPlayer::Insert(int iPlaylist, const CFileItemPtr &pItem, int iInde
   list.Insert(pItem, iIndex);
   if (list.IsShuffled())
     ReShuffle(iPlaylist, iSize);
+  else if (m_iCurrentPlayList == iPlaylist && m_iCurrentSong >= iIndex)
+    m_iCurrentSong++;
 }
 
 void CPlayListPlayer::Insert(int iPlaylist, CFileItemList& items, int iIndex)
@@ -605,6 +609,8 @@ void CPlayListPlayer::Insert(int iPlaylist, CFileItemList& items, int iIndex)
   list.Insert(items, iIndex);
   if (list.IsShuffled())
     ReShuffle(iPlaylist, iSize);
+  else if (m_iCurrentPlayList == iPlaylist && m_iCurrentSong >= iIndex)
+    m_iCurrentSong++;
 }
 
 void CPlayListPlayer::Remove(int iPlaylist, int iPosition)
@@ -613,6 +619,8 @@ void CPlayListPlayer::Remove(int iPlaylist, int iPosition)
     return;
   CPlayList& list = GetPlaylist(iPlaylist);
   list.Remove(iPosition);
+  if (m_iCurrentPlayList == iPlaylist && m_iCurrentSong >= iPosition)
+    m_iCurrentSong--;
 
   // its likely that the playlist changed
   CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -2023,18 +2023,7 @@ int CXbmcHttp::xbmcRemoveFromPlayList(int numParas, CStdString paras[])
       return SetResponse(openTag+"Error:Can't remove current playing song");
     if (itemToRemove<0 || itemToRemove>=g_playlistPlayer.GetPlaylist(iPlaylist).size())
       return SetResponse(openTag+"Error:Item not found or parameter out of range");
-    g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC).Remove(itemToRemove);
-
-    // Correct the current playing song in playlistplayer
-    if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC && g_application.IsPlayingAudio())
-    {
-      int iCurrentSong = g_playlistPlayer.GetCurrentSong();
-      if (itemToRemove <= iCurrentSong)
-      {
-        iCurrentSong--;
-        g_playlistPlayer.SetCurrentSong(iCurrentSong);
-      }
-    }
+    g_playlistPlayer.Remove(PLAYLIST_MUSIC, itemToRemove);
     return SetResponse(openTag+"OK");
   }
   else

--- a/xbmc/interfaces/json-rpc/AVPlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AVPlaylistOperations.cpp
@@ -141,7 +141,12 @@ JSON_STATUS CAVPlaylistOperations::Insert(const CStdString &method, ITransportLa
 
 JSON_STATUS CAVPlaylistOperations::Remove(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  g_application.getApplicationMessenger().PlayListPlayerRemove(GetPlaylist(method), (int)parameterObject["item"].asInteger());
+  int playlist = GetPlaylist(method);
+  int item = (int)parameterObject["item"].asInteger();
+  if (g_playlistPlayer.GetCurrentPlaylist() == playlist && item == g_playlistPlayer.GetCurrentSong())
+    return InvalidParams;
+
+  g_application.getApplicationMessenger().PlayListPlayerRemove(playlist, item);
 
   NotifyAll();
   return ACK;

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -346,18 +346,7 @@ void CGUIWindowMusicPlayList::RemovePlayListItem(int iItem)
       && g_playlistPlayer.GetCurrentSong() == iItem)
     return ;
 
-  g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC).Remove(iItem);
-
-  // Correct the current playing song in playlistplayer
-  if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_MUSIC && g_application.IsPlayingAudio())
-  {
-    int iCurrentSong = g_playlistPlayer.GetCurrentSong();
-    if (iItem <= iCurrentSong)
-    {
-      iCurrentSong--;
-      g_playlistPlayer.SetCurrentSong(iCurrentSong);
-    }
-  }
+  g_playlistPlayer.Remove(PLAYLIST_MUSIC, iItem);
 
   Update(m_vecItems->GetPath());
 

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -344,18 +344,7 @@ void CGUIWindowVideoPlaylist::RemovePlayListItem(int iItem)
       && g_playlistPlayer.GetCurrentSong() == iItem)
     return ;
 
-  g_playlistPlayer.GetPlaylist(PLAYLIST_VIDEO).Remove(iItem);
-
-  // Correct the current playing song in playlistplayer
-  if (g_playlistPlayer.GetCurrentPlaylist() == PLAYLIST_VIDEO && g_application.IsPlayingVideo())
-  {
-    int iCurrentSong = g_playlistPlayer.GetCurrentSong();
-    if (iItem <= iCurrentSong)
-    {
-      iCurrentSong--;
-      g_playlistPlayer.SetCurrentSong(iCurrentSong);
-    }
-  }
+  g_playlistPlayer.Remove(PLAYLIST_VIDEO, iItem);
 
   Update(m_vecItems->GetPath());
 


### PR DESCRIPTION
This commit adds the logic of updating the position of the currently playing item in a playlist into CPlaylistPlayer::Remove() and ::Insert() instead of having to do it manually everytime one of these actions are executed. This removes some duplicate code and fixes http://trac.xbmc.org/ticket/11763.
