### PR TITLE
Wav codec fixes (two of 'em)

### DIFF
--- a/xbmc/cores/paplayer/WAVcodec.cpp
+++ b/xbmc/cores/paplayer/WAVcodec.cpp
@@ -263,6 +263,18 @@ int WAVCodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
   return READ_ERROR;
 }
 
+int WAVCodec::ReadSamples(float *pBuffer, int numsamples, int *actualsamples)
+{
+  int ret = READ_ERROR;
+  *actualsamples = 0;
+  if (m_bHasFloat)
+  {
+    ret = ReadPCM((BYTE*)pBuffer, numsamples * (m_BitsPerSample >> 3), actualsamples);
+    *actualsamples /= (m_BitsPerSample >> 3);
+  }
+  return ret;
+}
+
 bool WAVCodec::CanInit()
 {
   return true;

--- a/xbmc/cores/paplayer/WAVcodec.h
+++ b/xbmc/cores/paplayer/WAVcodec.h
@@ -39,8 +39,8 @@ public:
 
 private:
   bool m_bHasFloat;
-  long m_iDataStart;
-  long m_iDataLen;
+  uint32_t m_iDataStart;
+  uint32_t m_iDataLen;
   DWORD m_ChannelMask;
 };
 

--- a/xbmc/cores/paplayer/WAVcodec.h
+++ b/xbmc/cores/paplayer/WAVcodec.h
@@ -34,6 +34,7 @@ public:
   virtual void DeInit();
   virtual __int64 Seek(__int64 iSeekTime);
   virtual int ReadPCM(BYTE *pBuffer, int size, int *actualsize);
+  virtual int ReadSamples(float *pBuffer, int numsamples, int *actualsamples);
   virtual bool CanInit();
   virtual bool HasFloatData() const { return m_bHasFloat; }
 


### PR DESCRIPTION
Fixed two problems with PAPlayer's WAVCodec: failure to play files > 2 GB and failure to play float format wav files.

Notes about testing: both of these fixes were tested by using XBMC's vfs to masquerade working wav files as problematic ones. Both tests confirmed that the current WAVCodec chokes on each condition and successfully plays the music after the fixes are applied.
