### PR TITLE
Split the deinterlacing setting in off/auto/on and a deinterlace method

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1475,7 +1475,7 @@
   <string id="16020">De-interlace</string>
   <string id="16021">Bob</string>
   <string id="16022">Bob (inverted)</string>
-  <string id="16023">Interlaced handling</string>
+  <string id="16023"></string>
   <string id="16024">Canceling...</string>
   <string id="16025">Enter the artist name</string>
   <string id="16026">Playback failed</string>
@@ -1489,7 +1489,12 @@
   <string id="16034">Could not get songs from database.</string>
   <string id="16035">Party mode playlist</string>
   <string id="16036">De-interlace (Half)</string>
-
+  <string id="16037">Deinterlace video</string>
+  <string id="16038">Deinterlace method</string>
+  <string id="16039">Off</string>
+  <string id="16040">Auto</string>
+  <string id="16041">On</string>
+  
   <string id="16100">All Videos</string>
   <string id="16101">Unwatched</string>
   <string id="16102">Watched</string>

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -2982,11 +2982,11 @@ bool CLinuxRendererGL::SupportsMultiPassRendering()
   return glewIsSupported("GL_EXT_framebuffer_object") && glCreateProgram;
 }
 
-bool CLinuxRendererGL::Supports(EINTERLACEMODE mode)
+bool CLinuxRendererGL::Supports(EDEINTERLACEMODE mode)
 {
-  if(mode == VS_INTERLACEMODE_OFF
-  || mode == VS_INTERLACEMODE_AUTO
-  || mode == VS_INTERLACEMODE_FORCE)
+  if(mode == VS_DEINTERLACEMODE_OFF
+  || mode == VS_DEINTERLACEMODE_AUTO
+  || mode == VS_DEINTERLACEMODE_FORCE)
     return true;
 
   return false;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -2982,10 +2982,19 @@ bool CLinuxRendererGL::SupportsMultiPassRendering()
   return glewIsSupported("GL_EXT_framebuffer_object") && glCreateProgram;
 }
 
+bool CLinuxRendererGL::Supports(EINTERLACEMODE mode)
+{
+  if(mode == VS_INTERLACEMODE_OFF
+  || mode == VS_INTERLACEMODE_AUTO
+  || mode == VS_INTERLACEMODE_FORCE)
+    return true;
+
+  return false;
+}
+
 bool CLinuxRendererGL::Supports(EINTERLACEMETHOD method)
 {
-  if(method == VS_INTERLACEMETHOD_NONE
-  || method == VS_INTERLACEMETHOD_AUTO)
+  if(method == VS_INTERLACEMETHOD_AUTO)
     return true;
 
   if(m_renderMethod & RENDER_VDPAU)

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -153,6 +153,7 @@ public:
   // Feature support
   virtual bool SupportsMultiPassRendering();
   virtual bool Supports(ERENDERFEATURE feature);
+  virtual bool Supports(EINTERLACEMODE mode);
   virtual bool Supports(EINTERLACEMETHOD method);
   virtual bool Supports(ESCALINGMETHOD method);
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -153,7 +153,7 @@ public:
   // Feature support
   virtual bool SupportsMultiPassRendering();
   virtual bool Supports(ERENDERFEATURE feature);
-  virtual bool Supports(EINTERLACEMODE mode);
+  virtual bool Supports(EDEINTERLACEMODE mode);
   virtual bool Supports(EINTERLACEMETHOD method);
   virtual bool Supports(ESCALINGMETHOD method);
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -1815,6 +1815,24 @@ bool CLinuxRendererGLES::SupportsMultiPassRendering()
   return false;
 }
 
+bool CLinuxRendererGLES::Supports(EINTERLACEMODE mode)
+{
+  if (mode == VS_INTERLACEMODE_OFF)
+    return true;
+
+  if(m_renderMethod & RENDER_OMXEGL)
+    return false;
+
+  if(m_renderMethod & RENDER_CVREF)
+    return false;
+
+  if(mode == VS_INTERLACEMODE_AUTO
+  || mode == VS_INTERLACEMODE_FORCE)
+    return true;
+
+  return false;
+}
+
 bool CLinuxRendererGLES::Supports(EINTERLACEMETHOD method)
 {
   if(m_renderMethod & RENDER_OMXEGL)
@@ -1823,8 +1841,7 @@ bool CLinuxRendererGLES::Supports(EINTERLACEMETHOD method)
   if(m_renderMethod & RENDER_CVREF)
     return false;
 
-  if(method == VS_INTERLACEMETHOD_NONE
-  || method == VS_INTERLACEMETHOD_AUTO)
+  if(method == VS_INTERLACEMETHOD_AUTO)
     return true;
 
   if(method == VS_INTERLACEMETHOD_DEINTERLACE)

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -1815,9 +1815,9 @@ bool CLinuxRendererGLES::SupportsMultiPassRendering()
   return false;
 }
 
-bool CLinuxRendererGLES::Supports(EINTERLACEMODE mode)
+bool CLinuxRendererGLES::Supports(EDEINTERLACEMODE mode)
 {
-  if (mode == VS_INTERLACEMODE_OFF)
+  if (mode == VS_DEINTERLACEMODE_OFF)
     return true;
 
   if(m_renderMethod & RENDER_OMXEGL)
@@ -1826,8 +1826,8 @@ bool CLinuxRendererGLES::Supports(EINTERLACEMODE mode)
   if(m_renderMethod & RENDER_CVREF)
     return false;
 
-  if(mode == VS_INTERLACEMODE_AUTO
-  || mode == VS_INTERLACEMODE_FORCE)
+  if(mode == VS_DEINTERLACEMODE_AUTO
+  || mode == VS_DEINTERLACEMODE_FORCE)
     return true;
 
   return false;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -148,7 +148,7 @@ public:
   // Feature support
   virtual bool SupportsMultiPassRendering();
   virtual bool Supports(ERENDERFEATURE feature);
-  virtual bool Supports(EINTERLACEMODE mode);
+  virtual bool Supports(EDEINTERLACEMODE mode);
   virtual bool Supports(EINTERLACEMETHOD method);
   virtual bool Supports(ESCALINGMETHOD method);
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -148,6 +148,7 @@ public:
   // Feature support
   virtual bool SupportsMultiPassRendering();
   virtual bool Supports(ERENDERFEATURE feature);
+  virtual bool Supports(EINTERLACEMODE mode);
   virtual bool Supports(EINTERLACEMETHOD method);
   virtual bool Supports(ESCALINGMETHOD method);
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -511,15 +511,15 @@ void CXBMCRenderManager::FlipPage(volatile bool& bStop, double timestamp /* = 0L
     m_presentfield = sync;
     m_presentstep  = PRESENT_FLIP;
     m_presentsource = source;
-    EINTERLACEMODE interlacemode = g_settings.m_currentVideoSettings.m_InterlaceMode;
+    EDEINTERLACEMODE deinterlacemode = g_settings.m_currentVideoSettings.m_DeinterlaceMode;
     EINTERLACEMETHOD interlacemethod = g_settings.m_currentVideoSettings.m_InterlaceMethod;
     bool invert = false;
 
-    if (interlacemode == VS_INTERLACEMODE_OFF)
+    if (deinterlacemode == VS_DEINTERLACEMODE_OFF)
       m_presentmethod = PRESENT_METHOD_SINGLE;
     else
     {
-      if (interlacemode == VS_INTERLACEMODE_AUTO && m_presentfield == FS_NONE)
+      if (deinterlacemode == VS_DEINTERLACEMODE_AUTO && m_presentfield == FS_NONE)
         m_presentmethod = PRESENT_METHOD_SINGLE;
       else
       {
@@ -544,7 +544,7 @@ void CXBMCRenderManager::FlipPage(volatile bool& bStop, double timestamp /* = 0L
         }
 
         /* default to odd field if we want to deinterlace and don't know better */
-        if (interlacemode == VS_INTERLACEMODE_FORCE && m_presentfield == FS_NONE)
+        if (deinterlacemode == VS_DEINTERLACEMODE_FORCE && m_presentfield == FS_NONE)
           m_presentfield = FS_TOP;
 
         /* invert present field */

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -99,7 +99,7 @@ CXBMCRenderManager::CXBMCRenderManager()
   m_presentstep = PRESENT_IDLE;
   m_rendermethod = 0;
   m_presentsource = 0;
-  m_presentmethod = VS_INTERLACEMETHOD_NONE;
+  m_presentmethod = PRESENT_METHOD_SINGLE;
   m_bReconfigured = false;
   m_hasCaptures = false;
 }
@@ -286,8 +286,7 @@ void CXBMCRenderManager::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
 
   CSharedLock lock(m_sharedSection);
 
-  if( m_presentmethod == VS_INTERLACEMETHOD_RENDER_WEAVE
-   || m_presentmethod == VS_INTERLACEMETHOD_RENDER_WEAVE_INVERTED)
+  if (m_presentmethod == PRESENT_METHOD_WEAVE)
     m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_BOTH, alpha);
   else
     m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_LAST, alpha);
