### PR TITLE
Fixed XBMC hanging when exiting with remote control

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2924,6 +2924,11 @@ bool CApplication::ProcessEventServer(float frameTime)
   bool isAxis = false;
   float fAmount = 0.0;
 
+  // es->ExecuteNextAction() invalidates the ref to the CEventServer instance
+  // when the action exits XBMC
+  es = CEventServer::GetInstance();
+  if (!es || !es->Running() || es->GetNumberOfClients()==0)
+    return false;
   WORD wKeyID = es->GetButtonCode(joystickName, isAxis, fAmount);
 
   if (wKeyID)


### PR DESCRIPTION
When exiting with a remote control with a press on "Exit" in the Shutdown dialog of Confluence's home page, XBMC throws an exception.

That's because in CEventServer::ProcessEventServer, ExecuteNextAction() shuts down network services (including CEventServer) and invalidates the reference to a CEventServer instance, which is dereferenced later.

I'm not sure this PR is a good fix: it gets a new reference to avoid the bad dereference in es->GetButtonCode.
