### PR TITLE
Jpeg loading refactor

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		18B7013C13A6ABBA0009C1AF /* AddonVersion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7013A13A6ABBA0009C1AF /* AddonVersion.cpp */; };
 		18B7013F13A6ABD20009C1AF /* KeymapLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7013D13A6ABD20009C1AF /* KeymapLoader.cpp */; };
 		18ECC9AA13CF17EB00A9ED6C /* StreamUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ECC9A813CF17EB00A9ED6C /* StreamUtils.cpp */; };
+		32D6D47C1423A9D8003641AC /* JpegIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 32D6D47A1423A9D8003641AC /* JpegIO.cpp */; };
 		4D5D2E131301753F006ABC13 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D5D2E121301753F006ABC13 /* CFNetwork.framework */; };
 		7C0A7ECD13A5DBF900AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7ECB13A5DBF900AFC2BD /* AppParamParser.cpp */; };
 		7C0A7FC813A9E75400AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC413A9E75400AFC2BD /* DirtyRegionSolvers.cpp */; };
@@ -949,6 +950,8 @@
 		18B7013E13A6ABD20009C1AF /* KeymapLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeymapLoader.h; sourceTree = "<group>"; };
 		18ECC9A813CF17EB00A9ED6C /* StreamUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamUtils.cpp; sourceTree = "<group>"; };
 		18ECC9A913CF17EB00A9ED6C /* StreamUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamUtils.h; sourceTree = "<group>"; };
+		32D6D47A1423A9D8003641AC /* JpegIO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JpegIO.cpp; sourceTree = "<group>"; };
+		32D6D47B1423A9D8003641AC /* JpegIO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JpegIO.h; sourceTree = "<group>"; };
 		4D5D2E121301753F006ABC13 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		7C0A7ECB13A5DBF900AFC2BD /* AppParamParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppParamParser.cpp; sourceTree = "<group>"; };
 		7C0A7ECC13A5DBF900AFC2BD /* AppParamParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppParamParser.h; sourceTree = "<group>"; };
@@ -4273,6 +4276,8 @@
 		F56C749F131EC152000AD0F6 /* guilib */ = {
 			isa = PBXGroup;
 			children = (
+				32D6D47A1423A9D8003641AC /* JpegIO.cpp */,
+				32D6D47B1423A9D8003641AC /* JpegIO.h */,
 				F56C74A0131EC152000AD0F6 /* AnimatedGif.h */,
 				F56C74A1131EC152000AD0F6 /* AudioContext.h */,
 				F56C74A2131EC152000AD0F6 /* D3DResource.h */,
@@ -6798,6 +6803,7 @@
 				18968DE814155E1D005BA742 /* ApplicationOperations.cpp in Sources */,
 				DFCFC53D1413F7F70004D0BF /* AFPDirectory.cpp in Sources */,
 				DFCFC53E1413F7F70004D0BF /* FileAFP.cpp in Sources */,
+				32D6D47C1423A9D8003641AC /* JpegIO.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6899,6 +6905,7 @@
 					"-lyajl",
 					"-L$XBMC_DEPENDS/lib/mysql",
 					"-lmysqlclient",
+					"-ljpeg",
 				);
 				PLIST_FILE_OUTPUT_FORMAT = xml;
 				PRODUCT_NAME = XBMC;
@@ -6993,6 +7000,7 @@
 					"-lyajl",
 					"-L$XBMC_DEPENDS/lib/mysql",
 					"-lmysqlclient",
+					"-ljpeg",
 				);
 				PLIST_FILE_OUTPUT_FORMAT = xml;
 				PRODUCT_NAME = XBMC;

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		18B700F613A6A7850009C1AF /* AddonVersion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B700F413A6A7850009C1AF /* AddonVersion.cpp */; };
 		18ECC99D13CF17D200A9ED6C /* StreamUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ECC99B13CF17D200A9ED6C /* StreamUtils.cpp */; };
 		3255316612B2D02400837CD2 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3255316512B2D02400837CD2 /* CoreAudio.framework */; };
+		3291892B1423A9B700E878CD /* JpegIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 329189291423A9B700E878CD /* JpegIO.cpp */; };
 		4D5D2E1E1301758F006ABC13 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */; };
 		7C0A7EDE13A5DC2800AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EDC13A5DC2800AFC2BD /* AppParamParser.cpp */; };
 		7C0A7F9D13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7F9B13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp */; };
