### PR TITLE
Make half rate yadif deinterlacing the setting for "Automatic"

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -509,7 +509,7 @@ void CDVDPlayerVideo::Process()
       else if(mInt == VS_INTERLACEMETHOD_DEINTERLACE_HALF)
         mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY | CDVDVideoCodec::FILTER_DEINTERLACE_HALFED;
       else if(mInt == VS_INTERLACEMETHOD_AUTO && !g_renderManager.Supports(VS_INTERLACEMETHOD_DXVA_ANY))
-        mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY | CDVDVideoCodec::FILTER_DEINTERLACE_FLAGGED;
+        mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY | CDVDVideoCodec::FILTER_DEINTERLACE_HALFED | CDVDVideoCodec::FILTER_DEINTERLACE_FLAGGED;
 
       mFilters = m_pVideoCodec->SetFilters(mFilters);
 


### PR DESCRIPTION
Rationale is that full yadif (the frame doubler) has better quality but does chop playback on low powered Atoms. Many people will just leave the setting to "automatic" so this should work on all platforms. Those with strong CPUs can still choose the better deinterlacer manually.
