### PR TITLE
fixed: if sources are empty return true to prevent broken video -> files 

### DIFF
--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -54,7 +54,7 @@ bool CSourcesDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
   g_mediaManager.GetRemovableDrives(sources);
 
   if (sources.empty())
-    return false;
+    return true;
 
   return GetDirectory(sources, items);
 }


### PR DESCRIPTION
Making this change fixes a UI bug when starting a new install and click video -> files, the page is 'broken'
