### PR TITLE
Skin variables - first attempt

### DIFF
--- a/addons/skin.confluence/720p/IncludesCodecFlagging.xml
+++ b/addons/skin.confluence/720p/IncludesCodecFlagging.xml
@@ -1,4 +1,23 @@
 <includes>
+  <variable name="typehackflagging">
+    <value condition="[substring(ListItem.FilenameAndPath,bluray) | substring(ListItem.FilenameAndPath,bdrip)]">bluray</value>
+    <value condition="substring(ListItem.FilenameAndPath,hddvd)">hddvd</value>
+    <value condition="substring(ListItem.FilenameAndPath,dvd)">dvd</value>
+    <value condition="[substring(ListItem.FilenameAndPath,pdtv) | substring(ListItem.FilenameAndPath,hdtv) | substring(ListItem.FilenameAndPath,dsr)]">TV</value>
+    <value condition="substring(ListItem.FilenameAndPath,vhs)">vhs</value>
+  </variable>
+  <variable name="rating">
+    <value condition="substring(listitem.mpaa,Rated G)">mpaa_general</value>
+    <value condition="substring(listitem.mpaa,Rated PG) + !substring(listitem.mpaa,Rated PG-13)">mpaa_pg</value>
+    <value condition="substring(listitem.mpaa,Rated PG-13)">mpaa_pg13</value>
+    <value condition="substring(Listitem.mpaa,Rated R)">mpaa_restricted</value>
+    <value condition="substring(Listitem.mpaa,Rated NC)">mpaa_nc17</value>
+  </variable>
+  <variable name="videocodec">
+    <value condition="[substring(ListItem.VideoCodec,div,left) | stringcompare(ListItem.VideoCodec,dx50)]">divx</value>
+    <value>$INFO[ListItem.VideoCodec]</value>
+  </variable>
+
 	<include name="VideoCodecFlaggingConditions">
 		<control type="image">
 			<description>Video rez Image</description>
@@ -8,105 +27,30 @@
 			<texture>$INFO[ListItem.VideoResolution,flagging/video/,.png]</texture>
 		</control>
 		<control type="image">
-			<description>Common Codec Image</description>
+			<description>Codec Image</description>
 			<width>80</width>
 			<height>35</height>
 			<aspectratio align="left">keep</aspectratio>
-			<texture>$INFO[ListItem.VideoCodec,flagging/video/,.png]</texture>
-			<!-- Don't show if its one of the 500 divx codecs -->
-			<visible>![substring(ListItem.VideoCodec,div,left) | stringcompare(ListItem.VideoCodec,dx50)]</visible>
-		</control>
-		<control type="image">
-			<description>Divx Codec Image</description>
-			<width>80</width>
-			<height>35</height>
-			<aspectratio align="left">keep</aspectratio>
-			<texture>flagging/video/divx.png</texture>
-			<visible>[substring(ListItem.VideoCodec,div,left) | stringcompare(ListItem.VideoCodec,dx50)]</visible>
+			<texture>$VAR[videocodec,flagging/video/,.png]</texture>
 		</control>
 	</include>
 	<include name="VideoTypeHackFlaggingConditions">
 		<control type="image">
-			<description>Bluray Image</description>
+			<description>Video Type Image</description>
 			<width>80</width>
 			<height>35</height>
 			<aspectratio align="left">keep</aspectratio>
-			<texture>flagging/video/bluray.png</texture>
-			<visible>[substring(ListItem.FilenameAndPath,bluray) | substring(ListItem.FilenameAndPath,bdrip)] + !Skin.HasSetting(HideFilenameFlagging)</visible>
-		</control>
-		<control type="image">
-			<description>HDDVD Image</description>
-			<width>80</width>
-			<height>35</height>
-			<aspectratio align="left">keep</aspectratio>
-			<texture>flagging/video/hddvd.png</texture>
-			<visible>substring(ListItem.FilenameAndPath,hddvd) + !Skin.HasSetting(HideFilenameFlagging)</visible>
-		</control>
-		<control type="image">
-			<description>DVD Image</description>
-			<width>80</width>
-			<height>35</height>
-			<aspectratio align="left">keep</aspectratio>
-			<texture>flagging/video/dvd.png</texture>
-			<visible>[substring(ListItem.FilenameAndPath,dvd) + ![substring(ListItem.FilenameAndPath,hddvd) | substring(ListItem.FilenameAndPath,bluray) | substring(ListItem.FilenameAndPath,bdrip)]] + !Skin.HasSetting(HideFilenameFlagging)</visible>
-		</control>
-		<control type="image">
-			<description>TV Types Image</description>
-			<width>80</width>
-			<height>35</height>
-			<aspectratio align="left">keep</aspectratio>
-			<texture>flagging/video/TV.png</texture>
-			<visible>[substring(ListItem.FilenameAndPath,pdtv) | substring(ListItem.FilenameAndPath,hdtv) | substring(ListItem.FilenameAndPath,dsr)] + !Skin.HasSetting(HideFilenameFlagging)</visible>
-		</control>
-		<control type="image">
-			<description>VHS Image</description>
-			<width>80</width>
-			<height>35</height>
-			<aspectratio align="left">keep</aspectratio>
-			<texture>flagging/video/vhs.png</texture>
-			<visible>substring(ListItem.FilenameAndPath,vhs) + !Skin.HasSetting(HideFilenameFlagging)</visible>
+			<texture>$VAR[typehackflagging,flagging/video/,.png]</texture>
+			<visible>!Skin.HasSetting(HideFilenameFlagging)</visible>
 		</control>
 	</include>
 	<include name="VideoMPAAFlaggingConditions">
 		<control type="image">
