### PR TITLE
Support for rendering double framerate deinterlaced video in background

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -284,16 +284,8 @@ void CXBMCRenderManager::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
     }
   }
 
-  CSharedLock lock(m_sharedSection);
+  Render(clear, flags, alpha);
 
-  if (m_presentmethod == PRESENT_METHOD_WEAVE)
-    m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_BOTH, alpha);
-  else
-    m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_LAST, alpha);
-
-  m_overlays.Render();
-
-  m_presentstep = PRESENT_IDLE;
   m_presentevent.Set();
 }
 
@@ -588,6 +580,22 @@ float CXBMCRenderManager::GetMaximumFPS()
   return fps;
 }
 
+void CXBMCRenderManager::Render(bool clear, DWORD flags, DWORD alpha)
+{
+  CSharedLock lock(m_sharedSection);
+
+  if( m_presentmethod == PRESENT_METHOD_BOB )
+    PresentBob(clear, flags, alpha);
+  else if( m_presentmethod == PRESENT_METHOD_WEAVE )
+    PresentWeave(clear, flags, alpha);
+  else if( m_presentmethod == PRESENT_METHOD_BLEND )
+    PresentBlend(clear, flags, alpha);
+  else
+    PresentSingle(clear, flags, alpha);
+
+  m_overlays.Render();
+}
+
 void CXBMCRenderManager::Present()
 {
   { CRetakeLock<CExclusiveLock> lock(m_sharedSection);
@@ -603,18 +611,7 @@ void CXBMCRenderManager::Present()
     }
   }
 
-  CSharedLock lock(m_sharedSection);
-
-  if     ( m_presentmethod == PRESENT_METHOD_BOB )
-    PresentBob();
-  else if( m_presentmethod == PRESENT_METHOD_WEAVE )
-    PresentWeave();
-  else if( m_presentmethod == PRESENT_METHOD_BLEND )
-    PresentBlend();
-  else
-    PresentSingle();
-
-  m_overlays.Render();
+  Render(true, 0, 255);
 
   /* wait for this present to be valid */
   if(g_graphicsContext.IsFullScreenVideo())
@@ -624,63 +621,63 @@ void CXBMCRenderManager::Present()
 }
 
 /* simple present method */
-void CXBMCRenderManager::PresentSingle()
+void CXBMCRenderManager::PresentSingle(bool clear, DWORD flags, DWORD alpha)
 {
   CSingleLock lock(g_graphicsContext);
 
-  m_pRenderer->RenderUpdate(true, 0, 255);
+  m_pRenderer->RenderUpdate(clear, flags, alpha);
   m_presentstep = PRESENT_IDLE;
 }
 
 /* new simpler method of handling interlaced material, *
  * we just render the two fields right after eachother */
-void CXBMCRenderManager::PresentBob()
+void CXBMCRenderManager::PresentBob(bool clear, DWORD flags, DWORD alpha)
 {
   CSingleLock lock(g_graphicsContext);
 
   if(m_presentstep == PRESENT_FRAME)
   {
     if( m_presentfield == FS_BOT)
-      m_pRenderer->RenderUpdate(true, RENDER_FLAG_BOT | RENDER_FLAG_FIELD0, 255);
+      m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_BOT | RENDER_FLAG_FIELD0, alpha);
     else
-      m_pRenderer->RenderUpdate(true, RENDER_FLAG_TOP | RENDER_FLAG_FIELD0, 255);
+      m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_TOP | RENDER_FLAG_FIELD0, alpha);
     m_presentstep = PRESENT_FRAME2;
     g_application.NewFrame();
   }
   else
   {
     if( m_presentfield == FS_TOP)
-      m_pRenderer->RenderUpdate(true, RENDER_FLAG_BOT | RENDER_FLAG_FIELD1, 255);
+      m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_BOT | RENDER_FLAG_FIELD1, alpha);
     else
-      m_pRenderer->RenderUpdate(true, RENDER_FLAG_TOP | RENDER_FLAG_FIELD1, 255);
+      m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_TOP | RENDER_FLAG_FIELD1, alpha);
     m_presentstep = PRESENT_IDLE;
   }
 }
 
