### PR TITLE
replace CGUIListItem::m_propertyMap and CGUIWindow::m_propertyMap values (CStdString) with CVariant values

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3581,7 +3581,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
   
   if( item.HasProperty("StartPercent") )
   {
-    options.startpercent = item.GetPropertyDouble("StartPercent");                    
+    options.startpercent = item.GetProperty("StartPercent").asDouble();
   }
   
   PLAYERCOREID eNewCore = EPC_NONE;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1059,7 +1059,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
       return "";
 
     CStdString property = m_listitemProperties[info - LISTITEM_PROPERTY_START-MUSICPLAYER_PROPERTY_OFFSET];
-    return m_currentFile->GetProperty(property);
+    return m_currentFile->GetProperty(property).asString();
   }
 
   if (info >= LISTITEM_START && info <= LISTITEM_END)
@@ -1351,7 +1351,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
     {
       CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
       if (window)
-        return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("showplot");
+        return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("showplot").asString();
     }
     break;
   case CONTAINER_TOTALTIME:
@@ -1602,28 +1602,28 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
     {
       CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
       if (window)
-        return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("fanart_color1");
+        return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("fanart_color1").asString();
     }
     break;
   case FANART_COLOR2:
     {
       CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
       if (window)
-        return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("fanart_color2");
+        return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("fanart_color2").asString();
     }
     break;
   case FANART_COLOR3:
     {
       CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
       if (window)
-        return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("fanart_color3");
+        return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("fanart_color3").asString();
     }
     break;
   case FANART_IMAGE:
     {
       CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
       if (window)
-        return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("fanart_image");
+        return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("fanart_image").asString();
     }
     break;
   case SYSTEM_RENDER_VENDOR:
@@ -2356,7 +2356,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
         else
         {
           CGUIWindow *window = g_windowManager.GetWindow(m_nextWindowID);
-          if (window && URIUtils::GetFileName(window->GetProperty("xmlfile")).Equals(m_stringParameters[info.GetData2()]))
+          if (window && URIUtils::GetFileName(window->GetProperty("xmlfile").asString()).Equals(m_stringParameters[info.GetData2()]))
             bReturn = true;
         }
         break;
@@ -2366,7 +2366,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
         else
         {
           CGUIWindow *window = g_windowManager.GetWindow(m_prevWindowID);
-          if (window && URIUtils::GetFileName(window->GetProperty("xmlfile")).Equals(m_stringParameters[info.GetData2()]))
+          if (window && URIUtils::GetFileName(window->GetProperty("xmlfile").asString()).Equals(m_stringParameters[info.GetData2()]))
             bReturn = true;
         }
         break;
@@ -2739,7 +2739,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
       window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
     }
     if (window)
-      return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty(m_stringParameters[info.GetData2()]);
+      return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty(m_stringParameters[info.GetData2()]).asString();
   }
   else if (info.m_info == CONTROL_GET_LABEL)
   {
@@ -2764,7 +2764,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
     }
 
     if (window)
-      return window->GetProperty(m_stringParameters[info.GetData2()]);
+      return window->GetProperty(m_stringParameters[info.GetData2()]).asString();
   }
   else if (info.m_info == SYSTEM_ADDON_TITLE ||
            info.m_info == SYSTEM_ADDON_ICON)
@@ -2831,13 +2831,13 @@ CStdString CGUIInfoManager::GetImage(int info, int contextWindow)
   {
     CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
     if (window)
-      return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("tvshowthumb");
+      return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("tvshowthumb").asString();
   }
   else if (info == CONTAINER_SEASONTHUMB)
   {
     CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
     if (window)
-      return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("seasonthumb");
+      return ((CGUIMediaWindow *)window)->CurrentDirectory().GetProperty("seasonthumb").asString();
   }
   else if (info == LISTITEM_THUMB || info == LISTITEM_ICON || info == LISTITEM_ACTUAL_ICON ||
           info == LISTITEM_OVERLAY || info == LISTITEM_RATING || info == LISTITEM_STAR_RATING)
@@ -3739,7 +3739,7 @@ bool CGUIInfoManager::GetItemInt(int &value, const CGUIListItem *item, int info)
   if (info >= LISTITEM_PROPERTY_START && info - LISTITEM_PROPERTY_START < (int)m_listitemProperties.size())
   { // grab the property
     CStdString property = m_listitemProperties[info - LISTITEM_PROPERTY_START];
-    CStdString val = item->GetProperty(property);
+    CStdString val = item->GetProperty(property).asString();
     value = atoi(val);
     return true;
   }
@@ -3765,7 +3765,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info) const
   if (info >= LISTITEM_PROPERTY_START && info - LISTITEM_PROPERTY_START < (int)m_listitemProperties.size())
   { // grab the property
     CStdString property = m_listitemProperties[info - LISTITEM_PROPERTY_START];
-    return item->GetProperty(property);
+    return item->GetProperty(property).asString();
   }
 
   switch (info)
@@ -4182,13 +4182,12 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
   if (condition >= LISTITEM_PROPERTY_START && condition - LISTITEM_PROPERTY_START < (int)m_listitemProperties.size())
   { // grab the property
     CStdString property = m_listitemProperties[condition - LISTITEM_PROPERTY_START];
-    CStdString val = item->GetProperty(property);
-    return (val == "1" || val.CompareNoCase("true") == 0);
+    return item->GetProperty(property).asBoolean();
   }
   else if (condition == LISTITEM_ISPLAYING)
   {
     if (item->HasProperty("playlistposition"))
-      return item->GetPropertyInt("playlisttype") == g_playlistPlayer.GetCurrentPlaylist() && item->GetPropertyInt("playlistposition") == g_playlistPlayer.GetCurrentSong();
+      return (int)item->GetProperty("playlisttype").asInteger() == g_playlistPlayer.GetCurrentPlaylist() && (int)item->GetProperty("playlistposition").asInteger() == g_playlistPlayer.GetCurrentSong();
     else if (item->IsFileItem() && !m_currentFile->GetPath().IsEmpty())
     {
       if (!g_application.m_strPlayListFile.IsEmpty())

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -133,7 +133,7 @@ int CPlayListPlayer::GetNextSong()
   if (RepeatedOne(m_iCurrentPlayList))
   {
     // otherwise immediately abort playback
-    if (m_iCurrentSong >= 0 && m_iCurrentSong < playlist.size() && playlist[m_iCurrentSong]->GetPropertyBOOL("unplayable"))
+    if (m_iCurrentSong >= 0 && m_iCurrentSong < playlist.size() && playlist[m_iCurrentSong]->GetProperty("unplayable").asBoolean())
     {
       CLog::Log(LOGERROR,"Playlist Player: RepeatOne stuck on unplayable item: %i, path [%s]", m_iCurrentSong, playlist[m_iCurrentSong]->GetPath().c_str());
       CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_STOPPED, 0, 0, m_iCurrentPlayList, m_iCurrentSong);

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -141,7 +141,7 @@ bool CThumbExtractor::DoWork()
     result = CDVDFileInfo::ExtractThumb(m_path, m_target, &m_item.GetVideoInfoTag()->m_streamDetails);
     if(result)
     {
-      m_item.SetProperty("HasAutoThumb", "1");
+      m_item.SetProperty("HasAutoThumb", true);
       m_item.SetProperty("AutoThumbImage", m_target);
       m_item.SetThumbnailImage(m_target);
     }
@@ -218,7 +218,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
         struct __stat64 st;
         if(CFile::Stat(cachedThumb, &st) == 0 && st.st_size > 0)
         {
-          pItem->SetProperty("HasAutoThumb", "1");
+          pItem->SetProperty("HasAutoThumb", true);
           pItem->SetProperty("AutoThumbImage", cachedThumb);
           pItem->SetThumbnailImage(cachedThumb);
         }

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -22,6 +22,7 @@
 #include "AddonDatabase.h"
 #include "addons/AddonManager.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 #include "XBDateTime.h"
 #include "addons/Service.h"
 #include "dbwrappers/dataset.h"

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -93,7 +93,7 @@ bool CGUIDialogAddonInfo::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTN_ENABLE)
       {
-        OnEnable(!m_item->GetProperty("Addon.Enabled").Equals("true"));
+        OnEnable(!m_item->GetProperty("Addon.Enabled").asBoolean());
         return true;
       }
       else if (iControl == CONTROL_BTN_SETTINGS)
@@ -132,14 +132,14 @@ void CGUIDialogAddonInfo::UpdateControls()
   CStdString xbmcPath = _P("special://xbmc/addons");
   bool isInstalled = NULL != m_localAddon.get();
   bool isSystem = isInstalled && m_localAddon->Path().Left(xbmcPath.size()).Equals(xbmcPath);
-  bool isEnabled = isInstalled && m_item->GetProperty("Addon.Enabled").Equals("true");
-  bool isUpdatable = isInstalled && m_item->GetProperty("Addon.UpdateAvail").Equals("true");
+  bool isEnabled = isInstalled && m_item->GetProperty("Addon.Enabled").asBoolean();
+  bool isUpdatable = isInstalled && m_item->GetProperty("Addon.UpdateAvail").asBoolean();
   if (isInstalled)
     GrabRollbackVersions();
 
   // TODO: System addons should be able to be disabled
   bool canDisable = isInstalled && !isSystem && !m_localAddon->IsInUse();
-  bool canInstall = !isInstalled && m_item->GetProperty("Addon.Broken").IsEmpty();
+  bool canInstall = !isInstalled && m_item->GetProperty("Addon.Broken").empty();
   bool isRepo = (isInstalled && m_localAddon->Type() == ADDON_REPOSITORY) || (m_addon && m_addon->Type() == ADDON_REPOSITORY);
 
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_INSTALL, canDisable || canInstall);
@@ -230,12 +230,12 @@ void CGUIDialogAddonInfo::OnChangeLog()
   else if (m_localAddon)
     name = m_localAddon->Name();
   pDlgInfo->SetHeading(g_localizeStrings.Get(24054)+" - "+name);
-  if (m_item->GetProperty("Addon.Changelog").IsEmpty())
+  if (m_item->GetProperty("Addon.Changelog").empty())
   {
     pDlgInfo->SetText(g_localizeStrings.Get(13413));
     CFileItemList items;
     if (m_localAddon && 
-        !m_item->GetProperty("Addon.UpdateAvail").Equals("true"))
+        !m_item->GetProperty("Addon.UpdateAvail").asBoolean())
     {
       items.Add(CFileItemPtr(new CFileItem(m_localAddon->ChangeLog(),false)));
     }
@@ -247,7 +247,7 @@ void CGUIDialogAddonInfo::OnChangeLog()
                             "special://temp/"),this);
   }
   else