-			<description>Rated G</description>
+			<description>Rating image</description>
 			<width>80</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
-			<texture>flagging/ratings/mpaa_general.png</texture>
-			<visible>substring(listitem.mpaa,Rated G)</visible>
-		</control>
-		<control type="image">
-			<description>Rated PG</description>
-			<width>80</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>flagging/ratings/mpaa_pg.png</texture>
-			<visible>substring(listitem.mpaa,Rated PG) + !substring(listitem.mpaa,Rated PG-13)</visible>
-		</control>
-		<control type="image">
-			<description>Rated PG-13</description>
-			<width>80</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>flagging/ratings/mpaa_pg13.png</texture>
-			<visible>substring(listitem.mpaa,Rated PG-13)</visible>
-		</control>
-		<control type="image">
-			<description>Rated R</description>
-			<width>80</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>flagging/ratings/mpaa_restricted.png</texture>
-			<visible>substring(Listitem.mpaa,Rated R)</visible>
-		</control>
-		<control type="image">
-			<description>Rated NC-17</description>
-			<width>80</width>
-			<height>35</height>
-			<aspectratio>keep</aspectratio>
-			<texture>flagging/ratings/mpaa_nc17.png</texture>
-			<visible>substring(Listitem.mpaa,Rated NC)</visible>
+			<texture>$VAR[rating,flagging/ratings/,.png]</texture>
 		</control>
 	</include>
 	<include name="AudioCodecFlaggingConditions">

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -462,6 +462,7 @@
     <ClCompile Include="..\..\xbmc\interfaces\http-api\HttpApi.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\http-api\XBMChttp.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\info\InfoBool.cpp" />
+    <ClCompile Include="..\..\xbmc\interfaces\info\SkinVariable.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\json-rpc\ApplicationOperations.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\json-rpc\AudioLibrary.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\json-rpc\FileItemHandler.cpp" />
@@ -1387,6 +1388,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\http-api\XBMChttp.h" />
     <ClInclude Include="..\..\xbmc\interfaces\IAnnouncer.h" />
     <ClInclude Include="..\..\xbmc\interfaces\info\InfoBool.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\info\SkinVariable.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\ApplicationOperations.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\AudioLibrary.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\FileItemHandler.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2502,6 +2502,9 @@
     <ClCompile Include="..\..\xbmc\cores\paplayer\BXAcodec.cpp">
       <Filter>cores\paplayer</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\info\SkinVariable.cpp">
+      <Filter>interfaces\info</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5026,6 +5029,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\paplayer\BXAcodec.h">
       <Filter>cores\paplayer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\interfaces\info\SkinVariable.h">
+      <Filter>interfaces\info</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3668,6 +3668,8 @@ void CGUIInfoManager::Clear()
   for (unsigned int i = 0; i < m_bools.size(); ++i)
     delete m_bools[i];
   m_bools.clear();
+
+  m_skinVariableStrings.clear();
 }
 
 void CGUIInfoManager::UpdateFPS()
@@ -4479,4 +4481,37 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
             GetLibraryBool(LIBRARY_HAS_MUSICVIDEOS));
   }
   return false;
