### PR TITLE
Settings GUI Cleanup

### DIFF
--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -555,7 +555,13 @@ void CGUISettings::Initialize()
   AddBool(vdl, "videolibrary.showunwatchedplots", 20369, true);
   AddBool(NULL, "videolibrary.seasonthumbs", 20382, true);
   AddBool(vdl, "videolibrary.actorthumbs", 20402, true);
-  AddInt(vdl, "videolibrary.flattentvshows", 20412, 1, 0, 1, 2, SPIN_CONTROL_TEXT);
+
+  map<int, int> flattenTVShowOptions;
+  flattenTVShowOptions.insert(make_pair(20420, 0));
+  flattenTVShowOptions.insert(make_pair(20421, 1));
+  flattenTVShowOptions.insert(make_pair(20422, 2));
+  AddInt(vdl, "videolibrary.flattentvshows", 20412, 1, flattenTVShowOptions, SPIN_CONTROL_TEXT);
+
   AddBool(NULL, "videolibrary.flattenmoviesets", 22002, false);
   AddBool(vdl, "videolibrary.updateonstartup", 22000, false);
   AddBool(vdl, "videolibrary.backgroundupdate", 22001, false);
@@ -626,9 +632,20 @@ void CGUISettings::Initialize()
   #define SYNCSETTINGS 1
 #endif
   AddBool(SYNCSETTINGS ? vp : NULL, "videoplayer.usedisplayasclock", 13510, false);
-  AddInt(SYNCSETTINGS ? vp : NULL, "videoplayer.synctype", 13500, SYNC_RESAMPLE, SYNC_DISCON, 1, SYNC_RESAMPLE, SPIN_CONTROL_TEXT);
+
+  map<int, int> syncTypes;
+  syncTypes.insert(make_pair(13501, SYNC_DISCON));
+  syncTypes.insert(make_pair(13502, SYNC_SKIPDUP));
+  syncTypes.insert(make_pair(13503, SYNC_RESAMPLE));
+  AddInt(SYNCSETTINGS ? vp : NULL, "videoplayer.synctype", 13500, SYNC_RESAMPLE, syncTypes, SPIN_CONTROL_TEXT);
   AddFloat(NULL, "videoplayer.maxspeedadjust", 13504, 5.0f, 0.0f, 0.1f, 10.0f);
-  AddInt(NULL, "videoplayer.resamplequality", 13505, RESAMPLE_MID, RESAMPLE_LOW, 1, RESAMPLE_REALLYHIGH, SPIN_CONTROL_TEXT);
+
+  map<int, int> resampleQualities;
+  resampleQualities.insert(make_pair(13506, RESAMPLE_LOW));
+  resampleQualities.insert(make_pair(13507, RESAMPLE_MID));
+  resampleQualities.insert(make_pair(13508, RESAMPLE_HIGH));
+  resampleQualities.insert(make_pair(13509, RESAMPLE_REALLYHIGH));
+  AddInt(NULL, "videoplayer.resamplequality", 13505, RESAMPLE_MID, resampleQualities, SPIN_CONTROL_TEXT);
   AddInt(vp, "videoplayer.errorinaspect", 22021, 0, 0, 1, 20, SPIN_CONTROL_INT_PLUS, MASK_PERCENT, TEXT_NONE);
 
   map<int,int> stretch;
@@ -651,7 +668,14 @@ void CGUISettings::Initialize()
   AddBool(vp, "videoplayer.teletextenabled", 23050, true);
 
   CSettingsCategory* vid = AddCategory(5, "myvideos", 14081);
-  AddInt(vid, "myvideos.selectaction", 22079, SELECT_ACTION_PLAY_OR_RESUME, SELECT_ACTION_CHOOSE, 1, SELECT_ACTION_INFO, SPIN_CONTROL_TEXT);
+
+  map<int, int> myVideosSelectActions;
+  myVideosSelectActions.insert(make_pair(22080, SELECT_ACTION_CHOOSE));
+  myVideosSelectActions.insert(make_pair(208,   SELECT_ACTION_PLAY_OR_RESUME));
+  myVideosSelectActions.insert(make_pair(13404, SELECT_ACTION_RESUME));
+  myVideosSelectActions.insert(make_pair(22081, SELECT_ACTION_INFO));
+  
+  AddInt(vid, "myvideos.selectaction", 22079, SELECT_ACTION_PLAY_OR_RESUME, myVideosSelectActions, SPIN_CONTROL_TEXT);
   AddBool(NULL, "myvideos.treatstackasfile", 20051, true);
   AddBool(vid, "myvideos.extractflags",20433, true);
   AddBool(vid, "myvideos.filemetadata", 20419, true);
@@ -660,12 +684,26 @@ void CGUISettings::Initialize()
   CSettingsCategory* sub = AddCategory(5, "subtitles", 287);
   AddString(sub, "subtitles.font", 14089, "arial.ttf", SPIN_CONTROL_TEXT);
   AddInt(sub, "subtitles.height", 289, 28, 16, 2, 74, SPIN_CONTROL_TEXT); // use text as there is a disk based lookup needed
-  AddInt(sub, "subtitles.style", 736, FONT_STYLE_BOLD, FONT_STYLE_NORMAL, 1, FONT_STYLE_BOLD_ITALICS, SPIN_CONTROL_TEXT);
+
+  map<int, int> fontStyles;
+  fontStyles.insert(make_pair(738, FONT_STYLE_NORMAL));
+  fontStyles.insert(make_pair(739, FONT_STYLE_BOLD));
+  fontStyles.insert(make_pair(740, FONT_STYLE_ITALICS));
+  fontStyles.insert(make_pair(741, FONT_STYLE_BOLD_ITALICS));
+
+  AddInt(sub, "subtitles.style", 736, FONT_STYLE_BOLD, fontStyles, SPIN_CONTROL_TEXT);
   AddInt(sub, "subtitles.color", 737, SUBTITLE_COLOR_START + 1, SUBTITLE_COLOR_START, 1, SUBTITLE_COLOR_END, SPIN_CONTROL_TEXT);
   AddString(sub, "subtitles.charset", 735, "DEFAULT", SPIN_CONTROL_TEXT);
   AddSeparator(sub, "subtitles.sep1");
   AddPath(sub, "subtitles.custompath", 21366, "", BUTTON_CONTROL_PATH_INPUT, false, 657);