@@ -950,6 +951,8 @@
 		18ECC99B13CF17D200A9ED6C /* StreamUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamUtils.cpp; sourceTree = "<group>"; };
 		18ECC99C13CF17D200A9ED6C /* StreamUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamUtils.h; sourceTree = "<group>"; };
 		3255316512B2D02400837CD2 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		329189291423A9B700E878CD /* JpegIO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JpegIO.cpp; sourceTree = "<group>"; };
+		3291892A1423A9B700E878CD /* JpegIO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JpegIO.h; sourceTree = "<group>"; };
 		4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		7C0A7EDC13A5DC2800AFC2BD /* AppParamParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppParamParser.cpp; sourceTree = "<group>"; };
 		7C0A7EDD13A5DC2800AFC2BD /* AppParamParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppParamParser.h; sourceTree = "<group>"; };
@@ -4632,6 +4635,8 @@
 		F56C8482131F42E9000AD0F6 /* guilib */ = {
 			isa = PBXGroup;
 			children = (
+				329189291423A9B700E878CD /* JpegIO.cpp */,
+				3291892A1423A9B700E878CD /* JpegIO.h */,
 				F56C8483131F42E9000AD0F6 /* AnimatedGif.h */,
 				F56C8484131F42E9000AD0F6 /* AudioContext.h */,
 				F56C8485131F42E9000AD0F6 /* D3DResource.h */,
@@ -6813,6 +6818,7 @@
 				18968DDE14155E01005BA742 /* ApplicationOperations.cpp in Sources */,
 				DFCFC52A1413F7D60004D0BF /* AFPDirectory.cpp in Sources */,
 				DFCFC52B1413F7D60004D0BF /* FileAFP.cpp in Sources */,
+				3291892B1423A9B700E878CD /* JpegIO.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6910,6 +6916,7 @@
 					"-lyajl",
 					"-L$XBMC_DEPENDS/lib/mysql",
 					"-lmysqlclient",
+					"-ljpeg",
 				);
 				PLIST_FILE_OUTPUT_FORMAT = xml;
 				PRODUCT_NAME = XBMC;
@@ -7004,6 +7011,7 @@
 					"-lyajl",
 					"-L$XBMC_DEPENDS/lib/mysql",
 					"-lmysqlclient",
+					"-ljpeg",
 				);
 				PLIST_FILE_OUTPUT_FORMAT = xml;
 				PRODUCT_NAME = XBMC;

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -379,6 +379,7 @@
 		18CCEAEE1112F5B800615FC6 /* PCMRemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18CCEAEC1112F5B800615FC6 /* PCMRemap.cpp */; };
 		18CCEAEF1112F5B800615FC6 /* PCMRemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18CCEAEC1112F5B800615FC6 /* PCMRemap.cpp */; };
 		18ECC96213CF178D00A9ED6C /* StreamUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ECC96013CF178D00A9ED6C /* StreamUtils.cpp */; };
+		32C631281423A90F00F18420 /* JpegIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 32C631261423A90F00F18420 /* JpegIO.cpp */; };
 		3802709A13D5A653009493DD /* SystemClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3802709813D5A653009493DD /* SystemClock.cpp */; };
 		384718D81325BA04000486D6 /* XBDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 384718D61325BA04000486D6 /* XBDateTime.cpp */; };
 		38F4E57013CCCB3B00664821 /* Implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F4E56C13CCCB3B00664821 /* Implementation.cpp */; };