@@ -512,26 +511,36 @@ void CXBMCRenderManager::FlipPage(volatile bool& bStop, double timestamp /* = 0L
     m_presentfield = sync;
     m_presentstep  = PRESENT_FLIP;
     m_presentsource = source;
-    m_presentmethod = g_settings.m_currentVideoSettings.m_InterlaceMethod;
+    EINTERLACEMETHOD interlacemethod = g_settings.m_currentVideoSettings.m_InterlaceMethod;
+    bool invert = false;
 
-    /* select render method for auto */
-    if(m_presentmethod == VS_INTERLACEMETHOD_AUTO)
+    if      (interlacemethod == VS_INTERLACEMETHOD_RENDER_BLEND)            m_presentmethod = PRESENT_METHOD_BLEND;
+    else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_WEAVE)            m_presentmethod = PRESENT_METHOD_WEAVE;
+    else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_WEAVE_INVERTED) { m_presentmethod = PRESENT_METHOD_WEAVE ; invert = true; }
+    else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_BOB)              m_presentmethod = PRESENT_METHOD_BOB;
+    else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_BOB_INVERTED)   { m_presentmethod = PRESENT_METHOD_BOB; invert = true; }
+    else if (interlacemethod == VS_INTERLACEMETHOD_DXVA_BOB)                m_presentmethod = PRESENT_METHOD_BOB;
+    else if (interlacemethod == VS_INTERLACEMETHOD_DXVA_BEST)               m_presentmethod = PRESENT_METHOD_BOB;
+    else if (interlacemethod == VS_INTERLACEMETHOD_AUTO)
     {
       if(m_presentfield == FS_NONE)
-        m_presentmethod = VS_INTERLACEMETHOD_NONE;
+        m_presentmethod = PRESENT_METHOD_SINGLE;
       else if(m_pRenderer->Supports(VS_INTERLACEMETHOD_RENDER_BOB) || m_pRenderer->Supports(VS_INTERLACEMETHOD_DXVA_ANY))
-        m_presentmethod = VS_INTERLACEMETHOD_RENDER_BOB;
+        m_presentmethod = PRESENT_METHOD_BOB;
       else
-        m_presentmethod = VS_INTERLACEMETHOD_NONE;
+        m_presentmethod = PRESENT_METHOD_SINGLE;
     }
-
+    else
+    {
+      m_presentmethod = PRESENT_METHOD_SINGLE;
+    }
+    
     /* default to odd field if we want to deinterlace and don't know better */
-    if(m_presentfield == FS_NONE && m_presentmethod != VS_INTERLACEMETHOD_NONE)
+    if(m_presentfield == FS_NONE && m_presentmethod != PRESENT_METHOD_SINGLE)
       m_presentfield = FS_TOP;
 
-    /* invert present field if we have one of those methods */
-    if( m_presentmethod == VS_INTERLACEMETHOD_RENDER_BOB_INVERTED
-     || m_presentmethod == VS_INTERLACEMETHOD_RENDER_WEAVE_INVERTED )
+    /* invert present field */
+    if(invert)
     {
       if( m_presentfield == FS_BOT )
         m_presentfield = FS_TOP;
@@ -585,15 +594,11 @@ void CXBMCRenderManager::Present()
 
   CSharedLock lock(m_sharedSection);
 
-  if     ( m_presentmethod == VS_INTERLACEMETHOD_RENDER_BOB
-        || m_presentmethod == VS_INTERLACEMETHOD_RENDER_BOB_INVERTED
-        || m_presentmethod == VS_INTERLACEMETHOD_DXVA_BOB
-        || m_presentmethod == VS_INTERLACEMETHOD_DXVA_BEST)
+  if     ( m_presentmethod == PRESENT_METHOD_BOB )
     PresentBob();
-  else if( m_presentmethod == VS_INTERLACEMETHOD_RENDER_WEAVE
-        || m_presentmethod == VS_INTERLACEMETHOD_RENDER_WEAVE_INVERTED)
+  else if( m_presentmethod == PRESENT_METHOD_WEAVE )
     PresentWeave();
-  else if( m_presentmethod == VS_INTERLACEMETHOD_RENDER_BLEND )
+  else if( m_presentmethod == PRESENT_METHOD_BLEND )
     PresentBlend();
   else
     PresentSingle();

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -511,42 +511,53 @@ void CXBMCRenderManager::FlipPage(volatile bool& bStop, double timestamp /* = 0L
     m_presentfield = sync;
     m_presentstep  = PRESENT_FLIP;
     m_presentsource = source;
+    EINTERLACEMODE interlacemode = g_settings.m_currentVideoSettings.m_InterlaceMode;
     EINTERLACEMETHOD interlacemethod = g_settings.m_currentVideoSettings.m_InterlaceMethod;
     bool invert = false;
 
-    if      (interlacemethod == VS_INTERLACEMETHOD_RENDER_BLEND)            m_presentmethod = PRESENT_METHOD_BLEND;
-    else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_WEAVE)            m_presentmethod = PRESENT_METHOD_WEAVE;
-    else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_WEAVE_INVERTED) { m_presentmethod = PRESENT_METHOD_WEAVE ; invert = true; }
-    else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_BOB)              m_presentmethod = PRESENT_METHOD_BOB;
-    else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_BOB_INVERTED)   { m_presentmethod = PRESENT_METHOD_BOB; invert = true; }
-    else if (interlacemethod == VS_INTERLACEMETHOD_DXVA_BOB)                m_presentmethod = PRESENT_METHOD_BOB;
-    else if (interlacemethod == VS_INTERLACEMETHOD_DXVA_BEST)               m_presentmethod = PRESENT_METHOD_BOB;
-    else if (interlacemethod == VS_INTERLACEMETHOD_AUTO)
-    {
-      if(m_presentfield == FS_NONE)
-        m_presentmethod = PRESENT_METHOD_SINGLE;
-      else if(m_pRenderer->Supports(VS_INTERLACEMETHOD_RENDER_BOB) || m_pRenderer->Supports(VS_INTERLACEMETHOD_DXVA_ANY))
-        m_presentmethod = PRESENT_METHOD_BOB;
-      else
-        m_presentmethod = PRESENT_METHOD_SINGLE;
-    }
+    if (interlacemode == VS_INTERLACEMODE_OFF)
+      m_presentmethod = PRESENT_METHOD_SINGLE;
     else
     {
-      m_presentmethod = PRESENT_METHOD_SINGLE;
-    }
-    
-    /* default to odd field if we want to deinterlace and don't know better */
-    if(m_presentfield == FS_NONE && m_presentmethod != PRESENT_METHOD_SINGLE)
-      m_presentfield = FS_TOP;
-
-    /* invert present field */
-    if(invert)
-    {
-      if( m_presentfield == FS_BOT )
-        m_presentfield = FS_TOP;
+      if (interlacemode == VS_INTERLACEMODE_AUTO && m_presentfield == FS_NONE)
+        m_presentmethod = PRESENT_METHOD_SINGLE;
       else
-        m_presentfield = FS_BOT;
+      {
+        if      (interlacemethod == VS_INTERLACEMETHOD_RENDER_BLEND)            m_presentmethod = PRESENT_METHOD_BLEND;
+        else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_WEAVE)            m_presentmethod = PRESENT_METHOD_WEAVE;
+        else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_WEAVE_INVERTED) { m_presentmethod = PRESENT_METHOD_WEAVE ; invert = true; }
+        else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_BOB)              m_presentmethod = PRESENT_METHOD_BOB;
+        else if (interlacemethod == VS_INTERLACEMETHOD_RENDER_BOB_INVERTED)   { m_presentmethod = PRESENT_METHOD_BOB; invert = true; }
+        else if (interlacemethod == VS_INTERLACEMETHOD_DXVA_BOB)                m_presentmethod = PRESENT_METHOD_BOB;
+        else if (interlacemethod == VS_INTERLACEMETHOD_DXVA_BEST)               m_presentmethod = PRESENT_METHOD_BOB;
+        else if (interlacemethod == VS_INTERLACEMETHOD_AUTO)
+        {
+          if(m_pRenderer->Supports(VS_INTERLACEMETHOD_RENDER_BOB)
+          || m_pRenderer->Supports(VS_INTERLACEMETHOD_DXVA_ANY))
+            m_presentmethod = PRESENT_METHOD_BOB;
+          else
+            m_presentmethod = PRESENT_METHOD_SINGLE;
+        }
+        else
+        {
+          m_presentmethod = PRESENT_METHOD_SINGLE;
+        }
+
+        /* default to odd field if we want to deinterlace and don't know better */
+        if (interlacemode == VS_INTERLACEMODE_FORCE && m_presentfield == FS_NONE)
+          m_presentfield = FS_TOP;
+
+        /* invert present field */
+        if(invert)
+        {
+          if( m_presentfield == FS_BOT )
+            m_presentfield = FS_TOP;
+          else
+            m_presentfield = FS_BOT;
+        }
+      }
     }
