### PR TITLE
[DXVA] Alternative implementation for CProcessor samples queue

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -160,12 +160,14 @@ protected:
 
   struct SVideoSample
   {
-    DXVA2_VideoSample sample;
+    REFERENCE_TIME start;
+    REFERENCE_TIME end;
+    UINT format;
     CSurfaceContext* context;
+    IDirect3DSurface9* surface;
   };
 
-  typedef std::deque<SVideoSample> SSamples;
-  SSamples          m_sample;
+  SVideoSample* m_samples;
 
   CCriticalSection  m_section;
 


### PR DESCRIPTION
This PR changes the samples queue implementation in CProcessor with a circular buffer. I think it's a better approach because:
- It is simpler than queue code so it's easier to understand and less error prone in case of future changes.
- It's faster (ok, not a speed boost but something faster).
- Fulfils all the Microsoft's requirements for VideoProcessBlt() even if the processor requires future reference frames which is not fully supported in current implementation.