@@ -2261,6 +2262,8 @@
 		18CCEAED1112F5B800615FC6 /* PCMRemap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCMRemap.h; sourceTree = "<group>"; };
 		18ECC96013CF178D00A9ED6C /* StreamUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamUtils.cpp; sourceTree = "<group>"; };
 		18ECC96113CF178D00A9ED6C /* StreamUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamUtils.h; sourceTree = "<group>"; };
+		32C631261423A90F00F18420 /* JpegIO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JpegIO.cpp; sourceTree = "<group>"; };
+		32C631271423A90F00F18420 /* JpegIO.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JpegIO.h; sourceTree = "<group>"; };
 		3802709713D5A62D009493DD /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
 		3802709813D5A653009493DD /* SystemClock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemClock.cpp; sourceTree = "<group>"; };
 		3802709913D5A653009493DD /* SystemClock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemClock.h; sourceTree = "<group>"; };
@@ -4046,6 +4049,8 @@
 		18B7C3AA1294219F009E7A26 /* guilib */ = {
 			isa = PBXGroup;
 			children = (
+				32C631261423A90F00F18420 /* JpegIO.cpp */,
+				32C631271423A90F00F18420 /* JpegIO.h */,
 				18B7C6F61294222D009E7A26 /* AnimatedGif.h */,
 				18B7C6F71294222D009E7A26 /* AudioContext.h */,
 				18B7C6F81294222D009E7A26 /* D3DResource.h */,
@@ -8122,6 +8127,7 @@
 				18968DC814155D7C005BA742 /* ApplicationOperations.cpp in Sources */,
 				DF24A6B41406C7C500C7721E /* AFPDirectory.cpp in Sources */,
 				DF24A6B51406C7C500C7721E /* FileAFP.cpp in Sources */,
+				32C631281423A90F00F18420 /* JpegIO.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9124,6 +9130,7 @@
 					"-lpython2.6",
 					"-L$XBMC_DEPENDS/lib/mysql",
 					"-lmysqlclient",
+					"-ljpeg",
 				);
 				PRODUCT_NAME = XBMC;
 				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
@@ -9219,6 +9226,7 @@
 					"-lpython2.6",
 					"-L$XBMC_DEPENDS/lib/mysql",
 					"-lmysqlclient",
+					"-ljpeg",
 				);
 				PRODUCT_NAME = XBMC;
 				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
@@ -9373,6 +9381,7 @@
 					"-lboost_thread",
 					"-L$XBMC_DEPENDS/lib/mysql",
 					"-lmysqlclient",
+					"-ljpeg",
 				);
 				PRODUCT_NAME = XBMC;
 				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
@@ -9470,6 +9479,7 @@
 					"-lboost_thread",
 					"-L$XBMC_DEPENDS/lib/mysql",
 					"-lmysqlclient",
+					"-ljpeg",
 				);
 				PRODUCT_NAME = XBMC;
 				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";

--- a/project/BuildDependencies/scripts/libjpeg-turbo_d.bat
+++ b/project/BuildDependencies/scripts/libjpeg-turbo_d.bat
@@ -1,0 +1,13 @@
+@ECHO OFF
+
+SET LOC_PATH=%CD%
+SET FILES=%LOC_PATH%\libjpeg-turbo_d.txt
+
+CALL dlextract.bat libjpeg-turbo %FILES%
+
+cd %TMP_PATH%
+
+xcopy libjpeg-turbo-1.1.1-win32\include\* "%CUR_PATH%\include\" /E /Q /I /Y
+copy libjpeg-turbo-1.1.1-win32\lib\jpeg-static.lib "%CUR_PATH%\lib\" /Y
+
+cd %LOC_PATH%

--- a/project/BuildDependencies/scripts/libjpeg-turbo_d.txt
+++ b/project/BuildDependencies/scripts/libjpeg-turbo_d.txt
@@ -1,0 +1,2 @@
+; filename                          source of the file
+libjpeg-turbo-1.1.1-win32.7z        http://mirrors.xbmc.org/build-deps/win32/

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -103,7 +103,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
       <AdditionalIncludeDirectories>..\..\;..\..\xbmc\;..\..\xbmc\win32\;..\..\xbmc\cores\dvdplayer;..\..\lib;..\..\lib\ffmpeg;..\..\lib\ffmpeg\include-xbmc-win32;..\..\lib\liblame\include;..\..\lib\libUPnP\Platinum\Source\Devices\MediaRenderer;..\..\lib\libUPnP\Platinum\Source\Devices\MediaConnect;..\..\lib\libUPnP\Platinum\Source\Devices\MediaServer;..\..\lib\libUPnP\Platinum\Source\Platinum;..\..\lib\libUPnP\Platinum\Source\Core;..\..\lib\libUPnP\Neptune\Source\Core;..\..\lib\libUPnP\Neptune\Source\System\Win32;..\..\lib\win32\pcre;..\..\lib\win32</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>TARGET_WINDOWS;_WINDOWS;_MSVC;WIN32;NDEBUG;_WIN32_WINNT=0x0501;NTDDI_VERSION=0x05010300;NOMINMAX;_USE_32BIT_TIME_T;HAS_GL;__STDC_CONSTANT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TARGET_WINDOWS;_WINDOWS;_MSVC;WIN32;NDEBUG;_WIN32_WINNT=0x0501;NTDDI_VERSION=0x05010300;NOMINMAX;_USE_32BIT_TIME_T;HAS_GL;__STDC_CONSTANT_MACROS;XMD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
       <MinimalRebuild>false</MinimalRebuild>
       <ExceptionHandling>Async</ExceptionHandling>
@@ -424,6 +424,7 @@
     <ClCompile Include="..\..\xbmc\guilib\GUIWindowManager.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\GUIWrappingListContainer.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\IWindowManagerCallback.cpp" />
+    <ClCompile Include="..\..\xbmc\guilib\JpegIO.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\Key.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\LocalizeStrings.cpp" />
     <ClCompile Include="..\..\xbmc\guilib\MatrixGLES.cpp" />
@@ -1337,6 +1338,7 @@
     <ClInclude Include="..\..\xbmc\guilib\IAudioDeviceChangedCallback.h" />
     <ClInclude Include="..\..\xbmc\guilib\IMsgTargetCallback.h" />
     <ClInclude Include="..\..\xbmc\guilib\IWindowManagerCallback.h" />
+    <ClInclude Include="..\..\xbmc\guilib\JpegIO.h" />
     <ClInclude Include="..\..\xbmc\guilib\Key.h" />
     <ClInclude Include="..\..\xbmc\guilib\LocalizeStrings.h" />
     <ClInclude Include="..\..\xbmc\guilib\MatrixGLES.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2496,6 +2496,9 @@
     <ClCompile Include="..\..\xbmc\interfaces\json-rpc\ApplicationOperations.cpp">
       <Filter>interfaces\json-rpc</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\guilib\JpegIO.cpp">
+      <Filter>guilib</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5011,6 +5014,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\ApplicationOperations.h">
       <Filter>interfaces\json-rpc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\guilib\JpegIO.h">
+      <Filter>guilib</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -55,8 +55,7 @@ CJpegIO::~CJpegIO()
 
 void CJpegIO::Close()
 {
-  if (m_inputBuff)
-    delete [] m_inputBuff;
+  delete [] m_inputBuff;
 }
 
 bool CJpegIO::Open(const CStdString& texturePath,  unsigned int minx, unsigned int miny)
@@ -73,7 +72,7 @@ bool CJpegIO::Open(const CStdString& texturePath,  unsigned int minx, unsigned i
     m_inputBuffSize = file.Read(m_inputBuff, m_imgsize);
     file.Close();
 
-    if ((m_imgsize != m_inputBuffSize) || (m_inputBuffSize <= 0))
+    if ((m_imgsize != m_inputBuffSize) || (m_inputBuffSize == 0))
       return false;
   }
   else
@@ -95,7 +94,7 @@ bool CJpegIO::Open(const CStdString& texturePath,  unsigned int minx, unsigned i
     If the res is greater than the one desired, use that one since there's no need
     to decode a bigger one just to squish it back down. If the res is greater than
     the gpu can hold, use the previous one.*/
-    if (m_minx <= 0 || m_miny <= 0)
+    if (m_minx == 0 || m_miny == 0)
     {
       m_minx = g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iWidth;
       m_miny = g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iHeight;

--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -1,0 +1,172 @@
+/*
+*      Copyright (C) 2005-2011 Team XBMC
+*      http://www.xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#include "pictures/DllImageLib.h"
+#include "pictures/DllLibExif.h"
+#include "windowing/WindowingFactory.h"
+#include "settings/GUISettings.h"
+#include "settings/Settings.h"
+#include "filesystem/File.h"
+#include "utils/log.h"
+#include "JpegIO.h"
+
+static void jpeg_error_exit (j_common_ptr cinfo)
+{
+  CStdString msg;
+  msg.Format("Error %i: %s",cinfo->err->msg_code, cinfo->err->jpeg_message_table[cinfo->err->msg_code]);
+  throw msg;
+}
+
+CJpegIO::CJpegIO()
+{
+  m_minx = 0;
+  m_miny = 0;
+  m_imgsize = 0;
+  m_width = 0;
+  m_height = 0;
+  m_orientation = 0;
+  m_inputBuffSize = 0;
+  m_inputBuff = NULL;
+  m_texturePath = "";
+}
+
+CJpegIO::~CJpegIO()
+{
+  Close();
+}
+
+void CJpegIO::Close()
+{
+  if (m_inputBuff)
+    delete [] m_inputBuff;
+}
+
+bool CJpegIO::Open(const CStdString& texturePath,  unsigned int minx, unsigned int miny)
+{
+  m_texturePath = texturePath;
+  m_minx = minx;
+  m_miny = miny;
+
+  XFILE::CFile file;
+  if (file.Open(m_texturePath.c_str(), 0))
+  {
+    m_imgsize = file.GetLength();
+    m_inputBuff = new unsigned char[m_imgsize];
+    m_inputBuffSize = file.Read(m_inputBuff, m_imgsize);
+    file.Close();
+
+    if ((m_imgsize != m_inputBuffSize) || (m_inputBuffSize <= 0))
+      return false;
+  }
+  else
+    return false;
+
+  m_cinfo.err = jpeg_std_error(&m_jerr);
+  m_jerr.error_exit = jpeg_error_exit;
+  jpeg_create_decompress(&m_cinfo);
+  jpeg_mem_src(&m_cinfo, m_inputBuff, m_inputBuffSize);
+
+  try
+  {
+    jpeg_read_header(&m_cinfo, TRUE);
+
+    /*  libjpeg can scale the image for us if it is too big. It must be in the format
+    num/denom, where (for our purposes) that is [1-8]/8 where 8/8 is the unscaled image.
+    The only way to know how big a resulting image will be is to try a ratio and
+    test its resulting size.
+    If the res is greater than the one desired, use that one since there's no need
+    to decode a bigger one just to squish it back down. If the res is greater than
+    the gpu can hold, use the previous one.*/
+    if (m_minx <= 0 || m_miny <= 0)
+    {
+      m_minx = g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iWidth;
+      m_miny = g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iHeight;
+    }
+    m_cinfo.scale_denom=8;
+    unsigned int maxtexsize = g_Windowing.GetMaxTextureSize();
+    for (m_cinfo.scale_num = 1;m_cinfo.scale_num <=8 ;m_cinfo.scale_num++)
+    {
+      jpeg_calc_output_dimensions (&m_cinfo);
+      if ((m_cinfo.output_width * m_cinfo.output_height) > (maxtexsize * maxtexsize))
+      {
+        m_cinfo.scale_num--;
+        break;
+      }
+      if ( m_cinfo.output_width >= m_minx && m_cinfo.output_height >= m_miny)
+        break;
+    }
+    jpeg_calc_output_dimensions (&m_cinfo);
+    m_width = m_cinfo.output_width;
+    m_height = m_cinfo.output_height;
+    m_pitch = (((m_cinfo.output_width + 1)* 3 / 4) * 4); //align to 4-bytes
+
+    GetExif();
+    return true;
+  }
+  catch (CStdString &msg)
+  {
+    CLog::Log(LOGWARNING, "JpegIO: %s", msg.c_str());
+    jpeg_destroy_decompress(&m_cinfo);
+    return false;
+  }
+}
+
+bool CJpegIO::GetExif()
+{
+  ExifInfo_t exifInfo;
+  IPTCInfo_t iptcInfo;
+  DllLibExif exifDll;
+  if (!exifDll.Load())
+  {
+    return false;
+  }
+  exifDll.process_jpeg(m_texturePath.c_str(), &exifInfo, &iptcInfo);
+  if (exifInfo.Orientation)
+  {
+    m_orientation = exifInfo.Orientation;
+    return true;
+  }
+  return false;
+}
+
+bool CJpegIO::Decode(const unsigned char *pixels)
+{
+  //requires a pre-allocated buffer of size pitch*3
+  unsigned char *dst = (unsigned char *) pixels;
+  try
+  {
+    jpeg_start_decompress( &m_cinfo );
+    while( m_cinfo.output_scanline < m_height )
+    {
+      jpeg_read_scanlines( &m_cinfo, &dst, 1 );
+      dst+=m_pitch;
+    }
+    jpeg_finish_decompress( &m_cinfo );
+  }
+  catch (CStdString &msg)
+  {
+    CLog::Log(LOGWARNING, "JpegIO: %s", msg.c_str());
+    jpeg_destroy_decompress(&m_cinfo);
+    return false;
+  }
+  jpeg_destroy_decompress( &m_cinfo );
+  return true;
+}

--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -28,12 +28,100 @@
 #include "utils/log.h"
 #include "JpegIO.h"
 
+/*Override libjpeg's error function to avoid an exit() call.*/
 static void jpeg_error_exit (j_common_ptr cinfo)
 {
   CStdString msg;
   msg.Format("Error %i: %s",cinfo->err->msg_code, cinfo->err->jpeg_message_table[cinfo->err->msg_code]);
   throw msg;
 }
+
+#if JPEG_LIB_VERSION < 80
+
+/*Versions of libjpeg prior to 8.0 did not have a pre-made mechanism for
+  decoding directly from memory. Here we backport the functions from v8.
+  When using v8 or higher, the built-in functions are used instead.
+  Original formatting left intact for the most part for easy comparison. */
+
+static void x_init_mem_source (j_decompress_ptr cinfo)
+{
+  /* no work necessary here */
+}
+
+void x_term_source (j_decompress_ptr cinfo)
+{
+  /* no work necessary here */
+}
+
+static boolean x_fill_mem_input_buffer (j_decompress_ptr cinfo)
+{
+  static JOCTET mybuffer[4];
+
+  /* The whole JPEG data is expected to reside in the supplied memory
+   * buffer, so any request for more data beyond the given buffer size
+   * is treated as an error.
+   */
+  /* Insert a fake EOI marker */
+  mybuffer[0] = (JOCTET) 0xFF;
+  mybuffer[1] = (JOCTET) JPEG_EOI;
+
+  cinfo->src->next_input_byte = mybuffer;
+  cinfo->src->bytes_in_buffer = 2;
+
+  return TRUE;
+}
+
+static void x_skip_input_data (j_decompress_ptr cinfo, long num_bytes)
+{
+  struct jpeg_source_mgr * src = cinfo->src;
+
+  /* Just a dumb implementation for now.  Could use fseek() except
+   * it doesn't work on pipes.  Not clear that being smart is worth
+   * any trouble anyway --- large skips are infrequent.
+   */
+  if (num_bytes > 0) {
+    while (num_bytes > (long) src->bytes_in_buffer) {
+      num_bytes -= (long) src->bytes_in_buffer;
+      (void) (*src->fill_input_buffer) (cinfo);
+      /* note we assume that fill_input_buffer will never return FALSE,
+       * so suspension need not be handled.
+       */
+    }
+    src->next_input_byte += (size_t) num_bytes;
+    src->bytes_in_buffer -= (size_t) num_bytes;
+  }
+}
+
+static void x_mem_src (j_decompress_ptr cinfo, unsigned char * inbuffer, unsigned long insize)
+{
+  struct jpeg_source_mgr * src;
+
+  if (inbuffer == NULL || insize == 0)	/* Treat empty input as fatal error */
+  {
+    (cinfo)->err->msg_code = 0;
+    (*(cinfo)->err->error_exit) ((j_common_ptr) (cinfo));
+  }
+
+  /* The source object is made permanent so that a series of JPEG images
+   * can be read from the same buffer by calling jpeg_mem_src only before
+   * the first one.
+   */
+  if (cinfo->src == NULL) {	/* first time for this JPEG object? */
+    cinfo->src = (struct jpeg_source_mgr *)
+      (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, JPOOL_PERMANENT,
+				  sizeof(struct jpeg_source_mgr));
+  }
+
+  src = cinfo->src;
+  src->init_source = x_init_mem_source;
+  src->fill_input_buffer = x_fill_mem_input_buffer;
+  src->skip_input_data = x_skip_input_data;
+  src->resync_to_restart = jpeg_resync_to_restart; /* use default method */
+  src->term_source = x_term_source;
+  src->bytes_in_buffer = (size_t) insize;
+  src->next_input_byte = (JOCTET *) inbuffer;
+}
+#endif
 
 CJpegIO::CJpegIO()
 {
@@ -81,7 +169,12 @@ bool CJpegIO::Open(const CStdString& texturePath,  unsigned int minx, unsigned i
   m_cinfo.err = jpeg_std_error(&m_jerr);
   m_jerr.error_exit = jpeg_error_exit;
   jpeg_create_decompress(&m_cinfo);
+#if JPEG_LIB_VERSION < 80
+  x_mem_src(&m_cinfo, m_inputBuff, m_inputBuffSize);
+#else
   jpeg_mem_src(&m_cinfo, m_inputBuff, m_inputBuffSize);
+#endif
+
 
   try
   {

--- a/xbmc/guilib/JpegIO.h
+++ b/xbmc/guilib/JpegIO.h
@@ -22,6 +22,11 @@
 #ifndef GUILIB_JPEGIO_H
 #define GUILIB_JPEGIO_H
 
+#ifdef TARGET_WINDOWS
+#define XMD_H
+#pragma comment(lib, "jpeg-static.lib")
+#endif
+
 #include <jpeglib.h>
 #include "utils/StdString.h"
 

--- a/xbmc/guilib/JpegIO.h
+++ b/xbmc/guilib/JpegIO.h
@@ -1,0 +1,61 @@
+/*
+*      Copyright (C) 2005-2011 Team XBMC
+*      http://www.xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#ifndef GUILIB_JPEGIO_H
+#define GUILIB_JPEGIO_H
+
+#include <jpeglib.h>
+#include "utils/StdString.h"
+
+class CJpegIO
+{
+
+public:
+  CJpegIO();
+  ~CJpegIO();
+  bool           Open(const CStdString& m_texturePath,  unsigned int m_minx=0, unsigned int m_miny=0);
+  bool           Decode(const unsigned char *pixels);
+  void           Close();
+
+  unsigned int   FileSize()    { return m_imgsize; }
+  unsigned int   Width()       { return m_width; }
+  unsigned int   Height()      { return m_height; }
+  unsigned int   Pitch()       { return m_pitch; }
+  unsigned int   Orientation() { return m_orientation; }
+
+protected:
+  bool           GetExif();
+  unsigned char  *m_inputBuff;
+  unsigned int   m_inputBuffSize;
+  unsigned int   m_minx;
+  unsigned int   m_miny;
+  struct         jpeg_decompress_struct m_cinfo;
+  struct         jpeg_error_mgr m_jerr;
+  CStdString     m_texturePath;
+
+  unsigned int   m_imgsize;
+  unsigned int   m_width;
+  unsigned int   m_height;
+  unsigned int   m_pitch;
+  unsigned int   m_orientation;
+};
+
+#endif

--- a/xbmc/guilib/Makefile.in
+++ b/xbmc/guilib/Makefile.in
@@ -64,6 +64,7 @@ SRCS=AnimatedGif.cpp \
      GUIWindowManager.cpp \
      GUIWrappingListContainer.cpp \
      IWindowManagerCallback.cpp \
+     JpegIO.cpp \
      Key.cpp \
      LocalizeStrings.cpp \
      Shader.cpp \

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -26,6 +26,7 @@
 #include "pictures/DllImageLib.h"
 #include "DDSImage.h"
 #include "filesystem/SpecialProtocol.h"
+#include "JpegIO.h"
 #if defined(__APPLE__) && defined(__arm__)
 #include <ImageIO/ImageIO.h>
 #include "filesystem/File.h"
@@ -82,7 +83,6 @@ void CBaseTexture::Allocate(unsigned int width, unsigned int height, unsigned in
   CLAMP(m_textureHeight, g_Windowing.GetMaxTextureSize());
   CLAMP(m_imageWidth, m_textureWidth);
   CLAMP(m_imageHeight, m_textureHeight);
-
   delete[] m_pixels;
   m_pixels = new unsigned char[GetPitch() * GetRows()];
 }
@@ -299,6 +299,26 @@ bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxW
   CFRelease(cfdata);
   delete [] imageBuff;
 #else
+  //ImageLib is sooo sloow for jpegs. Try our own decoder first. If it fails, fall back to ImageLib.
+  if (URIUtils::GetExtension(texturePath).Equals(".jpg") || URIUtils::GetExtension(texturePath).Equals(".tbn"))
+  {
+    CJpegIO jpegfile;
+    if (jpegfile.Open(texturePath))
+    {
+      if (jpegfile.Width() > 0 && jpegfile.Height() > 0)
+      {
+        Allocate(jpegfile.Width(), jpegfile.Height(), XB_FMT_RGB8);
+        if (jpegfile.Decode(m_pixels))
+        {
+          if (autoRotate && jpegfile.Orientation())
+            m_orientation = jpegfile.Orientation() - 1;
+          m_hasAlpha=false;
+          return true;
+        }
+      }
+    }
+  }
+
   DllImageLib dll;
   if (!dll.Load())
     return false;

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -440,6 +440,8 @@ unsigned int CBaseTexture::GetPitch(unsigned int width) const
     return ((width + 3) / 4) * 16;
   case XB_FMT_A8:
     return width;
+  case XB_FMT_RGB8:
+    return (((width + 1)* 3 / 4) * 4);
   case XB_FMT_RGBA8:
   case XB_FMT_A8R8G8B8:
   default:

--- a/xbmc/guilib/TextureDX.cpp
+++ b/xbmc/guilib/TextureDX.cpp
@@ -54,6 +54,7 @@ void CDXTexture::CreateTextureObject()
   case XB_FMT_DXT5_YCoCg:
     format = D3DFMT_DXT5;
     break;
+  case XB_FMT_RGB8:
   case XB_FMT_A8R8G8B8:
     format = D3DFMT_A8R8G8B8;
     break;
@@ -100,7 +101,24 @@ void CDXTexture::LoadToGPU()
     unsigned int minPitch = std::min(srcPitch, dstPitch);
 
     unsigned int rows = GetRows();
-    if (srcPitch == dstPitch)
+    if (m_format == XB_FMT_RGB8)
+    {
+      for (unsigned int y = 0; y < rows; y++)
+      {
+        unsigned char *dst2 = dst;
+        unsigned char *src2 = src;
+        for (unsigned int x = 0; x < srcPitch / 3; x++, dst2 += 4, src2 += 3)
+        {
+          dst2[0] = src2[2];
+          dst2[1] = src2[1];
+          dst2[2] = src2[0];
+          dst2[3] = 0xff;
+        }
+        src += srcPitch;
+        dst += dstPitch;
+      }
+    }
+    else if (srcPitch == dstPitch)
     {
       memcpy(dst, src, srcPitch * rows);
     }

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -91,6 +91,7 @@ void CGLTexture::LoadToGPU()
   }
 
   GLenum format;
+  GLint numcomponents;
 
   switch (m_format)
   {
@@ -104,15 +105,20 @@ void CGLTexture::LoadToGPU()
   case XB_FMT_DXT5_YCoCg:
     format = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
     break;
+  case XB_FMT_RGB8:
+    format = GL_RGB;
+    numcomponents = GL_RGB;
+    break;
   case XB_FMT_A8R8G8B8:
   default:
     format = GL_BGRA;
+    numcomponents = GL_RGBA;
     break;
   }
 
   if ((m_format & XB_FMT_DXT_MASK) == 0)
   {
-    glTexImage2D(GL_TEXTURE_2D, 0, 4, m_textureWidth, m_textureHeight, 0,
+    glTexImage2D(GL_TEXTURE_2D, 0, numcomponents, m_textureWidth, m_textureHeight, 0,
       format, GL_UNSIGNED_BYTE, m_pixels);
   }
   else
@@ -143,6 +149,9 @@ void CGLTexture::LoadToGPU()
   {
     case XB_FMT_RGBA8:
       internalformat = pixelformat = GL_RGBA;
+      break;
+    case XB_FMT_RGB8:
+      internalformat = pixelformat = GL_RGB;
       break;
     case XB_FMT_A8R8G8B8:
       if (g_Windowing.SupportsBGRA())

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -38,6 +38,7 @@
 #define XB_FMT_A8R8G8B8   16 // texture.xbt byte order (matches BGRA8)
 #define XB_FMT_A8         32
 #define XB_FMT_RGBA8      64
+#define XB_FMT_RGB8      128
 #define XB_FMT_OPAQUE  65536
 
 class CXBTFFrame


### PR DESCRIPTION
On all platforms other than IOS, we use cximage to load jpegs. It is incredibly slow. Using libjpeg(-turbo) directly results in a speedup of around 2x on average, and much higher for larger images.

I believe i have osx/win32/ios/linux acks already, just wanted to do a quick pr to be sure that no one had any fundamental concerns. @jmarshallnz We discussed this a while ago when I first started poking at it, and I believe you were ok with it as long as the exif orientation was working. It currently uses the libexif that we build, and is verified working, but I'd like to rip that out and add a quick function to grab it from our source imagebuffer, that way we avoid an unnecessary file open.

Other than that, I'm quite confident in this as a drop-in for what we have. If decode fails for any reason, it falls back gracefully to cximage.

Will push this in a day or two barring a good reason not to.
