### PR TITLE
changed: if we're in the 'root' of video sources, don't show a further parent directory

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -652,7 +652,7 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
       m_history.RemoveParentPath();
   }
 
-  if (m_guiState.get() && !m_guiState->HideParentDirItems() && !items.GetPath().IsEmpty())
+  if (m_guiState.get() && !m_guiState->HideParentDirItems() && !items.GetPath().IsEmpty() && !items.GetPath().Equals("sources://video/"))
   {
     CFileItemPtr pItem(new CFileItem(".."));
     pItem->SetPath(strParentPath);


### PR DESCRIPTION
It makes no sense (to me at least) that if we are showing the contents of sources://video/ that we should show a ".." directory irrespective of the options selected (i.e. to not show parent directories) we are already at the parent and therefore should not display it
