### PR TITLE
dirty-region 3d rotate render rectangle fixes

### DIFF
--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -696,15 +696,19 @@ CRect CGraphicContext::generateAABB(const CRect &rect) const
 
   float z = 0.0f;
   ScaleFinalCoords(x1, y1, z);
+  g_Windowing.Project(x1, y1, z);
 
   z = 0.0f;
   ScaleFinalCoords(x2, y2, z);
+  g_Windowing.Project(x2, y2, z);
 
   z = 0.0f;
   ScaleFinalCoords(x3, y3, z);
+  g_Windowing.Project(x3, y3, z);
 
   z = 0.0f;
   ScaleFinalCoords(x4, y4, z);
+  g_Windowing.Project(x4, y4, z);
 
   return CRect( min(min(min(x1, x2), x3), x4),
                 min(min(min(y1, y2), y3), y4),

--- a/xbmc/guilib/MatrixGLES.cpp
+++ b/xbmc/guilib/MatrixGLES.cpp
@@ -341,6 +341,51 @@ void CMatrixGLES::LookAt(GLfloat eyex, GLfloat eyey, GLfloat eyez, GLfloat cente
   Translatef(-eyex, -eyey, -eyez);
 }
 
+static void __gluMultMatrixVecf(const GLfloat matrix[16], const GLfloat in[4], GLfloat out[4])
+{
+  int i;
+
+  for (i=0; i<4; i++)
+  {
+    out[i] = in[0] * matrix[0*4+i] +
+             in[1] * matrix[1*4+i] +
+             in[2] * matrix[2*4+i] +
+             in[3] * matrix[3*4+i];
+  }
+}
+
+// gluProject implementation taken from Mesa3D
+bool CMatrixGLES::Project(GLfloat objx, GLfloat objy, GLfloat objz, const GLfloat modelMatrix[16], const GLfloat projMatrix[16], const GLint viewport[4], GLfloat* winx, GLfloat* winy, GLfloat* winz)
+{
+  GLfloat in[4];
+  GLfloat out[4];
+
+  in[0]=objx;
+  in[1]=objy;
+  in[2]=objz;
+  in[3]=1.0;
+  __gluMultMatrixVecf(modelMatrix, in, out);
+  __gluMultMatrixVecf(projMatrix, out, in);
+  if (in[3] == 0.0)
+    return false;
+  in[0] /= in[3];
+  in[1] /= in[3];
+  in[2] /= in[3];
+  /* Map x, y and z to range 0-1 */
+  in[0] = in[0] * 0.5 + 0.5;
+  in[1] = in[1] * 0.5 + 0.5;
+  in[2] = in[2] * 0.5 + 0.5;
+
+  /* Map x,y to viewport */
+  in[0] = in[0] * viewport[2] + viewport[0];
+  in[1] = in[1] * viewport[3] + viewport[1];
+
+  *winx=in[0];
+  *winy=in[1];
+  *winz=in[2];
+  return true;
+}
+
 void CMatrixGLES::PrintMatrix(void)
 {
   for (int i=0; i<(int)MM_MATRIXSIZE; i++)

--- a/xbmc/guilib/MatrixGLES.h
+++ b/xbmc/guilib/MatrixGLES.h
@@ -57,6 +57,7 @@ public:
   void MultMatrixf(const GLfloat *matrix);
   void LookAt(GLfloat eyex, GLfloat eyey, GLfloat eyez, GLfloat centerx, GLfloat centery, GLfloat centerz, GLfloat upx, GLfloat upy, GLfloat upz);
   void PrintMatrix(void);
+  bool Project(GLfloat objx, GLfloat objy, GLfloat objz, const GLfloat modelMatrix[16], const GLfloat projMatrix[16], const GLint viewport[4], GLfloat* winx, GLfloat* winy, GLfloat* winz);
 
 protected:
   vector<GLfloat*> m_matrices[(int)MM_MATRIXSIZE];

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -98,6 +98,11 @@ public:
 
   virtual bool TestRender() = 0;
 
+  /**
+   * Project (x,y,z) 3d scene coordinates to (x,y) 2d screen coordinates
+   */
+  virtual void Project(float &x, float &y, float &z) { }
+
   void GetRenderVersion(unsigned int& major, unsigned int& minor) const;
   const CStdString& GetRenderVendor() const { return m_RenderVendor; }
   const CStdString& GetRenderRenderer() const { return m_RenderRenderer; }

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -806,6 +806,22 @@ void CRenderSystemDX::SetCameraPosition(const CPoint &camera, int screenWidth, i
   D3DXMATRIX mtxProjection;
   D3DXMatrixPerspectiveOffCenterLH(&mtxProjection, (-w - offset.x)*0.5f, (w - offset.x)*0.5f, (-h + offset.y)*0.5f, (h + offset.y)*0.5f, h, 100*h);
   m_pD3DDevice->SetTransform(D3DTS_PROJECTION, &mtxProjection);
+
+  m_world = mtxWorld;
+  m_view = mtxView;
+  m_projection = mtxProjection;
+  m_viewPort = viewport;
+}
+
+void CRenderSystemDX::Project(float &x, float &y, float &z)
+{
+  D3DXVECTOR3 vScreenCoord;
+  D3DXVECTOR3 vLocation(x, y, z);
+
+  D3DXVec3Project(&vScreenCoord, &vLocation, &m_viewPort, &m_projection, &m_view, &m_world);
+  x = vScreenCoord.x;
+  y = vScreenCoord.y;
+  z = 0;
 }
 
 bool CRenderSystemDX::TestRender()

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -76,6 +76,8 @@ public:
 
   virtual bool TestRender();
 
+  virtual void Project(float &x, float &y, float &z);
+
   LPDIRECT3DDEVICE9 Get3DDevice() { return m_pD3DDevice; }
   int GetBackbufferCount() const { return m_D3DPP.BackBufferCount; }
 
@@ -151,6 +153,11 @@ protected:
   std::vector<ID3DResource*>  m_resources;
 
   bool                        m_inScene; ///< True if we're in a BeginScene()/EndScene() block
+
+  D3DVIEWPORT9                m_viewPort;
+  D3DXMATRIX                  m_projection;
+  D3DXMATRIX                  m_view;
+  D3DXMATRIX                  m_world;
 };
 
 #endif

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -19,14 +19,12 @@
 *
 */
 
-
-#include "system.h"
+#include "RenderSystemGL.h"
 
 #ifdef HAS_GL
 
 #include "guilib/GraphicContext.h"
 #include "settings/AdvancedSettings.h"
-#include "RenderSystemGL.h"
 #include "utils/log.h"
 #include "utils/GLUtils.h"
 #include "utils/TimeUtils.h"
@@ -445,7 +443,22 @@ void CRenderSystemGL::SetCameraPosition(const CPoint &camera, int screenWidth, i
   glFrustum( (-w - offset.x)*0.5f, (w - offset.x)*0.5f, (-h + offset.y)*0.5f, (h + offset.y)*0.5f, h, 100*h);
   glMatrixMode(GL_MODELVIEW);
 
+  glGetIntegerv(GL_VIEWPORT, m_viewPort);
+  glGetDoublev(GL_MODELVIEW_MATRIX, m_view);
+  glGetDoublev(GL_PROJECTION_MATRIX, m_projection);
+
   g_graphicsContext.EndPaint();
+}
+
+void CRenderSystemGL::Project(float &x, float &y, float &z)
+{
+  GLdouble coordX, coordY, coordZ;
+  if (gluProject(x, y, z, m_view, m_projection, m_viewPort, &coordX, &coordY, &coordZ) == GLU_TRUE)
+  {
+    x = (float)coordX;
+    y = (float)(m_viewPort[3] - coordY);
+    z = 0;
+  }
 }
 
 bool CRenderSystemGL::TestRender()

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "system.h"
 #include "rendering/RenderSystem.h"
 
 class CRenderSystemGL : public CRenderSystemBase
@@ -60,6 +61,8 @@ public:
 
   virtual bool TestRender();
 
+  virtual void Project(float &x, float &y, float &z);
+
   virtual void GetGLSLVersion(int& major, int& minor);
 
   virtual void ResetGLErrors();
@@ -82,6 +85,12 @@ protected:
 
   int        m_glslMajor;
   int        m_glslMinor;
+  
+#ifdef HAS_GL
+  GLdouble   m_view[16];
+  GLdouble   m_projection[16];
+  GLint      m_viewPort[4];
+#endif
 };
 
 #endif // RENDER_SYSTEM_H

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -395,7 +395,22 @@ void CRenderSystemGLES::SetCameraPosition(const CPoint &camera, int screenWidth,
   g_matrices.Frustum( (-w - offset.x)*0.5f, (w - offset.x)*0.5f, (-h + offset.y)*0.5f, (h + offset.y)*0.5f, h, 100*h);
   g_matrices.MatrixMode(MM_MODELVIEW);
 
+  glGetIntegerv(GL_VIEWPORT, m_viewPort);
+  glGetFloatv(GL_MODELVIEW_MATRIX, m_view);
+  glGetFloatv(GL_PROJECTION_MATRIX, m_projection);
+
   g_graphicsContext.EndPaint();
+}
+
+void CRenderSystemGLES::Platform(float &x, float &y, float &z)
+{
+  GLfloat coordX, coordY, coordZ;
+  if (g_matrices.Project(x, y, z, m_view, m_projection, m_viewPort, &coordX, &coordY, &coordZ))
+  {
+    x = coordX;
+    y = (float)(m_viewPort[3] - coordY);
+    z = 0;
+  }
 }
 
 bool CRenderSystemGLES::TestRender()

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -73,6 +73,8 @@ public:
   virtual void RestoreHardwareTransform();
 
   virtual bool TestRender();
