### PR TITLE
Move airplay setting above zeroconf as it reads better

### DIFF
--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -705,13 +705,13 @@ void CGUISettings::Initialize()
   AddInt(NULL,   "services.esinitialdelay",    795, 750, 5, 5, 10000, SPIN_CONTROL_INT);
   AddInt(NULL,   "services.escontinuousdelay", 796, 25, 5, 5, 10000, SPIN_CONTROL_INT);
 #endif
-#ifdef HAS_ZEROCONF
-  AddSeparator(srv, "services.sep2");
-  AddBool(srv, "services.zeroconf", 1260, true);
-#endif
-
 #ifdef HAS_AIRPLAY
+  AddSeparator(srv, "services.sep2");
   AddBool(srv, "services.airplay", 1270, false);
+#endif
+#ifdef HAS_ZEROCONF
+  AddSeparator(srv, "services.sep3");
+  AddBool(srv, "services.zeroconf", 1260, true);
 #endif
 
 #ifndef _WIN32


### PR DESCRIPTION
Well first I'd like to begin with that I have never tried airplay or know much about it, I mostly did this pull request as it might serve as a good place to discuss this. Anyways I started up xbmc and did some configurations and the order of the settings in network made me question the interpretation of what affects what. Current order is first a bunch of services, then zeroconf setting and then airplay. If airplay is underneath (and not grouped with the other services) I immediately wondered if airplay don't use zeroconf (which goes against what I know?) or wasn't affected by the setting.

So I guess the discussion I want to start here is a) is zeroconf setting in gui affecting airplay b) Should it
I'm guessing airplay does use zeroconf (as most apple stuff does afaik?) but I couldn't find any reference in code about it being registered on our zeroconf handler. So if it isn't affected and have internal, is that a good thing? makes the control a bit inconsistent? If a) I think this patch reads better and should be applied. if b) is decided that the setting shouldn't affect airplay (which makes sense it doesn't as airplay is rather useless without zeroconf I bet.) then perhaps we simply should rename the setting string.

For those wondering the setting string is "Announce these services to other systems via Zeroconf" the use of "these" makes me think its the above, the below or all. When I read this in the settings window and its not obvious I get confused, which I would assume others do aswell :) So we could move zeroconf configuration up to top or continue to have it in bottom. Another option would be alter the setting string, something I'm not sure what to relabel it as. Something which makes it obvious that only non-standard or non-forced services are announced (i.e. airplay always announce)