-    pDlgInfo->SetText(m_item->GetProperty("Addon.Changelog"));
+    pDlgInfo->SetText(m_item->GetProperty("Addon.Changelog").asString());
 
   m_changelog = true;
   pDlgInfo->DoModal();
@@ -307,7 +307,7 @@ bool CGUIDialogAddonInfo::SetItem(const CFileItemPtr& item)
   // grab the local addon, if it's available
   m_localAddon.reset();
   m_addon.reset();
-  if (CAddonMgr::Get().GetAddon(item->GetProperty("Addon.ID"), m_localAddon)) // sets m_addon if installed regardless of enabled state
+  if (CAddonMgr::Get().GetAddon(item->GetProperty("Addon.ID").asString(), m_localAddon)) // sets m_addon if installed regardless of enabled state
     m_item->SetProperty("Addon.Enabled", "true");
   else
     m_item->SetProperty("Addon.Enabled", "false");
@@ -315,9 +315,9 @@ bool CGUIDialogAddonInfo::SetItem(const CFileItemPtr& item)
 
   CAddonDatabase database;
   database.Open();
-  database.GetAddon(item->GetProperty("Addon.ID"),m_addon);
+  database.GetAddon(item->GetProperty("Addon.ID").asString(),m_addon);
 
-  if (TranslateType(item->GetProperty("Addon.intType")) == ADDON_REPOSITORY)
+  if (TranslateType(item->GetProperty("Addon.intType").asString()) == ADDON_REPOSITORY)
   {
     CAddonDatabase database;
     database.Open();

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -109,7 +109,7 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
         // iItem is checked for validity inside these routines
         if (iAction == ACTION_SHOW_INFO)
         {
-          if (!m_vecItems->Get(iItem)->GetProperty("Addon.ID").IsEmpty())
+          if (!m_vecItems->Get(iItem)->GetProperty("Addon.ID").empty())
             return CGUIDialogAddonInfo::ShowForItem((*m_vecItems)[iItem]);
           return false;
         }
@@ -146,7 +146,7 @@ void CGUIWindowAddonBrowser::GetContextButtons(int itemNumber,
     buttons.Add(CONTEXT_BUTTON_SCAN,24034);
   
   AddonPtr addon;
-  if (!CAddonMgr::Get().GetAddon(pItem->GetProperty("Addon.ID"), addon, ADDON_UNKNOWN, false)) // allow disabled addons
+  if (!CAddonMgr::Get().GetAddon(pItem->GetProperty("Addon.ID").asString(), addon, ADDON_UNKNOWN, false)) // allow disabled addons
     return;
 
   if (addon->Type() == ADDON_REPOSITORY && pItem->m_bIsFolder)
@@ -174,7 +174,7 @@ bool CGUIWindowAddonBrowser::OnContextButton(int itemNumber,
     }
   }
   AddonPtr addon;
-  if (!CAddonMgr::Get().GetAddon(pItem->GetProperty("Addon.ID"), addon, ADDON_UNKNOWN, false)) // allow disabled addons
+  if (!CAddonMgr::Get().GetAddon(pItem->GetProperty("Addon.ID").asString(), addon, ADDON_UNKNOWN, false)) // allow disabled addons
     return false;
 
   if (button == CONTEXT_BUTTON_SETTINGS)
@@ -223,10 +223,10 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem)
     if (item->HasProperty("Addon.Downloading"))
     {
       if (CGUIDialogYesNo::ShowAndGetInput(g_localizeStrings.Get(24000),
-                                           item->GetProperty("Addon.Name"),
+                                           item->GetProperty("Addon.Name").asString(),
                                            g_localizeStrings.Get(24066),""))
       {
-        if (CAddonInstaller::Get().Cancel(item->GetProperty("Addon.ID")))
+        if (CAddonInstaller::Get().Cancel(item->GetProperty("Addon.ID").asString()))
           Update(m_vecItems->GetPath());
       }
       return true;
@@ -295,7 +295,7 @@ void CGUIWindowAddonBrowser::SetItemLabel2(CFileItemPtr item)
 {
   if (!item || item->m_bIsFolder) return;
   unsigned int percent;
-  if (CAddonInstaller::Get().GetProgress(item->GetProperty("Addon.ID"), percent))
+  if (CAddonInstaller::Get().GetProgress(item->GetProperty("Addon.ID").asString(), percent))
   {
     CStdString progress;
     progress.Format(g_localizeStrings.Get(24042).c_str(), percent);
@@ -304,7 +304,7 @@ void CGUIWindowAddonBrowser::SetItemLabel2(CFileItemPtr item)
   }
   else
     item->ClearProperty("Addon.Downloading");
-  item->SetLabel2(item->GetProperty("Addon.Status"));
+  item->SetLabel2(item->GetProperty("Addon.Status").asString());
   // to avoid the view state overriding label 2
   item->SetLabelPreformated(true);
 }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.cpp
@@ -32,6 +32,7 @@
 #include "filesystem/IFile.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
+#include "utils/Variant.h"
 
 #include <string>
 
@@ -151,7 +152,7 @@ bool CDVDInputStreamRTMP::Open(const char* strFile, const std::string& content)
   m_optionvalues.clear();
   for (int i=0; options[i].name; i++)
   {
-    CStdString tmp = m_item.GetProperty(options[i].name);
+    CStdString tmp = m_item.GetProperty(options[i].name).asString();
     if (!tmp.empty())
     {
       m_optionvalues.push_back(tmp);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -68,6 +68,7 @@
 #include "utils/TimeUtils.h"
 #include "utils/StreamDetails.h"
 #include "utils/StreamUtils.h"
+#include "utils/Variant.h"
 #include "storage/MediaManager.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogKaiToast.h"
@@ -462,7 +463,7 @@ retry:
         m_mimetype = "bluray/iso";
         filename = m_filename;
         filename = filename + "/BDMV/index.bdmv";
-        int title = m_item.GetPropertyInt("BlurayStartingTitle");
+        int title = (int)m_item.GetProperty("BlurayStartingTitle").asInteger();
         if( title )
           filename.AppendFormat("?title=%d",title);
         
@@ -485,7 +486,7 @@ retry:
     // find any upnp subtitles
     CStdString key("upnp:subtitle:1");
     for(unsigned s = 1; m_item.HasProperty(key); key.Format("upnp:subtitle:%u", ++s))
-      filenames.push_back(m_item.GetProperty(key));
+      filenames.push_back(m_item.GetProperty(key).asString());
 
     for(unsigned int i=0;i<filenames.size();i++)
     {

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -181,12 +181,12 @@ bool CAddonsDirectory::GetDirectory(const CStdString& strPath, CFileItemList &it
     for (int i=0;i<items.Size();++i)
     {
       AddonPtr addon2;
-      database.GetAddon(items[i]->GetProperty("Addon.ID"),addon2);
-      if (addon2 && addon2->Version() > AddonVersion(items[i]->GetProperty("Addon.Version"))
+      database.GetAddon(items[i]->GetProperty("Addon.ID").asString(),addon2);
+      if (addon2 && addon2->Version() > AddonVersion(items[i]->GetProperty("Addon.Version").asString())
                  && !database.IsAddonBlacklisted(addon2->ID(),addon2->Version().c_str()))
       {
         items[i]->SetProperty("Addon.Status",g_localizeStrings.Get(24068));
-        items[i]->SetProperty("Addon.UpdateAvail","true");
+        items[i]->SetProperty("Addon.UpdateAvail", true);
       }
     }
   }
@@ -219,7 +219,7 @@ void CAddonsDirectory::GenerateListing(CURL &path, VECADDONS& addons, CFileItemL
     if (addon2 && addon2->Version() < addon->Version())
     {
       pItem->SetProperty("Addon.Status",g_localizeStrings.Get(24068));
-      pItem->SetProperty("Addon.UpdateAvail","true");
+      pItem->SetProperty("Addon.UpdateAvail", true);
     }
     CAddonDatabase::SetPropertiesFromAddon(addon,pItem);
     items.Add(pItem);

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -199,7 +199,7 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, C
       // TODO: we shouldn't be checking the gui setting here;
       // callers should use getHidden instead
       if ((!item->m_bIsFolder && !pDirectory->IsAllowed(item->GetPath())) ||
-          (item->GetPropertyBOOL("file:hidden") && !getHidden && !g_guiSettings.GetBool("filelists.showhidden")))
+          (item->GetProperty("file:hidden").asBoolean() && !getHidden && !g_guiSettings.GetBool("filelists.showhidden")))
       {
         items.Remove(i);
         i--; // don't confuse loop

--- a/xbmc/filesystem/FileSFTP.cpp
+++ b/xbmc/filesystem/FileSFTP.cpp
@@ -26,6 +26,7 @@
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
+#include "utils/Variant.h"
 #include "Util.h"
 #include <fcntl.h>
 #include <sstream>

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -562,10 +562,10 @@ static void ParseItem(CFileItem* item, TiXmlElement* root, const CStdString& pat
     vtag->m_strWritingCredits.Delete(0, 2);
 
     if(item->HasProperty("duration")    && vtag->m_strRuntime.IsEmpty())
-      vtag->m_strRuntime = item->GetProperty("duration");
+      vtag->m_strRuntime = item->GetProperty("duration").asString();
 
     if(item->HasProperty("description") && vtag->m_strPlot.IsEmpty())
-      vtag->m_strPlot = item->GetProperty("description");
+      vtag->m_strPlot = item->GetProperty("description").asString();
 
     if(vtag->m_strPlotOutline.IsEmpty() && !vtag->m_strPlot.IsEmpty())
     {

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -50,6 +50,7 @@
 #include "filesystem/File.h"
 #include "utils/StringUtils.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/Variant.h"
 
 using namespace std;
 using namespace XFILE::VIDEODATABASEDIRECTORY;
@@ -304,8 +305,8 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
         for (int i = 0; i < items.Size(); i++)
         {
           CFileItemPtr item = items[i];
-          watched += item->GetPropertyInt("watchedepisodes");
-          unwatched += item->GetPropertyInt("unwatchedepisodes");
+          watched += (int)item->GetProperty("watchedepisodes").asInteger();
+          unwatched += (int)item->GetProperty("unwatchedepisodes").asInteger();
         }
         pItem->SetProperty("totalepisodes", watched + unwatched);
         pItem->SetProperty("numepisodes", watched + unwatched); // will be changed later to reflect watchmode setting

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -25,6 +25,7 @@
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
+#include "utils/Variant.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
@@ -75,7 +76,7 @@ bool CDirectoryNodeSeasons::GetContent(CFileItemList& items) const
     int count = 0;
     for(int i = 0; i < items.Size(); i++) 
     {
-      if (items[i]->GetPropertyInt("unwatchedepisodes") != 0 && items[i]->GetVideoInfoTag()->m_iSeason != 0)
+      if (items[i]->GetProperty("unwatchedepisodes").asInteger() != 0 && items[i]->GetVideoInfoTag()->m_iSeason != 0)
         count++;
     }
     bFlatten = (count < 2); // flatten if there is only 1 unwatched season (not counting specials)

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -221,7 +221,7 @@ void CGUIListItem::Archive(CArchive &ar)
     ar << m_bSelected;
     ar << m_overlayIcon;
     ar << (int)m_mapProperties.size();
-    for (std::map<CStdString, CStdString, icompare>::const_iterator it = m_mapProperties.begin(); it != m_mapProperties.end(); it++)
+    for (PropertyMap::const_iterator it = m_mapProperties.begin(); it != m_mapProperties.end(); it++)
     {
       ar << it->first;
       ar << it->second;
@@ -245,7 +245,8 @@ void CGUIListItem::Archive(CArchive &ar)
     ar >> mapSize;
     for (int i = 0; i < mapSize; i++)
     {
-      CStdString key, value;
+      CStdString key;
+      CVariant value;
       ar >> key;
       ar >> value;
       SetProperty(key, value);
@@ -262,7 +263,7 @@ void CGUIListItem::Serialize(CVariant &value)
   value["strIcon"] = m_strIcon;
   value["selected"] = m_bSelected;
 
-  for (std::map<CStdString, CStdString, icompare>::const_iterator it = m_mapProperties.begin(); it != m_mapProperties.end(); it++)
+  for (PropertyMap::const_iterator it = m_mapProperties.begin(); it != m_mapProperties.end(); it++)
   {
     value["properties"][it->first] = it->second;
   }
@@ -320,21 +321,16 @@ void CGUIListItem::SetInvalid()
   if (m_focusedLayout) m_focusedLayout->SetInvalid();
 }
 
-void CGUIListItem::SetProperty(const CStdString &strKey, const char *strValue)
+void CGUIListItem::SetProperty(const CStdString &strKey, const CVariant &value)
 {
-  m_mapProperties[strKey] = strValue;
+  m_mapProperties[strKey] = value;
 }
 
-void CGUIListItem::SetProperty(const CStdString &strKey, const CStdString &strValue)
-{
-  m_mapProperties[strKey] = strValue;
-}
-
-CStdString CGUIListItem::GetProperty(const CStdString &strKey) const
+CVariant CGUIListItem::GetProperty(const CStdString &strKey) const
 {
   PropertyMap::const_iterator iter = m_mapProperties.find(strKey);
   if (iter == m_mapProperties.end())
-    return "";
+    return CVariant(CVariant::VariantTypeNull);
 
   return iter->second;
 }
@@ -350,7 +346,7 @@ bool CGUIListItem::HasProperty(const CStdString &strKey) const
 
 void CGUIListItem::ClearProperty(const CStdString &strKey)
 {
-  PropertyMap::iterator iter = m_mapProperties.find(strKey);
+  PropertyMap::const_iterator iter = m_mapProperties.find(strKey);
   if (iter != m_mapProperties.end())
     m_mapProperties.erase(iter);
 }
@@ -360,52 +356,18 @@ void CGUIListItem::ClearProperties()
   m_mapProperties.clear();
 }
 
-void CGUIListItem::SetProperty(const CStdString &strKey, int nVal)
-{
-  CStdString strVal;
-  strVal.Format("%d",nVal);
-  SetProperty(strKey, strVal);
-}
-
 void CGUIListItem::IncrementProperty(const CStdString &strKey, int nVal)
 {
-  int i = GetPropertyInt(strKey);
+  int64_t i = GetProperty(strKey).asInteger();
   i += nVal;
   SetProperty(strKey, i);
 }
 
-void CGUIListItem::SetProperty(const CStdString &strKey, bool bVal)
-{
-  SetProperty(strKey, bVal?"1":"0");
-}
-
-void CGUIListItem::SetProperty(const CStdString &strKey, double dVal)
-{
-  CStdString strVal;
-  strVal.Format("%f",dVal);
-  SetProperty(strKey, strVal);
-}
-
 void CGUIListItem::IncrementProperty(const CStdString &strKey, double dVal)
 {
-  double d = GetPropertyDouble(strKey);
+  double d = GetProperty(strKey).asDouble();
   d += dVal;
   SetProperty(strKey, d);
-}
-
-bool CGUIListItem::GetPropertyBOOL(const CStdString &strKey) const
-{
-  return GetProperty(strKey) == "1";
-}
-
-int CGUIListItem::GetPropertyInt(const CStdString &strKey) const
-{
-  return atoi(GetProperty(strKey).c_str()) ;
-}
-
-double CGUIListItem::GetPropertyDouble(const CStdString &strKey) const
-{
-  return atof(GetProperty(strKey).c_str()) ;
 }
 
 void CGUIListItem::AppendProperties(const CGUIListItem &item)

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -102,11 +102,7 @@ public:
 
   bool m_bIsFolder;     ///< is item a folder or a file
 
-  void SetProperty(const CStdString &strKey, const char *strValue);
-  void SetProperty(const CStdString &strKey, const CStdString &strValue);
-  void SetProperty(const CStdString &strKey, int nVal);
-  void SetProperty(const CStdString &strKey, bool bVal);
-  void SetProperty(const CStdString &strKey, double dVal);
+  void SetProperty(const CStdString &strKey, const CVariant &value);
 
   void IncrementProperty(const CStdString &strKey, int nVal);
   void IncrementProperty(const CStdString &strKey, double dVal);
@@ -127,10 +123,7 @@ public:
   bool       HasProperties() const { return m_mapProperties.size() > 0; };
   void       ClearProperty(const CStdString &strKey);
 
-  CStdString GetProperty(const CStdString &strKey) const;
-  bool       GetPropertyBOOL(const CStdString &strKey) const;
-  int        GetPropertyInt(const CStdString &strKey) const;
-  double     GetPropertyDouble(const CStdString &strKey) const;
+  CVariant   GetProperty(const CStdString &strKey) const;
 
 protected:
   CStdString m_strLabel2;     // text of column2
@@ -149,8 +142,8 @@ protected:
       return s1.CompareNoCase(s2) < 0;
     }
   };
-  
-  typedef std::map<CStdString, CStdString, icompare> PropertyMap;
+
+  typedef std::map<CStdString, CVariant, icompare> PropertyMap;
   PropertyMap m_mapProperties;
 private:
   CStdStringW m_sortLabel;    // text for sorting. Need to be UTF16 for proper sorting

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -23,6 +23,7 @@
 #include "utils/XMLUtils.h"
 #include "GUIControlFactory.h"
 #include "GUIInfoManager.h"
+#include "utils/Variant.h"
 
 using namespace std;
 
@@ -64,7 +65,7 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
       CGUIInfoLabel prop;
       if (!name.IsEmpty() && CGUIControlFactory::GetInfoLabelFromElement(property, prop))
       {
-        SetProperty(name, prop.GetLabel(parentID, true));
+        SetProperty(name, prop.GetLabel(parentID, true).c_str());
         if (!prop.IsConstant())
           m_info.push_back(make_pair(prop, name));
       }
@@ -105,7 +106,7 @@ void CGUIStaticItem::UpdateProperties(int contextWindow)
     else if (name.Equals("icon"))
       SetIconImage(value);
     else
-      SetProperty(name, value);
+      SetProperty(name, value.c_str());
   }
 }
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -41,6 +41,7 @@
 #include "utils/XMLUtils.h"
 #include "GUIAudioManager.h"
 #include "Application.h"
+#include "utils/Variant.h"
 
 #ifdef HAS_PERFORMANCE_SAMPLE
 #include "utils/PerformanceSample.h"
@@ -636,7 +637,7 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
   start = CurrentHostCounter();
 #endif
   // load skin xml fil
-  CStdString xmlFile = GetProperty("xmlfile");
+  CStdString xmlFile = GetProperty("xmlfile").asString();
   bool bHasPath=false;
   if (xmlFile.Find("\\") > -1 || xmlFile.Find("/") > -1 )
     bHasPath = true;
@@ -685,7 +686,7 @@ bool CGUIWindow::Initialize()
 {
   if (!g_windowManager.Initialized())
     return false;     // can't load if we have no skin yet
-  return Load(GetProperty("xmlfile"));
+  return Load(GetProperty("xmlfile").asString());
 }
 
 void CGUIWindow::SetInitialVisibility()
@@ -901,60 +902,20 @@ void CGUIWindow::ChangeButtonToEdit(int id, bool singleLabel /* = false*/)
 #endif
 }
 
-void CGUIWindow::SetProperty(const CStdString &key, const CStdString &value)
+void CGUIWindow::SetProperty(const CStdString &strKey, const CVariant &value)
 {
   CSingleLock lock(*this);
-  m_mapProperties[key] = value;
+  m_mapProperties[strKey] = value;
 }
 
-void CGUIWindow::SetProperty(const CStdString &key, const char *value)
+CVariant CGUIWindow::GetProperty(const CStdString &strKey) const
 {
   CSingleLock lock(*this);
-  m_mapProperties[key] = value;
-}
-
-void CGUIWindow::SetProperty(const CStdString &key, int value)
-{
-  CStdString strVal;
-  strVal.Format("%d", value);
-  SetProperty(key, strVal);
-}
-
-void CGUIWindow::SetProperty(const CStdString &key, bool value)
-{
-  SetProperty(key, value ? "1" : "0");
-}
-
-void CGUIWindow::SetProperty(const CStdString &key, double value)
-{
-  CStdString strVal;
-  strVal.Format("%f", value);
-  SetProperty(key, strVal);
-}
-
-CStdString CGUIWindow::GetProperty(const CStdString &key) const
-{
-  CSingleLock lock(*this);
-  std::map<CStdString,CStdString,icompare>::const_iterator iter = m_mapProperties.find(key);
+  std::map<CStdString, CVariant, icompare>::const_iterator iter = m_mapProperties.find(strKey);
   if (iter == m_mapProperties.end())
-    return "";
+    return CVariant(CVariant::VariantTypeNull);
 
   return iter->second;
-}
-
-int CGUIWindow::GetPropertyInt(const CStdString &key) const
-{
-  return atoi(GetProperty(key).c_str());
-}
-
-bool CGUIWindow::GetPropertyBool(const CStdString &key) const
-{
-  return GetProperty(key) == "1";
-}
-
-double CGUIWindow::GetPropertyDouble(const CStdString &key) const
-{
-  return atof(GetProperty(key).c_str());
 }
 
 void CGUIWindow::ClearProperties()

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -56,6 +56,7 @@ class CFileItem; typedef boost::shared_ptr<CFileItem> CFileItemPtr;
 class TiXmlNode;
 class TiXmlElement;
 class TiXmlDocument;
+class CVariant;
 
 class COrigin
 {
@@ -171,39 +172,13 @@ public:
    \param value value to set, may be a string, integer, boolean or double.
    \sa GetProperty
    */
-  void SetProperty(const CStdString &key, const CStdString &value);
-  void SetProperty(const CStdString &key, const char *value);
-  void SetProperty(const CStdString &key, int value);
-  void SetProperty(const CStdString &key, bool value);
-  void SetProperty(const CStdString &key, double value);
+  void SetProperty(const CStdString &key, const CVariant &value);
 
   /*! \brief Retreive a property
    \param key name of the property to retrieve
    \return value of the property, empty if it doesn't exist
-   \sa SetProperty, GetPropertyInt, GetPropertyBool, GetPropertyDouble
    */
-  CStdString GetProperty(const CStdString &key) const;
-
-  /*! \brief Retreive an integer property
-   \param key name of the property to retrieve
-   \return value of the property, 0 if it doesn't exist
-   \sa SetProperty, GetProperty
-   */
-  int        GetPropertyInt(const CStdString &key) const;
-
-  /*! \brief Retreive a boolean property
-   \param key name of the property to retrieve
-   \return value of the property, false if it doesn't exist
-   \sa SetProperty, GetProperty
-   */
-  bool       GetPropertyBool(const CStdString &key) const;
-
-  /*! \brief Retreive a double precision property
-   \param key name of the property to retrieve
-   \return value of the property, 0 if it doesn't exist
-   \sa SetProperty, GetProperty
-   */
-  double     GetPropertyDouble(const CStdString &key) const;
+  CVariant GetProperty(const CStdString &key) const;
 
   /*! \brief Clear a all the window's properties
    \sa SetProperty, HasProperty, GetProperty
@@ -300,7 +275,7 @@ protected:
   int m_exclusiveMouseControl; ///< \brief id of child control that wishes to receive all mouse events \sa GUI_MSG_EXCLUSIVE_MOUSE
 
 private:
-  std::map<CStdString, CStdString, icompare> m_mapProperties;
+  std::map<CStdString, CVariant, icompare> m_mapProperties;
 
 };
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -33,6 +33,7 @@
 #include "addons/Skin.h"
 #include "GUITexture.h"
 #include "windowing/WindowingFactory.h"
+#include "utils/Variant.h"
 
 using namespace std;
 
@@ -816,12 +817,12 @@ bool CGUIWindowManager::IsWindowActive(const CStdString &xmlFile, bool ignoreClo
 {
   CSingleLock lock(g_graphicsContext);
   CGUIWindow *window = GetWindow(GetActiveWindow());
-  if (window && URIUtils::GetFileName(window->GetProperty("xmlfile")).Equals(xmlFile)) return true;
+  if (window && URIUtils::GetFileName(window->GetProperty("xmlfile").asString()).Equals(xmlFile)) return true;
   // run through the dialogs
   for (ciDialog it = m_activeDialogs.begin(); it != m_activeDialogs.end(); ++it)
   {
     CGUIWindow *window = *it;
-    if (URIUtils::GetFileName(window->GetProperty("xmlfile")).Equals(xmlFile) && (!ignoreClosing || !window->IsAnimating(ANIM_TYPE_WINDOW_CLOSE)))
+    if (URIUtils::GetFileName(window->GetProperty("xmlfile").asString()).Equals(xmlFile) && (!ignoreClosing || !window->IsAnimating(ANIM_TYPE_WINDOW_CLOSE)))
       return true;
   }
   return false; // window isn't active
@@ -943,7 +944,7 @@ bool CGUIWindowManager::IsWindowTopMost(int id) const
 bool CGUIWindowManager::IsWindowTopMost(const CStdString &xmlFile) const
 {
   CGUIWindow *topMost = GetTopMostDialog();
-  if (topMost && URIUtils::GetFileName(topMost->GetProperty("xmlfile")).Equals(xmlFile))
+  if (topMost && URIUtils::GetFileName(topMost->GetProperty("xmlfile").asString()).Equals(xmlFile))
     return true;
   return false;
 }

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -490,7 +490,7 @@ int CBuiltins::Execute(const CStdString& execString)
        (params.size() == 2 && params[1].Equals("isdir")))
       item.m_bIsFolder = true;
     else if (item.IsPlugin())
-      item.SetProperty("IsPlayable","true");
+      item.SetProperty("IsPlayable", true);
 
     // restore to previous window if needed
     if( g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW ||

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -57,9 +57,7 @@ void CFileItemHandler::FillDetails(ISerializable* info, CFileItemPtr item, const
         field = "label";
       if (item->IsAlbum() && item->HasProperty("album_" + field))
       {
-        if (field == "rating")
-          result[field] = item->GetPropertyInt("album_rating");
-        else if (field == "label")
+        if (field == "label")
           result["albumlabel"] = item->GetProperty("album_label");
         else
           result[field] = item->GetProperty("album_" + field);

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -164,7 +164,7 @@ JSON_STATUS CFileOperations::GetDirectory(const CStdString &method, ITransportLa
 
 JSON_STATUS CFileOperations::Download(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  return transport->Download(parameterObject["path"].asString(), result) ? OK : InvalidParams;
+  return transport->Download(parameterObject["path"].asString().c_str(), result) ? OK : InvalidParams;
 }
 
 bool CFileOperations::FillFileItem(const CStdString &strFilename, CFileItem &item, CStdString media /* = "" */)

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -135,13 +135,13 @@ JSON_STATUS CJSONRPC::SetConfiguration(const CStdString &method, ITransportLayer
 JSON_STATUS CJSONRPC::NotifyAll(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant& parameterObject, CVariant &result)
 {
   if (parameterObject["data"].isNull())
-    CAnnouncementManager::Announce(Other, parameterObject["sender"].asString(),  
-      parameterObject["message"].asString());
+    CAnnouncementManager::Announce(Other, parameterObject["sender"].asString().c_str(),  
+      parameterObject["message"].asString().c_str());
   else
   {
     CVariant data(parameterObject["data"].asString());
-    CAnnouncementManager::Announce(Other, parameterObject["sender"].asString(),  
-      parameterObject["message"].asString(), data);
+    CAnnouncementManager::Announce(Other, parameterObject["sender"].asString().c_str(),  
+      parameterObject["message"].asString().c_str(), data);
   }
 
   return ACK;

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -1096,7 +1096,7 @@ JSON_STATUS CJSONServiceDescription::checkType(const CVariant &value, const JSON
   // If we have a string, we need to check the length
   if (HasType(type.type, StringValue) && value.isString())
   {
-    int size = strlen(value.asString());
+    int size = value.asString().size();
     if (size < type.minLength)
     {
       CLog::Log(LOGWARNING, "JSONRPC: Value does not meet minLength requirements in type %s", type.name.c_str());

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -154,7 +154,7 @@ JSON_STATUS CPlayerOperations::SetSpeed(const CStdString &method, ITransportLaye
       else if (parameterObject["speed"].isString())
       {
         speed = g_application.GetPlaySpeed();
-        if (stricmp(parameterObject["speed"].asString(), "increment") == 0)
+        if (parameterObject["speed"].asString().compare("increment") == 0)
           CBuiltins::Execute("playercontrol(forward)");
         else
           CBuiltins::Execute("playercontrol(rewind)");

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.cpp
@@ -280,7 +280,7 @@ void CGUIPythonWindowXML::PulseActionEvent()
 void CGUIPythonWindowXML::AllocResources(bool forceLoad /*= FALSE */)
 {
   CStdString tmpDir;
-  URIUtils::GetDirectory(GetProperty("xmlfile"), tmpDir);
+  URIUtils::GetDirectory(GetProperty("xmlfile").asString(), tmpDir);
   CStdString fallbackMediaPath;
   URIUtils::GetParentPath(tmpDir, fallbackMediaPath);
   URIUtils::RemoveSlashAtEnd(fallbackMediaPath);

--- a/xbmc/interfaces/python/xbmcmodule/listitem.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/listitem.cpp
@@ -27,6 +27,7 @@
 #include "pictures/PictureInfoTag.h"
 #include "music/tags/MusicInfoTag.h"
 #include "FileItem.h"
+#include "utils/Variant.h"
 
 using namespace std;
 
@@ -716,7 +717,7 @@ namespace PYXBMC
       value.Format("%f", self->item->m_lStartOffset / 75.0);
     }
     else
-      value = self->item->GetProperty(lowerKey.ToLower());
+      value = self->item->GetProperty(lowerKey.ToLower()).asString();
     PyXBMCGUIUnlock();
 
     return Py_BuildValue((char*)"s", value.c_str());

--- a/xbmc/interfaces/python/xbmcmodule/window.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/window.cpp
@@ -956,7 +956,7 @@ namespace PYXBMC
 
     GilSafeSingleLock lock(g_graphicsContext);
     CStdString lowerKey = key;
-    string value = self->pWindow->GetProperty(lowerKey.ToLower());
+    string value = self->pWindow->GetProperty(lowerKey.ToLower()).asString();
 
     return Py_BuildValue((char*)"s", value.c_str());
   }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -862,7 +862,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
   if (itemNumber >= 0 && itemNumber < m_vecItems->Size())
     item = m_vecItems->Get(itemNumber);
 
-  if (item && !item->GetPropertyBOOL("pluginreplacecontextitems"))
+  if (item && !item->GetProperty("pluginreplacecontextitems").asBoolean())
   {
     if (item && !item->IsParentFolder())
     {

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -160,7 +160,7 @@ bool CGUIWindowMusicNav::OnMessage(CGUIMessage& message)
           SetProperty("search", selected.GetLabel());
           return true;
         }
-        CStdString search(GetProperty("search"));
+        CStdString search(GetProperty("search").asString());
         CGUIDialogKeyboard::ShowAndGetFilter(search, true);
         SetProperty("search", search);
         return true;
@@ -251,7 +251,7 @@ bool CGUIWindowMusicNav::OnClick(int iItem)
       OnSearchUpdate();
     else
     {
-      CStdString search(GetProperty("search"));
+      CStdString search(GetProperty("search").asString());
       CGUIDialogKeyboard::ShowAndGetFilter(search, true);
       SetProperty("search", search);
     }
@@ -399,7 +399,7 @@ void CGUIWindowMusicNav::OnWindowLoaded()
   if (m_searchWithEdit)
   {
     SendMessage(GUI_MSG_SET_TYPE, CONTROL_SEARCH, CGUIEditControl::INPUT_TYPE_SEARCH);
-    SET_CONTROL_LABEL2(CONTROL_SEARCH, GetProperty("search"));
+    SET_CONTROL_LABEL2(CONTROL_SEARCH, GetProperty("search").asString());
   }
 }
 
@@ -754,7 +754,7 @@ void CGUIWindowMusicNav::DisplayEmptyDatabaseMessage(bool bDisplay)
 
 void CGUIWindowMusicNav::OnSearchUpdate()
 {
-  CStdString search(GetProperty("search"));
+  CStdString search(GetProperty("search").asString());
   CURL::Encode(search);
   if (!search.IsEmpty())
   {
@@ -803,7 +803,7 @@ void CGUIWindowMusicNav::AddSearchFolder()
     // add our remove the musicsearch source
     VECSOURCES &sources = viewState->GetSources();
     bool haveSearchSource = false;
-    bool needSearchSource = !GetProperty("search").IsEmpty() || !m_searchWithEdit; // we always need it if we don't have the edit control
+    bool needSearchSource = !GetProperty("search").empty() || !m_searchWithEdit; // we always need it if we don't have the edit control
     for (IVECSOURCES it = sources.begin(); it != sources.end(); ++it)
     {
       CMediaSource& share = *it;

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -315,7 +315,7 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
     else
     {
       CGUIWindowMusicBase::GetContextButtons(itemNumber, buttons);
-      if (item->GetPropertyBOOL("pluginreplacecontextitems"))
+      if (item->GetProperty("pluginreplacecontextitems").asBoolean())
         return;
       if (!item->IsPlayList())
       {

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -420,7 +420,7 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
   if (itemNumber >= 0 && itemNumber < m_vecItems->Size())
     item = m_vecItems->Get(itemNumber);
 
-  if (item && !item->GetPropertyBOOL("pluginreplacecontextitems"))
+  if (item && !item->GetProperty("pluginreplacecontextitems").asBoolean())
   {
     if ( m_vecItems->IsVirtualDirectoryRoot() && item)
     {
@@ -453,7 +453,7 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
     }
   }
   CGUIMediaWindow::GetContextButtons(itemNumber, buttons);
-  if (item && !item->GetPropertyBOOL("pluginreplacecontextitems"))
+  if (item && !item->GetProperty("pluginreplacecontextitems").asBoolean())
     buttons.Add(CONTEXT_BUTTON_SETTINGS, 5);                  // Settings
 }
 

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -27,6 +27,7 @@
 #include "filesystem/File.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
 
 //using namespace std;
 using namespace MUSIC_INFO;
@@ -366,7 +367,7 @@ void CPlayList::SetUnPlayable(int iItem)
   }
 
   CFileItemPtr item = m_vecItems[iItem];
-  if (!item->GetPropertyBOOL("unplayable"))
+  if (!item->GetProperty("unplayable").asBoolean())
   {
     item->SetProperty("unplayable", true);
     m_iPlayableItems--;

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -26,6 +26,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
+#include "utils/Variant.h"
 #ifndef _LINUX
 #include "cores/dllloader/exports/emu_msvcrt.h"
 #endif
@@ -136,16 +137,16 @@ bool CPlayListXML::Load( const CStdString& strFileName )
 
        // Set language as metadata
        if ( !lang.IsEmpty() )
-         newItem->SetProperty("language", lang );
+         newItem->SetProperty("language", lang.c_str() );
 
        // Set category as metadata
        if ( !category.IsEmpty() )
-         newItem->SetProperty("category", category );
+         newItem->SetProperty("category", category.c_str() );
 
        // Set channel as extra info and as metadata
        if ( !channel.IsEmpty() )
        {
-         newItem->SetProperty("remotechannel", channel );
+         newItem->SetProperty("remotechannel", channel.c_str() );
          newItem->SetExtraInfo( "Channel: " + channel );
        }
 
@@ -188,13 +189,13 @@ void CPlayListXML::Save(const CStdString& strFileName) const
     write.AppendFormat("    <url>%s</url>", item->GetPath().c_str() );
     write.AppendFormat("    <name>%s</name>", item->GetLabel().c_str() );
 
-    if ( !item->GetProperty("language").IsEmpty() )
+    if ( !item->GetProperty("language").empty() )
       write.AppendFormat("    <lang>%s</lang>", item->GetProperty("language").c_str() );
 
-    if ( !item->GetProperty("category").IsEmpty() )
+    if ( !item->GetProperty("category").empty() )
       write.AppendFormat("    <category>%s</category>", item->GetProperty("category").c_str() );
 
-    if ( !item->GetProperty("remotechannel").IsEmpty() )
+    if ( !item->GetProperty("remotechannel").empty() )
       write.AppendFormat("    <channel>%s</channel>", item->GetProperty("remotechannel").c_str() );
 
     if ( item->m_iHasLock > 0 )

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -128,7 +128,7 @@ void CGUIWindowPrograms::GetContextButtons(int itemNumber, CContextButtons &butt
   if (itemNumber < 0 || itemNumber >= m_vecItems->Size())
     return;
   CFileItemPtr item = m_vecItems->Get(itemNumber);
-  if (item && !item->GetPropertyBOOL("pluginreplacecontextitems"))
+  if (item && !item->GetProperty("pluginreplacecontextitems").asBoolean())
   {
     if ( m_vecItems->IsVirtualDirectoryRoot() )
     {
@@ -260,7 +260,7 @@ bool CGUIWindowPrograms::GetDirectory(const CStdString &strDirectory, CFileItemL
   {
     for (int i=0;i<items.Size();++i)
     {
-      items[i]->SetLabel2(items[i]->GetProperty("Addon.Version"));
+      items[i]->SetLabel2(items[i]->GetProperty("Addon.Version").asString());
       items[i]->SetLabelPreformated(true);
     }
   }

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -21,6 +21,7 @@
 
 #include "Archive.h"
 #include "filesystem/File.h"
+#include "Variant.h"
 
 using namespace XFILE;
 
@@ -119,6 +120,18 @@ CArchive& CArchive::operator<<(int64_t i64)
   return *this;
 }
 
+CArchive& CArchive::operator<<(uint64_t ui64)
+{
+  int size = sizeof(uint64_t);
+  if (m_BufferPos + size >= BUFFER_MAX)
+    FlushBuffer();
+
+  memcpy(&m_pBuffer[m_BufferPos], &ui64, size);
+  m_BufferPos += size;
+
+  return *this;
+}
+
 CArchive& CArchive::operator<<(bool b)
 {
   int size = sizeof(bool);
@@ -210,6 +223,48 @@ CArchive& CArchive::operator<<(IArchivable& obj)
   return *this;
 }
 
+CArchive& CArchive::operator<<(const CVariant& variant)
+{
+  *this << (int)variant.type();
+  switch (variant.type())
+  {
+  case CVariant::VariantTypeInteger:
+    *this << variant.asInteger();
+    break;
+  case CVariant::VariantTypeUnsignedInteger:
+    *this << variant.asUnsignedInteger();
+    break;
+  case CVariant::VariantTypeBoolean:
+    *this << variant.asBoolean();
+    break;
+  case CVariant::VariantTypeString:
+    *this << variant.asString();
+    break;
+  case CVariant::VariantTypeDouble:
+    *this << variant.asDouble();
+    break;
+  case CVariant::VariantTypeArray:
+    *this << variant.size();
+    for (unsigned int index = 0; index < variant.size(); index++)
+      *this << variant[index];
+    break;
+  case CVariant::VariantTypeObject:
+    *this << variant.size();
+    for (CVariant::const_iterator_map itr = variant.begin_map(); itr != variant.end_map(); itr++)
+    {
+      *this << itr->first.c_str();
+      *this << itr->second;
+    }
+    break;
+  case CVariant::VariantTypeNull:
+  case CVariant::VariantTypeConstNull:
+  default:
+    break;
+  }
+
+  return *this;
+}
+
 CArchive& CArchive::operator>>(float& f)
 {
   m_pFile->Read((void*)&f, sizeof(float));
@@ -241,6 +296,13 @@ CArchive& CArchive::operator>>(unsigned int& i)
 CArchive& CArchive::operator>>(int64_t& i64)
 {
   m_pFile->Read((void*)&i64, sizeof(int64_t));
+
+  return *this;
+}
+
+CArchive& CArchive::operator>>(uint64_t& ui64)
+{
+  m_pFile->Read((void*)&ui64, sizeof(uint64_t));
 
   return *this;
 }
@@ -293,6 +355,84 @@ CArchive& CArchive::operator>>(SYSTEMTIME& time)
 CArchive& CArchive::operator>>(IArchivable& obj)
 {
   obj.Archive(*this);
+
+  return *this;
+}
+
+CArchive& CArchive::operator>>(CVariant& variant)
+{
+  int type;
+  *this >> type;
+  variant = CVariant((CVariant::VariantType)type);
+
+  switch (variant.type())
+  {
+  case CVariant::VariantTypeInteger:
+  {
+    int64_t value;
+    *this >> value;
+    variant = value;
+    break;
+  }
+  case CVariant::VariantTypeUnsignedInteger:
+  {
+    uint64_t value;
+    *this >> value;
+    variant = value;
+    break;
+  }
+  case CVariant::VariantTypeBoolean:
+  {
+    bool value;
+    *this >> value;
+    variant = value;
+    break;
+  }
+  case CVariant::VariantTypeString:
+  {
+    CStdString value;
+    *this >> value;
+    variant = value;
+    break;
+  }
+  case CVariant::VariantTypeDouble:
+  {
+    double value;
+    *this >> value;
+    variant = value;
+    break;
+  }
+  case CVariant::VariantTypeArray:
+  {
+    unsigned int size;
+    *this >> size;
+    for (; size > 0; size--)
+    {
+      CVariant value;
+      *this >> value;
+      variant.append(value);
+    }
+    break;
+  }
+  case CVariant::VariantTypeObject:
+  {
+    unsigned int size;
+    *this >> size;
+    for (; size > 0; size--)
+    {
+      CStdString name;
+      CVariant value;
+      *this >> name;
+      *this >> value;
+      variant[name] = value;
+    }
+    break;
+  }
+  case CVariant::VariantTypeNull:
+  case CVariant::VariantTypeConstNull:
+  default:
+    break;
+  }
 
   return *this;
 }

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -238,7 +238,7 @@ CArchive& CArchive::operator<<(const CVariant& variant)
     *this << variant.asBoolean();
     break;
   case CVariant::VariantTypeString:
-    *this << variant.asString();
+    *this << CStdString(variant.asString());
     break;
   case CVariant::VariantTypeDouble:
     *this << variant.asDouble();
@@ -252,7 +252,7 @@ CArchive& CArchive::operator<<(const CVariant& variant)
     *this << variant.size();
     for (CVariant::const_iterator_map itr = variant.begin_map(); itr != variant.end_map(); itr++)
     {
-      *this << itr->first.c_str();
+      *this << CStdString(itr->first);
       *this << itr->second;
     }
     break;

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -28,6 +28,7 @@ namespace XFILE
 {
   class CFile;
 }
+class CVariant;
 
 class CArchive;
 
@@ -49,12 +50,14 @@ public:
   CArchive& operator<<(int i);
   CArchive& operator<<(unsigned int i);
   CArchive& operator<<(int64_t i64);
+  CArchive& operator<<(uint64_t ui64);
   CArchive& operator<<(bool b);
   CArchive& operator<<(char c);
   CArchive& operator<<(const CStdString& str);
   CArchive& operator<<(const CStdStringW& str);
   CArchive& operator<<(const SYSTEMTIME& time);
   CArchive& operator<<(IArchivable& obj);
+  CArchive& operator<<(const CVariant& variant);
 
   // loading
   CArchive& operator>>(float& f);
@@ -62,12 +65,14 @@ public:
   CArchive& operator>>(int& i);
   CArchive& operator>>(unsigned int& i);
   CArchive& operator>>(int64_t& i64);
+  CArchive& operator>>(uint64_t& ui64);
   CArchive& operator>>(bool& b);
   CArchive& operator>>(char& c);
   CArchive& operator>>(CStdString& str);
   CArchive& operator>>(CStdStringW& str);
   CArchive& operator>>(SYSTEMTIME& time);
   CArchive& operator>>(IArchivable& obj);
+  CArchive& operator>>(CVariant& variant);
 
   bool IsLoading();
   bool IsStoring();

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -30,6 +30,7 @@
 #include "music/MusicDatabase.h"
 #include "music/tags/MusicInfoTag.h"
 #include "settings/Settings.h"
+#include "utils/Variant.h"
 
 #define NUM_ITEMS 10
 

--- a/xbmc/utils/SaveFileStateJob.h
+++ b/xbmc/utils/SaveFileStateJob.h
@@ -86,7 +86,7 @@ bool CSaveFileStateJob::DoWork()
           CUtil::DeleteVideoDatabaseDirectoryCache();
           CFileItemPtr msgItem(new CFileItem(m_item));
           if (m_item.HasProperty("original_listitem_url"))
-            msgItem->SetPath(m_item.GetProperty("original_listitem_url"));
+            msgItem->SetPath(m_item.GetProperty("original_listitem_url").asString());
           CGUIMessage message(GUI_MSG_NOTIFY_ALL, g_windowManager.GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 1, msgItem); // 1 to update the listing as well
           g_windowManager.SendThreadMessage(message);
         }

--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -190,50 +190,109 @@ CVariant::VariantType CVariant::type() const
 
 int64_t CVariant::asInteger(int64_t fallback) const
 {
-  if (m_type == VariantTypeInteger)
-    return m_data.integer;
-  else
-    return fallback;
+  switch (m_type)
+  {
+    case VariantTypeInteger:
+      return m_data.integer;
+    case VariantTypeUnsignedInteger:
+      return (int64_t)m_data.unsignedinteger;
+    case VariantTypeDouble:
+      return (int64_t)m_data.dvalue;
+  }
+  
+  return fallback;
 }
 
 uint64_t CVariant::asUnsignedInteger(uint64_t fallback) const
 {
-  if (m_type == VariantTypeUnsignedInteger)
-    return m_data.unsignedinteger;
-  else
-    return fallback;
+  switch (m_type)
+  {
+    case VariantTypeUnsignedInteger:
+      return m_data.unsignedinteger;
+    case VariantTypeInteger:
+      return (uint64_t)m_data.integer;
+    case VariantTypeDouble:
+      return (uint64_t)m_data.dvalue;
+  }
+  
+  return fallback;
 }
 
 double CVariant::asDouble(double fallback) const
 {
-  if (m_type == VariantTypeDouble)
-    return m_data.dvalue;
-  else
-    return fallback;
+  switch (m_type)
+  {
+    case VariantTypeDouble:
+      return m_data.dvalue;
+    case VariantTypeInteger:
+      return (double)m_data.integer;
+    case VariantTypeUnsignedInteger:
+      return (double)m_data.unsignedinteger;
+  }
+  
+  return fallback;
 }
 
 float CVariant::asFloat(float fallback) const
 {
-  if (m_type == VariantTypeDouble)
-    return (float)m_data.dvalue;
-  else
-    return fallback;
+  switch (m_type)
+  {
+    case VariantTypeDouble:
+      return (float)m_data.dvalue;
+    case VariantTypeInteger:
+      return (float)m_data.integer;
+    case VariantTypeUnsignedInteger:
+      return (float)m_data.unsignedinteger;
+  }
+  
+  return fallback;
 }
 
 bool CVariant::asBoolean(bool fallback) const
 {
-  if (m_type == VariantTypeBoolean)
-    return m_data.boolean;
-  else
-    return fallback;
+  switch (m_type)
+  {
+    case VariantTypeBoolean:
+      return m_data.boolean;
+    case VariantTypeInteger:
+      return (bool)m_data.integer;
+    case VariantTypeUnsignedInteger:
+      return (bool)m_data.unsignedinteger;
+    case VariantTypeDouble:
+      return (bool)m_data.dvalue;
+    case VariantTypeString:
+      if (m_data.string->empty() || m_data.string->compare("0") || m_data.string->compare("false"))
+        return false;
+      return true;
+  }
+  
+  return fallback;
 }
 
-const char *CVariant::asString(const char *fallback) const
+std::string CVariant::asString(std::string fallback) const
 {
-  if (m_type == VariantTypeString)
-    return m_data.string->c_str();
-  else
-    return fallback;
+  switch (m_type)
+  {
+    case VariantTypeString:
+      return *(m_data.string);
+    case VariantTypeBoolean:
+      return m_data.boolean ? "true" : "false";
+    case VariantTypeInteger:
+    case VariantTypeUnsignedInteger:
+    case VariantTypeDouble:
+    {
+      std::ostringstream strStream;
+      if (m_type == VariantTypeInteger)
+        strStream << m_data.integer;
+      else if (m_type == VariantTypeUnsignedInteger)
+        strStream << m_data.unsignedinteger;
+      else
+        strStream << m_data.dvalue;
+      return strStream.str();
+    }
+  }
+  
+  return fallback;
 }
 
 CVariant &CVariant::operator[](string key)
@@ -465,6 +524,8 @@ bool CVariant::empty() const
     return m_data.map->empty();
   else if (m_type == VariantTypeArray)
     return m_data.array->empty();
+  else if (m_type == VariantTypeString)
+    return m_data.string->empty();
   else
     return true;
 }

--- a/xbmc/utils/Variant.h
+++ b/xbmc/utils/Variant.h
@@ -69,7 +69,7 @@ public:
   int64_t asInteger(int64_t fallback = 0) const;
   uint64_t asUnsignedInteger(uint64_t fallback = 0u) const;
   bool asBoolean(bool fallback = false) const;
-  const char *asString(const char *fallback = "") const;
+  std::string asString(std::string fallback = "") const;
   double asDouble(double fallback = 0.0) const;
   float asFloat(float fallback = 0.0f) const;
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4610,7 +4610,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->SetProperty("numepisodes", it->second.numEpisodes); // will be changed later to reflect watchmode setting
         pItem->SetProperty("watchedepisodes", it->second.numWatched);
         pItem->SetProperty("unwatchedepisodes", it->second.numEpisodes - it->second.numWatched);
-        if (iSeason == 0) pItem->SetProperty("isspecial", "true");
+        if (iSeason == 0) pItem->SetProperty("isspecial", true);
         pItem->GetVideoInfoTag()->m_playCount = (it->second.numEpisodes == it->second.numWatched) ? 1 : 0;
         pItem->SetCachedSeasonThumb();
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, (pItem->GetVideoInfoTag()->m_playCount > 0) && (pItem->GetVideoInfoTag()->m_iEpisode > 0));
@@ -4647,7 +4647,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->SetProperty("numepisodes", totalEpisodes); // will be changed later to reflect watchmode setting
         pItem->SetProperty("watchedepisodes", watchedEpisodes);
         pItem->SetProperty("unwatchedepisodes", totalEpisodes - watchedEpisodes);
-        if (iSeason == 0) pItem->SetProperty("isspecial", "true");
+        if (iSeason == 0) pItem->SetProperty("isspecial", true);
         pItem->GetVideoInfoTag()->m_playCount = (totalEpisodes == watchedEpisodes) ? 1 : 0;
         pItem->SetCachedSeasonThumb();
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, (pItem->GetVideoInfoTag()->m_playCount > 0) && (pItem->GetVideoInfoTag()->m_iEpisode > 0));
@@ -4845,7 +4845,7 @@ void CVideoDatabase::Stack(CFileItemList& items, VIDEODB_CONTENT_TYPE type, bool
       {
         CFileItemPtr pItem = items.Get(i);
         CStdString strTitle = pItem->GetVideoInfoTag()->m_strTitle;
-        CStdString strFanArt = pItem->GetProperty("fanart_image");
+        CStdString strFanArt = pItem->GetProperty("fanart_image").asString();
 
         int j = i + 1;
         bool bStacked = false;
@@ -4866,14 +4866,14 @@ void CVideoDatabase::Stack(CFileItemList& items, VIDEODB_CONTENT_TYPE type, bool
 
             // increment episode counts
             pItem->GetVideoInfoTag()->m_iEpisode += jItem->GetVideoInfoTag()->m_iEpisode;
-            pItem->IncrementProperty("totalepisodes", jItem->GetPropertyInt("totalepisodes"));
-            pItem->IncrementProperty("numepisodes", jItem->GetPropertyInt("numepisodes")); // will be changed later to reflect watchmode setting
-            pItem->IncrementProperty("watchedepisodes", jItem->GetPropertyInt("watchedepisodes"));
-            pItem->IncrementProperty("unwatchedepisodes", jItem->GetPropertyInt("unwatchedepisodes"));
+            pItem->IncrementProperty("totalepisodes", (int)jItem->GetProperty("totalepisodes").asInteger());
+            pItem->IncrementProperty("numepisodes", (int)jItem->GetProperty("numepisodes").asInteger()); // will be changed later to reflect watchmode setting
+            pItem->IncrementProperty("watchedepisodes", (int)jItem->GetProperty("watchedepisodes").asInteger());
+            pItem->IncrementProperty("unwatchedepisodes", (int)jItem->GetProperty("unwatchedepisodes").asInteger());
 
             // check for fanart if not already set
             if (strFanArt.IsEmpty())
-              strFanArt = jItem->GetProperty("fanart_image");
+              strFanArt = jItem->GetProperty("fanart_image").asString();
 
             // remove duplicate entry
             items.Remove(j);
@@ -4885,7 +4885,7 @@ void CVideoDatabase::Stack(CFileItemList& items, VIDEODB_CONTENT_TYPE type, bool
         // update playcount and fanart
         if (bStacked)
         {
-          pItem->GetVideoInfoTag()->m_playCount = (pItem->GetVideoInfoTag()->m_iEpisode == pItem->GetPropertyInt("watchedepisodes")) ? 1 : 0;
+          pItem->GetVideoInfoTag()->m_playCount = (pItem->GetVideoInfoTag()->m_iEpisode == (int)pItem->GetProperty("watchedepisodes").asInteger()) ? 1 : 0;
           pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, (pItem->GetVideoInfoTag()->m_playCount > 0) && (pItem->GetVideoInfoTag()->m_iEpisode > 0));
           if (!strFanArt.IsEmpty())
             pItem->SetProperty("fanart_image", strFanArt);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -442,7 +442,7 @@ namespace VIDEO
     {
       INFO_RET ret = RetrieveInfoForEpisodes(pItem, idTvShow, info2, useLocal, pDlgProgress);
       if (ret == INFO_ADDED)
-        m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash"));
+        m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash").asString());
       return ret;
     }
 
@@ -476,7 +476,7 @@ namespace VIDEO
       {
         INFO_RET ret = RetrieveInfoForEpisodes(pItem, lResult, info2, useLocal, pDlgProgress);
         if (ret == INFO_ADDED)
-          m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash"));
+          m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash").asString());
         return ret;
       }
       return INFO_ADDED;
@@ -502,7 +502,7 @@ namespace VIDEO
     {
       INFO_RET ret = RetrieveInfoForEpisodes(pItem, lResult, info2, useLocal, pDlgProgress);
       if (ret == INFO_ADDED)
-        m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash"));
+        m_database.SetPathHash(pItem->GetPath(), pItem->GetProperty("hash").asString());
     }
     else
       if (g_guiSettings.GetBool("videolibrary.seasonthumbs"))

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -433,7 +433,7 @@ void CGUIDialogVideoInfo::Refresh()
       if (CFile::Exists(thumbImage))
       {
         if (m_movieItem->HasProperty("set_folder_thumb"))
-          VIDEO::CVideoInfoScanner::ApplyThumbToFolder(m_movieItem->GetProperty("set_folder_thumb"), thumbImage);
+          VIDEO::CVideoInfoScanner::ApplyThumbToFolder(m_movieItem->GetProperty("set_folder_thumb").asString(), thumbImage);
         hasUpdatedThumb = true;
       }
     }
@@ -720,7 +720,7 @@ void CGUIDialogVideoInfo::OnGetThumb()
   m_movieItem->SetThumbnailImage(cachedThumb);
   if (m_movieItem->HasProperty("set_folder_thumb"))
   { // have a folder thumb to set as well
-    VIDEO::CVideoInfoScanner::ApplyThumbToFolder(m_movieItem->GetProperty("set_folder_thumb"), cachedThumb);
+    VIDEO::CVideoInfoScanner::ApplyThumbToFolder(m_movieItem->GetProperty("set_folder_thumb").asString(), cachedThumb);
   }
   m_hasUpdatedThumb = true;
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1069,7 +1069,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
     item = m_vecItems->Get(itemNumber);
 
   // contextual buttons
-  if (item && !item->GetPropertyBOOL("pluginreplacecontextitems"))
+  if (item && !item->GetProperty("pluginreplacecontextitems").asBoolean())
   {
     if (!item->IsParentFolder())
     {

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -851,9 +851,9 @@ void CGUIWindowVideoNav::OnPrepareFileItems(CFileItemList &items)
     if(item->HasVideoInfoTag() && (node == NODE_TYPE_TITLE_TVSHOWS || node == NODE_TYPE_SEASONS))
     {
       if (watchMode == VIDEO_SHOW_UNWATCHED)
-        item->GetVideoInfoTag()->m_iEpisode = item->GetPropertyInt("unwatchedepisodes");
+        item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("unwatchedepisodes").asInteger();
       if (watchMode == VIDEO_SHOW_WATCHED)
-        item->GetVideoInfoTag()->m_iEpisode = item->GetPropertyInt("watchedepisodes");
+        item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("watchedepisodes").asInteger();
       item->SetProperty("numepisodes", item->GetVideoInfoTag()->m_iEpisode);
     }
 
@@ -877,7 +877,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
 
   CGUIWindowVideoBase::GetContextButtons(itemNumber, buttons);
 
-  if (item && item->GetPropertyBOOL("pluginreplacecontextitems"))
+  if (item && item->GetProperty("pluginreplacecontextitems").asBoolean())
     return;
 
   CVideoDatabaseDirectory dir;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -270,9 +270,9 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
           OnFilterItems(selected.GetLabel());
           return true;
         }
-        if (GetProperty("filter").IsEmpty())
+        if (GetProperty("filter").empty())
         {
-          CStdString filter = GetProperty("filter");
+          CStdString filter = GetProperty("filter").asString();
           CGUIDialogKeyboard::ShowAndGetFilter(filter, false);
           SetProperty("filter", filter);
         }
@@ -400,7 +400,7 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
       }
       else if (message.GetParam1() == GUI_MSG_FILTER_ITEMS && IsActive())
       {
-        CStdString filter(GetProperty("filter"));
+        CStdString filter(GetProperty("filter").asString());
         if (message.GetParam2() == 1) // append
           filter += message.GetStringParam();
         else if (message.GetParam2() == 2)
@@ -547,8 +547,8 @@ void CGUIMediaWindow::UpdateButtons()
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   //#ifdef PRE_SKIN_VERSION_3
-  SET_CONTROL_SELECTED(GetID(),CONTROL_BTN_FILTER, !GetProperty("filter").IsEmpty());
-  SET_CONTROL_LABEL2(CONTROL_BTN_FILTER, GetProperty("filter"));
+  SET_CONTROL_SELECTED(GetID(),CONTROL_BTN_FILTER, !GetProperty("filter").empty());
+  SET_CONTROL_LABEL2(CONTROL_BTN_FILTER, GetProperty("filter").asString());
   //#endif
 }
 
@@ -832,7 +832,7 @@ void CGUIMediaWindow::OnFinalizeFileItems(CFileItemList &items)
 {
   m_unfilteredItems->Append(items);
   
-  CStdString filter(GetProperty("filter"));
+  CStdString filter(GetProperty("filter").asString());
   if (!filter.IsEmpty())
   {
     items.ClearItems();
@@ -935,7 +935,7 @@ bool CGUIMediaWindow::OnClick(int iItem)
 
     return true;
   }
-  else if (pItem->IsPlugin() && pItem->GetProperty("isplayable") != "true")
+  else if (pItem->IsPlugin() && !pItem->GetProperty("isplayable").asBoolean())
   {
     return XFILE::CPluginDirectory::RunScriptWithParams(pItem->GetPath());
   }
@@ -1402,17 +1402,17 @@ void CGUIMediaWindow::GetContextButtons(int itemNumber, CContextButtons &buttons
   for (int i = CONTEXT_BUTTON_USER1; i <= CONTEXT_BUTTON_USER10; i++)
   {
     label.Format("contextmenulabel(%i)", i - CONTEXT_BUTTON_USER1);
-    if (item->GetProperty(label).IsEmpty())
+    if (item->GetProperty(label).empty())
       break;
 
     action.Format("contextmenuaction(%i)", i - CONTEXT_BUTTON_USER1);
-    if (item->GetProperty(action).IsEmpty())
+    if (item->GetProperty(action).empty())
       break;
 
-    buttons.Add((CONTEXT_BUTTON)i, item->GetProperty(label));
+    buttons.Add((CONTEXT_BUTTON)i, item->GetProperty(label).asString());
   }
 
-  if (item->GetPropertyBOOL("pluginreplacecontextitems"))
+  if (item->GetProperty("pluginreplacecontextitems").asBoolean())
     return;
 
   // TODO: FAVOURITES Conditions on masterlock and localisation
@@ -1458,7 +1458,7 @@ bool CGUIMediaWindow::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     {
       CStdString action;
       action.Format("contextmenuaction(%i)", button - CONTEXT_BUTTON_USER1);
-      g_application.getApplicationMessenger().ExecBuiltIn(m_vecItems->Get(itemNumber)->GetProperty(action));
+      g_application.getApplicationMessenger().ExecBuiltIn(m_vecItems->Get(itemNumber)->GetProperty(action).asString());
       return true;
     }
   default:

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -33,6 +33,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/GUIControlProfiler.h"
 #include "GUIInfoManager.h"
+#include "utils/Variant.h"
 
 CGUIWindowDebugInfo::CGUIWindowDebugInfo(void)
     : CGUIDialog(98, "")
@@ -124,9 +125,9 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
     {
       CStdString windowName = CButtonTranslator::TranslateWindow(window->GetID());
       if (!windowName.IsEmpty())
-        windowName += " (" + window->GetProperty("xmlfile") + ")";
+        windowName += " (" + CStdString(window->GetProperty("xmlfile").asString()) + ")";
       else
-        windowName = window->GetProperty("xmlfile");
+        windowName = window->GetProperty("xmlfile").asString();
       info += "Window: " + windowName + "  ";
       // transform the mouse coordinates to this window's coordinates
       g_graphicsContext.SetScalingResolution(window->GetCoordsRes(), true);


### PR DESCRIPTION
While extending the work done in https://github.com/xbmc/xbmc/pull/394 to music items as well I ran into the problem that the propertymap in CGUIListItem only stores CStdString values which IMO is a bit... hm how should I call it... suboptimal. As we have the pretty nice CVariant class I started to replace the std::map< CStdString, CStdString, icompare > map with a std::map< CStdString, CVariant > map in both CGUIListItem and CGUIWindow. This allows more flexibel usage of the propertymaps. Actually it would even be possible to replace the whole std::map< > with a CVariant of type object which is the same as a std::map< CStdString, CVariant > but for the sake of keeping the change not to complex I reused the std::map< >.

This should probably not go in before Eden because it touches quite a lot of files and I couldn't test all the places I changed. I just started this pull request to get feedback to two questions:
1. Is this change welcome?
2. Are there any other propertymaps that could be altered the same way?

Thanks for the feedback.