+
   }
 
   g_application.NewFrame();

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -198,13 +198,22 @@ protected:
   , PRESENT_FRAME2
   };
 
+  enum EPRESENTMETHOD
+  {
+    PRESENT_METHOD_SINGLE = 0,
+    PRESENT_METHOD_BLEND,
+    PRESENT_METHOD_WEAVE,
+    PRESENT_METHOD_BOB,
+  };
+
+
   double     m_presenttime;
   double     m_presentcorr;
   double     m_presenterr;
   double     m_errorbuff[ERRORBUFFSIZE];
   int        m_errorindex;
   EFIELDSYNC m_presentfield;
-  EINTERLACEMETHOD m_presentmethod;
+  EPRESENTMETHOD m_presentmethod;
   EPRESENTSTEP     m_presentstep;
   int        m_presentsource;
   CEvent     m_presentevent;

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -117,6 +117,15 @@ public:
       return false;
   }
 
+  bool Supports(EINTERLACEMODE method)
+  {
+    CSharedLock lock(m_sharedSection);
+    if (m_pRenderer)
+      return m_pRenderer->Supports(method);
+    else
+      return false;
+  }
+
   bool Supports(EINTERLACEMETHOD method)
   {
     CSharedLock lock(m_sharedSection);

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -117,7 +117,7 @@ public:
       return false;
   }
 
-  bool Supports(EINTERLACEMODE method)
+  bool Supports(EDEINTERLACEMODE method)
   {
     CSharedLock lock(m_sharedSection);
     if (m_pRenderer)

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -1051,11 +1051,11 @@ bool CWinRenderer::CreateYV12Texture(int index)
   return true;
 }
 
-bool CWinRenderer::Supports(EINTERLACEMODE mode)
+bool CWinRenderer::Supports(EDEINTERLACEMODE mode)
 {
-  if(mode == VS_INTERLACEMODE_OFF
-  || mode == VS_INTERLACEMODE_AUTO
-  || mode == VS_INTERLACEMODE_FORCE)
+  if(mode == VS_DEINTERLACEMODE_OFF
+  || mode == VS_DEINTERLACEMODE_AUTO
+  || mode == VS_DEINTERLACEMODE_FORCE)
     return true;
 
   return false;

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -1051,10 +1051,19 @@ bool CWinRenderer::CreateYV12Texture(int index)
   return true;
 }
 
+bool CWinRenderer::Supports(EINTERLACEMODE mode)
+{
+  if(mode == VS_INTERLACEMODE_OFF
+  || mode == VS_INTERLACEMODE_AUTO
+  || mode == VS_INTERLACEMODE_FORCE)
+    return true;
+
+  return false;
+}
+
 bool CWinRenderer::Supports(EINTERLACEMETHOD method)
 {
-  if(method == VS_INTERLACEMETHOD_NONE
-  || method == VS_INTERLACEMETHOD_AUTO)
+  if(method == VS_INTERLACEMETHOD_AUTO)
     return true;
 
   if (m_renderMethod == RENDER_DXVA)

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -183,6 +183,7 @@ public:
   virtual bool         IsConfigured() { return m_bConfigured; }
 
   virtual bool         Supports(ERENDERFEATURE feature);
+  virtual bool         Supports(EINTERLACEMODE mode);
   virtual bool         Supports(EINTERLACEMETHOD method);
   virtual bool         Supports(ESCALINGMETHOD method);
 

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -183,7 +183,7 @@ public:
   virtual bool         IsConfigured() { return m_bConfigured; }
 
   virtual bool         Supports(ERENDERFEATURE feature);
-  virtual bool         Supports(EINTERLACEMODE mode);
+  virtual bool         Supports(EDEINTERLACEMODE mode);
   virtual bool         Supports(EINTERLACEMETHOD method);
   virtual bool         Supports(ESCALINGMETHOD method);
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -152,7 +152,9 @@ protected:
   unsigned         m_size;
   unsigned         m_max_back_refs;
   unsigned         m_max_fwd_refs;
+  EDEINTERLACEMODE m_deinterlace_mode;
   EINTERLACEMETHOD m_interlace_method;
+  bool             m_progressive; // true for progressive source or to force ignoring interlacing flags.
   unsigned         m_index;
   unsigned         m_last_field_rendered;
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -112,6 +112,7 @@ CVDPAU::CVDPAU()
 
   tmpBrightness  = 0;
   tmpContrast    = 0;
+  tmpDeintMode   = 0;
   tmpDeint       = 0;
   max_references = 0;
 
@@ -474,9 +475,11 @@ void CVDPAU::CheckFeatures()
     tmpSharpness = g_settings.m_currentVideoSettings.m_Sharpness;
     SetSharpness();
   }