-  AddInt(sub, "subtitles.align", 21460, SUBTITLE_ALIGN_MANUAL, SUBTITLE_ALIGN_MANUAL, 1, SUBTITLE_ALIGN_TOP_OUTSIDE, SPIN_CONTROL_TEXT);
+
+  map<int, int> subtitleAlignments;
+  subtitleAlignments.insert(make_pair(21461, SUBTITLE_ALIGN_MANUAL));
+  subtitleAlignments.insert(make_pair(21462, SUBTITLE_ALIGN_BOTTOM_INSIDE));
+  subtitleAlignments.insert(make_pair(21463, SUBTITLE_ALIGN_BOTTOM_OUTSIDE));
+  subtitleAlignments.insert(make_pair(21464, SUBTITLE_ALIGN_TOP_INSIDE));
+  subtitleAlignments.insert(make_pair(21465, SUBTITLE_ALIGN_TOP_OUTSIDE));
+  AddInt(sub, "subtitles.align", 21460, SUBTITLE_ALIGN_MANUAL, subtitleAlignments, SPIN_CONTROL_TEXT);
 
   CSettingsCategory* dvd = AddCategory(5, "dvds", 14087);
   AddBool(dvd, "dvds.autorun", 14088, false);
@@ -731,14 +769,25 @@ void CGUISettings::Initialize()
   {
 #ifndef __APPLE__
     AddString(NULL, "network.interface",775,"", SPIN_CONTROL_TEXT);
-    AddInt(NULL, "network.assignment", 715, NETWORK_DHCP, NETWORK_DHCP, 1, NETWORK_DISABLED, SPIN_CONTROL_TEXT);
+
+    map<int, int> networkAssignments;
+    networkAssignments.insert(make_pair(716, NETWORK_DHCP));
+    networkAssignments.insert(make_pair(717, NETWORK_STATIC));
+    networkAssignments.insert(make_pair(787, NETWORK_DISABLED));
+    AddInt(NULL, "network.assignment", 715, NETWORK_DHCP, networkAssignments, SPIN_CONTROL_TEXT);
     AddString(NULL, "network.ipaddress", 719, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
     AddString(NULL, "network.subnet", 720, "255.255.255.0", EDIT_CONTROL_IP_INPUT);
     AddString(NULL, "network.gateway", 721, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
     AddString(NULL, "network.dns", 722, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
     AddString(NULL, "network.dnssuffix", 22002, "", EDIT_CONTROL_INPUT, true);
     AddString(NULL, "network.essid", 776, "0.0.0.0", BUTTON_CONTROL_STANDARD);
-    AddInt(NULL, "network.enc", 778, ENC_NONE, ENC_NONE, 1, ENC_WPA2, SPIN_CONTROL_TEXT);
+
+    map<int, int> networkEncapsulations;
+    networkEncapsulations.insert(make_pair(780, ENC_NONE));
+    networkEncapsulations.insert(make_pair(781, ENC_WEP));
+    networkEncapsulations.insert(make_pair(782, ENC_WPA));
+    networkEncapsulations.insert(make_pair(783, ENC_WPA2));
+    AddInt(NULL, "network.enc", 778, ENC_NONE, networkEncapsulations, SPIN_CONTROL_TEXT);
     AddString(NULL, "network.key", 777, "0.0.0.0", EDIT_CONTROL_INPUT);
 #ifndef _WIN32
     AddString(NULL, "network.save", 779, "", BUTTON_CONTROL_STANDARD);

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -441,16 +441,8 @@ void CGUISettings::Initialize()
   AddBool(ao, "audiooutput.dontnormalizelevels", 346, true);
 
 #if (defined(__APPLE__) && defined(__arm__))
-  if (g_sysinfo.IsAppleTV2())
-  {
-    AddBool(ao, "audiooutput.ac3passthrough", 364, false);
-    AddBool(ao, "audiooutput.dtspassthrough", 254, false);
-  }
-  else
-  {
-    AddBool(NULL, "audiooutput.ac3passthrough", 364, false);
-    AddBool(NULL, "audiooutput.dtspassthrough", 254, false);
-  }
+  AddBool(g_sysinfo.IsAppleTV2() ? ao : NULL, "audiooutput.ac3passthrough", 364, false);
+  AddBool(g_sysinfo.IsAppleTV2() ? ao : NULL, "audiooutput.dtspassthrough", 254, false);
 #else
   AddBool(ao, "audiooutput.ac3passthrough", 364, true);
   AddBool(ao, "audiooutput.dtspassthrough", 254, true);

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -331,6 +331,19 @@ void CGUIWindowSettingsCategory::SetupControls()
   m_defaultControl = CONTROL_START_BUTTONS;
 }
 
+CGUIControl* CGUIWindowSettingsCategory::AddIntBasedSpinControl(CSetting *pSetting, float groupWidth, int &iControlID)
+{
+  CSettingInt *pSettingInt = (CSettingInt*)pSetting;
+  CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, groupWidth, iControlID);
+  if (!pSettingInt->m_entries.empty())
+  {
+    for (map<int,int>::iterator it=pSettingInt->m_entries.begin(); it != pSettingInt->m_entries.end();++it)
+      pControl->AddLabel(g_localizeStrings.Get(it->first), it->second);
+    pControl->SetValue(pSettingInt->GetData());
+  }
+  return pControl;
+}
+
 void CGUIWindowSettingsCategory::CreateSettings()
 {
   FreeSettingsControls();
@@ -344,94 +357,127 @@ void CGUIWindowSettingsCategory::CreateSettings()
   for (unsigned int i = 0; i < settings.size(); i++)
   {
     CSetting *pSetting = settings[i];
-    AddSetting(pSetting, group->GetWidth(), iControlID);
     CStdString strSetting = pSetting->GetSetting();
     if (pSetting->GetType() == SETTINGS_TYPE_INT)
     {
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddIntBasedSpinControl(pSetting, group->GetWidth(), iControlID);
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      if (!pSettingInt->m_entries.empty())
+      if (strSetting.Equals("videolibrary.flattentvshows"))
       {
-        CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
-        for (map<int,int>::iterator it=pSettingInt->m_entries.begin();
-             it != pSettingInt->m_entries.end();++it)
+        pControl->AddLabel(g_localizeStrings.Get(20420), 0); // Never
+        pControl->AddLabel(g_localizeStrings.Get(20421), 1); // One Season
+        pControl->AddLabel(g_localizeStrings.Get(20422), 2); // Always
+        pControl->SetValue(pSettingInt->GetData());
+      }
+      else if (strSetting.Equals("videoplayer.pauseafterrefreshchange"))
+      {
+        pControl->AddLabel(g_localizeStrings.Get(13551), 0);
+
+        for (int i = 1; i <= MAXREFRESHCHANGEDELAY; i++)
         {
-          pControl->AddLabel(g_localizeStrings.Get(it->first), it->second);
+          CStdString delayText;
+          if (i < 20)
+            delayText.Format(g_localizeStrings.Get(13552).c_str(), (double)i / 10.0);
+          else
+            delayText.Format(g_localizeStrings.Get(13553).c_str(), (double)i / 10.0);
+
+          pControl->AddLabel(delayText, i);
         }
         pControl->SetValue(pSettingInt->GetData());
-        continue;
       }
+      else if (strSetting.Equals("myvideos.selectaction"))
+      {
+        pControl->AddLabel(g_localizeStrings.Get(22080), SELECT_ACTION_CHOOSE);
+        pControl->AddLabel(g_localizeStrings.Get(208),   SELECT_ACTION_PLAY_OR_RESUME);
+        pControl->AddLabel(g_localizeStrings.Get(13404), SELECT_ACTION_RESUME);
+        pControl->AddLabel(g_localizeStrings.Get(22081), SELECT_ACTION_INFO);
+        pControl->SetValue(pSettingInt->GetData());
+      }
+      else if (strSetting.Equals("subtitles.style"))
+      {
+        pControl->AddLabel(g_localizeStrings.Get(738), FONT_STYLE_NORMAL);
+        pControl->AddLabel(g_localizeStrings.Get(739), FONT_STYLE_BOLD);
+        pControl->AddLabel(g_localizeStrings.Get(740), FONT_STYLE_ITALICS);
+        pControl->AddLabel(g_localizeStrings.Get(741), FONT_STYLE_BOLD_ITALICS);
+        pControl->SetValue(pSettingInt->GetData());
+      }
+      else if (strSetting.Equals("subtitles.color"))
+      {
+        for (int i = SUBTITLE_COLOR_START; i <= SUBTITLE_COLOR_END; i++)
+          pControl->AddLabel(g_localizeStrings.Get(760 + i), i);
+        pControl->SetValue(pSettingInt->GetData());
+      }
+      else if (strSetting.Equals("lookandfeel.startupwindow"))
+        FillInStartupWindow(pSetting);
+      else if (strSetting.Equals("subtitles.height") || strSetting.Equals("karaoke.fontheight") )
+        FillInSubtitleHeights(pSetting, pControl);
+      else if (strSetting.Equals("videoscreen.screen"))
+        FillInScreens(strSetting, g_guiSettings.GetResolution());
+      else if (strSetting.Equals("videoscreen.resolution"))
+        FillInResolutions(strSetting, g_guiSettings.GetInt("videoscreen.screen"), g_guiSettings.GetResolution(), false);
+      continue;
     }
     if (strSetting.Equals("videooutput.aspect"))
     {
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
       pControl->AddLabel(g_localizeStrings.Get(21375), VIDEO_NORMAL);
       pControl->AddLabel(g_localizeStrings.Get(21376), VIDEO_LETTERBOX);
       pControl->AddLabel(g_localizeStrings.Get(21377), VIDEO_WIDESCREEN);
       pControl->SetValue(pSettingInt->GetData());
+      continue;
     }
 #ifdef HAS_WEB_SERVER
     else if (strSetting.Equals("services.webserverport"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       CBaseSettingControl *control = GetSetting(pSetting->GetSetting());
       control->SetDelayed();
+      continue;
     }
 #endif
     else if (strSetting.Equals("services.esport"))
     {
 #ifdef HAS_EVENT_SERVER
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       CBaseSettingControl *control = GetSetting(pSetting->GetSetting());
       control->SetDelayed();
+      continue;
 #endif
     }
     else if (strSetting.Equals("network.assignment"))
     {
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
       pControl->AddLabel(g_localizeStrings.Get(716), NETWORK_DHCP);
       pControl->AddLabel(g_localizeStrings.Get(717), NETWORK_STATIC);
       pControl->AddLabel(g_localizeStrings.Get(787), NETWORK_DISABLED);
       pControl->SetValue(pSettingInt->GetData());
+      continue;
     }
     else if (strSetting.Equals("network.httpproxyport"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       CBaseSettingControl *control = GetSetting(pSetting->GetSetting());
       control->SetDelayed();
-    }
-    else if (strSetting.Equals("subtitles.style"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
-      pControl->AddLabel(g_localizeStrings.Get(738), FONT_STYLE_NORMAL);
-      pControl->AddLabel(g_localizeStrings.Get(739), FONT_STYLE_BOLD);
-      pControl->AddLabel(g_localizeStrings.Get(740), FONT_STYLE_ITALICS);
-      pControl->AddLabel(g_localizeStrings.Get(741), FONT_STYLE_BOLD_ITALICS);
-      pControl->SetValue(pSettingInt->GetData());
-    }
-    else if (strSetting.Equals("subtitles.color"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
-      for (int i = SUBTITLE_COLOR_START; i <= SUBTITLE_COLOR_END; i++)
-        pControl->AddLabel(g_localizeStrings.Get(760 + i), i);
-      pControl->SetValue(pSettingInt->GetData());
-    }
-    else if (strSetting.Equals("subtitles.height") || strSetting.Equals("karaoke.fontheight") )
-    {
-      FillInSubtitleHeights(pSetting);
+      continue;
     }
     else if (strSetting.Equals("subtitles.font") || strSetting.Equals("karaoke.font") )
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInSubtitleFonts(pSetting);
+      continue;
     }
     else if (strSetting.Equals("subtitles.charset") || strSetting.Equals("locale.charset") || strSetting.Equals("karaoke.charset"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInCharSets(pSetting);
+      continue;
     }
     else if (strSetting.Equals("subtitles.align"))
     {
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
       pControl->AddLabel(g_localizeStrings.Get(21461), SUBTITLE_ALIGN_MANUAL);
       pControl->AddLabel(g_localizeStrings.Get(21462), SUBTITLE_ALIGN_BOTTOM_INSIDE);
       pControl->AddLabel(g_localizeStrings.Get(21463), SUBTITLE_ALIGN_BOTTOM_OUTSIDE);
@@ -441,15 +487,21 @@ void CGUIWindowSettingsCategory::CreateSettings()
     }
     else if (strSetting.Equals("lookandfeel.font"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInSkinFonts(pSetting);
+      continue;
     }
     else if (strSetting.Equals("lookandfeel.soundskin"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInSoundSkins(pSetting);
+      continue;
     }
     else if (strSetting.Equals("locale.language"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInLanguages(pSetting);
+      continue;
     }
 #ifdef _LINUX
     else if (strSetting.Equals("locale.timezonecountry"))
@@ -457,7 +509,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
       CStdString myTimezoneCountry = g_guiSettings.GetString("locale.timezonecountry");
       int myTimezeoneCountryIndex = 0;
 
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
       vector<CStdString> countries = g_timezone.GetCounties();
       for (unsigned int i=0; i < countries.size(); i++)
       {
@@ -466,6 +518,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
         pControl->AddLabel(countries[i], i);
       }
       pControl->SetValue(myTimezeoneCountryIndex);
+      continue;
     }
     else if (strSetting.Equals("locale.timezone"))
     {
@@ -473,7 +526,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
       CStdString myTimezone = g_guiSettings.GetString("locale.timezone");
       int myTimezoneIndex = 0;
 
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
       pControl->Clear();
       vector<CStdString> timezones = g_timezone.GetTimezonesByCountry(myTimezoneCountry);
       for (unsigned int i=0; i < timezones.size(); i++)
@@ -483,27 +536,26 @@ void CGUIWindowSettingsCategory::CreateSettings()
         pControl->AddLabel(timezones[i], i);
       }
       pControl->SetValue(myTimezoneIndex);
+      continue;
     }
 #endif
-    else if (strSetting.Equals("videoscreen.screen"))
-    {
-      FillInScreens(strSetting, g_guiSettings.GetResolution());
-    }
-    else if (strSetting.Equals("videoscreen.resolution"))
-    {
-      FillInResolutions(strSetting,  g_guiSettings.GetInt("videoscreen.screen"), g_guiSettings.GetResolution(), false);
-    }
     else if (strSetting.Equals("videoscreen.screenmode"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInRefreshRates(strSetting, g_guiSettings.GetResolution(), false);
+      continue;
     }
     else if (strSetting.Equals("lookandfeel.skintheme"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInSkinThemes(pSetting);
+      continue;
     }
     else if (strSetting.Equals("lookandfeel.skincolors"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInSkinColors(pSetting);
+      continue;
     }
     /*
     FIXME: setting is hidden in GUI because not supported properly.
@@ -515,109 +567,81 @@ void CGUIWindowSettingsCategory::CreateSettings()
     else if (strSetting.Equals("videoplayer.highqualityupscaling"))
     {
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
       pControl->AddLabel(g_localizeStrings.Get(13113), SOFTWARE_UPSCALING_DISABLED);
       pControl->AddLabel(g_localizeStrings.Get(13114), SOFTWARE_UPSCALING_SD_CONTENT);
       pControl->AddLabel(g_localizeStrings.Get(13115), SOFTWARE_UPSCALING_ALWAYS);
       pControl->SetValue(pSettingInt->GetData());
+      continue;
     }
     else if (strSetting.Equals("videoplayer.upscalingalgorithm"))
     {
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
       pControl->AddLabel(g_localizeStrings.Get(13117), VS_SCALINGMETHOD_BICUBIC_SOFTWARE);
       pControl->AddLabel(g_localizeStrings.Get(13118), VS_SCALINGMETHOD_LANCZOS_SOFTWARE);
       pControl->AddLabel(g_localizeStrings.Get(13119), VS_SCALINGMETHOD_SINC_SOFTWARE);
       pControl->AddLabel(g_localizeStrings.Get(13120), VS_SCALINGMETHOD_VDPAU_HARDWARE);
       pControl->SetValue(pSettingInt->GetData());
-    }
-    else if (strSetting.Equals("videolibrary.flattentvshows"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
-      pControl->AddLabel(g_localizeStrings.Get(20420), 0); // Never
-      pControl->AddLabel(g_localizeStrings.Get(20421), 1); // One Season
-      pControl->AddLabel(g_localizeStrings.Get(20422), 2); // Always
-      pControl->SetValue(pSettingInt->GetData());
-    }
-    else if (strSetting.Equals("myvideos.selectaction"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
-      pControl->AddLabel(g_localizeStrings.Get(22080), SELECT_ACTION_CHOOSE);
-      pControl->AddLabel(g_localizeStrings.Get(208), SELECT_ACTION_PLAY_OR_RESUME);
-      pControl->AddLabel(g_localizeStrings.Get(13404), SELECT_ACTION_RESUME);
-      pControl->AddLabel(g_localizeStrings.Get(22081), SELECT_ACTION_INFO);
-      pControl->SetValue(pSettingInt->GetData());
+      continue;
     }
     else if (strSetting.Equals("network.enc"))
     {
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
       pControl->AddLabel(g_localizeStrings.Get(780), ENC_NONE);
       pControl->AddLabel(g_localizeStrings.Get(781), ENC_WEP);
       pControl->AddLabel(g_localizeStrings.Get(782), ENC_WPA);
       pControl->AddLabel(g_localizeStrings.Get(783), ENC_WPA2);
       pControl->SetValue(pSettingInt->GetData());
-    }
-    else if (strSetting.Equals("lookandfeel.startupwindow"))
-    {
-      FillInStartupWindow(pSetting);
+      continue;
     }
     else if (strSetting.Equals("locale.country"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInRegions(pSetting);
+      continue;
     }
     else if (strSetting.Equals("network.interface"))
     {
-       FillInNetworkInterfaces(pSetting);
+      AddSetting(pSetting, group->GetWidth(), iControlID);
+      FillInNetworkInterfaces(pSetting);
+      continue;
     }
     else if (strSetting.Equals("audiooutput.audiodevice"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInAudioDevices(pSetting);
+      continue;
     }
     else if (strSetting.Equals("audiooutput.passthroughdevice"))
     {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInAudioDevices(pSetting,true);
-    }
-    else if (strSetting.Equals("videoplayer.pauseafterrefreshchange"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
-      pControl->AddLabel(g_localizeStrings.Get(13551), 0);
-
-      for (int i = 1; i <= MAXREFRESHCHANGEDELAY; i++)
-      {
-        CStdString delayText;
-        if (i < 20)
-          delayText.Format(g_localizeStrings.Get(13552).c_str(), (double)i / 10.0);
-        else
-          delayText.Format(g_localizeStrings.Get(13553).c_str(), (double)i / 10.0);
-
-        pControl->AddLabel(delayText, i);
-      }
-
-      pControl->SetValue(pSettingInt->GetData());
+      continue;
     }
     else if (strSetting.Equals("videoplayer.synctype"))
     {
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
       pControl->AddLabel(g_localizeStrings.Get(13501), SYNC_DISCON);
       pControl->AddLabel(g_localizeStrings.Get(13502), SYNC_SKIPDUP);
       pControl->AddLabel(g_localizeStrings.Get(13503), SYNC_RESAMPLE);
       pControl->SetValue(pSettingInt->GetData());
+      continue;
     }
     else if (strSetting.Equals("videoplayer.resamplequality"))
     {
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(strSetting)->GetID());
+      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
       pControl->AddLabel(g_localizeStrings.Get(13506), RESAMPLE_LOW);
       pControl->AddLabel(g_localizeStrings.Get(13507), RESAMPLE_MID);
       pControl->AddLabel(g_localizeStrings.Get(13508), RESAMPLE_HIGH);
       pControl->AddLabel(g_localizeStrings.Get(13509), RESAMPLE_REALLYHIGH);
       pControl->SetValue(pSettingInt->GetData());
+      continue;
     }
+    AddSetting(pSetting, group->GetWidth(), iControlID);
   }
 
   if (m_vecSections[m_iSection]->m_strCategory == "network")
@@ -1432,7 +1456,8 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
     CSettingString *pSettingString = (CSettingString *)pSettingControl->GetSetting();
     CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(pSettingControl->GetID());
     pSettingString->SetData(pControl->GetCurrentLabel());
-    FillInSubtitleHeights(g_guiSettings.GetSetting("subtitles.height"));
+    CSetting *pSetting = (CSetting *)g_guiSettings.GetSetting("subtitles.height");
+    FillInSubtitleHeights(pSetting, (CGUISpinControlEx *)GetControl(GetSetting(pSetting->GetSetting())->GetID()));
   }
   else if (strSetting.Equals("subtitles.charset"))
   {
@@ -1457,7 +1482,8 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
     CSettingString *pSettingString = (CSettingString *)pSettingControl->GetSetting();
     CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(pSettingControl->GetID());
     pSettingString->SetData(pControl->GetCurrentLabel());
-    FillInSubtitleHeights(g_guiSettings.GetSetting("karaoke.fontheight"));
+    CSetting *pSetting = (CSetting *)g_guiSettings.GetSetting("karaoke.fontheight");
+    FillInSubtitleHeights(pSetting, (CGUISpinControlEx *)GetControl(GetSetting(pSetting->GetSetting())->GetID()));
   }
   else if (strSetting.Equals("karaoke.charset"))
   {
@@ -1977,15 +2003,15 @@ void CGUIWindowSettingsCategory::FreeSettingsControls()
   m_vecSettings.clear();
 }
 
-void CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float width, int &iControlID)
+CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float width, int &iControlID)
 {
-  if (!pSetting->IsVisible()) return;  // not displayed in current session
+  if (!pSetting->IsVisible()) return NULL;  // not displayed in current session
   CBaseSettingControl *pSettingControl = NULL;
   CGUIControl *pControl = NULL;
   if (pSetting->GetControlType() == CHECKMARK_CONTROL)
   {
     pControl = new CGUIRadioButtonControl(*m_pOriginalRadioButton);
-    if (!pControl) return ;
+    if (!pControl) return NULL;
     ((CGUIRadioButtonControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
     pControl->SetWidth(width);
     pSettingControl = new CRadioButtonSettingControl((CGUIRadioButtonControl *)pControl, iControlID, pSetting);
@@ -1993,7 +2019,7 @@ void CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float width, int
   else if (pSetting->GetControlType() == SPIN_CONTROL_FLOAT || pSetting->GetControlType() == SPIN_CONTROL_INT_PLUS || pSetting->GetControlType() == SPIN_CONTROL_TEXT || pSetting->GetControlType() == SPIN_CONTROL_INT)
   {
     pControl = new CGUISpinControlEx(*m_pOriginalSpin);
-    if (!pControl) return ;
+    if (!pControl) return NULL;
     pControl->SetWidth(width);
     ((CGUISpinControlEx *)pControl)->SetText(g_localizeStrings.Get(pSetting->GetLabel()));
     pSettingControl = new CSpinExSettingControl((CGUISpinControlEx *)pControl, iControlID, pSetting);
@@ -2001,7 +2027,7 @@ void CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float width, int
   else if (pSetting->GetControlType() == SEPARATOR_CONTROL && m_pOriginalImage)
   {
     pControl = new CGUIImage(*m_pOriginalImage);
-    if (!pControl) return;
+    if (!pControl) return NULL;
     pControl->SetWidth(width);
     pSettingControl = new CSeparatorSettingControl((CGUIImage *)pControl, iControlID, pSetting);
   }
@@ -2012,7 +2038,7 @@ void CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float width, int
            pSetting->GetControlType() == EDIT_CONTROL_IP_INPUT)
   {
     pControl = new CGUIEditControl(*m_pOriginalEdit);
-    if (!pControl) return ;
+    if (!pControl) return NULL;
     ((CGUIEditControl *)pControl)->SettingsCategorySetTextAlign(XBFONT_CENTER_Y);
     ((CGUIEditControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
     pControl->SetWidth(width);
@@ -2021,7 +2047,7 @@ void CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float width, int
   else if (pSetting->GetControlType() != SEPARATOR_CONTROL) // button control
   {
     pControl = new CGUIButtonControl(*m_pOriginalButton);
-    if (!pControl) return ;
+    if (!pControl) return NULL;
     ((CGUIButtonControl *)pControl)->SettingsCategorySetTextAlign(XBFONT_CENTER_Y);
     ((CGUIButtonControl *)pControl)->SetLabel(g_localizeStrings.Get(pSetting->GetLabel()));
     pControl->SetWidth(width);
@@ -2030,7 +2056,7 @@ void CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float width, int
   if (!pControl)
   {
     delete pSettingControl;
-    return;
+    return NULL;
   }
   pControl->SetID(iControlID++);
   pControl->SetVisible(true);
@@ -2041,6 +2067,7 @@ void CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float width, int
     group->AddControl(pControl);
     m_vecSettings.push_back(pSettingControl);
   }
+  return pControl;
 }
 
 void CGUIWindowSettingsCategory::FrameMove()
@@ -2148,10 +2175,9 @@ void CGUIWindowSettingsCategory::CheckNetworkSettings()
   }
 }
 
-void CGUIWindowSettingsCategory::FillInSubtitleHeights(CSetting *pSetting)
+void CGUIWindowSettingsCategory::FillInSubtitleHeights(CSetting *pSetting, CGUISpinControlEx *pControl)
 {
   CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-  CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(pSetting->GetSetting())->GetID());
   pControl->SetType(SPIN_CONTROL_TYPE_TEXT);
   pControl->Clear();
   if (CUtil::IsUsingTTFSubtitles())

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -514,8 +514,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
     }
     else if (strSetting.Equals("network.interface"))
     {
-      AddSetting(pSetting, group->GetWidth(), iControlID);
-      FillInNetworkInterfaces(pSetting);
+      FillInNetworkInterfaces(pSetting, group->GetWidth(), iControlID);
       continue;
     }
     else if (strSetting.Equals("audiooutput.audiodevice"))
@@ -534,9 +533,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
   }
 
   if (m_vecSections[m_iSection]->m_strCategory == "network")
-  {
      NetworkInterfaceChanged();
-  }
 
   // update our settings (turns controls on/off as appropriate)
   UpdateSettings();
@@ -2709,9 +2706,9 @@ void CGUIWindowSettingsCategory::FillInSortMethods(CSetting *pSetting, int windo
   delete state;
 }
 
-void CGUIWindowSettingsCategory::FillInNetworkInterfaces(CSetting *pSetting)
+void CGUIWindowSettingsCategory::FillInNetworkInterfaces(CSetting *pSetting, float groupWidth, int &iControlID)
 {
-  CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(pSetting->GetSetting())->GetID());
+  CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, groupWidth, iControlID);
   pControl->Clear();
 
   // query list of interfaces
@@ -2728,9 +2725,7 @@ void CGUIWindowSettingsCategory::FillInNetworkInterfaces(CSetting *pSetting)
 
   int iInterface = 0;
   for (unsigned int i = 0; i < vecInterfaces.size(); ++i)
-  {
     pControl->AddLabel(vecInterfaces[i], iInterface++);
-  }
 }
 
 void CGUIWindowSettingsCategory::FillInAudioDevices(CSetting* pSetting, bool Passthrough)

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -362,14 +362,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
     {
       CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddIntBasedSpinControl(pSetting, group->GetWidth(), iControlID);
       CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      if (strSetting.Equals("videolibrary.flattentvshows"))
-      {
-        pControl->AddLabel(g_localizeStrings.Get(20420), 0); // Never
-        pControl->AddLabel(g_localizeStrings.Get(20421), 1); // One Season
-        pControl->AddLabel(g_localizeStrings.Get(20422), 2); // Always
-        pControl->SetValue(pSettingInt->GetData());
-      }
-      else if (strSetting.Equals("videoplayer.pauseafterrefreshchange"))
+      if (strSetting.Equals("videoplayer.pauseafterrefreshchange"))
       {
         pControl->AddLabel(g_localizeStrings.Get(13551), 0);
 
@@ -379,22 +372,6 @@ void CGUIWindowSettingsCategory::CreateSettings()
           delayText.Format(g_localizeStrings.Get(13553).c_str(), (double)i / 10.0);
           pControl->AddLabel(delayText, i);
         }
-        pControl->SetValue(pSettingInt->GetData());
-      }
-      else if (strSetting.Equals("myvideos.selectaction"))
-      {
-        pControl->AddLabel(g_localizeStrings.Get(22080), SELECT_ACTION_CHOOSE);
-        pControl->AddLabel(g_localizeStrings.Get(208),   SELECT_ACTION_PLAY_OR_RESUME);
-        pControl->AddLabel(g_localizeStrings.Get(13404), SELECT_ACTION_RESUME);
-        pControl->AddLabel(g_localizeStrings.Get(22081), SELECT_ACTION_INFO);
-        pControl->SetValue(pSettingInt->GetData());
-      }
-      else if (strSetting.Equals("subtitles.style"))
-      {
-        pControl->AddLabel(g_localizeStrings.Get(738), FONT_STYLE_NORMAL);
-        pControl->AddLabel(g_localizeStrings.Get(739), FONT_STYLE_BOLD);
-        pControl->AddLabel(g_localizeStrings.Get(740), FONT_STYLE_ITALICS);
-        pControl->AddLabel(g_localizeStrings.Get(741), FONT_STYLE_BOLD_ITALICS);
         pControl->SetValue(pSettingInt->GetData());
       }
       else if (strSetting.Equals("subtitles.color"))
@@ -441,16 +418,6 @@ void CGUIWindowSettingsCategory::CreateSettings()
       continue;
 #endif
     }
-    else if (strSetting.Equals("network.assignment"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
-      pControl->AddLabel(g_localizeStrings.Get(716), NETWORK_DHCP);
-      pControl->AddLabel(g_localizeStrings.Get(717), NETWORK_STATIC);
-      pControl->AddLabel(g_localizeStrings.Get(787), NETWORK_DISABLED);
-      pControl->SetValue(pSettingInt->GetData());
-      continue;
-    }
     else if (strSetting.Equals("network.httpproxyport"))
     {
       AddSetting(pSetting, group->GetWidth(), iControlID);
@@ -469,17 +436,6 @@ void CGUIWindowSettingsCategory::CreateSettings()
       AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInCharSets(pSetting);
       continue;
-    }
-    else if (strSetting.Equals("subtitles.align"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
-      pControl->AddLabel(g_localizeStrings.Get(21461), SUBTITLE_ALIGN_MANUAL);
-      pControl->AddLabel(g_localizeStrings.Get(21462), SUBTITLE_ALIGN_BOTTOM_INSIDE);
-      pControl->AddLabel(g_localizeStrings.Get(21463), SUBTITLE_ALIGN_BOTTOM_OUTSIDE);
-      pControl->AddLabel(g_localizeStrings.Get(21464), SUBTITLE_ALIGN_TOP_INSIDE);
-      pControl->AddLabel(g_localizeStrings.Get(21465), SUBTITLE_ALIGN_TOP_OUTSIDE);
-      pControl->SetValue(pSettingInt->GetData());
     }
     else if (strSetting.Equals("lookandfeel.font"))
     {
@@ -581,17 +537,6 @@ void CGUIWindowSettingsCategory::CreateSettings()
       pControl->SetValue(pSettingInt->GetData());
       continue;
     }
-    else if (strSetting.Equals("network.enc"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
-      pControl->AddLabel(g_localizeStrings.Get(780), ENC_NONE);
-      pControl->AddLabel(g_localizeStrings.Get(781), ENC_WEP);
-      pControl->AddLabel(g_localizeStrings.Get(782), ENC_WPA);
-      pControl->AddLabel(g_localizeStrings.Get(783), ENC_WPA2);
-      pControl->SetValue(pSettingInt->GetData());
-      continue;
-    }
     else if (strSetting.Equals("locale.country"))
     {
       AddSetting(pSetting, group->GetWidth(), iControlID);
@@ -614,27 +559,6 @@ void CGUIWindowSettingsCategory::CreateSettings()
     {
       AddSetting(pSetting, group->GetWidth(), iControlID);
       FillInAudioDevices(pSetting,true);
-      continue;
-    }
-    else if (strSetting.Equals("videoplayer.synctype"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
-      pControl->AddLabel(g_localizeStrings.Get(13501), SYNC_DISCON);
-      pControl->AddLabel(g_localizeStrings.Get(13502), SYNC_SKIPDUP);
-      pControl->AddLabel(g_localizeStrings.Get(13503), SYNC_RESAMPLE);
-      pControl->SetValue(pSettingInt->GetData());
-      continue;
-    }
-    else if (strSetting.Equals("videoplayer.resamplequality"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
-      pControl->AddLabel(g_localizeStrings.Get(13506), RESAMPLE_LOW);
-      pControl->AddLabel(g_localizeStrings.Get(13507), RESAMPLE_MID);
-      pControl->AddLabel(g_localizeStrings.Get(13508), RESAMPLE_HIGH);
-      pControl->AddLabel(g_localizeStrings.Get(13509), RESAMPLE_REALLYHIGH);
-      pControl->SetValue(pSettingInt->GetData());
       continue;
     }
     AddSetting(pSetting, group->GetWidth(), iControlID);

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -376,11 +376,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
         for (int i = 1; i <= MAXREFRESHCHANGEDELAY; i++)
         {
           CStdString delayText;
-          if (i < 20)
-            delayText.Format(g_localizeStrings.Get(13552).c_str(), (double)i / 10.0);
-          else
-            delayText.Format(g_localizeStrings.Get(13553).c_str(), (double)i / 10.0);
-
+          delayText.Format(g_localizeStrings.Get(13553).c_str(), (double)i / 10.0);
           pControl->AddLabel(delayText, i);
         }
         pControl->SetValue(pSettingInt->GetData());

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -390,16 +390,6 @@ void CGUIWindowSettingsCategory::CreateSettings()
         FillInResolutions(strSetting, g_guiSettings.GetInt("videoscreen.screen"), g_guiSettings.GetResolution(), false);
       continue;
     }
-    if (strSetting.Equals("videooutput.aspect"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
-      pControl->AddLabel(g_localizeStrings.Get(21375), VIDEO_NORMAL);
-      pControl->AddLabel(g_localizeStrings.Get(21376), VIDEO_LETTERBOX);
-      pControl->AddLabel(g_localizeStrings.Get(21377), VIDEO_WIDESCREEN);
-      pControl->SetValue(pSettingInt->GetData());
-      continue;
-    }
 #ifdef HAS_WEB_SERVER
     else if (strSetting.Equals("services.webserverport"))
     {
@@ -516,27 +506,6 @@ void CGUIWindowSettingsCategory::CreateSettings()
       FillInResolutions(pSetting);
     }
     */
-    else if (strSetting.Equals("videoplayer.highqualityupscaling"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
-      pControl->AddLabel(g_localizeStrings.Get(13113), SOFTWARE_UPSCALING_DISABLED);
-      pControl->AddLabel(g_localizeStrings.Get(13114), SOFTWARE_UPSCALING_SD_CONTENT);
-      pControl->AddLabel(g_localizeStrings.Get(13115), SOFTWARE_UPSCALING_ALWAYS);
-      pControl->SetValue(pSettingInt->GetData());
-      continue;
-    }
-    else if (strSetting.Equals("videoplayer.upscalingalgorithm"))
-    {
-      CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-      CGUISpinControlEx *pControl = (CGUISpinControlEx *)AddSetting(pSetting, group->GetWidth(), iControlID);
-      pControl->AddLabel(g_localizeStrings.Get(13117), VS_SCALINGMETHOD_BICUBIC_SOFTWARE);
-      pControl->AddLabel(g_localizeStrings.Get(13118), VS_SCALINGMETHOD_LANCZOS_SOFTWARE);
-      pControl->AddLabel(g_localizeStrings.Get(13119), VS_SCALINGMETHOD_SINC_SOFTWARE);
-      pControl->AddLabel(g_localizeStrings.Get(13120), VS_SCALINGMETHOD_VDPAU_HARDWARE);
-      pControl->SetValue(pSettingInt->GetData());
-      continue;
-    }
     else if (strSetting.Equals("locale.country"))
     {
       AddSetting(pSetting, group->GetWidth(), iControlID);
@@ -580,21 +549,8 @@ void CGUIWindowSettingsCategory::UpdateSettings()
     CBaseSettingControl *pSettingControl = m_vecSettings[i];
     pSettingControl->Update();
     CStdString strSetting = pSettingControl->GetSetting()->GetSetting();
-    if (strSetting.Equals("videoplayer.upscalingalgorithm"))
-    {
-      CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
-      if (pControl)
-      {
-        int value = g_guiSettings.GetInt("videoplayer.highqualityupscaling");
-
-        if (value == SOFTWARE_UPSCALING_DISABLED)
-          pControl->SetEnabled(false);
-        else
-          pControl->SetEnabled(true);
-      }
-    }
 #ifdef HAVE_LIBVDPAU
-    else if (strSetting.Equals("videoplayer.vdpauUpscalingLevel"))
+    if (strSetting.Equals("videoplayer.vdpauUpscalingLevel"))
     {
       CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
       if (pControl)
@@ -602,8 +558,9 @@ void CGUIWindowSettingsCategory::UpdateSettings()
         pControl->SetEnabled(true);
       }
     }
+    else
 #endif
-    else if (strSetting.Equals("videoscreen.resolution"))
+    if (strSetting.Equals("videoscreen.resolution"))
     {
       CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
       if (pControl)

--- a/xbmc/settings/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/GUIWindowSettingsCategory.h
@@ -43,7 +43,7 @@ protected:
   virtual void OnInitWindow();
 
   void CheckNetworkSettings();
-  void FillInSubtitleHeights(CSetting *pSetting);
+  void FillInSubtitleHeights(CSetting *pSetting, CGUISpinControlEx *pControl);
   void FillInSubtitleFonts(CSetting *pSetting);
   void FillInCharSets(CSetting *pSetting);
   void FillInSkinFonts(CSetting *pSetting);
@@ -67,6 +67,7 @@ protected:
   void FillInAudioDevices(CSetting* pSetting, bool Passthrough = false);
 
   virtual void SetupControls();
+  CGUIControl* AddIntBasedSpinControl(CSetting *pSetting, float groupWidth, int &iControlID);
   void CreateSettings();
   void UpdateSettings();
   void UpdateRealTimeSettings();
@@ -75,7 +76,7 @@ protected:
   virtual void FreeControls();
   virtual void OnClick(CBaseSettingControl *pSettingControl);
   virtual void OnSettingChanged(CBaseSettingControl *pSettingControl);
-  void AddSetting(CSetting *pSetting, float width, int &iControlID);
+  CGUIControl* AddSetting(CSetting *pSetting, float width, int &iControlID);
   CBaseSettingControl* GetSetting(const CStdString &strSetting);
 
   void ValidatePortNumber(CBaseSettingControl* pSettingControl, const CStdString& userPort, const CStdString& privPort, bool listening=true);

--- a/xbmc/settings/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/GUIWindowSettingsCategory.h
@@ -61,7 +61,7 @@ protected:
   void FillInSkinThemes(CSetting *pSetting);
   void FillInSkinColors(CSetting *pSetting);
 
-  void FillInNetworkInterfaces(CSetting *pSetting);
+  void FillInNetworkInterfaces(CSetting *pSetting, float groupWidth, int &iControlID);
   void NetworkInterfaceChanged(void);
 
   void FillInAudioDevices(CSetting* pSetting, bool Passthrough = false);


### PR DESCRIPTION
I've been through the Settings GUI and made a few useful changes:

Code is cleaner, the GUIWindowSettingsCategory logic is easier to follow (I could spend hours and hours saving a few lines of code but I'm not going to bother) also dead logic has been removed

Moved various hardcoded options from this file to GUISettings where the rest of them were located.

Cosmetically refactored the Initialize method in GUISettings so that the treelike structure is easier to see from an overview perspective

Moved Video Output from System category into Video category, and renamed Music into Music & Audio and moved Audio Output settings into that category also. This allows System category to be renamed Advanced which fits better with what it actually does, this also means that the navigation reads

System -> Settings -> Advanced instead of System -> Settings -> System which is confusing

Options inside Appearance which may have only one option available (namely Theme and Colour) are hidden by if they only have a single option

Other minor language fixup, which probably needs a larger discussion as although I am native English speaker, my knowledge of the finer points of grammar and syntax escape me :)
