### PR TITLE
Auto download RSS Editor Add-on if required

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2224,6 +2224,7 @@
   <string id="24073">Could not connect</string>
   <string id="24074">Needs to restart</string>
   <string id="24075">Disable</string>
+  <string id="24076">Add-on Required</string>
   <string id="24080">Try to reconnect?</string>
   <string id="24089">Add-on restarts</string>
   <string id="24090">Lock Add-on manager</string>
@@ -2234,6 +2235,8 @@
   <string id="24097">Would you like to disable it on your system?</string>
   <string id="24098">Broken</string>
   <string id="24099">Would you like to switch to this skin?</string>
+  <string id="24100">To use this feature you must download an Add-on:</string>
+  <string id="24101">Would you like to download this Add-on?</string>
   <string id="25000">Notifications</string>
 
   <!-- strings 29800 thru 29998 reserved strings used only in the default Project Mayhem III skin and not c++ code -->

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -58,6 +58,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "addons/Visualisation.h"
 #include "addons/AddonManager.h"
+#include "addons/AddonInstaller.h"
 #include "storage/MediaManager.h"
 #include "network/Network.h"
 #include "guilib/GUIControlGroupList.h"
@@ -973,9 +974,7 @@ void CGUIWindowSettingsCategory::UpdateSettings()
     else if (strSetting.Equals("lookandfeel.rssedit"))
     {
       CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
-      AddonPtr addon;
-      CAddonMgr::Get().GetAddon("script.rss.editor",addon);
-      pControl->SetEnabled(addon && g_guiSettings.GetBool("lookandfeel.enablerssfeeds"));
+      pControl->SetEnabled(g_guiSettings.GetBool("lookandfeel.enablerssfeeds"));
     }
     else if (strSetting.Equals("videoplayer.pauseafterrefreshchange"))
     {
@@ -1075,7 +1074,17 @@ void CGUIWindowSettingsCategory::OnClick(CBaseSettingControl *pSettingControl)
     }
   }
   else if (strSetting.Equals("lookandfeel.rssedit"))
+  {
+    AddonPtr addon;
+    CAddonMgr::Get().GetAddon("script.rss.editor",addon);
+    if (!addon)
+    {
+      if (!CGUIDialogYesNo::ShowAndGetInput(g_localizeStrings.Get(24076), g_localizeStrings.Get(24100),"RSS Editor",g_localizeStrings.Get(24101)))
+        return;
+      CAddonInstaller::Get().Install("script.rss.editor", true, "", false);
+    }
     CBuiltins::Execute("RunScript(script.rss.editor)");
+  }
   else if (pSettingControl->GetSetting()->GetType() == SETTINGS_TYPE_ADDON)
   { // prompt for the addon
     CSettingAddon *setting = (CSettingAddon *)pSettingControl->GetSetting();


### PR DESCRIPTION
added: Edit rss feed button is enabled (if rss feeds are enabled) always, if script.rss.editor is missing then prompt to download before continuing, instead of just showing as disabled and expecting user to know they must install rss addon