+}
+
+int CGUIInfoManager::RegisterSkinVariableString(const CSkinVariableString& info)
+{
+  CSingleLock lock(m_critInfo);
+  int id = TranslateSkinVariableString(info.GetName());
+  if (id != 0)
+    return id;
+
+  m_skinVariableStrings.push_back(info);
+  return CONDITIONAL_LABEL_START + m_skinVariableStrings.size() - 1;
+}
+
+int CGUIInfoManager::TranslateSkinVariableString(const CStdString& name)
+{
+  for (vector<CSkinVariableString>::const_iterator it = m_skinVariableStrings.begin();
+       it != m_skinVariableStrings.end(); ++it)
+  {
+    if (it->GetName().Equals(name))
+      return it - m_skinVariableStrings.begin() + CONDITIONAL_LABEL_START;
+  }
+  return 0;
+}
+
+CStdString CGUIInfoManager::GetSkinVariableString(int info, int contextWindow, 
+                                                  bool preferImage /*= false*/,
+                                                  const CGUIListItem *item /*= NULL*/)
+{
+  info -= CONDITIONAL_LABEL_START;
+  if (info >= 0 && info < (int)m_skinVariableStrings.size())
+    return m_skinVariableStrings[info].GetValue(contextWindow, preferImage, item);
+
+  return "";
 }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1045,6 +1045,9 @@ TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const CStdString &format)
 
 CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
 {
+  if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
+    return GetSkinVariableString(info, contextWindow, false);
+
   CStdString strLabel;
   if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
     return GetMultiInfoLabel(m_multiInfo[info - MULTI_INFO_START], contextWindow);
@@ -2602,7 +2605,7 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const GUIInfo &info, int conte
 }
 
 /// \brief Examines the multi information sent and returns the string as appropriate
-CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWindow) const
+CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWindow)
 {
   if (info.m_info == SKIN_STRING)
   {
@@ -2784,6 +2787,9 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
 /// \brief Obtains the filename of the image to show from whichever subsystem is needed
 CStdString CGUIInfoManager::GetImage(int info, int contextWindow)
 {
+  if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
+    return GetSkinVariableString(info, contextWindow, false);
+
   if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
   {
     return GetMultiInfoLabel(m_multiInfo[info - MULTI_INFO_START], contextWindow);
@@ -3032,7 +3038,7 @@ CStdString CGUIInfoManager::GetMusicPartyModeLabel(int item)
   return "";
 }
 
-const CStdString CGUIInfoManager::GetMusicPlaylistInfo(const GUIInfo& info) const
+const CStdString CGUIInfoManager::GetMusicPlaylistInfo(const GUIInfo& info)
 {
   PLAYLIST::CPlayList& playlist = g_playlistPlayer.GetPlaylist(PLAYLIST_MUSIC);
   if (playlist.size() < 1)
@@ -3184,7 +3190,7 @@ CStdString CGUIInfoManager::GetMusicLabel(int item)
   return GetMusicTagLabel(item, m_currentFile);
 }
 
-CStdString CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item) const
+CStdString CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item)
 {
   if (!item->HasMusicInfoTag()) return "";
   const CMusicInfoTag &tag = *item->GetMusicInfoTag();
@@ -3758,9 +3764,12 @@ bool CGUIInfoManager::GetItemInt(int &value, const CGUIListItem *item, int info)
   return false;
 }
 
-CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info) const
+CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info)
 {
   if (!item) return "";
+
+  if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
+    return GetSkinVariableString(info, 0, false, item);
 
   if (info >= LISTITEM_PROPERTY_START && info - LISTITEM_PROPERTY_START < (int)m_listitemProperties.size())
   { // grab the property
@@ -4143,8 +4152,11 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info) const
   return "";
 }
 
-CStdString CGUIInfoManager::GetItemImage(const CFileItem *item, int info) const
+CStdString CGUIInfoManager::GetItemImage(const CFileItem *item, int info)
 {
+  if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
+    return GetSkinVariableString(info, 0, false, item);
+
   switch (info)
   {
   case LISTITEM_RATING:  // old song rating format
@@ -4258,7 +4270,7 @@ void CGUIInfoManager::UpdateFromTuxBox()
   }
 }
 
