### PR TITLE
Dynamic range compression

### DIFF
--- a/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
@@ -106,6 +106,7 @@ bool CALSADirectSound::Initialize(IAudioCallback* pCallback, const CStdString& d
   m_uiSamplesPerSec = uiSamplesPerSec;
   m_uiBitsPerSample = uiBitsPerSample;
   m_bPassthrough = bPassthrough;
+  m_drc = 0;
 
   m_nCurrentVolume = g_settings.m_nVolumeLevel;
   if (!m_bPassthrough)
@@ -522,9 +523,13 @@ unsigned int CALSADirectSound::AddPackets(const void* data, unsigned int len)
   {
     if (m_remap.CanRemap())
     {
+      float gain = 1.0f;
+      if (m_drc > 0)
+        gain = pow(10.0f, (float)m_drc / 1000.0f);
+
       /* remap the data to the correct channels */
       uint8_t outData[bytesToWrite];
-      m_remap.Remap((void *)data, outData, framesToWrite);
+      m_remap.Remap((void *)data, outData, framesToWrite, gain);
       writeResult = snd_pcm_writei(m_pPlayHandle, outData, framesToWrite);
     }
     else

--- a/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
@@ -508,10 +508,6 @@ unsigned int CALSADirectSound::AddPackets(const void* data, unsigned int len)
     return 0;
   }
 
-  // handle volume de-amp
-  if (!m_bPassthrough)
-    m_amp.DeAmplify((short *)data, framesToWrite * m_uiDataChannels);
-
   int writeResult;
   if (m_bPassthrough && m_nCurrentVolume == VOLUME_MINIMUM)
   {
@@ -526,10 +522,16 @@ unsigned int CALSADirectSound::AddPackets(const void* data, unsigned int len)
       /* remap the data to the correct channels */
       uint8_t outData[bytesToWrite];
       m_remap.Remap((void *)data, outData, framesToWrite, m_drc);
+      m_amp.DeAmplify((short *)outData, bytesToWrite / 2);
       writeResult = snd_pcm_writei(m_pPlayHandle, outData, framesToWrite);
     }
     else
+    {
+      if (!m_bPassthrough)
+        m_amp.DeAmplify((short *)data, framesToWrite * m_uiDataChannels);
+
       writeResult = snd_pcm_writei(m_pPlayHandle, data, framesToWrite);
+    }
   }
   if (  writeResult == -EPIPE  )
   {

--- a/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
@@ -523,13 +523,9 @@ unsigned int CALSADirectSound::AddPackets(const void* data, unsigned int len)
   {
     if (m_remap.CanRemap())
     {
-      float gain = 1.0f;
-      if (m_drc > 0)
-        gain = pow(10.0f, (float)m_drc / 1000.0f);
-
       /* remap the data to the correct channels */
       uint8_t outData[bytesToWrite];
-      m_remap.Remap((void *)data, outData, framesToWrite, gain);
+      m_remap.Remap((void *)data, outData, framesToWrite, m_drc);
       writeResult = snd_pcm_writei(m_pPlayHandle, outData, framesToWrite);
     }
     else

--- a/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
@@ -70,7 +70,7 @@ bool CALSADirectSound::Initialize(IAudioCallback* pCallback, const CStdString& d
   if (!bPassthrough && channelMap)
   {
     /* set the input format, and get the channel layout so we know what we need to open */
-    outLayout = m_remap.SetInputFormat (iChannels, channelMap, uiBitsPerSample / 8);
+    outLayout = m_remap.SetInputFormat (iChannels, channelMap, uiBitsPerSample / 8, uiSamplesPerSec);
     unsigned int outChannels = 0;
     unsigned int ch = 0, map;
     while(outLayout[ch] != PCM_INVALID)

--- a/xbmc/cores/AudioRenderers/ALSADirectSound.h
+++ b/xbmc/cores/AudioRenderers/ALSADirectSound.h
@@ -63,6 +63,7 @@ public:
   virtual long GetCurrentVolume() const;
   virtual void Mute(bool bMute);
   virtual bool SetCurrentVolume(long nVolume);
+  virtual void SetDynamicRangeCompression(long drc) { m_drc = drc; }
   virtual int SetPlaySpeed(int iSpeed);
   virtual void WaitCompletion();
   virtual void SwitchChannels(int iAudioStream, bool bAudioOnAllSpeakers);
@@ -78,6 +79,7 @@ private:
   IAudioCallback* m_pCallback;
   CPCMAmplifier 	m_amp;
   long m_nCurrentVolume;
+  long m_drc;
   snd_pcm_uframes_t m_dwFrameCount;
   snd_pcm_uframes_t m_uiBufferSize;
   unsigned int      m_dwNumPackets;

--- a/xbmc/cores/AudioRenderers/IAudioRenderer.h
+++ b/xbmc/cores/AudioRenderers/IAudioRenderer.h
@@ -63,6 +63,7 @@ public:
   virtual void Mute(bool bMute) = 0;
   virtual bool SetCurrentVolume(long nVolume) = 0;
   virtual void SetDynamicRangeCompression(long drc) {};
+  virtual float GetCurrentAttenuation() { return m_remap.GetCurrentAttenuation(); }
   virtual int SetPlaySpeed(int iSpeed) = 0;
   virtual void WaitCompletion() = 0;
   virtual void SwitchChannels(int iAudioStream, bool bAudioOnAllSpeakers) = 0;

--- a/xbmc/cores/AudioRenderers/IOSAudioRenderer.cpp
+++ b/xbmc/cores/AudioRenderers/IOSAudioRenderer.cpp
@@ -83,7 +83,7 @@ bool CIOSAudioRenderer::Initialize(IAudioCallback* pCallback, const CStdString& 
     enum PCMChannels *outLayout;
 
     /* set the input format, and get the channel layout so we know what we need to open */
-    outLayout = m_remap.SetInputFormat (iChannels, channelMap, uiBitsPerSample / 8);
+    outLayout = m_remap.SetInputFormat (iChannels, channelMap, uiBitsPerSample / 8, uiSamplesPerSec);
     unsigned int outChannels = 0;
     unsigned int ch = 0, map;
     while(outLayout[ch] != PCM_INVALID)

--- a/xbmc/cores/AudioRenderers/PulseAudioDirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/PulseAudioDirectSound.cpp
@@ -153,7 +153,7 @@ bool CPulseAudioDirectSound::Initialize(IAudioCallback* pCallback, const CStdStr
   if (!bPassthrough && channelMap)
   {
     /* set the input format, and get the channel layout so we know what we need to open */
-    outLayout = m_remap.SetInputFormat(iChannels, channelMap, uiBitsPerSample / 8);
+    outLayout = m_remap.SetInputFormat(iChannels, channelMap, uiBitsPerSample / 8, uiSamplesPerSec);
     enum PCMChannels *channel;
     iChannels = 0;
     for(channel = outLayout; *channel != PCM_INVALID; ++channel)

--- a/xbmc/cores/AudioRenderers/PulseAudioDirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/PulseAudioDirectSound.cpp
@@ -522,13 +522,9 @@ unsigned int CPulseAudioDirectSound::AddPackets(const void* data, unsigned int l
 
   if (m_remap.CanRemap())
   {
-    float gain = 1.0f;
-    if (m_drc > 0)
-      gain = pow(10.0f, (float)m_drc / 1000.0f);
-
     /* remap the data to the correct channels */
     uint8_t outData[length];
-    m_remap.Remap((void *)data, outData, frames, gain);
+    m_remap.Remap((void *)data, outData, frames, m_drc);
     if (pa_stream_write(m_Stream, outData, length, NULL, 0, PA_SEEK_RELATIVE) < 0)
       CLog::Log(LOGERROR, "CPulseAudioDirectSound::AddPackets - pa_stream_write failed\n");
 

--- a/xbmc/cores/AudioRenderers/PulseAudioDirectSound.h
+++ b/xbmc/cores/AudioRenderers/PulseAudioDirectSound.h
@@ -59,6 +59,7 @@ public:
   virtual long GetCurrentVolume() const;
   virtual void Mute(bool bMute);
   virtual bool SetCurrentVolume(long nVolume);
+  virtual void SetDynamicRangeCompression(long drc) { m_drc = drc; }
   virtual int SetPlaySpeed(int iSpeed);
   virtual void WaitCompletion();
   virtual void SwitchChannels(int iAudioStream, bool bAudioOnAllSpeakers);
@@ -74,6 +75,7 @@ private:
   IAudioCallback* m_pCallback;
 
   long m_nCurrentVolume;
+  long m_drc;
   unsigned int m_dwPacketSize;
   unsigned int m_dwNumPackets;
 

--- a/xbmc/cores/AudioRenderers/Win32DirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/Win32DirectSound.cpp
@@ -347,13 +347,9 @@ unsigned int CWin32DirectSound::AddPackets(const void* data, unsigned int len)
       break;
     }
 
-    float gain = 1.0f;
-    if (m_drc > 0)
-      gain = pow(10.0f, (float)m_drc / 1000.0f);
-
     // Remap the data to the correct channels into the buffer
     if (m_remap.CanRemap())
-      m_remap.Remap((void*)pBuffer, start, size / m_uiBytesPerFrame, gain);
+      m_remap.Remap((void*)pBuffer, start, size / m_uiBytesPerFrame, m_drc);
     else
       memcpy(start, pBuffer, size);
 

--- a/xbmc/cores/AudioRenderers/Win32DirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/Win32DirectSound.cpp
@@ -93,7 +93,7 @@ bool CWin32DirectSound::Initialize(IAudioCallback* pCallback, const CStdString& 
     if(!channelMap)
       channelMap = (PCMChannels *)dsound_default_channel_layout[iChannels - 1];
 
-    PCMChannels *outLayout = m_remap.SetInputFormat(iChannels, channelMap, uiBitsPerSample / 8);
+    PCMChannels *outLayout = m_remap.SetInputFormat(iChannels, channelMap, uiBitsPerSample / 8, uiSamplesPerSec);
 
     for(iChannels = 0; outLayout[iChannels] != PCM_INVALID;) ++iChannels;
 

--- a/xbmc/cores/AudioRenderers/Win32DirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/Win32DirectSound.cpp
@@ -361,7 +361,7 @@ unsigned int CWin32DirectSound::AddPackets(const void* data, unsigned int len)
     {
       // Remap the data to the correct channels into the buffer
       if (m_remap.CanRemap())
-        m_remap.Remap((void*)pBuffer, startWrap, sizeWrap / m_uiBytesPerFrame, gain);
+        m_remap.Remap((void*)pBuffer, startWrap, sizeWrap / m_uiBytesPerFrame, m_drc);
       else
         memcpy(startWrap, pBuffer, sizeWrap);
       m_BufferOffset = sizeWrap;

--- a/xbmc/cores/AudioRenderers/Win32DirectSound.h
+++ b/xbmc/cores/AudioRenderers/Win32DirectSound.h
@@ -58,6 +58,7 @@ public:
   virtual long GetCurrentVolume() const;
   virtual void Mute(bool bMute);
   virtual bool SetCurrentVolume(long nVolume);
+  virtual void SetDynamicRangeCompression(long drc) { m_drc = drc; }
   virtual int SetPlaySpeed(int iSpeed);
   virtual void WaitCompletion();
   virtual void SwitchChannels(int iAudioStream, bool bAudioOnAllSpeakers);
@@ -75,6 +76,7 @@ private:
   IAudioCallback* m_pCallback;
 
   long m_nCurrentVolume;
+  long m_drc;
   unsigned int m_dwChunkSize;
   unsigned int m_dwDataChunkSize;
   unsigned int m_dwBufferLen;

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
@@ -669,13 +669,9 @@ void CWin32WASAPI::WaitCompletion()
 //***********************************************************************************************
 void CWin32WASAPI::AddDataToBuffer(unsigned char* pData, unsigned int len, unsigned char* pOut)
 {
-  float gain = 1.0f;
-  if (m_drc > 0)
-    gain = pow(10.0f, (float)m_drc / 1000.0f);
-
   // Remap the data to the correct channels
   if(m_remap.CanRemap() && !m_bPassthrough)
-    m_remap.Remap((void*)pData, pOut, len / m_uiBytesPerSrcFrame);
+    m_remap.Remap((void*)pData, pOut, len / m_uiBytesPerSrcFrame, m_drc);
   else
     memcpy(pOut, pData, len);
 }

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
@@ -144,6 +144,7 @@ bool CWin32WASAPI::Initialize(IAudioCallback* pCallback, const CStdString& devic
 
   m_nCurrentVolume = g_settings.m_nVolumeLevel;
   m_pcmAmplifier.SetVolume(m_nCurrentVolume);
+  m_drc = 0;
   
   WAVEFORMATEXTENSIBLE wfxex = {0};
 
@@ -668,6 +669,10 @@ void CWin32WASAPI::WaitCompletion()
 //***********************************************************************************************
 void CWin32WASAPI::AddDataToBuffer(unsigned char* pData, unsigned int len, unsigned char* pOut)
 {
+  float gain = 1.0f;
+  if (m_drc > 0)
+    gain = pow(10.0f, (float)m_drc / 1000.0f);
+
   // Remap the data to the correct channels
   if(m_remap.CanRemap() && !m_bPassthrough)
     m_remap.Remap((void*)pData, pOut, len / m_uiBytesPerSrcFrame);

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
@@ -113,7 +113,7 @@ bool CWin32WASAPI::Initialize(IAudioCallback* pCallback, const CStdString& devic
     if(!channelMap)
       channelMap = (PCMChannels *)wasapi_default_channel_layout[iChannels - 1];
 
-    PCMChannels *outLayout = m_remap.SetInputFormat(iChannels, channelMap, uiBitsPerSample / 8);
+    PCMChannels *outLayout = m_remap.SetInputFormat(iChannels, channelMap, uiBitsPerSample / 8, uiSamplesPerSec);
 
     for(PCMChannels *channel = outLayout; *channel != PCM_INVALID; channel++)
         ++layoutChannels;

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.h
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.h
@@ -59,6 +59,7 @@ public:
   virtual long GetCurrentVolume() const;
   virtual void Mute(bool bMute);
   virtual bool SetCurrentVolume(long nVolume);
+  virtual void SetDynamicRangeCompression(long drc) { m_drc = drc; }
   virtual int SetPlaySpeed(int iSpeed);
   virtual void WaitCompletion();
   virtual void SwitchChannels(int iAudioStream, bool bAudioOnAllSpeakers);
@@ -78,6 +79,7 @@ private:
   IAudioCallback* m_pCallback;
 
   long m_nCurrentVolume;
+  long m_drc;
   float m_fVolAdjustFactor;
 
   unsigned int m_uiChunkSize;

--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -27,6 +27,7 @@
 #include "DVDCodecs/DVDCodecs.h"
 #include "DVDPlayerAudio.h"
 #include "../AudioRenderers/AudioRendererFactory.h"
+#include "settings/Settings.h"
 
 using namespace std;
 
@@ -98,6 +99,8 @@ bool CDVDAudio::Create(const DVDAudioFrame &audioframe, CodecID codec)
 
   if(m_pCallback && !m_bPassthrough)
     m_pCallback->OnInitialize(m_iChannels, m_iBitrate, m_iBitsPerSample);
+
+  SetDynamicRangeCompression((long)(g_settings.m_currentVideoSettings.m_VolumeAmplification * 100));
 
   return true;
 }

--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -272,6 +272,15 @@ void CDVDAudio::SetDynamicRangeCompression(long drc)
   if (m_pAudioDecoder) m_pAudioDecoder->SetDynamicRangeCompression(drc);
 }
 
+float CDVDAudio::GetCurrentAttenuation()
+{
+  CSingleLock lock (m_critSection);
+  if (m_pAudioDecoder)
+    return m_pAudioDecoder->GetCurrentAttenuation();
+  else
+    return 1.0f;
+}
+
 void CDVDAudio::Pause()
 {
   CSingleLock lock (m_critSection);

--- a/xbmc/cores/dvdplayer/DVDAudio.h
+++ b/xbmc/cores/dvdplayer/DVDAudio.h
@@ -59,6 +59,7 @@ public:
 
   void SetVolume(int iVolume);
   void SetDynamicRangeCompression(long drc);
+  float GetCurrentAttenuation();
   void Pause();
   void Resume();
   bool Create(const DVDAudioFrame &audioframe, CodecID codec);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/Encoders/DVDAudioEncoderFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/Encoders/DVDAudioEncoderFFmpeg.cpp
@@ -124,7 +124,7 @@ bool CDVDAudioEncoderFFmpeg::Initialize(unsigned int channels, enum PCMChannels 
   if (m_CodecCtx->channel_layout & AV_CH_TOP_BACK_CENTER      ) m_ChannelMap[index++] = PCM_TOP_BACK_CENTER      ;
   if (m_CodecCtx->channel_layout & AV_CH_TOP_BACK_RIGHT       ) m_ChannelMap[index++] = PCM_TOP_BACK_RIGHT       ;
 
-  m_Remap.SetInputFormat (channels, channelMap, bitsPerSample / 8);
+  m_Remap.SetInputFormat (channels, channelMap, bitsPerSample / 8, sampleRate);
   m_Remap.SetOutputFormat(index, m_ChannelMap, true);
 
   if (!m_Remap.CanRemap())

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -904,6 +904,8 @@ string CDVDPlayerAudio::GetPlayerInfo()
   if (m_synctype == SYNC_RESAMPLE)
     s << ", rr:" << fixed << setprecision(5) << 1.0 / m_resampleratio;
 
+  s << ", att:" << fixed << setprecision(1) << log(GetCurrentAttenuation()) * 10.0f << " dB";
+
   return s.str();
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -114,6 +114,7 @@ public:
 
   void SetVolume(long nVolume)                          { m_dvdAudio.SetVolume(nVolume); }
   void SetDynamicRangeCompression(long drc)             { m_dvdAudio.SetDynamicRangeCompression(drc); }
+  float GetCurrentAttenuation()                         { return m_dvdAudio.GetCurrentAttenuation(); }
 
   std::string GetPlayerInfo();
   int GetAudioBitrate();

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -52,7 +52,7 @@ void CAdvancedSettings::Initialize()
 
   //default hold time of 25 ms, this allows a 20 hertz sine to pass undistorted
   m_limiterHold = 0.025f;
-  m_limiterRelease = 1.0f;
+  m_limiterRelease = 0.1f;
 
   m_karaokeSyncDelayCDG = 0.0f;
   m_karaokeSyncDelayLRC = 0.0f;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -50,6 +50,10 @@ void CAdvancedSettings::Initialize()
   m_audioApplyDrc = true;
   m_dvdplayerIgnoreDTSinWAV = false;
 
+  //default hold time of 25 ms, this allows a 20 hertz sine to pass undistorted
+  m_limiterHold = 0.025f;
+  m_limiterRelease = 1.0f;
+
   m_karaokeSyncDelayCDG = 0.0f;
   m_karaokeSyncDelayLRC = 0.0f;
   m_karaokeChangeGenreForKaraokeSongs = false;
@@ -365,6 +369,9 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetString(pElement, "audiohost", m_audioHost);
     XMLUtils::GetBoolean(pElement, "applydrc", m_audioApplyDrc);
     XMLUtils::GetBoolean(pElement, "dvdplayerignoredtsinwav", m_dvdplayerIgnoreDTSinWAV);
+
+    XMLUtils::GetFloat(pElement, "limiterhold", m_limiterHold, 0.0f, 100.0f);
+    XMLUtils::GetFloat(pElement, "limiterrelease", m_limiterRelease, 0.001f, 100.0f);
   }
 
   pElement = pRootElement->FirstChildElement("karaoke");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -82,6 +82,8 @@ class CAdvancedSettings
     CStdString m_audioDefaultPlayer;
     float m_audioPlayCountMinimumPercent;
     bool m_dvdplayerIgnoreDTSinWAV;
+    float m_limiterHold;
+    float m_limiterRelease;
 
     float m_videoSubsDelayRange;
     float m_videoAudioDelayRange;

--- a/xbmc/utils/PCMRemap.cpp
+++ b/xbmc/utils/PCMRemap.cpp
@@ -565,6 +565,15 @@ void CPCMRemap::Remap(void *data, void *out, unsigned int samples, float gain /*
         m_attenuationInc = 1.0f - m_attenuation;
         m_holdCounter = MathUtils::round_int(m_sampleRate * g_advancedSettings.m_limiterHold);
       }
+      else if (m_attenuation < 1.0f)
+      {
+        //if we're attenuating, and we get within 5% of clipping, hold the current attenuation
+        if (value * m_attenuation < (float)INT16_MIN * 0.95 || value * m_attenuation > (float)INT16_MAX * 0.95)
+        {
+          m_holdCounter = MathUtils::round_int(m_sampleRate * g_advancedSettings.m_limiterHold);
+          m_attenuationInc = 1.0f - m_attenuation;
+        }
+      }
 
       //convert to signed int and clamp to 16 bit
       int outvalue = MathUtils::round_int(value * m_attenuation);

--- a/xbmc/utils/PCMRemap.cpp
+++ b/xbmc/utils/PCMRemap.cpp
@@ -174,7 +174,8 @@ CPCMRemap::CPCMRemap() :
   m_attenuation (1.0),
   m_attenuationInc(0.0),
   m_sampleRate  (48000.0), //safe default
-  m_holdCounter (0)
+  m_holdCounter (0),
+  m_limiterEnabled(false)
 {
   Dispose();
 }
@@ -607,6 +608,12 @@ void CPCMRemap::ProcessLimiter(unsigned int samples, float gain)
   //if one of the channels can clip, enable a limiter
   if (highestgain > 1.0001f) 
   {
+    if (!m_limiterEnabled)
+    {
+      CLog::Log(LOGDEBUG, "CPCMRemap:: max gain: %f, enabling limiter", highestgain);
+      m_limiterEnabled = true;
+    }
+
     for (unsigned int i = 0; i < samples; i++)
     {
       //for each collection of samples, get the highest absolute value
@@ -659,6 +666,12 @@ void CPCMRemap::ProcessLimiter(unsigned int samples, float gain)
   }
   else
   {
+    if (m_limiterEnabled)
+    {
+      CLog::Log(LOGDEBUG, "CPCMRemap:: max gain: %f, disabling limiter", highestgain);
+      m_limiterEnabled = false;
+    }
+
     //reset the limiter
     m_attenuation = 1.0f;
     m_attenuationInc = 0.0f;

--- a/xbmc/utils/PCMRemap.cpp
+++ b/xbmc/utils/PCMRemap.cpp
@@ -507,7 +507,7 @@ void CPCMRemap::SetOutputFormat(unsigned int channels, enum PCMChannels *channel
 }
 
 /* remap the supplied data into out, which must be pre-allocated */
-void CPCMRemap::Remap(void *data, void *out, unsigned int samples)
+void CPCMRemap::Remap(void *data, void *out, unsigned int samples, float gain /*= 1.0f*/)
 {
   unsigned int i, ch;
   uint8_t      *insample, *outsample;
@@ -532,7 +532,7 @@ void CPCMRemap::Remap(void *data, void *out, unsigned int samples)
       if (info->channel == PCM_INVALID) continue;
 
       /* if it is a 1-1 map, we just copy the data to avoid rounding errors */
-      if (info->copy)
+      if (info->copy && gain == 1.0f)
       {
         src = insample  + info->in_offset;
         dst = outsample + ch * m_inSampleSize;
@@ -546,6 +546,8 @@ void CPCMRemap::Remap(void *data, void *out, unsigned int samples)
         value += (float)(*(int16_t*)src) * info->level;
       }
       dst = outsample + ch * m_inSampleSize;
+
+      value *= gain;
 
       //if value * m_attenuation clips (above INT16_MAX or below INT16_MIN),
       //adjust m_attenuation so that INT16_MIN <= value * m_attenuation <= INT16_MAX

--- a/xbmc/utils/PCMRemap.cpp
+++ b/xbmc/utils/PCMRemap.cpp
@@ -513,6 +513,15 @@ void CPCMRemap::SetOutputFormat(unsigned int channels, enum PCMChannels *channel
   m_holdCounter = 0;
 }
 
+void CPCMRemap::Remap(void *data, void *out, unsigned int samples, long drc)
+{
+  float gain = 1.0f;
+  if (drc > 0)
+    gain = pow(10.0f, (float)drc / 1000.0f);
+
+  Remap(data, out, samples, gain);
+}
+
 /* remap the supplied data into out, which must be pre-allocated */
 void CPCMRemap::Remap(void *data, void *out, unsigned int samples, float gain /*= 1.0f*/)
 {

--- a/xbmc/utils/PCMRemap.cpp
+++ b/xbmc/utils/PCMRemap.cpp
@@ -173,6 +173,7 @@ CPCMRemap::CPCMRemap() :
   m_bufsize(0),
   m_attenuation (1.0),
   m_attenuationInc(0.0),
+  m_attenuationMin(1.0),
   m_sampleRate  (48000.0), //safe default
   m_holdCounter (0),
   m_limiterEnabled(false)
@@ -605,9 +606,13 @@ void CPCMRemap::ProcessLimiter(unsigned int samples, float gain)
       highestgain = chgain;
   }
 
+  m_attenuationMin = 1.0f;
+
   //if one of the channels can clip, enable a limiter
   if (highestgain > 1.0001f) 
   {
+    m_attenuationMin = m_attenuation;
+
     if (!m_limiterEnabled)
     {
       CLog::Log(LOGDEBUG, "CPCMRemap:: max gain: %f, enabling limiter", highestgain);
@@ -631,6 +636,8 @@ void CPCMRemap::ProcessLimiter(unsigned int samples, float gain)
       {
         //set m_attenuation so that m_attenuation * sample is the maximum output value
         m_attenuation = 1.0f / maxAbs;
+        if (m_attenuation < m_attenuationMin)
+          m_attenuationMin = m_attenuation;
         //value to add to m_attenuation to make it 1.0f
         m_attenuationInc = 1.0f - m_attenuation;
         //amount of samples to hold m_attenuation

--- a/xbmc/utils/PCMRemap.h
+++ b/xbmc/utils/PCMRemap.h
@@ -110,6 +110,7 @@ protected:
   float              m_attenuationInc;
   float              m_sampleRate;
   unsigned int       m_holdCounter;
+  bool               m_limiterEnabled;
 
   struct PCMMapInfo* ResolveChannel(enum PCMChannels channel, float level, bool ifExists, std::vector<enum PCMChannels> path, struct PCMMapInfo *tablePtr);
   void               ResolveChannels(); //!< Partial BuildMap(), just enough to see which output channels are active

--- a/xbmc/utils/PCMRemap.h
+++ b/xbmc/utils/PCMRemap.h
@@ -135,6 +135,7 @@ public:
   void Reset();
   enum PCMChannels *SetInputFormat (unsigned int channels, enum PCMChannels *channelMap, unsigned int sampleSize, unsigned int sampleRate);
   void SetOutputFormat(unsigned int channels, enum PCMChannels *channelMap, bool ignoreLayout = false);
+  void Remap(void *data, void *out, unsigned int samples, long drc);
   void Remap(void *data, void *out, unsigned int samples, float gain = 1.0f);
   bool CanRemap();
   int  InBytesToFrames (int bytes );

--- a/xbmc/utils/PCMRemap.h
+++ b/xbmc/utils/PCMRemap.h
@@ -124,7 +124,7 @@ public:
   void Reset();
   enum PCMChannels *SetInputFormat (unsigned int channels, enum PCMChannels *channelMap, unsigned int sampleSize, unsigned int sampleRate);
   void SetOutputFormat(unsigned int channels, enum PCMChannels *channelMap, bool ignoreLayout = false);
-  void Remap(void *data, void *out, unsigned int samples);
+  void Remap(void *data, void *out, unsigned int samples, float gain = 1.0f);
   bool CanRemap();
   int  InBytesToFrames (int bytes );
   int  FramesToOutBytes(int frames);

--- a/xbmc/utils/PCMRemap.h
+++ b/xbmc/utils/PCMRemap.h
@@ -104,6 +104,11 @@ protected:
   struct PCMMapInfo  m_lookupMap[PCM_MAX_CH + 1][PCM_MAX_CH + 1];
   int                m_counts[PCM_MAX_CH];
 
+  float              m_attenuation;
+  float              m_attenuationInc;
+  float              m_sampleRate;
+  unsigned int       m_holdCounter;
+
   struct PCMMapInfo* ResolveChannel(enum PCMChannels channel, float level, bool ifExists, std::vector<enum PCMChannels> path, struct PCMMapInfo *tablePtr);
   void               ResolveChannels(); //!< Partial BuildMap(), just enough to see which output channels are active
   void               BuildMap();
@@ -117,7 +122,7 @@ public:
   ~CPCMRemap();
 
   void Reset();
-  enum PCMChannels *SetInputFormat (unsigned int channels, enum PCMChannels *channelMap, unsigned int sampleSize);
+  enum PCMChannels *SetInputFormat (unsigned int channels, enum PCMChannels *channelMap, unsigned int sampleSize, unsigned int sampleRate);
   void SetOutputFormat(unsigned int channels, enum PCMChannels *channelMap, bool ignoreLayout = false);
   void Remap(void *data, void *out, unsigned int samples);
   bool CanRemap();

--- a/xbmc/utils/PCMRemap.h
+++ b/xbmc/utils/PCMRemap.h
@@ -104,6 +104,8 @@ protected:
   struct PCMMapInfo  m_lookupMap[PCM_MAX_CH + 1][PCM_MAX_CH + 1];
   int                m_counts[PCM_MAX_CH];
 
+  float*             m_buf;
+  int                m_bufsize;
   float              m_attenuation;
   float              m_attenuationInc;
   float              m_sampleRate;
@@ -116,6 +118,13 @@ protected:
   void               Dispose();
   CStdString         PCMChannelStr(enum PCMChannels ename);
   CStdString         PCMLayoutStr(enum PCMLayout ename);
+
+  void               CheckBufferSize(int size);
+  void               ProcessInput(void* data, void* out, unsigned int samples, float gain);
+  void               AddGain(float* buf, unsigned int samples, float gain);
+  void               ProcessLimiter(unsigned int samples, float gain);
+  void               ProcessOutput(void* out, unsigned int samples, float gain);
+
 public:
 
   CPCMRemap();

--- a/xbmc/utils/PCMRemap.h
+++ b/xbmc/utils/PCMRemap.h
@@ -108,6 +108,7 @@ protected:
   int                m_bufsize;
   float              m_attenuation;
   float              m_attenuationInc;
+  float              m_attenuationMin; //lowest attenuation value during a call of Remap(), used for the codec info
   float              m_sampleRate;
   unsigned int       m_holdCounter;
   bool               m_limiterEnabled;
@@ -139,6 +140,7 @@ public:
   int  InBytesToFrames (int bytes );
   int  FramesToOutBytes(int frames);
   int  FramesToInBytes (int frames);
+  float GetCurrentAttenuation() { return m_attenuationMin; }
 };
 
 #endif

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -79,7 +79,7 @@ void CGUIDialogAudioSubtitleSettings::CreateSettings()
   AddSlider(AUDIO_SETTINGS_VOLUME, 13376, &m_volume, VOLUME_MINIMUM * 0.01f, (VOLUME_MAXIMUM - VOLUME_MINIMUM) * 0.0001f, VOLUME_MAXIMUM * 0.01f, FormatDecibel, false);
   if (g_application.m_pPlayer && g_application.m_pPlayer->IsPassthrough())
     EnableSettings(AUDIO_SETTINGS_VOLUME,false);
-  AddSlider(AUDIO_SETTINGS_VOLUME_AMPLIFICATION, 660, &g_settings.m_currentVideoSettings.m_VolumeAmplification, VOLUME_DRC_MINIMUM * 0.01f, (VOLUME_DRC_MAXIMUM - VOLUME_DRC_MINIMUM) * 0.0005f, VOLUME_DRC_MAXIMUM * 0.01f, FormatDecibel, false);
+  AddSlider(AUDIO_SETTINGS_VOLUME_AMPLIFICATION, 660, &g_settings.m_currentVideoSettings.m_VolumeAmplification, VOLUME_DRC_MINIMUM * 0.01f, (VOLUME_DRC_MAXIMUM - VOLUME_DRC_MINIMUM) / 3000.0f, VOLUME_DRC_MAXIMUM * 0.01f, FormatDecibel, false);
   AddSlider(AUDIO_SETTINGS_DELAY, 297, &g_settings.m_currentVideoSettings.m_AudioDelay, -g_advancedSettings.m_videoAudioDelayRange, .025f, g_advancedSettings.m_videoAudioDelayRange, FormatDelay);
   AddAudioStreams(AUDIO_SETTINGS_STREAM);
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -77,9 +77,12 @@ void CGUIDialogAudioSubtitleSettings::CreateSettings()
   // create our settings
   m_volume = g_settings.m_nVolumeLevel * 0.01f;
   AddSlider(AUDIO_SETTINGS_VOLUME, 13376, &m_volume, VOLUME_MINIMUM * 0.01f, (VOLUME_MAXIMUM - VOLUME_MINIMUM) * 0.0001f, VOLUME_MAXIMUM * 0.01f, FormatDecibel, false);
-  if (g_application.m_pPlayer && g_application.m_pPlayer->IsPassthrough())
-    EnableSettings(AUDIO_SETTINGS_VOLUME,false);
   AddSlider(AUDIO_SETTINGS_VOLUME_AMPLIFICATION, 660, &g_settings.m_currentVideoSettings.m_VolumeAmplification, VOLUME_DRC_MINIMUM * 0.01f, (VOLUME_DRC_MAXIMUM - VOLUME_DRC_MINIMUM) / 3000.0f, VOLUME_DRC_MAXIMUM * 0.01f, FormatDecibel, false);
+  if (g_application.m_pPlayer && g_application.m_pPlayer->IsPassthrough())
+  {
+    EnableSettings(AUDIO_SETTINGS_VOLUME,false);
+    EnableSettings(AUDIO_SETTINGS_VOLUME_AMPLIFICATION,false);
+  }
   AddSlider(AUDIO_SETTINGS_DELAY, 297, &g_settings.m_currentVideoSettings.m_AudioDelay, -g_advancedSettings.m_videoAudioDelayRange, .025f, g_advancedSettings.m_videoAudioDelayRange, FormatDelay);
   AddAudioStreams(AUDIO_SETTINGS_STREAM);
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -79,9 +79,7 @@ void CGUIDialogAudioSubtitleSettings::CreateSettings()
   AddSlider(AUDIO_SETTINGS_VOLUME, 13376, &m_volume, VOLUME_MINIMUM * 0.01f, (VOLUME_MAXIMUM - VOLUME_MINIMUM) * 0.0001f, VOLUME_MAXIMUM * 0.01f, FormatDecibel, false);
   if (g_application.m_pPlayer && g_application.m_pPlayer->IsPassthrough())
     EnableSettings(AUDIO_SETTINGS_VOLUME,false);
-#if 0
   AddSlider(AUDIO_SETTINGS_VOLUME_AMPLIFICATION, 660, &g_settings.m_currentVideoSettings.m_VolumeAmplification, VOLUME_DRC_MINIMUM * 0.01f, (VOLUME_DRC_MAXIMUM - VOLUME_DRC_MINIMUM) * 0.0005f, VOLUME_DRC_MAXIMUM * 0.01f, FormatDecibel, false);
-#endif
   AddSlider(AUDIO_SETTINGS_DELAY, 297, &g_settings.m_currentVideoSettings.m_AudioDelay, -g_advancedSettings.m_videoAudioDelayRange, .025f, g_advancedSettings.m_videoAudioDelayRange, FormatDelay);
   AddAudioStreams(AUDIO_SETTINGS_STREAM);
 


### PR DESCRIPTION
This pull request adds simple dynamic range compression, by multiplying audio samples with a certain value, then process them through a limiter to prevent clipping.
The limiter has configurable hold and release times (through advancedsettings.xml).
The limiter is also turned on whenever a downmix configuration in CPCMRemap can produce clipping (so also when boost volume on downmix is turned on).

Also, I've rewritten CPCMRemap::Remap() for better efficiency, by moving things out of the inner loop.

The implementation on windows needs to be tested (I don't even know if it compiles), and it needs to be hooked up for osx.
