### PR TITLE
fixes: error prompt when searching for addons

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -930,7 +930,7 @@ bool CGUIMediaWindow::OnClick(int iItem)
       items.RemoveDiscCache(GetID());
 
     CFileItem directory(*pItem);
-    if (!Update(directory.GetPath()))
+    if (!Update(directory.GetPath()) && !directory.GetPath().Equals("addons://search/"))
       ShowShareErrorMessage(&directory);
 
     return true;


### PR DESCRIPTION
fixed: error prompt when search for an empty string addon or trying to cancel out of the search dialog

I am not 100% happy with the way we engage the dialog box, its very functional, set something here, go back through the loop hope something works, which resulted in me having to put a string check in GUIMediaWindow, this hooks addons into this page, which I would have rather avoided and tried to keep addon logic in its own files

any suggestions welcome