-CStdString CGUIInfoManager::GetPictureLabel(int info) const
+CStdString CGUIInfoManager::GetPictureLabel(int info)
 {
   if (info == SLIDE_FILE_NAME)
     return GetItemLabel(m_currentSlide, LISTITEM_FILENAME);

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -616,12 +616,12 @@ public:
   const CVideoInfoTag* GetCurrentMovieTag() const;
 
   CStdString GetMusicLabel(int item);
-  CStdString GetMusicTagLabel(int info, const CFileItem *item) const;
+  CStdString GetMusicTagLabel(int info, const CFileItem *item);
   CStdString GetVideoLabel(int item);
   CStdString GetPlaylistLabel(int item) const;
   CStdString GetMusicPartyModeLabel(int item);
-  const CStdString GetMusicPlaylistInfo(const GUIInfo& info) const;
-  CStdString GetPictureLabel(int item) const;
+  const CStdString GetMusicPlaylistInfo(const GUIInfo& info);
+  CStdString GetPictureLabel(int item);
 
   __int64 GetPlayTime() const;  // in ms
   CStdString GetCurrentPlayTime(TIME_FORMAT format = TIME_FORMAT_GUESS) const;
@@ -652,8 +652,8 @@ public:
 
   void ResetCache();
   bool GetItemInt(int &value, const CGUIListItem *item, int info) const;
-  CStdString GetItemLabel(const CFileItem *item, int info) const;
-  CStdString GetItemImage(const CFileItem *item, int info) const;
+  CStdString GetItemLabel(const CFileItem *item, int info);
+  CStdString GetItemImage(const CFileItem *item, int info);
 
   // Called from tuxbox service thread to update current status
   void UpdateFromTuxBox();
@@ -704,7 +704,7 @@ protected:
 
   bool GetMultiInfoBool(const GUIInfo &info, int contextWindow = 0, const CGUIListItem *item = NULL);
   bool GetMultiInfoInt(int &value, const GUIInfo &info, int contextWindow = 0) const;
-  CStdString GetMultiInfoLabel(const GUIInfo &info, int contextWindow = 0) const;
+  CStdString GetMultiInfoLabel(const GUIInfo &info, int contextWindow = 0);
   int TranslateListItem(const Property &info);
   int TranslateMusicPlayerString(const CStdString &info) const;
   TIME_FORMAT TranslateTimeFormat(const CStdString &format);

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -32,6 +32,7 @@
 #include "guilib/IMsgTargetCallback.h"
 #include "inttypes.h"
 #include "XBDateTime.h"
+#include "interfaces/info/SkinVariable.h"
 
 #include <list>
 #include <map>
@@ -492,6 +493,9 @@ namespace INFO
 
 #define MUSICPLAYER_PROPERTY_OFFSET 900 // last 100 id's reserved for musicplayer props.
 
+#define CONDITIONAL_LABEL_START       LISTITEM_END + 1 // 36001
+#define CONDITIONAL_LABEL_END         37000
+
 // the multiple information vector
 #define MULTI_INFO_START              40000
 #define MULTI_INFO_END                99999
@@ -672,6 +676,9 @@ public:
 
   int TranslateSingleString(const CStdString &strCondition);
 
+  int RegisterSkinVariableString(const INFO::CSkinVariableString& info);
+  int TranslateSkinVariableString(const CStdString& name);
+  CStdString GetSkinVariableString(int info, int contextWindow, bool preferImage = false, const CGUIListItem *item=NULL);
 protected:
   friend class INFO::InfoSingle;
   bool GetBool(int condition, int contextWindow = 0, const CGUIListItem *item=NULL);
@@ -763,6 +770,7 @@ protected:
   int m_prevWindowID;
 
   std::vector<INFO::InfoBool*> m_bools;
+  std::vector<INFO::CSkinVariableString> m_skinVariableStrings;
   unsigned int m_updateTime;
 
   int m_libraryHasMusic;

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -25,6 +25,7 @@
 #include "utils/log.h"
 #include "tinyXML/tinyxml.h"
 #include "utils/StringUtils.h"
+#include "interfaces/info/SkinVariable.h"
 
 using namespace std;
 
@@ -151,6 +152,9 @@ bool CGUIIncludes::LoadIncludesFromXML(const TiXmlElement *root)
     }
     node = node->NextSiblingElement("constant");
   }
+
+  INFO::CSkinVariable::LoadFromXML(root);
+
   return true;
 }
 

--- a/xbmc/interfaces/info/Makefile
+++ b/xbmc/interfaces/info/Makefile
@@ -1,4 +1,5 @@
 SRCS=InfoBool.cpp \
+     SkinVariable.cpp \
      
 LIB=info.a
 

