### PR TITLE
changed: if the user has never visited the addon settings section, (i.e. 

### DIFF
--- a/xbmc/addons/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -107,6 +107,9 @@ VECSOURCES& CGUIViewStateAddonBrowser::GetSources()
     m_sources.push_back(share);
   }
 
+  //User has visited addon section at least once, record this state (they are now assumed to be familiar with the addon system in XBMC)
+  g_settings.m_bAddonPromptOnBroken = true;
+
   return CGUIViewState::GetSources();
 }
 

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -222,11 +222,18 @@ bool CRepositoryUpdateJob::DoWork()
     {
       if (database.IsAddonBroken(addons[i]->ID()).IsEmpty())
       {
-        if (addon && CGUIDialogYesNo::ShowAndGetInput(addons[i]->Name(),
+        if (addon && g_settings.m_bAddonPromptOnBroken && CGUIDialogYesNo::ShowAndGetInput(addons[i]->Name(),
                                              g_localizeStrings.Get(24096),
                                              g_localizeStrings.Get(24097),
                                              ""))
+        {
           database.DisableAddon(addons[i]->ID());
+        }
+        else if (!g_settings.m_bAddonPromptOnBroken)
+        {
+          CLog::Log(LOGINFO, "ADDON: User has not visited addon section, auto disabling broken addon - %s", addons[i]->ID().c_str());
+          database.DisableAddon(addons[i]->ID());
+        }
       }
     }
     database.BreakAddon(addons[i]->ID(), addons[i]->Props().broken);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -93,7 +93,7 @@ void CSettings::Initialize()
   m_bStartVideoWindowed = false;
   m_bAddonAutoUpdate = true;
   m_bAddonNotifications = true;
-
+  m_bAddonPromptOnBroken = false;
   m_nVolumeLevel = 0;
   m_dynamicRangeCompressionLevel = 0;
   m_iPreMuteVolumeLevel = 0;
@@ -674,6 +674,13 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
     XMLUtils::GetBoolean(pElement, "addonnotifications", m_bAddonNotifications);
   }
 
+  //addon settings
+  pElement = pRootElement->FirstChildElement("addons");
+  if (pElement)
+  {
+    XMLUtils::GetBoolean(pElement, "promptonbroken", m_bAddonPromptOnBroken);
+  }
+
   pElement = pRootElement->FirstChildElement("defaultvideosettings");
   if (pElement)
   {
@@ -848,6 +855,11 @@ bool CSettings::SaveSettings(const CStdString& strSettingsFile, CGUISettings *lo
   XMLUtils::SetInt(pNode, "httpapibroadcastlevel", m_HttpApiBroadcastLevel);
   XMLUtils::SetBoolean(pNode, "addonautoupdate", m_bAddonAutoUpdate);
   XMLUtils::SetBoolean(pNode, "addonnotifications", m_bAddonNotifications);
+
+  TiXmlElement addonsNode("addons");
+  pNode = pRoot->InsertEndChild(addonsNode);
+  if (!pNode) return false;
+  XMLUtils::SetBoolean(pNode, "promptonbroken", m_bAddonPromptOnBroken);
 
   // default video settings
   TiXmlElement videoSettingsNode("defaultvideosettings");

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -201,6 +201,7 @@ public:
   bool m_bMyVideoNavFlatten;
   bool m_bStartVideoWindowed;
   bool m_bAddonAutoUpdate;
+  bool m_bAddonPromptOnBroken;
   bool m_bAddonNotifications;
 
   int m_iVideoStartWindow;


### PR DESCRIPTION
changed: if the user has never visited the addon settings section, (i.e. they are a new user) do not bombard user with prompts about broken addons, automatically disable the addons instead. Only prompt after the user has visited the addon section at least once
