### PR TITLE
video player: do not call render functions from video thread, fix segfault

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -355,6 +355,11 @@ bool CDVDPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
     m_filename = file.GetPath();
 
     m_ready.Reset();
+	
+#if defined(HAS_VIDEO_PLAYBACK)
+    g_renderManager.PreInit();
+#endif
+	
     Create();
     if(!m_ready.WaitMSec(100))
     {

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -178,11 +178,6 @@ bool CDVDPlayerVideo::OpenStream( CDVDStreamInfo &hint )
 {
   unsigned int surfaces = 0;
 #ifdef HAS_VIDEO_PLAYBACK
-  if(!m_output.inited)
-  {
-    g_renderManager.PreInit();
-    m_output.inited = true;
-  }
   surfaces = g_renderManager.GetProcessorSize();
 #endif
 
@@ -749,8 +744,6 @@ void CDVDPlayerVideo::OnExit()
     m_pOverlayCodecCC->Dispose();
     m_pOverlayCodecCC = NULL;
   }
-
-  m_output.inited = false;
 
   CLog::Log(LOGNOTICE, "thread end: video_thread");
 }

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -159,7 +159,6 @@ protected:
     unsigned int color_primaries;
     unsigned int color_transfer;
     double       framerate;
-    bool         inited;
   } m_output; //holds currently configured output
 
   bool m_bAllowFullscreen;


### PR DESCRIPTION
video player: do not call render functions from video thread, fix segfault indroduced with 2f6e0fb3ce8f33cbe92e6db17cf41c3bce8be017

I think this has been wrong before but shows up now because 2f6e0fb3ce8f33cbe92e6db17cf41c3bce8be017 sets m_output.inited to false