-  if (tmpDeint != g_settings.m_currentVideoSettings.m_InterlaceMethod)
+  if (tmpDeintMode != g_settings.m_currentVideoSettings.m_DeinterlaceMode ||
+      tmpDeint     != g_settings.m_currentVideoSettings.m_InterlaceMethod)
   {
-    tmpDeint = g_settings.m_currentVideoSettings.m_InterlaceMethod;
+    tmpDeintMode = g_settings.m_currentVideoSettings.m_DeinterlaceMode;
+    tmpDeint     = g_settings.m_currentVideoSettings.m_InterlaceMethod;
     SetDeinterlacing();
   }
 }
@@ -600,39 +603,48 @@ void CVDPAU::SetHWUpscaling()
 void CVDPAU::SetDeinterlacing()
 {
   VdpStatus vdp_st;
+  EINTERLACEMODE   mode   = g_settings.m_currentVideoSettings.m_InterlaceMode;
   EINTERLACEMETHOD method = g_settings.m_currentVideoSettings.m_InterlaceMethod;
 
   VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_DEINTERLACE_TEMPORAL,
                                      VDP_VIDEO_MIXER_FEATURE_DEINTERLACE_TEMPORAL_SPATIAL,
                                      VDP_VIDEO_MIXER_FEATURE_INVERSE_TELECINE };
-
-  if (method == VS_INTERLACEMETHOD_AUTO)
-  {
-    VdpBool enabled[]={1,0,0}; // Same features as VS_INTERLACEMETHOD_VDPAU_TEMPORAL
-    vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
-  }
-  else if (method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL
-       ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF)
-  {
-    VdpBool enabled[]={1,0,0};
-    vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
-  }
-  else if (method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL
-       ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF)
-  {
-    VdpBool enabled[]={1,1,0};
-    vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
-  }
-  else if (method == VS_INTERLACEMETHOD_VDPAU_INVERSE_TELECINE)
-  {
-    VdpBool enabled[]={1,0,1};
-    vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
-  }
-  else
+  if (mode == VS_INTERLACEMODE_OFF)
   {
     VdpBool enabled[]={0,0,0};
     vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
   }
+  else
+  {
+    if (method == VS_INTERLACEMETHOD_AUTO)
+    {
+      VdpBool enabled[]={1,0,0}; // Same features as VS_INTERLACEMETHOD_VDPAU_TEMPORAL
+      vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
+    }
+    else if (method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL
+         ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF)
+    {
+      VdpBool enabled[]={1,0,0};
+      vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
+    }
+    else if (method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL
+         ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF)
+    {
+      VdpBool enabled[]={1,1,0};
+      vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
+    }
+    else if (method == VS_INTERLACEMETHOD_VDPAU_INVERSE_TELECINE)
+    {
+      VdpBool enabled[]={1,0,1};
+      vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
+    }
+    else
+    {
+      VdpBool enabled[]={0,0,0};
+      vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
+    }
+  }
+
   CheckStatus(vdp_st, __LINE__);
 }
 
@@ -1130,6 +1142,7 @@ int CVDPAU::Decode(AVCodecContext *avctx, AVFrame *pFrame)
     outRectVid.y1 = OutHeight;
   }
 
+  EINTERLACEMODE   mode   = g_settings.m_currentVideoSettings.m_InterlaceMode;
   EINTERLACEMETHOD method = g_settings.m_currentVideoSettings.m_InterlaceMethod;
 
   if(pFrame)
@@ -1165,26 +1178,34 @@ int CVDPAU::Decode(AVCodecContext *avctx, AVFrame *pFrame)
         m_DVDVideoPics.pop();
     }
 