-void CXBMCRenderManager::PresentBlend()
+void CXBMCRenderManager::PresentBlend(bool clear, DWORD flags, DWORD alpha)
 {
   CSingleLock lock(g_graphicsContext);
 
   if( m_presentfield == FS_BOT )
   {
-    m_pRenderer->RenderUpdate(true, RENDER_FLAG_BOT | RENDER_FLAG_NOOSD, 255);
-    m_pRenderer->RenderUpdate(false, RENDER_FLAG_TOP, 128);
+    m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_BOT | RENDER_FLAG_NOOSD, alpha);
+    m_pRenderer->RenderUpdate(false, flags | RENDER_FLAG_TOP, alpha / 2);
   }
   else
   {
-    m_pRenderer->RenderUpdate(true, RENDER_FLAG_TOP | RENDER_FLAG_NOOSD, 255);
-    m_pRenderer->RenderUpdate(false, RENDER_FLAG_BOT, 128);
+    m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_TOP | RENDER_FLAG_NOOSD, alpha);
+    m_pRenderer->RenderUpdate(false, flags | RENDER_FLAG_BOT, alpha / 2);
   }
   m_presentstep = PRESENT_IDLE;
 }
 
 /* renders the two fields as one, but doing fieldbased *
  * scaling then reinterlaceing resulting image         */
-void CXBMCRenderManager::PresentWeave()
+void CXBMCRenderManager::PresentWeave(bool clear, DWORD flags, DWORD alpha)
 {
   CSingleLock lock(g_graphicsContext);
 
-  m_pRenderer->RenderUpdate(true, RENDER_FLAG_BOTH, 255);
+  m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_BOTH, alpha);
   m_presentstep = PRESENT_IDLE;
 }
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -30,6 +30,7 @@
 #include "Application.h"
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"
+#include "settings/AdvancedSettings.h"
 
 #ifdef _LINUX
 #include "PlatformInclude.h"
@@ -284,7 +285,13 @@ void CXBMCRenderManager::RenderUpdate(bool clear, DWORD flags, DWORD alpha)
     }
   }
 
-  Render(clear, flags, alpha);
+  if (g_advancedSettings.m_videoDisableBackgroundDeinterlace)
+  {
+    CSharedLock lock(m_sharedSection);
+    PresentSingle(clear, flags, alpha);
+  }
+  else
+    Render(clear, flags, alpha);
 
   m_presentevent.Set();
 }

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -175,11 +175,12 @@ public:
   CSharedSection& GetSection() { return m_sharedSection; };
 
 protected:
+  void Render(bool clear, DWORD flags, DWORD alpha);
 
-  void PresentSingle();
-  void PresentWeave();
-  void PresentBob();
-  void PresentBlend();
+  void PresentSingle(bool clear, DWORD flags, DWORD alpha);
+  void PresentWeave(bool clear, DWORD flags, DWORD alpha);
+  void PresentBob(bool clear, DWORD flags, DWORD alpha);
+  void PresentBlend(bool clear, DWORD flags, DWORD alpha);
 
   bool m_bPauseDrawing;   // true if we should pause rendering
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -89,6 +89,7 @@ void CAdvancedSettings::Initialize()
   m_videoEnableHighQualityHwScalers = false;
   m_videoAutoScaleMaxFps = 30.0f;
   m_videoAllowMpeg4VDPAU = false;
+  m_videoDisableBackgroundDeinterlace = false;
   m_DXVACheckCompatibility = false;
   m_DXVACheckCompatibilityPresent = false;
   m_DXVAForceProcessorRenderer = true;
@@ -443,6 +444,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement,"enablehighqualityhwscalers", m_videoEnableHighQualityHwScalers);
     XMLUtils::GetFloat(pElement,"autoscalemaxfps",m_videoAutoScaleMaxFps, 0.0f, 1000.0f);
     XMLUtils::GetBoolean(pElement,"allowmpeg4vdpau",m_videoAllowMpeg4VDPAU);
+    XMLUtils::GetBoolean(pElement, "disablebackgrounddeinterlace", m_videoDisableBackgroundDeinterlace);
 
     TiXmlElement* pAdjustRefreshrate = pElement->FirstChildElement("adjustrefreshrate");
     if (pAdjustRefreshrate)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -121,6 +121,7 @@ class CAdvancedSettings
     float m_videoAutoScaleMaxFps;
     bool  m_videoAllowMpeg4VDPAU;
     std::vector<RefreshOverride> m_videoAdjustRefreshOverrides;
+    bool m_videoDisableBackgroundDeinterlace;
     bool m_DXVACheckCompatibility;
     bool m_DXVACheckCompatibilityPresent;
     bool m_DXVAForceProcessorRenderer;


### PR DESCRIPTION
This modification adds support for rendering played video in background at correct double framerate (if deinterlace is used) when displaying main menu GUI.