--- a/xbmc/interfaces/info/SkinVariable.cpp
+++ b/xbmc/interfaces/info/SkinVariable.cpp
@@ -1,0 +1,52 @@
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "SkinVariable.h"
+#include "GUIInfoManager.h"
+
+using namespace std;
+using namespace INFO;
+
+#define DEFAULT_VALUE -1
+
+CSkinVariableString::CSkinVariableString()
+{
+}
+
+const CStdString& CSkinVariableString::GetName() const
+{
+  return m_name;
+}
+
+CStdString CSkinVariableString::GetValue(int contextWindow, bool preferImage /* = false*/, const CGUIListItem *item /* = NULL */)
+{
+  for (VECCONDITIONLABELPAIR::const_iterator it = m_conditionLabelPairs.begin() ; it != m_conditionLabelPairs.end(); it++)
+  {
+    if (it->m_condition == DEFAULT_VALUE || g_infoManager.GetBoolValue(it->m_condition, item))
+    {
+      if (item)
+        return it->m_label.GetItemLabel(item, preferImage);
+      else
+        return it->m_label.GetLabel(contextWindow, preferImage);
+    }
+  }
+  return "";
+}

--- a/xbmc/interfaces/info/SkinVariable.cpp
+++ b/xbmc/interfaces/info/SkinVariable.cpp
@@ -21,11 +21,52 @@
 
 #include "SkinVariable.h"
 #include "GUIInfoManager.h"
+#include "tinyXML/tinyxml.h"
 
 using namespace std;
 using namespace INFO;
 
 #define DEFAULT_VALUE -1
+
+void CSkinVariable::LoadFromXML(const TiXmlElement *root)
+{
+  const TiXmlElement* node = root->FirstChildElement("variable");
+  while (node)
+  {
+    if (node->Attribute("name") && node->FirstChild())
+    {
+      const char* type = node->Attribute("type");
+
+      // parameter type will be used in future for numeric and bool variables
+      if (!type || strnicmp(type, "text", 4) == 0)
+      {
+        CSkinVariableString tmp;
+        tmp.m_name = node->Attribute("name");
+        const TiXmlElement* valuenode = node->FirstChildElement("value");
+        while (valuenode)
+        {
+          if (valuenode->FirstChild())
+          {
+            CSkinVariableString::ConditionLabelPair pair;
+            if (valuenode->Attribute("condition"))
+              pair.m_condition = g_infoManager.Register(valuenode->Attribute("condition"));
+            else
+              pair.m_condition = DEFAULT_VALUE;
+
+            pair.m_label = CGUIInfoLabel(valuenode->FirstChild()->Value());
+            tmp.m_conditionLabelPairs.push_back(pair);
+            if (pair.m_condition == DEFAULT_VALUE)
+              break; // once we reach default value (without condition) break iterating
+          }
+          valuenode = valuenode->NextSiblingElement("value");
+        }
+        if (tmp.m_conditionLabelPairs.size() > 0)
+          g_infoManager.RegisterSkinVariableString(tmp);
+      }
+    }
+    node = node->NextSiblingElement("variable");
+  }
+}
 
 CSkinVariableString::CSkinVariableString()
 {

--- a/xbmc/interfaces/info/SkinVariable.h
+++ b/xbmc/interfaces/info/SkinVariable.h
@@ -1,0 +1,47 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "guilib/GUIInfoTypes.h"
+
+namespace INFO
+{
+class CSkinVariableString
+{
+public:
+  const CStdString& GetName() const;
+  CStdString GetValue(int contextWindow, bool preferImage = false, const CGUIListItem *item = NULL );
+private:
+  CSkinVariableString();
+
+  CStdString m_name;
+
+  struct ConditionLabelPair
+  {
+    int m_condition;
+    CGUIInfoLabel m_label;
+  };
+
+  typedef std::vector<ConditionLabelPair> VECCONDITIONLABELPAIR;
+  VECCONDITIONLABELPAIR m_conditionLabelPairs;
+};
+
+}

--- a/xbmc/interfaces/info/SkinVariable.h
+++ b/xbmc/interfaces/info/SkinVariable.h
@@ -22,8 +22,16 @@
 
 #include "guilib/GUIInfoTypes.h"
 
+class TiXmlElement;
+
 namespace INFO
 {
+class CSkinVariable
+{
+public:
+  static void LoadFromXML(const TiXmlElement *root);
+};
+
 class CSkinVariableString
 {
 public:
@@ -42,6 +50,8 @@ private:
 
   typedef std::vector<ConditionLabelPair> VECCONDITIONLABELPAIR;
   VECCONDITIONLABELPAIR m_conditionLabelPairs;
+
+  friend class CSkinVariable;
 };
 
 }


### PR DESCRIPTION
This is very first attempt at implementing long talked skin variables. It's not yet finished - some null checks are missing, new class/methods aren't yet documented. Reason I posted this PR is to present direction I took and get feedback from anyone interested in this.

Whole idea is pretty straight-forward: allow defining custom "infolabels" - skin variables to avoid duplicating similiar controls that differs only by visibility condition and label/texture (see initial support in confluence commit)
