### PR TITLE
Adjust picture flags when deinterlacing with libpostproc

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
@@ -93,8 +93,10 @@ bool CDVDVideoPPFFmpeg::CheckInit(int iWidth, int iHeight)
     return false;
 }
 
-void CDVDVideoPPFFmpeg::SetType(const CStdString& mType)
+void CDVDVideoPPFFmpeg::SetType(const CStdString& mType, bool deinterlace)
 {
+  m_deinterlace = deinterlace;
+
   if (mType == m_sType)
     return;
 
@@ -141,6 +143,8 @@ bool CDVDVideoPPFFmpeg::Process(DVDVideoPicture* pPicture)
 
   //Copy frame information over to target, but make sure it is set as allocated should decoder have forgotten
   m_pTarget->iFlags = m_pSource->iFlags | DVP_FLAG_ALLOCATED;
+  if (m_deinterlace)
+    m_pTarget->iFlags &= ~DVP_FLAG_INTERLACED;
   m_pTarget->iFrameType = m_pSource->iFrameType;
   m_pTarget->iRepeatPicture = m_pSource->iRepeatPicture;;
   m_pTarget->iDuration = m_pSource->iDuration;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoPPFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoPPFFmpeg.h
@@ -32,7 +32,7 @@ public:
   ~CDVDVideoPPFFmpeg();
 
 
-  void SetType(const CStdString& mType);
+  void SetType(const CStdString& mType, bool deinterlace);
   void SetTarget(DVDVideoPicture *pPicture){ m_pTarget = pPicture; };
   bool Process   (DVDVideoPicture *pPicture);
   bool GetPicture(DVDVideoPicture *pPicture);
@@ -42,6 +42,7 @@ protected:
 
   void *m_pContext;
   void *m_pMode;
+  bool m_deinterlace;
 
   DVDVideoPicture m_FrameBuffer;
   DVDVideoPicture *m_pSource;

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -304,6 +304,7 @@ void CDVDPlayerVideo::Process()
   CPulldownCorrection pulldown;
   CDVDVideoPPFFmpeg mPostProcess("");
   CStdString sPostProcessType;
+  bool bPostProcessDeint = false;
 
   memset(&picture, 0, sizeof(DVDVideoPicture));
 
@@ -622,6 +623,7 @@ void CDVDPlayerVideo::Process()
                   if (!sPostProcessType.empty())
                     sPostProcessType += ",";
                   sPostProcessType += g_advancedSettings.m_videoPPFFmpegDeint;
+                  bPostProcessDeint = true;
                 }
               }
             }
@@ -636,7 +638,7 @@ void CDVDPlayerVideo::Process()
 
             if (!sPostProcessType.empty())
             {
-              mPostProcess.SetType(sPostProcessType);
+              mPostProcess.SetType(sPostProcessType, bPostProcessDeint);
               if (mPostProcess.Process(&picture))
                 mPostProcess.GetPicture(&picture);
             }


### PR DESCRIPTION
The picture flags still indicate an interlaced picture after deinterlacing with libpostproc.

This PR clears the flags similar to what libavfilter does when running yadif.

I'm not sure which flags should be cleared though: I tested libavfilter and it only clears the interlaced flag, but a true progressive picture would never have interlaced or top_field_first, and maybe not even repeat_top_field (from libmpeg2 only).