+
+  virtual void Project(float &x, float &y, float &z);
   
   void InitialiseGUIShader();
   void EnableGUIShader(ESHADERMETHOD method);
@@ -101,6 +103,10 @@ protected:
 
   CGUIShader  **m_pGUIshader;  // One GUI shader for each method
   ESHADERMETHOD m_method;      // Current GUI Shader method
+
+  GLfloat    m_view[16];
+  GLfloat    m_projection[16];
+  GLint      m_viewPort[4];
 };
 
 #endif // RENDER_SYSTEM_H


### PR DESCRIPTION
Currently to calculate GUIControl's render rect we apply our translation/rotation/etc transformation matrices and from resulting [x, y, z] vertices we simply take [x, y] (so essentially we are doing orthographic projection on XY plane). This is fine if we are not playing with Z coordinate, but when we apply f.e. y-axis rotation this cause this: http://www.youtube.com/watch?v=n_JyR4kmfPs

We need to do perspective projection of our [x,y,z] to get 2d screen coordinates - with this commit I get proper render rect: http://www.youtube.com/watch?v=DckXR58T5AI

This PR is mainly to present issue and maybe get some hints from people who actually know anything about our render system (I did only DX and essentially c&p'ed it from some DX tutorial as I have no clue about DX or GL).

This bug results in such "artifacts" width d-r enabled: http://i.imgur.com/24Ha0.jpg ,http://img7.imageshack.us/img7/8177/screenshot197.png
