### PR TITLE
Add key mapping for equals to VolumeUp

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -68,6 +68,7 @@
       <s mod="ctrl">Screenshot</s>
       <minus>VolumeDown</minus>
       <plus>VolumeUp</plus>
+      <equals>VolumeUp</equals>
       <zero>Number0</zero>
       <one>Number1</one>
       <two>Number2</two>


### PR DESCRIPTION
On UK and US keyboards the equals/plus key has traditionally been used for VolumeUp. With the rewrite of the key handling code XBMC can now tell the difference between equals and plus (i.e. shift-equals) so pressing the equals key no longer executes VolumeUp. This patch restores the original behaviour.

On most keyboards equals either shares a key with plus or it's shift-zero, so this shouldn't cause problems for most international users.