-    if((method == VS_INTERLACEMETHOD_AUTO &&
-                  m_DVDVideoPics.front().iFlags & DVP_FLAG_INTERLACED)
-    ||  method == VS_INTERLACEMETHOD_VDPAU_BOB
-    ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL
-    ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF
-    ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL
-    ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF
-    ||  method == VS_INTERLACEMETHOD_VDPAU_INVERSE_TELECINE )
+    if (mode == VS_INTERLACEMODE_FORCE
+    || (mode == VS_INTERLACEMODE_AUTO && m_DVDVideoPics.front().iFlags & DVP_FLAG_INTERLACED))
     {
-      if(method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF
-      || method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF
-      || avctx->skip_frame == AVDISCARD_NONREF)
-        m_mixerstep = 0;
-      else
-        m_mixerstep = 1;
+      if((method == VS_INTERLACEMETHOD_AUTO
+      ||  method == VS_INTERLACEMETHOD_VDPAU_BOB
+      ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL
+      ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF
+      ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL
+      ||  method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF
+      ||  method == VS_INTERLACEMETHOD_VDPAU_INVERSE_TELECINE )
+      {
+        if(method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF
+        || method == VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF
+        || avctx->skip_frame == AVDISCARD_NONREF)
+          m_mixerstep = 0;
+        else
+          m_mixerstep = 1;
 
-      if(m_DVDVideoPics.front().iFlags & DVP_FLAG_TOP_FIELD_FIRST)
-        m_mixerfield = VDP_VIDEO_MIXER_PICTURE_STRUCTURE_TOP_FIELD;
+        if(m_DVDVideoPics.front().iFlags & DVP_FLAG_TOP_FIELD_FIRST)
+          m_mixerfield = VDP_VIDEO_MIXER_PICTURE_STRUCTURE_TOP_FIELD;
+        else
+          m_mixerfield = VDP_VIDEO_MIXER_PICTURE_STRUCTURE_BOTTOM_FIELD;
+      }
       else
-        m_mixerfield = VDP_VIDEO_MIXER_PICTURE_STRUCTURE_BOTTOM_FIELD;
+      {
+        m_mixerstep  = 0;
+        m_mixerfield = VDP_VIDEO_MIXER_PICTURE_STRUCTURE_FRAME;
+      }
     }
     else
     {

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -603,13 +603,13 @@ void CVDPAU::SetHWUpscaling()
 void CVDPAU::SetDeinterlacing()
 {
   VdpStatus vdp_st;
-  EINTERLACEMODE   mode   = g_settings.m_currentVideoSettings.m_InterlaceMode;
+  EDEINTERLACEMODE   mode = g_settings.m_currentVideoSettings.m_DeinterlaceMode;
   EINTERLACEMETHOD method = g_settings.m_currentVideoSettings.m_InterlaceMethod;
 
   VdpVideoMixerFeature feature[] = { VDP_VIDEO_MIXER_FEATURE_DEINTERLACE_TEMPORAL,
                                      VDP_VIDEO_MIXER_FEATURE_DEINTERLACE_TEMPORAL_SPATIAL,
                                      VDP_VIDEO_MIXER_FEATURE_INVERSE_TELECINE };
-  if (mode == VS_INTERLACEMODE_OFF)
+  if (mode == VS_DEINTERLACEMODE_OFF)
   {
     VdpBool enabled[]={0,0,0};
     vdp_st = vdp_video_mixer_set_feature_enables(videoMixer, ARSIZE(feature), feature, enabled);
@@ -1142,7 +1142,7 @@ int CVDPAU::Decode(AVCodecContext *avctx, AVFrame *pFrame)
     outRectVid.y1 = OutHeight;
   }
 
-  EINTERLACEMODE   mode   = g_settings.m_currentVideoSettings.m_InterlaceMode;
+  EDEINTERLACEMODE   mode = g_settings.m_currentVideoSettings.m_DeinterlaceMode;
   EINTERLACEMETHOD method = g_settings.m_currentVideoSettings.m_InterlaceMethod;
 
   if(pFrame)
@@ -1178,8 +1178,8 @@ int CVDPAU::Decode(AVCodecContext *avctx, AVFrame *pFrame)
         m_DVDVideoPics.pop();
     }
 
-    if (mode == VS_INTERLACEMODE_FORCE
-    || (mode == VS_INTERLACEMODE_AUTO && m_DVDVideoPics.front().iFlags & DVP_FLAG_INTERLACED))
+    if (mode == VS_DEINTERLACEMODE_FORCE
+    || (mode == VS_DEINTERLACEMODE_AUTO && m_DVDVideoPics.front().iFlags & DVP_FLAG_INTERLACED))
     {
       if((method == VS_INTERLACEMETHOD_AUTO
       ||  method == VS_INTERLACEMETHOD_VDPAU_BOB

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -115,7 +115,7 @@ public:
   pictureAge picAge;
   bool       recover;
   vdpau_render_state *past[2], *current, *future;
-  int        tmpDeint;
+  int        tmpDeintMode, tmpDeint;
   float      tmpNoiseReduction, tmpSharpness;
   float      tmpBrightness, tmpContrast;
   int        OutWidth, OutHeight;

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -501,11 +501,11 @@ void CDVDPlayerVideo::Process()
       m_pVideoCodec->SetDropState(bRequestDrop);
 
       // ask codec to do deinterlacing if possible
-      EINTERLACEMODE   mIntMode = g_settings.m_currentVideoSettings.m_InterlaceMode;
+      EDEINTERLACEMODE mDeintMode = g_settings.m_currentVideoSettings.m_DeinterlaceMode;
       EINTERLACEMETHOD mInt     = g_settings.m_currentVideoSettings.m_InterlaceMethod;
       unsigned int     mFilters = 0;
 
-      if (mIntMode != VS_INTERLACEMODE_OFF)
+      if (mDeintMode != VS_DEINTERLACEMODE_OFF)
       {
         if(mInt == VS_INTERLACEMETHOD_AUTO && !g_renderManager.Supports(VS_INTERLACEMETHOD_DXVA_ANY))
           mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY | CDVDVideoCodec::FILTER_DEINTERLACE_HALFED;
@@ -514,7 +514,7 @@ void CDVDPlayerVideo::Process()
         else if(mInt == VS_INTERLACEMETHOD_DEINTERLACE_HALF)
           mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY | CDVDVideoCodec::FILTER_DEINTERLACE_HALFED;
 
-        if (mIntMode == VS_INTERLACEMODE_AUTO && mFilters)
+        if (mDeintMode == VS_DEINTERLACEMODE_AUTO && mFilters)
           mFilters |=  CDVDVideoCodec::FILTER_DEINTERLACE_FLAGGED;
       }
 
@@ -611,7 +611,7 @@ void CDVDPlayerVideo::Process()
 
             //Deinterlace if codec said format was interlaced or if we have selected we want to deinterlace
             //this video
-            if ((mIntMode == VS_INTERLACEMODE_AUTO && (picture.iFlags & DVP_FLAG_INTERLACED)) || mIntMode == VS_INTERLACEMODE_FORCE)
+            if ((mDeintMode == VS_DEINTERLACEMODE_AUTO && (picture.iFlags & DVP_FLAG_INTERLACED)) || mDeintMode == VS_DEINTERLACEMODE_FORCE)
             {
               if(!(mFilters & CDVDVideoCodec::FILTER_DEINTERLACE_ANY))
               {

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -501,15 +501,22 @@ void CDVDPlayerVideo::Process()
       m_pVideoCodec->SetDropState(bRequestDrop);
 
       // ask codec to do deinterlacing if possible
-      EINTERLACEMETHOD mInt = g_settings.m_currentVideoSettings.m_InterlaceMethod;
+      EINTERLACEMODE   mIntMode = g_settings.m_currentVideoSettings.m_InterlaceMode;
+      EINTERLACEMETHOD mInt     = g_settings.m_currentVideoSettings.m_InterlaceMethod;
       unsigned int     mFilters = 0;
 
-      if(mInt == VS_INTERLACEMETHOD_DEINTERLACE)
-        mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY;
-      else if(mInt == VS_INTERLACEMETHOD_DEINTERLACE_HALF)
-        mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY | CDVDVideoCodec::FILTER_DEINTERLACE_HALFED;
-      else if(mInt == VS_INTERLACEMETHOD_AUTO && !g_renderManager.Supports(VS_INTERLACEMETHOD_DXVA_ANY))
-        mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY | CDVDVideoCodec::FILTER_DEINTERLACE_HALFED | CDVDVideoCodec::FILTER_DEINTERLACE_FLAGGED;
+      if (mIntMode != VS_INTERLACEMODE_OFF)
+      {
+        if(mInt == VS_INTERLACEMETHOD_AUTO && !g_renderManager.Supports(VS_INTERLACEMETHOD_DXVA_ANY))
+          mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY | CDVDVideoCodec::FILTER_DEINTERLACE_HALFED;
+        else if (mInt == VS_INTERLACEMETHOD_DEINTERLACE)
+          mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY;
+        else if(mInt == VS_INTERLACEMETHOD_DEINTERLACE_HALF)
+          mFilters = CDVDVideoCodec::FILTER_DEINTERLACE_ANY | CDVDVideoCodec::FILTER_DEINTERLACE_HALFED;
+
+        if (mIntMode == VS_INTERLACEMODE_AUTO && mFilters)
+          mFilters |=  CDVDVideoCodec::FILTER_DEINTERLACE_FLAGGED;
+      }
 
       mFilters = m_pVideoCodec->SetFilters(mFilters);
 
@@ -604,16 +611,18 @@ void CDVDPlayerVideo::Process()
 
             //Deinterlace if codec said format was interlaced or if we have selected we want to deinterlace
             //this video
-            if(!(mFilters & CDVDVideoCodec::FILTER_DEINTERLACE_ANY))
+            if ((mIntMode == VS_INTERLACEMODE_AUTO && (picture.iFlags & DVP_FLAG_INTERLACED)) || mIntMode == VS_INTERLACEMODE_FORCE)
             {
-              if((mInt == VS_INTERLACEMETHOD_DEINTERLACE)
-              || (mInt == VS_INTERLACEMETHOD_AUTO && (picture.iFlags & DVP_FLAG_INTERLACED)
-                                                  && !g_renderManager.Supports(VS_INTERLACEMETHOD_RENDER_BOB)
-                                                  && !g_renderManager.Supports(VS_INTERLACEMETHOD_DXVA_ANY)))
+              if(!(mFilters & CDVDVideoCodec::FILTER_DEINTERLACE_ANY))
               {
-                if (!sPostProcessType.empty())
-                  sPostProcessType += ",";
-                sPostProcessType += g_advancedSettings.m_videoPPFFmpegDeint;
+                if((mInt == VS_INTERLACEMETHOD_DEINTERLACE)
+                || (mInt == VS_INTERLACEMETHOD_AUTO && !g_renderManager.Supports(VS_INTERLACEMETHOD_RENDER_BOB)
+                                                    && !g_renderManager.Supports(VS_INTERLACEMETHOD_DXVA_ANY)))
+                {
+                  if (!sPostProcessType.empty())
+                    sPostProcessType += ",";
+                  sPostProcessType += g_advancedSettings.m_videoPPFFmpegDeint;
+                }
               }
             }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -677,8 +677,11 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
   pElement = pRootElement->FirstChildElement("defaultvideosettings");
   if (pElement)
   {
+    int interlaceMode;
+    GetInteger(pElement, "interlacemode", interlaceMode, VS_INTERLACEMODE_OFF, VS_INTERLACEMODE_OFF, VS_INTERLACEMODE_FORCE);
+    m_defaultVideoSettings.m_InterlaceMode = (EINTERLACEMODE)interlaceMode;
     int interlaceMethod;
-    GetInteger(pElement, "interlacemethod", interlaceMethod, VS_INTERLACEMETHOD_NONE, VS_INTERLACEMETHOD_NONE, VS_INTERLACEMETHOD_INVERSE_TELECINE);
+    GetInteger(pElement, "interlacemethod", interlaceMethod, VS_INTERLACEMETHOD_AUTO, VS_INTERLACEMETHOD_AUTO, VS_INTERLACEMETHOD_INVERSE_TELECINE);
     m_defaultVideoSettings.m_InterlaceMethod = (EINTERLACEMETHOD)interlaceMethod;
     int scalingMethod;
     GetInteger(pElement, "scalingmethod", scalingMethod, VS_SCALINGMETHOD_LINEAR, VS_SCALINGMETHOD_NEAREST, VS_SCALINGMETHOD_AUTO);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -678,8 +678,8 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
   if (pElement)
   {
     int interlaceMode;
-    GetInteger(pElement, "interlacemode", interlaceMode, VS_INTERLACEMODE_OFF, VS_INTERLACEMODE_OFF, VS_INTERLACEMODE_FORCE);
-    m_defaultVideoSettings.m_InterlaceMode = (EINTERLACEMODE)interlaceMode;
+    GetInteger(pElement, "interlacemode", interlaceMode, VS_DEINTERLACEMODE_OFF, VS_DEINTERLACEMODE_OFF, VS_DEINTERLACEMODE_FORCE);
+    m_defaultVideoSettings.m_DeinterlaceMode = (EDEINTERLACEMODE)interlaceMode;
     int interlaceMethod;
     GetInteger(pElement, "interlacemethod", interlaceMethod, VS_INTERLACEMETHOD_AUTO, VS_INTERLACEMETHOD_AUTO, VS_INTERLACEMETHOD_INVERSE_TELECINE);
     m_defaultVideoSettings.m_InterlaceMethod = (EINTERLACEMETHOD)interlaceMethod;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -677,11 +677,28 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
   pElement = pRootElement->FirstChildElement("defaultvideosettings");
   if (pElement)
   {
-    int interlaceMode;
-    GetInteger(pElement, "interlacemode", interlaceMode, VS_DEINTERLACEMODE_OFF, VS_DEINTERLACEMODE_OFF, VS_DEINTERLACEMODE_FORCE);
-    m_defaultVideoSettings.m_DeinterlaceMode = (EDEINTERLACEMODE)interlaceMode;
+    int deinterlaceMode;
+    bool deinterlaceModePresent = GetInteger(pElement, "deinterlacemode", deinterlaceMode, VS_DEINTERLACEMODE_OFF, VS_DEINTERLACEMODE_OFF, VS_DEINTERLACEMODE_FORCE);
     int interlaceMethod;
-    GetInteger(pElement, "interlacemethod", interlaceMethod, VS_INTERLACEMETHOD_AUTO, VS_INTERLACEMETHOD_AUTO, VS_INTERLACEMETHOD_INVERSE_TELECINE);
+    bool interlaceMethodPresent = GetInteger(pElement, "interlacemethod", interlaceMethod, VS_INTERLACEMETHOD_AUTO, VS_INTERLACEMETHOD_RENDER_BLEND, VS_INTERLACEMETHOD_INVERSE_TELECINE);
+    // For smooth conversion of settings stored before the deinterlaceMode existed
+    if (!deinterlaceModePresent && interlaceMethodPresent)
+    {
+      if (interlaceMethod == VS_INTERLACEMETHOD_NONE)
+      {
+        deinterlaceMode = VS_DEINTERLACEMODE_OFF;
+        interlaceMethod = VS_INTERLACEMETHOD_AUTO;
+      }
+      else if (interlaceMethod == VS_INTERLACEMETHOD_AUTO)
+      {
+        deinterlaceMode = VS_DEINTERLACEMODE_AUTO;
+      }
+      else
+      {
+        deinterlaceMode = VS_DEINTERLACEMODE_FORCE;
+      }
+    }
+    m_defaultVideoSettings.m_DeinterlaceMode = (EDEINTERLACEMODE)deinterlaceMode;
     m_defaultVideoSettings.m_InterlaceMethod = (EINTERLACEMETHOD)interlaceMethod;
     int scalingMethod;
     GetInteger(pElement, "scalingmethod", scalingMethod, VS_SCALINGMETHOD_LINEAR, VS_SCALINGMETHOD_NEAREST, VS_SCALINGMETHOD_AUTO);

--- a/xbmc/settings/VideoSettings.cpp
+++ b/xbmc/settings/VideoSettings.cpp
@@ -31,7 +31,8 @@
 
 CVideoSettings::CVideoSettings()
 {
-  m_InterlaceMethod = VS_INTERLACEMETHOD_NONE;
+  m_InterlaceMode = VS_INTERLACEMODE_OFF;
+  m_InterlaceMethod = VS_INTERLACEMETHOD_AUTO;
   m_ScalingMethod = VS_SCALINGMETHOD_LINEAR;
   m_ViewMode = VIEW_MODE_NORMAL;
   m_CustomZoomAmount = 1.0f;
@@ -62,6 +63,7 @@ CVideoSettings::CVideoSettings()
 
 bool CVideoSettings::operator!=(const CVideoSettings &right) const
 {
+  if (m_InterlaceMode != right.m_InterlaceMode) return true;
   if (m_InterlaceMethod != right.m_InterlaceMethod) return true;
   if (m_ScalingMethod != right.m_ScalingMethod) return true;
   if (m_ViewMode != right.m_ViewMode) return true;

--- a/xbmc/settings/VideoSettings.cpp
+++ b/xbmc/settings/VideoSettings.cpp
@@ -31,7 +31,7 @@
 
 CVideoSettings::CVideoSettings()
 {
-  m_InterlaceMode = VS_INTERLACEMODE_OFF;
+  m_DeinterlaceMode = VS_DEINTERLACEMODE_OFF;
   m_InterlaceMethod = VS_INTERLACEMETHOD_AUTO;
   m_ScalingMethod = VS_SCALINGMETHOD_LINEAR;
   m_ViewMode = VIEW_MODE_NORMAL;
@@ -63,7 +63,7 @@ CVideoSettings::CVideoSettings()
 
 bool CVideoSettings::operator!=(const CVideoSettings &right) const
 {
-  if (m_InterlaceMode != right.m_InterlaceMode) return true;
+  if (m_DeinterlaceMode != right.m_DeinterlaceMode) return true;
   if (m_InterlaceMethod != right.m_InterlaceMethod) return true;
   if (m_ScalingMethod != right.m_ScalingMethod) return true;
   if (m_ViewMode != right.m_ViewMode) return true;

--- a/xbmc/settings/VideoSettings.h
+++ b/xbmc/settings/VideoSettings.h
@@ -29,11 +29,11 @@
 #pragma once
 #endif // _MSC_VER > 1000
 
-enum EINTERLACEMODE
+enum EDEINTERLACEMODE
 {
-  VS_INTERLACEMODE_OFF=0,
-  VS_INTERLACEMODE_AUTO=1,
-  VS_INTERLACEMODE_FORCE=2
+  VS_DEINTERLACEMODE_OFF=0,
+  VS_DEINTERLACEMODE_AUTO=1,
+  VS_DEINTERLACEMODE_FORCE=2
 };
 
 enum EINTERLACEMETHOD
@@ -97,7 +97,7 @@ public:
 
   bool operator!=(const CVideoSettings &right) const;
 
-  EINTERLACEMODE   m_InterlaceMode;
+  EDEINTERLACEMODE m_DeinterlaceMode;
   EINTERLACEMETHOD m_InterlaceMethod;
   ESCALINGMETHOD   m_ScalingMethod;
   int m_ViewMode;   // current view mode

--- a/xbmc/settings/VideoSettings.h
+++ b/xbmc/settings/VideoSettings.h
@@ -29,9 +29,16 @@
 #pragma once
 #endif // _MSC_VER > 1000
 
+enum EINTERLACEMODE
+{
+  VS_INTERLACEMODE_OFF=0,
+  VS_INTERLACEMODE_AUTO=1,
+  VS_INTERLACEMODE_FORCE=2
+};
+
 enum EINTERLACEMETHOD
 {
-  VS_INTERLACEMETHOD_NONE=0,
+  VS_INTERLACEMETHOD_NONE=0, // Legacy
   VS_INTERLACEMETHOD_AUTO=1,
   VS_INTERLACEMETHOD_RENDER_BLEND=2,
 
@@ -90,6 +97,7 @@ public:
 
   bool operator!=(const CVideoSettings &right) const;
 
+  EINTERLACEMODE   m_InterlaceMode;
   EINTERLACEMETHOD m_InterlaceMethod;
   ESCALINGMETHOD   m_ScalingMethod;
   int m_ViewMode;   // current view mode

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3030,6 +3030,7 @@ bool CVideoDatabase::GetVideoSettings(const CStdString &strFilenameAndPath, CVid
       settings.m_CropRight = m_pDS->fv("CropRight").get_asInt();
       settings.m_CropTop = m_pDS->fv("CropTop").get_asInt();
       settings.m_CropBottom = m_pDS->fv("CropBottom").get_asInt();
+      settings.m_DeinterlaceMode = (EDEINTERLACEMODE)m_pDS->fv("DeinterlaceMode").get_asInt();
       settings.m_InterlaceMethod = (EINTERLACEMETHOD)m_pDS->fv("Deinterlace").get_asInt();
       settings.m_VolumeAmplification = m_pDS->fv("VolumeAmplification").get_asFloat();
       settings.m_OutputToAllSpeakers = m_pDS->fv("OutputToAllSpeakers").get_asBool();
@@ -3066,11 +3067,13 @@ void CVideoDatabase::SetVideoSettings(const CStdString& strFilenameAndPath, cons
       // update the item
       strSQL=PrepareSQL("update settings set Deinterlace=%i,ViewMode=%i,ZoomAmount=%f,PixelRatio=%f,VerticalShift=%f,"
                        "AudioStream=%i,SubtitleStream=%i,SubtitleDelay=%f,SubtitlesOn=%i,Brightness=%f,Contrast=%f,Gamma=%f,"
-                       "VolumeAmplification=%f,AudioDelay=%f,OutputToAllSpeakers=%i,Sharpness=%f,NoiseReduction=%f,NonLinStretch=%i,PostProcess=%i,ScalingMethod=%i,",
+                       "VolumeAmplification=%f,AudioDelay=%f,OutputToAllSpeakers=%i,Sharpness=%f,NoiseReduction=%f,NonLinStretch=%i,PostProcess=%i,ScalingMethod=%i,"
+                       "DeinterlaceMode=%i",
                        setting.m_InterlaceMethod, setting.m_ViewMode, setting.m_CustomZoomAmount, setting.m_CustomPixelRatio, setting.m_CustomVerticalShift,
                        setting.m_AudioStream, setting.m_SubtitleStream, setting.m_SubtitleDelay, setting.m_SubtitleOn,
                        setting.m_Brightness, setting.m_Contrast, setting.m_Gamma, setting.m_VolumeAmplification, setting.m_AudioDelay,
-                       setting.m_OutputToAllSpeakers,setting.m_Sharpness,setting.m_NoiseReduction,setting.m_CustomNonLinStretch,setting.m_PostProcess,setting.m_ScalingMethod);
+                       setting.m_OutputToAllSpeakers,setting.m_Sharpness,setting.m_NoiseReduction,setting.m_CustomNonLinStretch,setting.m_PostProcess,setting.m_ScalingMethod,
+                       setting.m_DeinterlaceMode);
       CStdString strSQL2;
       strSQL2=PrepareSQL("ResumeTime=%i,Crop=%i,CropLeft=%i,CropRight=%i,CropTop=%i,CropBottom=%i where idFile=%i\n", setting.m_ResumeTime, setting.m_Crop, setting.m_CropLeft, setting.m_CropRight, setting.m_CropTop, setting.m_CropBottom, idFile);
       strSQL += strSQL2;
@@ -3084,14 +3087,15 @@ void CVideoDatabase::SetVideoSettings(const CStdString& strFilenameAndPath, cons
                 "AudioStream,SubtitleStream,SubtitleDelay,SubtitlesOn,Brightness,"
                 "Contrast,Gamma,VolumeAmplification,AudioDelay,OutputToAllSpeakers,"
                 "ResumeTime,Crop,CropLeft,CropRight,CropTop,CropBottom,"
-                "Sharpness,NoiseReduction,NonLinStretch,PostProcess,ScalingMethod) "
+                "Sharpness,NoiseReduction,NonLinStretch,PostProcess,ScalingMethod,DeinterlaceMode) "
               "VALUES ";
-      strSQL += PrepareSQL("(%i,%i,%i,%f,%f,%f,%i,%i,%f,%i,%f,%f,%f,%f,%f,%i,%i,%i,%i,%i,%i,%i,%f,%f,%i,%i,%i)",
+      strSQL += PrepareSQL("(%i,%i,%i,%f,%f,%f,%i,%i,%f,%i,%f,%f,%f,%f,%f,%i,%i,%i,%i,%i,%i,%i,%f,%f,%i,%i,%i,%i)",
                            idFile, setting.m_InterlaceMethod, setting.m_ViewMode, setting.m_CustomZoomAmount, setting.m_CustomPixelRatio, setting.m_CustomVerticalShift,
                            setting.m_AudioStream, setting.m_SubtitleStream, setting.m_SubtitleDelay, setting.m_SubtitleOn, setting.m_Brightness,
                            setting.m_Contrast, setting.m_Gamma, setting.m_VolumeAmplification, setting.m_AudioDelay, setting.m_OutputToAllSpeakers,
                            setting.m_ResumeTime, setting.m_Crop, setting.m_CropLeft, setting.m_CropRight, setting.m_CropTop, setting.m_CropBottom,
-                           setting.m_Sharpness, setting.m_NoiseReduction, setting.m_CustomNonLinStretch, setting.m_PostProcess, setting.m_ScalingMethod);
+                           setting.m_Sharpness, setting.m_NoiseReduction, setting.m_CustomNonLinStretch, setting.m_PostProcess, setting.m_ScalingMethod,
+                           setting.m_DeinterlaceMode);
       m_pDS->exec(strSQL.c_str());
     }
   }
@@ -3473,6 +3477,10 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
     { // Change INDEX for bookmark table
       m_pDS->dropIndex("bookmark", "ix_bookmark");
       m_pDS->exec("CREATE INDEX ix_bookmark ON bookmark (idFile, type)");
+    }
+    if (iVersion < 55)
+    {
+      m_pDS->exec("ALTER TABLE settings ADD DeinterlaceMode integer");
     }
   }
   catch (...)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3481,6 +3481,9 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
     if (iVersion < 55)
     {
       m_pDS->exec("ALTER TABLE settings ADD DeinterlaceMode integer");
+      m_pDS->exec("UPDATE settings SET DeinterlaceMode = 2 WHERE Deinterlace NOT IN (0,1)"); // anything other than none: method auto => mode force
+      m_pDS->exec("UPDATE settings SET DeinterlaceMode = 1 WHERE Deinterlace = 1"); // method auto => mode auto
+      m_pDS->exec("UPDATE settings SET DeinterlaceMode = 0, Deinterlace = 1 WHERE Deinterlace = 0"); // method none => mode off, method auto
     }
   }
   catch (...)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -720,7 +720,7 @@ private:
    */
   bool LookupByFolders(const CStdString &path, bool shows = false);
 
-  virtual int GetMinVersion() const { return 54; };
+  virtual int GetMinVersion() const { return 55; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -66,7 +66,7 @@ CGUIDialogVideoSettings::~CGUIDialogVideoSettings(void)
 #define VIDEO_SETTINGS_NONLIN_STRETCH     21
 #define VIDEO_SETTINGS_POSTPROCESS        22
 #define VIDEO_SETTINGS_VERTICAL_SHIFT     23
-#define VIDEO_SETTINGS_INTERLACEMODE      24
+#define VIDEO_SETTINGS_DEINTERLACEMODE    24
 
 void CGUIDialogVideoSettings::CreateSettings()
 {
@@ -76,20 +76,20 @@ void CGUIDialogVideoSettings::CreateSettings()
   // create our settings
   {
     vector<pair<int, int> > entries;
-    entries.push_back(make_pair(VS_INTERLACEMODE_OFF    , 16039));
-    entries.push_back(make_pair(VS_INTERLACEMODE_AUTO   , 16040));
-    entries.push_back(make_pair(VS_INTERLACEMODE_FORCE  , 16041));
+    entries.push_back(make_pair(VS_DEINTERLACEMODE_OFF    , 16039));
+    entries.push_back(make_pair(VS_DEINTERLACEMODE_AUTO   , 16040));
+    entries.push_back(make_pair(VS_DEINTERLACEMODE_FORCE  , 16041));
 
     /* remove unsupported methods */
     for(vector<pair<int, int> >::iterator it = entries.begin(); it != entries.end();)
     {
-      if(g_renderManager.Supports((EINTERLACEMODE)it->first))
+      if(g_renderManager.Supports((EDEINTERLACEMODE)it->first))
         it++;
       else
         it = entries.erase(it);
     }
 
-    AddSpin(VIDEO_SETTINGS_INTERLACEMODE, 16037, (int*)&g_settings.m_currentVideoSettings.m_InterlaceMode, entries);
+    AddSpin(VIDEO_SETTINGS_DEINTERLACEMODE, 16037, (int*)&g_settings.m_currentVideoSettings.m_DeinterlaceMode, entries);
   }
   {
     vector<pair<int, int> > entries;

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -121,6 +121,8 @@ void CGUIDialogVideoSettings::CreateSettings()
     }
 
     AddSpin(VIDEO_SETTINGS_INTERLACEMETHOD, 16038, (int*)&g_settings.m_currentVideoSettings.m_InterlaceMethod, entries);
+    if (g_settings.m_currentVideoSettings.m_DeinterlaceMode == VS_DEINTERLACEMODE_OFF)
+      EnableSettings(VIDEO_SETTINGS_INTERLACEMETHOD, false);
   }
   {
     vector<pair<int, int> > entries;
@@ -233,6 +235,10 @@ void CGUIDialogVideoSettings::OnSettingChanged(SettingInfo &setting)
       g_settings.m_defaultVideoSettings.m_AudioStream = -1;
       g_settings.Save();
     }
+  }
+  else if (setting.id == VIDEO_SETTINGS_DEINTERLACEMODE)
+  {
+    EnableSettings(VIDEO_SETTINGS_INTERLACEMETHOD, g_settings.m_currentVideoSettings.m_DeinterlaceMode != VS_DEINTERLACEMODE_OFF);
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -66,6 +66,7 @@ CGUIDialogVideoSettings::~CGUIDialogVideoSettings(void)
 #define VIDEO_SETTINGS_NONLIN_STRETCH     21
 #define VIDEO_SETTINGS_POSTPROCESS        22
 #define VIDEO_SETTINGS_VERTICAL_SHIFT     23
+#define VIDEO_SETTINGS_INTERLACEMODE      24
 
 void CGUIDialogVideoSettings::CreateSettings()
 {
@@ -75,7 +76,23 @@ void CGUIDialogVideoSettings::CreateSettings()
   // create our settings
   {
     vector<pair<int, int> > entries;
-    entries.push_back(make_pair(VS_INTERLACEMETHOD_NONE                 , 16018));
+    entries.push_back(make_pair(VS_INTERLACEMODE_OFF    , 16039));
+    entries.push_back(make_pair(VS_INTERLACEMODE_AUTO   , 16040));
+    entries.push_back(make_pair(VS_INTERLACEMODE_FORCE  , 16041));
+
+    /* remove unsupported methods */
+    for(vector<pair<int, int> >::iterator it = entries.begin(); it != entries.end();)
+    {
+      if(g_renderManager.Supports((EINTERLACEMODE)it->first))
+        it++;
+      else
+        it = entries.erase(it);
+    }
+
+    AddSpin(VIDEO_SETTINGS_INTERLACEMODE, 16037, (int*)&g_settings.m_currentVideoSettings.m_InterlaceMode, entries);
+  }
+  {
+    vector<pair<int, int> > entries;
     entries.push_back(make_pair(VS_INTERLACEMETHOD_AUTO                 , 16019));
     entries.push_back(make_pair(VS_INTERLACEMETHOD_RENDER_BLEND         , 20131));
     entries.push_back(make_pair(VS_INTERLACEMETHOD_RENDER_WEAVE_INVERTED, 20130));
@@ -103,7 +120,7 @@ void CGUIDialogVideoSettings::CreateSettings()
         it = entries.erase(it);
     }
 
-    AddSpin(VIDEO_SETTINGS_INTERLACEMETHOD, 16023, (int*)&g_settings.m_currentVideoSettings.m_InterlaceMethod, entries);
+    AddSpin(VIDEO_SETTINGS_INTERLACEMETHOD, 16038, (int*)&g_settings.m_currentVideoSettings.m_InterlaceMethod, entries);
   }
   {
     vector<pair<int, int> > entries;


### PR DESCRIPTION
This PR splits the deinterlacing setting in two settings.
1. Deinterlacing Mode: decides when/if deinterlacing will be activated. 
   Values:
   Off - never deinterlace, treat as progressive even if flagged as interlaced
   Auto - turn on the deinterlacing method based on flagging
   Force - always turn on deinterlacing, create the flags when missing
2. Deinterlacing Method:
   Values: same values as the current setting, same behavior for Auto (Bob if available, Yadiff otherwise)

The benefit of the PR is that you can have deinterlacing on flags (Auto) with the method of your choice. Meaning single frame rate for progressive, double rate only for interlaced.
I think going forward the defaults should be Auto/Auto but for now left them as Off/Auto, as the current code does.

I'm looking for feedback on this feature and testing for GL, GLES and vdpau. I changed them but can't test.

Also feel free to suggest different messages in strings.xml.
