### PR TITLE
Afp4linux

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -996,26 +996,22 @@ fi
 
 # libafpclient
 USE_LIBAFPCLIENT=0
-if test "$host_vendor" = "apple" ; then
-  if test "x$use_libafpclient" != "xno"; then
-    AC_CHECK_HEADERS([afpfs-ng/libafpclient.h],,
-     [if test "x$use_libafpclient" = "xyes"; then
-        AC_MSG_ERROR($libafpclient_not_found)
-      elif test "x$use_libafpclient" != "xno"; then
-        AC_MSG_NOTICE($libafpclient_not_found)
-        use_libafpclient="no"
-      fi
-     ])
-    if test "x$use_libafpclient" != "xno"; then
-      XB_FIND_SONAME([AFPCLIENT], [afpclient], [use_libafpclient])
-      AC_DEFINE([HAVE_LIBAFPCLIENT], [1], [Whether to use libafpclient library.])
-      USE_LIBAFPCLIENT=1
+if test "x$use_libafpclient" != "xno"; then
+  AC_CHECK_HEADERS([afpfs-ng/libafpclient.h],,
+   [if test "x$use_libafpclient" = "xyes"; then
+      AC_MSG_ERROR($libafpclient_not_found)
+    elif test "x$use_libafpclient" != "xno"; then
+      AC_MSG_NOTICE($libafpclient_not_found)
+      use_libafpclient="no"
     fi
-  else
-    AC_MSG_NOTICE($libafpclient_disabled)
+   ])
+  if test "x$use_libafpclient" != "xno"; then
+    XB_FIND_SONAME([AFPCLIENT], [afpclient], [use_libafpclient])
+    AC_DEFINE([HAVE_LIBAFPCLIENT], [1], [Whether to use libafpclient library.])
+    USE_LIBAFPCLIENT=1
   fi
 else
-  use_libafpclient="no"
+  AC_MSG_NOTICE($libafpclient_disabled)
 fi
 
 # libplist for airplay feature

--- a/lib/afpfs-ng/01-gcrypt.patch
+++ b/lib/afpfs-ng/01-gcrypt.patch
@@ -1,0 +1,26 @@
+diff -ru afpfs-ng-0.8.1/configure.ac afpfs-ng-0.8.1+iPhone/configure.ac
+--- afpfs-ng-0.8.1/configure.ac	2008-03-08 16:23:12.000000000 +0000
++++ afpfs-ng-0.8.1+iPhone/configure.ac	2010-10-24 05:26:15.000000000 +0000
+@@ -50,21 +50,6 @@
+ 	case $host in
+ 		*-*-darwin*) 
+ 		AC_MSG_CHECKING([for correct gcrypt version])
+-		AC_RUN_IFELSE(
+-			[AC_LANG_PROGRAM([
+-				#include <gcrypt.h>
+-				#include <stdio.h>],[
+-				char*p= GCRYPT_VERSION;
+-				unsigned int vers;
+-				vers=atoi(p)*10000;
+-				p=strchr(p,'.')+1;
+-				vers+=atoi(p)*100;
+-				p=strchr(p,'.')+1;
+-				vers+=atoi(p);
+-				if (vers<10400) return 1;
+-			])],
+-			[AC_MSG_RESULT([yes])],
+-			[AC_MSG_ERROR([version is < 1.4.0])])
+ 		AM_CONDITIONAL(HAVE_LIBGCRYPT, true)
+ 		AC_DEFINE([HAVE_LIBGCRYPT], [1] )
+ 		;;
+

--- a/lib/afpfs-ng/02-pointer.patch
+++ b/lib/afpfs-ng/02-pointer.patch
@@ -1,0 +1,280 @@
+diff -up afpfs-ng-0.8.1/cmdline/getstatus.c.pointer afpfs-ng-0.8.1/cmdline/getstatus.c
+--- afpfs-ng-0.8.1/cmdline/getstatus.c.pointer	2011-06-14 17:06:35.000000000 +0200
++++ afpfs-ng-0.8.1/cmdline/getstatus.c	2011-06-14 17:07:25.000000000 +0200
+@@ -1,4 +1,5 @@
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <string.h>
+ #include <pthread.h>
+ 
+diff -up afpfs-ng-0.8.1/fuse/client.c.pointer afpfs-ng-0.8.1/fuse/client.c
+--- afpfs-ng-0.8.1/fuse/client.c.pointer	2008-03-08 03:44:16.000000000 +0100
++++ afpfs-ng-0.8.1/fuse/client.c	2011-06-14 17:02:15.000000000 +0200
+@@ -61,8 +61,9 @@ static int start_afpfsd(void)
+ 			snprintf(filename, PATH_MAX,
+ 				"/usr/local/bin/%s",AFPFSD_FILENAME);
+ 			if (access(filename,X_OK)) {
+-				snprintf(filename, "/usr/bin/%s",
++				snprintf(filename, sizeof(filename), "/usr/bin/%s",
+ 					AFPFSD_FILENAME);
++				filename[sizeof(filename) - 1] = 0;
+ 				if (access(filename,X_OK)) {
+ 					printf("Could not find server (%s)\n",
+ 						filename);
+diff -up afpfs-ng-0.8.1/fuse/fuse_int.c.pointer afpfs-ng-0.8.1/fuse/fuse_int.c
+--- afpfs-ng-0.8.1/fuse/fuse_int.c.pointer	2008-03-02 06:06:24.000000000 +0100
++++ afpfs-ng-0.8.1/fuse/fuse_int.c	2011-06-14 17:02:15.000000000 +0200
+@@ -197,7 +197,7 @@ static int fuse_open(const char *path, s
+ 	ret = ml_open(volume,path,flags,&fp);
+ 
+ 	if (ret==0) 
+-		fi->fh=(void *) fp;
++		fi->fh=(unsigned long) fp;
+ 
+ 	return ret;
+ }
+diff -up afpfs-ng-0.8.1/include/afpfs-ng/afp.h.pointer afpfs-ng-0.8.1/include/afp.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/afp.h.pointer	2008-03-08 17:08:18.000000000 +0100
++++ afpfs-ng-0.8.1/include/afpfs-ng/afp.h	2011-06-14 17:02:15.000000000 +0200
+@@ -370,7 +370,7 @@ int afp_unmount_all_volumes(struct afp_s
+ 
+ int afp_opendt(struct afp_volume *volume, unsigned short * refnum);
+ 
+-int afp_closedt(struct afp_server * server, unsigned short * refnum);
++int afp_closedt(struct afp_server * server, unsigned short refnum);
+ 
+ int afp_getcomment(struct afp_volume *volume, unsigned int did,
+         const char * pathname, struct afp_comment * comment);
+diff -up afpfs-ng-0.8.1/include/afpfs-gn/utils.h.pointer afpfs-ng-0.8.1/include/utils.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/utils.h.pointer	2008-02-18 04:33:58.000000000 +0100
++++ afpfs-ng-0.8.1/include/afpfs-ng/utils.h	2011-06-14 17:02:15.000000000 +0200
+@@ -8,8 +8,8 @@
+ #define hton64(x)       (x)
+ #define ntoh64(x)       (x)
+ #else /* BYTE_ORDER == BIG_ENDIAN */
+-#define hton64(x)       ((u_int64_t) (htonl(((x) >> 32) & 0xffffffffLL)) | \
+-                         (u_int64_t) ((htonl(x) & 0xffffffffLL) << 32))
++#define hton64(x)       ((u_int64_t) (htonl((((unsigned long long)(x)) >> 32) & 0xffffffffLL)) | \
++                         (u_int64_t) ((htonl((unsigned long long)(x)) & 0xffffffffLL) << 32))
+ #define ntoh64(x)       (hton64(x))
+ #endif /* BYTE_ORDER == BIG_ENDIAN */
+ 
+diff -up afpfs-ng-0.8.1/lib/afp_url.c.pointer afpfs-ng-0.8.1/lib/afp_url.c
+--- afpfs-ng-0.8.1/lib/afp_url.c.pointer	2008-03-04 21:16:49.000000000 +0100
++++ afpfs-ng-0.8.1/lib/afp_url.c	2011-06-14 17:02:15.000000000 +0200
+@@ -33,7 +33,7 @@ static int check_port(char * port) 
+ static int check_uamname(const char * uam) 
+ {
+ 	char * p;
+-	for (p=uam;*p;p++) {
++	for (p=(char *)uam;*p;p++) {
+ 		if (*p==' ') continue;
+ 		if ((*p<'A') || (*p>'z')) return -1;
+ 	}
+@@ -188,7 +188,7 @@ int afp_parse_url(struct afp_url * url, 
+ 		return -1;
+ 
+ 	}
+-	if (p==NULL) p=toparse;
++	if (p==NULL) p=(char *)toparse;
+ 
+ 	/* Now split on the first / */
+ 	if (sscanf(p,"%[^/]/%[^$]",
+diff -up afpfs-ng-0.8.1/lib/did.c.pointer afpfs-ng-0.8.1/lib/did.c
+--- afpfs-ng-0.8.1/lib/did.c.pointer	2008-02-18 04:39:17.000000000 +0100
++++ afpfs-ng-0.8.1/lib/did.c	2011-06-14 17:02:15.000000000 +0200
+@@ -226,7 +226,7 @@ int get_dirid(struct afp_volume * volume
+ 
+ 
+ 	/* Go to the end of last known entry */
+-	p=path+(p-copy);
++	p=(char *)path+(p-copy);
+ 	p2=p;
+ 
+ 	while ((p=strchr(p+1,'/'))) {
+diff -up afpfs-ng-0.8.1/lib/dsi.c.pointer afpfs-ng-0.8.1/lib/dsi.c
+--- afpfs-ng-0.8.1/lib/dsi.c.pointer	2008-02-18 04:53:03.000000000 +0100
++++ afpfs-ng-0.8.1/lib/dsi.c	2011-06-14 17:02:15.000000000 +0200
+@@ -474,7 +474,7 @@ void dsi_getstatus_reply(struct afp_serv
+ 	}
+ 	server->flags=ntohs(reply1->flags);
+ 
+-	p=(void *)((unsigned int) server->incoming_buffer + sizeof(*reply1));
++	p=(void *)((unsigned long) server->incoming_buffer + sizeof(*reply1));
+ 	p+=copy_from_pascal(server->server_name,p,AFP_SERVER_NAME_LEN)+1;
+ 
+ 	/* Now work our way through the variable bits */
+@@ -757,7 +757,7 @@ gotenough:
+ 		printf("<<< read() of rest of AFP, %d bytes\n",amount_to_read);
+ 		#endif
+ 		ret = read(server->fd, (void *)
+-		(((unsigned int) server->incoming_buffer)+server->data_read),
++		(((unsigned long) server->incoming_buffer)+server->data_read),
+ 			amount_to_read);
+ 		if (ret<0) return -1;
+ 		if (ret==0) {
+diff -up afpfs-ng-0.8.1/lib/loop.c.pointer afpfs-ng-0.8.1/lib/loop.c
+--- afpfs-ng-0.8.1/lib/loop.c.pointer	2008-02-18 04:40:11.000000000 +0100
++++ afpfs-ng-0.8.1/lib/loop.c	2011-06-14 17:02:15.000000000 +0200
+@@ -25,7 +25,7 @@
+ static unsigned char exit_program=0;
+ 
+ static pthread_t ending_thread;
+-static pthread_t main_thread = NULL;
++static pthread_t main_thread = (pthread_t)NULL;
+ 
+ static int loop_started=0;
+ static pthread_cond_t loop_started_condition;
+diff -up afpfs-ng-0.8.1/lib/lowlevel.c.pointer afpfs-ng-0.8.1/lib/lowlevel.c
+--- afpfs-ng-0.8.1/lib/lowlevel.c.pointer	2008-02-20 02:33:17.000000000 +0100
++++ afpfs-ng-0.8.1/lib/lowlevel.c	2011-06-14 17:02:15.000000000 +0200
+@@ -582,7 +582,7 @@ int ll_getattr(struct afp_volume * volum
+ 	if (volume->server->using_version->av_number>=30)
+ 		stbuf->st_mode |= fp.unixprivs.permissions;
+ 	else
+-		set_nonunix_perms(stbuf,&fp);
++		set_nonunix_perms(&stbuf->st_mode,&fp);
+ 
+ 	stbuf->st_uid=fp.unixprivs.uid;
+ 	stbuf->st_gid=fp.unixprivs.gid;
+diff -up afpfs-ng-0.8.1/lib/midlevel.c.pointer afpfs-ng-0.8.1/lib/midlevel.c
+--- afpfs-ng-0.8.1/lib/midlevel.c.pointer	2008-03-08 17:08:18.000000000 +0100
++++ afpfs-ng-0.8.1/lib/midlevel.c	2011-06-14 17:02:15.000000000 +0200
+@@ -713,7 +713,7 @@ int ml_write(struct afp_volume * volume,
+ {
+ 
+ 	int ret,err=0;
+-	int totalwritten = 0;
++	size_t totalwritten = 0;
+ 	uint64_t sizetowrite, ignored;
+ 	unsigned char flags = 0;
+ 	unsigned int max_packet_size=volume->server->tx_quantum;
+diff -up afpfs-ng-0.8.1/lib/proto_attr.c.pointer afpfs-ng-0.8.1/lib/proto_attr.c
+--- afpfs-ng-0.8.1/lib/proto_attr.c.pointer	2008-01-30 05:37:58.000000000 +0100
++++ afpfs-ng-0.8.1/lib/proto_attr.c	2011-06-14 17:02:15.000000000 +0200
+@@ -166,7 +166,7 @@ int afp_getextattr(struct afp_volume * v
+ 	copy_path(server,p,pathname,strlen(pathname));
+ 	unixpath_to_afppath(server,p);
+ 	p2=p+sizeof_path_header(server)+strlen(pathname);
+-	if (((unsigned int ) p2) & 0x1) p2++;
++	if (((unsigned long) p2) & 0x1) p2++;
+ 	req2=(void *) p2;
+ 
+ 	req2->len=htons(namelen);
+diff -up afpfs-ng-0.8.1/lib/proto_desktop.c.pointer afpfs-ng-0.8.1/lib/proto_desktop.c
+--- afpfs-ng-0.8.1/lib/proto_desktop.c.pointer	2008-02-18 04:44:11.000000000 +0100
++++ afpfs-ng-0.8.1/lib/proto_desktop.c	2011-06-14 17:02:15.000000000 +0200
+@@ -168,7 +168,7 @@ int afp_getcomment_reply(struct afp_serv
+ 	return 0;
+ }
+ 
+-int afp_closedt(struct afp_server * server, unsigned short * refnum) 
++int afp_closedt(struct afp_server * server, unsigned short refnum) 
+ {
+ 	struct {
+ 		struct dsi_header dsi_header __attribute__((__packed__));
+diff -up afpfs-ng-0.8.1/lib/proto_directory.c.pointer afpfs-ng-0.8.1/lib/proto_directory.c
+--- afpfs-ng-0.8.1/lib/proto_directory.c.pointer	2008-02-19 03:39:29.000000000 +0100
++++ afpfs-ng-0.8.1/lib/proto_directory.c	2011-06-14 17:02:15.000000000 +0200
+@@ -248,6 +248,7 @@ int afp_enumerate_reply(struct afp_serve
+ 
+ 	return 0;
+ }
++
+ int afp_enumerateext2_reply(struct afp_server *server, char * buf, unsigned int size, void * other) 
+ {
+ 
+@@ -266,8 +267,7 @@ int afp_enumerateext2_reply(struct afp_s
+ 	char * p = buf + sizeof(*reply);
+ 	int i;
+ 	char  *max=buf+size;
+-	struct afp_file_info * filebase = NULL, *filecur=NULL, *new_file=NULL;
+-	void ** x = other;
++	struct afp_file_info * filebase = NULL, *filecur = NULL, *new_file = NULL, **x = (struct afp_file_info **) other;
+ 
+ 	if (reply->dsi_header.return_code.error_code) {
+ 		return reply->dsi_header.return_code.error_code;
+diff -up afpfs-ng-0.8.1/lib/proto_map.c.pointer afpfs-ng-0.8.1/lib/proto_map.c
+--- afpfs-ng-0.8.1/lib/proto_map.c.pointer	2008-01-30 05:37:59.000000000 +0100
++++ afpfs-ng-0.8.1/lib/proto_map.c	2011-06-14 17:02:15.000000000 +0200
+@@ -122,7 +122,7 @@ int afp_mapid_reply(struct afp_server *s
+ 
+ 	if (reply->header.return_code.error_code!=kFPNoErr) return -1;
+ 
+-	copy_from_pascal_two(name,&reply->name,255);
++	copy_from_pascal_two(name,reply->name,255);
+ 
+ 	return 0;
+ }
+diff -up afpfs-ng-0.8.1/lib/proto_session.c.pointer afpfs-ng-0.8.1/lib/proto_session.c
+--- afpfs-ng-0.8.1/lib/proto_session.c.pointer	2008-02-18 04:46:19.000000000 +0100
++++ afpfs-ng-0.8.1/lib/proto_session.c	2011-06-14 17:02:15.000000000 +0200
+@@ -39,7 +39,7 @@ int afp_getsessiontoken(struct afp_serve
+ 	switch (type) {
+ 	case kLoginWithTimeAndID:
+ 	case kReconnWithTimeAndID: {
+-		uint32_t *p = (void *) (((unsigned int) request)+
++		uint32_t *p = (void *) (((unsigned long) request)+
+ 			sizeof(*request));
+ 
+ 		offset=sizeof(timestamp);
+@@ -63,7 +63,7 @@ int afp_getsessiontoken(struct afp_serve
+ 		goto error;
+ 	}
+ 
+-	data=(void *) (((unsigned int) request)+sizeof(*request)+offset);
++	data=(void *) (((unsigned long) request)+sizeof(*request)+offset);
+ 	request->idlength=htonl(datalen);
+ 	request->pad=0;
+ 	request->type=htons(type);
+@@ -127,7 +127,7 @@ int afp_disconnectoldsession(struct afp_
+ 	if ((request=malloc(sizeof(*request) + AFP_TOKEN_MAX_LEN))==NULL)
+ 		return -1;
+ 
+-	token_data  = request + sizeof(*request);
++	token_data  = (char *)request + sizeof(*request);
+ 
+ 	request->type=htons(type);
+ 
+diff -up afpfs-ng-0.8.1/lib/uams.c.pointer afpfs-ng-0.8.1/lib/uams.c
+--- afpfs-ng-0.8.1/lib/uams.c.pointer	2008-01-04 04:52:44.000000000 +0100
++++ afpfs-ng-0.8.1/lib/uams.c	2011-06-14 17:02:15.000000000 +0200
+@@ -180,7 +180,7 @@ static int cleartxt_login(struct afp_ser
+ 		goto cleartxt_fail;
+ 
+ 	p += copy_to_pascal(p, username) + 1;
+-	if ((int)p & 0x1)
++	if ((long)p & 0x1)
+ 		len--;
+ 	else
+ 		p++;
+@@ -230,7 +230,7 @@ static int cleartxt_passwd(struct afp_se
+ 		goto cleartxt_fail;
+ 
+ 	p += copy_to_pascal(p, username) + 1;
+-	if ((int)p & 0x1)
++	if ((long)p & 0x1)
+ 		len--;
+ 	else
+ 		p++;
+@@ -580,7 +580,7 @@ static int dhx_login(struct afp_server *
+ 	if (ai == NULL)
+ 		goto dhx_noctx_fail;
+ 	d += copy_to_pascal(ai, username) + 1;
+-	if (((int)d) % 2)
++	if (((long)d) % 2)
+ 		d++;
+ 	else
+ 		ai_len--;
+diff -up afpfs-ng-0.8.1/lib/utils.c.pointer afpfs-ng-0.8.1/lib/utils.c
+--- afpfs-ng-0.8.1/lib/utils.c.pointer	2008-02-18 04:53:37.000000000 +0100
++++ afpfs-ng-0.8.1/lib/utils.c	2011-06-14 17:02:15.000000000 +0200
+@@ -196,7 +196,7 @@ int invalid_filename(struct afp_server *
+ 			maxlen=255;
+ 
+ 
+-	p=filename+1;
++	p=(char *)filename+1;
+ 	while ((q=strchr(p,'/'))) {
+ 		if (q>p+maxlen)
+ 			return 1;

--- a/lib/afpfs-ng/04-boxee1.patch
+++ b/lib/afpfs-ng/04-boxee1.patch
@@ -1,0 +1,25 @@
+--- afpfs-ng-0.8.1/include/afpfs-ng/dsi.h	2008-02-18 04:33:24.000000000 +0100
++++ afpfs-ng-0.8.1/include/afpfs-ng/dsi.h	2011-08-26 21:33:33.000000000 +0200
+@@ -6,13 +6,15 @@
+ 
+ struct dsi_request
+ {
+-	unsigned short requestid;
+-	unsigned char subcommand;
+-	void * other;
+-	unsigned char wait;
+-	pthread_cond_t  condition_cond;
+-	struct dsi_request * next;
+-	int return_code;
++        unsigned short requestid;
++        unsigned char subcommand;
++        void * other;
++        int wait;
++        int done_waiting;
++        pthread_cond_t  waiting_cond;
++        pthread_mutex_t waiting_mutex;
++        struct dsi_request * next;
++        int return_code;
+ };
+ 
+ int dsi_receive(struct afp_server * server, void * data, int size);

--- a/lib/afpfs-ng/05-boxee2.patch
+++ b/lib/afpfs-ng/05-boxee2.patch
@@ -1,0 +1,89 @@
+--- afpfs-ng-0.8.1/lib/afp.c	2008-03-08 03:44:16.000000000 +0100
++++ afpfs-ng-0.8.1/lib/afp.c	2011-08-26 21:33:33.000000000 +0200
+@@ -68,7 +68,7 @@
+ 	afp_getsessiontoken_reply,afp_blank_reply, NULL, NULL,
+ 	afp_enumerateext2_reply, NULL, NULL, NULL,    /*64 - 71 */
+ 	afp_listextattrs_reply, NULL, NULL, NULL,
+-	afp_blank_reply, NULL, NULL, NULL,                       /*72 - 79 */
++	afp_blank_reply, NULL, afp_blank_reply, afp_blank_reply,                       /*72 - 79 */
+ 
+ 	NULL, NULL, NULL, NULL,
+ 	NULL, NULL, NULL, NULL,
+@@ -320,8 +320,16 @@
+ 	
+ 	struct dsi_request * p;
+ 	struct afp_server *s2;
++
++
++	if (s==NULL) 
++		goto out;
++
+ 	for (p=s->command_requests;p;p=p->next) {
+-		pthread_cond_signal(&p->condition_cond);
++		pthread_mutex_lock(&p->waiting_mutex);
++		p->done_waiting=1;
++		pthread_cond_signal(&p->waiting_cond);
++		pthread_mutex_unlock(&p->waiting_mutex);
+ 	}
+ 
+ 	if (s==server_base) {
+@@ -354,7 +362,7 @@
+ 	s->exit_flag = 0;
+ 	s->path_encoding=kFPUTF8Name;  /* This is a default */
+ 	s->next=NULL;
+-	s->bufsize=2048;
++	s->bufsize=4096;
+ 	s->incoming_buffer=malloc(s->bufsize);
+ 
+ 	s->attention_quantum=AFP_DEFAULT_ATTENTION_QUANTUM;
+@@ -524,13 +532,14 @@
+ 			kFPVolCreateDateBit|kFPVolIDBit |
+ 			kFPVolNameBit;
+ 	char new_encoding;
++     	int ret;
+ 
+ 	if (server->using_version->av_number>=30) 
+ 		bitmap|= kFPVolNameBit|kFPVolBlockSizeBit;
+ 
+-	switch (afp_volopen(volume,bitmap,
+-		(strlen(volume->volpassword)>0) ? volume->volpassword : NULL)) 
+-	{
++	ret = afp_volopen(volume,bitmap,
++		(strlen(volume->volpassword)>0) ? volume->volpassword : NULL);
++	switch(ret){
+ 	case kFPAccessDenied:
+ 		*l+=snprintf(mesg,max-*l,
+ 			"Incorrect volume password\n");
+@@ -544,6 +553,10 @@
+ 		*l+=snprintf(mesg,max-*l,
+ 			"Could not open volume\n");
+ 		goto error;
++	case ETIMEDOUT:
++		*l+=snprintf(mesg,max-*l,
++			"Timed out waiting to open volume\n");
++		goto error;
+ 	}
+ 
+ 	/* It is said that if a volume's encoding will be the same 
+@@ -641,7 +654,6 @@
+ 	add_server(server);
+ 
+ 	add_fd_and_signal(server->fd);
+-
+ 	if (!full) {
+ 		return 0;
+ 	}
+@@ -649,10 +661,13 @@
+ 	/* Get the status, and calculate the transmit time.  We use this to
+ 	* calculate our rx quantum. */
+ 	gettimeofday(&t1,NULL);
++
+ 	if ((error=dsi_getstatus(server))!=0) 
+ 		goto error;
+ 	gettimeofday(&t2,NULL);
+ 
++        afp_server_identify(server);
++
+ 	if ((t2.tv_sec - t1.tv_sec) > 0)
+ 		server->tx_delay= (t2.tv_sec - t1.tv_sec) * 1000;
+ 	else

--- a/lib/afpfs-ng/06-boxee3.patch
+++ b/lib/afpfs-ng/06-boxee3.patch
@@ -1,0 +1,141 @@
+--- afpfs-ng-0.8.1/lib/dsi.c	2011-08-26 17:27:16.000000000 +0200
++++ afpfs-ng-0.8.1/lib/dsi.c	2011-08-26 21:33:33.000000000 +0200
+@@ -64,7 +64,7 @@
+ 	rx.size=0;
+ 	dsi_setup_header(server,&header,DSI_DSIGetStatus);
+ 	/* We're intentionally ignoring the results */
+-	ret=dsi_send(server,(char *) &header,sizeof(struct dsi_header),20,
++	ret=dsi_send(server,(char *) &header,sizeof(struct dsi_header),60,
+ 		0,(void *) &rx);
+ 
+ 	free(rx.data);
+@@ -197,6 +197,7 @@
+ 	new_request->other=other;
+ 	new_request->wait=wait;
+ 	new_request->next=NULL;
++      	new_request->done_waiting=0;
+ 
+ 	pthread_mutex_lock(&server->request_queue_mutex);
+ 	if (server->command_requests==NULL) {
+@@ -208,7 +209,8 @@
+ 	server->stats.requests_pending++;
+ 	pthread_mutex_unlock(&server->request_queue_mutex);
+ 
+-	pthread_cond_init(&new_request->condition_cond,NULL);
++	pthread_cond_init(&new_request->waiting_cond,NULL);
++	pthread_mutex_init(&new_request->waiting_mutex,NULL);
+ 
+ 	if (server->connect_state==SERVER_STATE_DISCONNECTED) {
+ 		char mesg[1024];
+@@ -240,16 +242,12 @@
+ 	server->stats.tx_bytes+=size;
+ 	pthread_mutex_unlock(&server->send_mutex);
+ 
+-	int tmpwait=new_request->wait;
+ 	#ifdef DEBUG_DSI
+ 	printf("=== Waiting for response for %d %s\n",
+ 		new_request->requestid,
+ 		afp_get_command_name(new_request->subcommand));
+ 	#endif
+-	if (tmpwait<0) {
+-
+-		pthread_mutex_t     mutex = PTHREAD_MUTEX_INITIALIZER;
+-		pthread_mutex_lock(&mutex);
++	if (new_request->wait<0) {
+ 
+ 		/* Wait forever */
+ 		#ifdef DEBUG_DSI
+@@ -258,14 +256,17 @@
+ 			afp_get_command_name(new_request->subcommand));
+ 		#endif
+ 
+-		rc=pthread_cond_wait( 
+-			&new_request->condition_cond, 
+-				&mutex );
+-		pthread_mutex_unlock(&mutex);
+-
+-	} else if (tmpwait>0) {
+-		pthread_mutex_t     mutex = PTHREAD_MUTEX_INITIALIZER;
+-		pthread_mutex_lock(&mutex);
++		pthread_mutex_lock(&new_request->waiting_mutex);
++
++		if (new_request->done_waiting==0)
++			rc=pthread_cond_wait( 
++				&new_request->waiting_cond, 
++					&new_request->waiting_mutex );
++
++		pthread_mutex_unlock(&new_request->waiting_mutex);
++
++	} else if (new_request->wait>0) {
++		/* wait for new_request->wait seconds */
+ 
+ 		#ifdef DEBUG_DSI
+ 		printf("=== Waiting for %d %s, for %ds\n",
+@@ -283,13 +284,15 @@
+ 			printf("=== Changing my mind, no longer waiting for %d\n",
+ 				new_request->requestid);
+ 			#endif
+-			pthread_mutex_unlock(&mutex);
+ 			goto skip;
+ 		}
+-		rc=pthread_cond_timedwait( 
+-			&new_request->condition_cond, 
+-			&mutex,&ts);
+-		pthread_mutex_unlock(&mutex);
++		pthread_mutex_lock(&new_request->waiting_mutex);
++		if (new_request->done_waiting==0) 
++			rc=pthread_cond_timedwait( 
++				&new_request->waiting_cond, 
++				&new_request->waiting_mutex,&ts);
++		pthread_mutex_unlock(&new_request->waiting_mutex);
++
+ 		if (rc==ETIMEDOUT) {
+ /* FIXME: should handle this case properly */
+ 			#ifdef DEBUG_DSI
+@@ -299,6 +302,7 @@
+ 			goto out;
+ 		}
+ 	} else {
++                /* Don't wait */
+ 		#ifdef DEBUG_DSI
+ 		printf("=== Skipping wait altogether for %d\n",new_request->requestid);
+ 		#endif
+@@ -474,7 +478,7 @@
+ 	}
+ 	server->flags=ntohs(reply1->flags);
+ 
+-	p=(void *)((unsigned long) server->incoming_buffer + sizeof(*reply1));
++	p=(void *)((unsigned int) server->incoming_buffer + sizeof(*reply1));
+ 	p+=copy_from_pascal(server->server_name,p,AFP_SERVER_NAME_LEN)+1;
+ 
+ 	/* Now work our way through the variable bits */
+@@ -577,6 +581,7 @@
+ 	unsigned char mins=0;
+ 	unsigned char checkmessage=0;
+ 
++	memset(mesg,0,AFP_LOGINMESG_LEN);
+ 
+ 	/* The logic here's undocumented.  If we get an attention packet and
+ 	   there's no flag, then go check the message.  Also, go check the
+@@ -757,7 +762,7 @@
+ 		printf("<<< read() of rest of AFP, %d bytes\n",amount_to_read);
+ 		#endif
+ 		ret = read(server->fd, (void *)
+-		(((unsigned long) server->incoming_buffer)+server->data_read),
++		(((unsigned int) server->incoming_buffer)+server->data_read),
+ 			amount_to_read);
+ 		if (ret<0) return -1;
+ 		if (ret==0) {
+@@ -862,8 +867,11 @@
+ 			#ifdef DEBUG_DSI
+ 			printf("<<< Signalling %d, returning %d or %d\n",request->requestid,request->return_code,rc);
+ 			#endif
++			pthread_mutex_lock(&request->waiting_mutex);
+ 			request->wait=0;
+-			pthread_cond_signal(&request->condition_cond);
++			request->done_waiting=1;
++			pthread_cond_signal(&request->waiting_cond);
++			pthread_mutex_unlock(&request->waiting_mutex);
+ 		} else {
+ 			dsi_remove_from_request_queue(server,request);
+ 		}

--- a/lib/afpfs-ng/07-boxee4.patch
+++ b/lib/afpfs-ng/07-boxee4.patch
@@ -1,0 +1,27 @@
+--- afpfs-ng-0.8.1/lib/identify.c	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1/lib/identify.c	2011-08-26 21:33:33.000000000 +0200
+@@ -0,0 +1,24 @@
++#include <string.h>
++#include <afpfs-ng/afp.h>
++
++
++/* 
++ * afp_server_identify()
++ *
++ * Identifies a server
++ *
++ * Right now, this only does identification using the machine_type
++ * given in getsrvrinfo, but this could later use mDNS to get 
++ * more details.
++ */
++void afp_server_identify(struct afp_server * s)
++{
++	if (strcmp(s->machine_type,"Netatalk")==0)
++		s->server_type=AFPFS_SERVER_TYPE_NETATALK;
++	else if (strcmp(s->machine_type,"AirPort")==0)
++		s->server_type=AFPFS_SERVER_TYPE_AIRPORT;
++	else if (strcmp(s->machine_type,"Macintosh")==0)
++		s->server_type=AFPFS_SERVER_TYPE_MACINTOSH;
++	else
++		s->server_type=AFPFS_SERVER_TYPE_UNKNOWN;
++}

--- a/lib/afpfs-ng/08-boxee5.patch
+++ b/lib/afpfs-ng/08-boxee5.patch
@@ -1,0 +1,11 @@
+--- afpfs-ng-0.8.1/lib/Makefile.am	2008-02-18 04:34:32.000000000 +0100
++++ afpfs-ng-0.8.1/lib/Makefile.am	2011-08-26 21:33:33.000000000 +0200
+@@ -4,7 +4,7 @@
+ 
+ lib_LTLIBRARIES = libafpclient.la
+ 
+-libafpclient_la_SOURCES = afp.c codepage.c did.c dsi.c map_def.c uams.c uams_def.c unicode.c users.c utils.c resource.c log.c client.c server.c connect.c loop.c midlevel.c proto_attr.c proto_desktop.c proto_directory.c proto_files.c proto_fork.c proto_login.c proto_map.c proto_replyblock.c proto_server.c proto_volume.c proto_session.c afp_url.c status.c forklist.c debug.c lowlevel.c
++libafpclient_la_SOURCES = afp.c codepage.c did.c dsi.c map_def.c uams.c uams_def.c unicode.c users.c utils.c resource.c log.c client.c server.c connect.c loop.c midlevel.c proto_attr.c proto_desktop.c proto_directory.c proto_files.c proto_fork.c proto_login.c proto_map.c proto_replyblock.c proto_server.c proto_volume.c proto_session.c afp_url.c status.c forklist.c debug.c lowlevel.c identify.c
+ 
+ # libafpclient_la_LDFLAGS = -module -avoid-version
+ 

--- a/lib/afpfs-ng/10-fix-errno.patch
+++ b/lib/afpfs-ng/10-fix-errno.patch
@@ -1,0 +1,23 @@
+--- afpfs-ng-0.8.1/lib/afp.c	2011-09-04 19:42:42.000000000 +0200
++++ afpfs-ng-0.8.1/lib/afp.c	2011-09-04 19:39:44.000000000 +0200
+@@ -19,7 +19,6 @@
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+-#include <errno.h>
+ 
+ #include <afpfs-ng/afp_protocol.h>
+ #include <afpfs-ng/libafpclient.h>
+--- afpfs-ng-0.8.1/lib/afp_url.c	2011-09-04 19:42:42.000000000 +0200
++++ afpfs-ng-0.8.1/lib/afp_url.c	2011-09-04 19:40:27.000000000 +0200
+@@ -21,7 +21,9 @@
+ 
+ static int check_port(char * port) 
+ {
+-	long long ret = strtol(port,NULL,10);
++	long long ret = 0;
++	errno = 0;
++	ret = strtol(port,NULL,10);
+ 	if ((ret<0) || (ret>32767)) return -1;
+ 	if (errno) {
+ 		printf("port error\n");

--- a/lib/afpfs-ng/Makefile
+++ b/lib/afpfs-ng/Makefile
@@ -1,0 +1,66 @@
+#  A quick and dirty Makefile to download/build and install
+#
+#  Usage:
+#    make
+#    sudo make install
+
+# lib name, version
+LIBNAME=afpfs-ng
+VERSION=0.8.1
+SOURCE=$(LIBNAME)-$(VERSION)
+
+# download location and format
+BASE_URL=http://mirrors.xbmc.org/build-deps/darwin-libs
+ARCHIVE=$(SOURCE).tar.gz.
+TARBALLS_LOCATION=.
+RETRIEVE_TOOL=/usr/bin/curl
+RETRIEVE_TOOL_FLAGS=-Ls --create-dirs --output $(TARBALLS_LOCATION)/$(ARCHIVE)
+ARCHIVE_TOOL=tar
+ARCHIVE_TOOL_FLAGS=xf
+PREFIX ?= /usr
+AFPFSNG_CONFIGOPTS ?= --prefix=$(PREFIX)
+
+
+ARCHIVE=$(SOURCE).tar.bz2
+
+
+
+# configuration settings
+export PATH:=$(TOOLCHAIN)/bin:$(PATH)
+CONFIGURE=./configure $(AFPFSNG_CONFIGOPTS) \
+  --disable-fuse ac_cv_func_malloc_0_nonnull=yes
+
+SO_NAME=$(SOURCE)/lib/.libs/libafpclient.so
+
+all: $(SO_NAME)
+
+$(TARBALLS_LOCATION)/$(ARCHIVE):
+	$(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
+
+$(SOURCE): $(TARBALLS_LOCATION)/$(ARCHIVE)
+	rm -rf $(SOURCE)
+	$(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	echo $(SOURCE) > .gitignore
+	cd $(SOURCE); patch -p1 <../fix_afpfs-ng_includes.patch
+	cd $(SOURCE); patch -p1 <../01-gcrypt.patch
+	cd $(SOURCE); patch -p1 <../02-pointer.patch
+	cd $(SOURCE); patch -p1 <../04-boxee1.patch
+	cd $(SOURCE); patch -p1 <../05-boxee2.patch
+	cd $(SOURCE); patch -p1 <../06-boxee3.patch
+	cd $(SOURCE); patch -p1 <../07-boxee4.patch
+	cd $(SOURCE); patch -p1 <../08-boxee5.patch
+	cd $(SOURCE); patch -p1 <../10-fix-errno.patch
+	cd $(SOURCE); autoreconf -vif
+	cd $(SOURCE); $(CONFIGURE)
+
+$(SO_NAME): $(SOURCE)
+	make -j 1 -C $(SOURCE)
+
+install:
+	make -C $(SOURCE) install
+
+clean:
+	make -C $(SOURCE) clean
+
+distclean::
+	rm -rf $(SOURCE) $(ARCHIVE)

--- a/lib/afpfs-ng/fix_afpfs-ng_includes.patch
+++ b/lib/afpfs-ng/fix_afpfs-ng_includes.patch
@@ -1,0 +1,3082 @@
+diff -Naur afpfs-ng-0.8.1/cmdline/cmdline_afp.c afpfs-ng-0.8.1.patch/cmdline/cmdline_afp.c
+--- afpfs-ng-0.8.1/cmdline/cmdline_afp.c	2008-02-19 02:54:19.000000000 +0100
++++ afpfs-ng-0.8.1.patch/cmdline/cmdline_afp.c	2011-09-10 12:13:50.102124369 +0200
+@@ -3,9 +3,9 @@
+ 	
+ */
+ 
+-#include "afp.h"
+-#include "midlevel.h"
+-#include "map_def.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/midlevel.h"
++#include "afpfs-ng/map_def.h"
+ 
+ #include <string.h>
+ #include <stdio.h>
+diff -Naur afpfs-ng-0.8.1/cmdline/cmdline_testafp.c afpfs-ng-0.8.1.patch/cmdline/cmdline_testafp.c
+--- afpfs-ng-0.8.1/cmdline/cmdline_testafp.c	2008-03-04 21:16:50.000000000 +0100
++++ afpfs-ng-0.8.1.patch/cmdline/cmdline_testafp.c	2011-09-10 12:13:50.102124369 +0200
+@@ -3,8 +3,8 @@
+ 	
+ */
+ 
+-#include "afp.h"
+-#include "midlevel.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/midlevel.h"
+ 
+ #include "cmdline_main.h"
+ 
+diff -Naur afpfs-ng-0.8.1/cmdline/getstatus.c afpfs-ng-0.8.1.patch/cmdline/getstatus.c
+--- afpfs-ng-0.8.1/cmdline/getstatus.c	2008-02-18 04:28:09.000000000 +0100
++++ afpfs-ng-0.8.1.patch/cmdline/getstatus.c	2011-09-10 12:13:50.109124463 +0200
+@@ -2,7 +2,7 @@
+ #include <string.h>
+ #include <pthread.h>
+ 
+-#include "afp.h"
++#include "afpfs-ng/afp.h"
+ 
+ static int getstatus(char * address_string, unsigned int port)
+ {
+diff -Naur afpfs-ng-0.8.1/configure.ac afpfs-ng-0.8.1.patch/configure.ac
+--- afpfs-ng-0.8.1/configure.ac	2008-03-08 17:23:12.000000000 +0100
++++ afpfs-ng-0.8.1.patch/configure.ac	2011-09-10 12:13:50.109124463 +0200
+@@ -11,6 +11,7 @@
+ AC_PROG_CC
+ AC_PROG_INSTALL
+ AC_PROG_LIBTOOL
++AM_PROG_CC_C_O
+ 
+ # Checks for libraries.
+ # FIXME: Replace `main' with a function in `-lncurses':
+@@ -105,7 +106,7 @@
+ 
+ 
+ 
+-AC_CONFIG_FILES([lib/Makefile fuse/Makefile cmdline/Makefile Makefile docs/Makefile])
++AC_CONFIG_FILES([lib/Makefile fuse/Makefile cmdline/Makefile Makefile include/Makefile include/afpfs-ng/Makefile docs/Makefile])
+ 
+ AC_OUTPUT
+ 
+diff -Naur afpfs-ng-0.8.1/fuse/client.c afpfs-ng-0.8.1.patch/fuse/client.c
+--- afpfs-ng-0.8.1/fuse/client.c	2008-03-08 03:44:16.000000000 +0100
++++ afpfs-ng-0.8.1.patch/fuse/client.c	2011-09-10 12:13:50.110124477 +0200
+@@ -12,11 +12,11 @@
+ #include <grp.h>
+ 
+ #include "config.h"
+-#include <afp.h>
++#include <afpfs-ng/afp.h>
+ #include "afp_server.h"
+-#include "uams_def.h"
+-#include "map_def.h"
+-#include "libafpclient.h"
++#include "afpfs-ng/uams_def.h"
++#include "afpfs-ng/map_def.h"
++#include "afpfs-ng/libafpclient.h"
+ 
+ #define default_uam "Cleartxt Passwrd"
+ 
+diff -Naur afpfs-ng-0.8.1/fuse/commands.c afpfs-ng-0.8.1.patch/fuse/commands.c
+--- afpfs-ng-0.8.1/fuse/commands.c	2008-03-08 17:06:25.000000000 +0100
++++ afpfs-ng-0.8.1.patch/fuse/commands.c	2011-09-10 12:13:50.110124477 +0200
+@@ -19,15 +19,15 @@
+ #include <getopt.h>
+ #include <signal.h>
+ 
+-#include "afp.h"
+-#include "dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/dsi.h"
+ #include "afp_server.h"
+-#include "utils.h"
++#include "afpfs-ng/utils.h"
+ #include "daemon.h"
+-#include "uams_def.h"
+-#include "codepage.h"
+-#include "libafpclient.h"
+-#include "map_def.h"
++#include "afpfs-ng/uams_def.h"
++#include "afpfs-ng/codepage.h"
++#include "afpfs-ng/libafpclient.h"
++#include "afpfs-ng/map_def.h"
+ #include "fuse_int.h"
+ #include "fuse_error.h"
+ #include "fuse_internal.h"
+diff -Naur afpfs-ng-0.8.1/fuse/daemon.c afpfs-ng-0.8.1.patch/fuse/daemon.c
+--- afpfs-ng-0.8.1/fuse/daemon.c	2008-03-04 18:26:05.000000000 +0100
++++ afpfs-ng-0.8.1.patch/fuse/daemon.c	2011-09-10 12:13:50.110124477 +0200
+@@ -23,11 +23,11 @@
+ #include <signal.h>
+ #include <sys/socket.h>
+ 
+-#include "afp.h"
++#include "afpfs-ng/afp.h"
+ 
+-#include "dsi.h"
++#include "afpfs-ng/dsi.h"
+ #include "afp_server.h"
+-#include "utils.h"
++#include "afpfs-ng/utils.h"
+ #include "daemon.h"
+ #include "commands.h"
+ 
+diff -Naur afpfs-ng-0.8.1/fuse/fuse_error.c afpfs-ng-0.8.1.patch/fuse/fuse_error.c
+--- afpfs-ng-0.8.1/fuse/fuse_error.c	2008-01-18 05:40:10.000000000 +0100
++++ afpfs-ng-0.8.1.patch/fuse/fuse_error.c	2011-09-10 12:13:50.111124491 +0200
+@@ -4,7 +4,7 @@
+ #include <unistd.h>
+ #include <string.h>
+ #include <stdio.h>
+-#include "libafpclient.h"
++#include "afpfs-ng/libafpclient.h"
+ #include "fuse_internal.h"
+ 
+ #define TMP_FILE "/tmp/fuse_stderr"
+diff -Naur afpfs-ng-0.8.1/fuse/fuse_int.c afpfs-ng-0.8.1.patch/fuse/fuse_int.c
+--- afpfs-ng-0.8.1/fuse/fuse_int.c	2008-03-02 06:06:24.000000000 +0100
++++ afpfs-ng-0.8.1.patch/fuse/fuse_int.c	2011-09-10 12:13:50.111124491 +0200
+@@ -18,7 +18,7 @@
+ #define FUSE_USE_VERSION 25
+ 
+ 
+-#include "afp.h"
++#include "afpfs-ng/afp.h"
+ 
+ #include <fuse.h>
+ #include <stdio.h>
+@@ -39,10 +39,10 @@
+ #include <pwd.h>
+ #include <stdarg.h>
+ 
+-#include "dsi.h"
+-#include "afp_protocol.h"
+-#include "codepage.h"
+-#include "midlevel.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp_protocol.h"
++#include "afpfs-ng/codepage.h"
++#include "afpfs-ng/midlevel.h"
+ #include "fuse_error.h"
+ 
+ /* Uncomment the following line to enable full debugging: */
+diff -Naur afpfs-ng-0.8.1/include/afpfs-ng/afp.h afpfs-ng-0.8.1.patch/include/afpfs-ng/afp.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/afp.h	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afpfs-ng/afp.h	2011-09-10 12:13:50.112124505 +0200
+@@ -0,0 +1,533 @@
++
++#ifndef _AFP_H_
++#define _AFP_H_
++
++#include <arpa/inet.h>
++#include <pthread.h>
++#include <netdb.h>
++#include <sys/statvfs.h>
++#include <pwd.h>
++#include <afpfs-ng/afp_protocol.h>
++#include <afpfs-ng/libafpclient.h>
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <unistd.h>
++#include <netinet/in.h>
++
++
++#define AFPFS_VERSION "0.8.1"
++
++/* This is the maximum AFP version this library supports */
++#define AFP_MAX_SUPPORTED_VERSION 32
++
++/* afp_url is used to pass locations around */
++struct afp_url {
++	enum {TCPIP,AT} protocol;
++	char username[AFP_MAX_USERNAME_LEN];
++	char uamname[50];
++	char password[AFP_MAX_PASSWORD_LEN];
++	char servername[AFP_SERVER_NAME_UTF8_LEN];
++	int port;
++	char volumename[AFP_VOLUME_NAME_UTF8_LEN];
++	char path[AFP_MAX_PATH];
++
++	int requested_version;
++	char zone[AFP_ZONE_LEN]; /* Only used for Appletalk */
++	char volpassword[9];;
++};
++
++struct afp_token {
++	unsigned int length;
++	char data[AFP_TOKEN_MAX_LEN];
++};
++
++#define SERVER_MAX_VERSIONS 10
++#define SERVER_MAX_UAMS 10
++
++struct afp_rx_buffer {
++	unsigned int size;
++	unsigned int maxsize;
++	char * data;
++	int errorcode;
++};
++
++
++struct afp_file_info {
++	unsigned short attributes;
++	unsigned int did;
++	unsigned int creation_date;
++	unsigned int modification_date;
++	unsigned int backup_date;
++	unsigned int fileid;
++	unsigned short offspring;
++	char sync;
++	char finderinfo[32];
++	char name[AFP_MAX_PATH];
++	char basename[AFP_MAX_PATH];
++	char translated_name[AFP_MAX_PATH];
++	struct afp_unixprivs unixprivs;
++	unsigned int accessrights;
++	struct afp_file_info * next;
++	struct afp_file_info * largelist_next;
++	unsigned char isdir;
++	unsigned long long size;
++	unsigned short resourcesize;
++	unsigned int resource;
++	unsigned short forkid;
++	struct afp_icon * icon;
++	int eof;
++};
++
++
++#define VOLUME_EXTRA_FLAGS_VOL_CHMOD_KNOWN 0x1
++#define VOLUME_EXTRA_FLAGS_VOL_CHMOD_BROKEN 0x2
++#define VOLUME_EXTRA_FLAGS_SHOW_APPLEDOUBLE 0x4
++#define VOLUME_EXTRA_FLAGS_VOL_SUPPORTS_UNIX 0x8
++#define VOLUME_EXTRA_FLAGS_NO_LOCKING 0x10
++#define VOLUME_EXTRA_FLAGS_IGNORE_UNIXPRIVS 0x20
++#define VOLUME_EXTRA_FLAGS_READONLY 0x40
++
++#define AFP_VOLUME_UNMOUNTED 0
++#define AFP_VOLUME_MOUNTED 1
++#define AFP_VOLUME_UNMOUNTING 2
++
++struct afp_volume {
++	unsigned short volid;
++	char flags;  /* This is from afpGetSrvrParms */
++	unsigned short attributes; /* This is from VolOpen */
++	unsigned short signature;  /* This is fixed or variable */
++	unsigned int creation_date;
++	unsigned int modification_date;
++	unsigned int backup_date;
++	struct statvfs stat;
++	unsigned char mounted;
++	char mountpoint[255];
++	struct afp_server * server;
++	char volume_name[AFP_VOLUME_NAME_LEN];
++	char volume_name_printable[AFP_VOLUME_NAME_UTF8_LEN];
++	unsigned short dtrefnum;
++	char volpassword[AFP_VOLPASS_LEN];
++	unsigned int extra_flags; /* This is an afpfs-ng specific field */
++
++	/* Our directory ID cache */
++	struct did_cache_entry * did_cache_base;
++	pthread_mutex_t did_cache_mutex;
++
++	/* Our journal of open forks */
++	struct afp_file_info * open_forks;
++	pthread_mutex_t open_forks_mutex;
++
++	/* Used to trigger startup */
++        pthread_cond_t  startup_condition_cond;
++
++	struct {
++		uint64_t hits;
++		uint64_t misses;
++		uint64_t expired;
++		uint64_t force_removed;
++	} did_cache_stats;
++
++	void * priv;  /* This is a private structure for fuse/cmdline, etc */
++	pthread_t thread; /* This is the per-volume thread */
++
++	int mapping;
++
++};
++
++#define SERVER_STATE_CONNECTED 1
++#define SERVER_STATE_DISCONNECTED 2
++
++enum server_type{
++	AFPFS_SERVER_TYPE_UNKNOWN,
++	AFPFS_SERVER_TYPE_NETATALK,
++	AFPFS_SERVER_TYPE_AIRPORT,
++	AFPFS_SERVER_TYPE_MACINTOSH,
++};
++
++#define is_netatalk(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_NETATALK )
++#define is_airport(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_AIRPORT )
++#define is_macintosh(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_MACINTOSH )
++
++
++
++struct afp_versions {
++        char        *av_name;
++        int         av_number;
++};
++extern struct afp_versions afp_versions[];
++
++struct afp_server {
++
++	/* Our buffer sizes */
++	unsigned int tx_quantum;
++	unsigned int rx_quantum;
++
++	unsigned int tx_delay;
++
++	/* Connection information */
++	struct sockaddr_in address;
++	int fd;
++
++	/* Some stats, for information only */
++	struct {
++		uint64_t runt_packets;
++		uint64_t incoming_dsi;
++		uint64_t rx_bytes;
++		uint64_t tx_bytes;
++		uint64_t requests_pending;
++	} stats;
++
++	/* General information */
++	char server_name[AFP_SERVER_NAME_LEN];
++	char server_name_utf8[AFP_SERVER_NAME_UTF8_LEN];
++        char server_name_printable[AFP_SERVER_NAME_UTF8_LEN];
++
++	char machine_type[17];
++	char icon[256];
++	char signature[16];
++	unsigned short flags;
++	int connect_state;
++	enum server_type server_type;
++
++	/* This is the time we connected */
++	time_t connect_time;
++
++	/* UAMs */
++	unsigned int supported_uams;
++	unsigned int using_uam;
++
++	/* Authentication */
++	char username[AFP_MAX_USERNAME_LEN];
++	char password[AFP_MAX_PASSWORD_LEN];
++
++	/* Session */
++	struct afp_token token;
++	char need_resume;
++
++	/* Versions */
++	unsigned char requested_version;
++	unsigned char versions[SERVER_MAX_VERSIONS];
++	struct afp_versions *using_version;
++
++	/* Volumes */
++	unsigned char num_volumes;
++	struct afp_volume * volumes;
++
++	void * dsi;
++	unsigned int exit_flag;
++
++	/* Our DSI request queue */
++	pthread_mutex_t requestid_mutex;
++	pthread_mutex_t request_queue_mutex;
++	unsigned short lastrequestid;
++	unsigned short expectedrequestid;
++	struct dsi_request * command_requests;
++
++
++	char loginmesg[200];
++	char servermesg[200];
++	char path_encoding;
++
++	/* This is the data for the incoming buffer */
++	char * incoming_buffer;
++	int data_read;
++	int bufsize;
++
++	/* And this is for the outgoing queue */
++	pthread_mutex_t send_mutex;
++
++	/* This is for user mapping */
++	struct passwd passwd;
++	unsigned int server_uid, server_gid;
++	int server_gid_valid;
++
++	struct afp_server *next;
++
++	/* These are for DSI attention packets */
++	unsigned int attention_quantum;
++	unsigned int attention_len;
++	char * attention_buffer;
++
++};
++
++struct afp_extattr_info {
++	unsigned int maxsize;
++	unsigned int size;
++	char data[1024];
++};
++struct afp_comment {
++	unsigned int maxsize;
++	unsigned int size;
++	char *data;
++};
++
++struct afp_icon {
++	unsigned int maxsize;
++	unsigned int size;
++	char *data;
++};
++
++#define AFP_DEFAULT_ATTENTION_QUANTUM 1024
++
++void afp_unixpriv_to_stat(struct afp_file_info *fp,
++	struct stat *stat);
++
++int init_uams(void) ;
++
++unsigned int find_uam_by_name(const char * name);
++char * uam_bitmap_to_string(unsigned int bitmap);
++
++
++char * get_uam_names_list(void);
++
++unsigned int default_uams_mask(void);
++
++struct afp_volume * find_volume_by_name(struct afp_server * server,
++        const char * volname);
++
++struct afp_connection_request {
++        unsigned int uam_mask;
++	struct afp_url url;
++};
++
++void afp_default_url(struct afp_url *url);
++int afp_parse_url(struct afp_url * url, const char * toparse, int verbose);
++void afp_print_url(struct afp_url * url);
++int afp_url_validate(char * url_string, struct afp_url * valid_url);
++
++int afp_list_volnames(struct afp_server * server, char * names, int max);
++
++/* User mapping */
++int afp_detect_mapping(struct afp_volume * volume);
++
++/* These are some functions that help with simple status text generation */
++
++int afp_status_header(char * text, int * len);
++int afp_status_server(struct afp_server * s,char * text, int * len);
++
++
++struct afp_server * afp_server_full_connect(void * priv, struct afp_connection_request * req);
++
++void * just_end_it_now(void *other);
++void add_fd_and_signal(int fd);
++void loop_disconnect(struct afp_server *s);
++void afp_wait_for_started_loop(void);
++
++
++struct afp_versions * pick_version(unsigned char *versions,
++	unsigned char requested) ;
++int pick_uam(unsigned int u1, unsigned int u2);
++
++int afp_server_login(struct afp_server *server,
++        char * mesg, unsigned int *l, unsigned int max);
++
++
++int afp_dologin(struct afp_server *server,
++	unsigned int uam, char * username, char * passwd);
++
++void afp_free_server(struct afp_server **server);
++
++struct afp_server * afp_server_init(struct sockaddr_in * address);
++int afp_get_address(void * priv, const char * hostname, unsigned int port,
++	struct sockaddr_in * address);
++
++
++int afp_main_loop(int command_fd);
++int afp_main_quick_startup(pthread_t * thread);
++
++int afp_server_destroy(struct afp_server *s) ;
++int afp_server_reconnect(struct afp_server * s, char * mesg,
++        unsigned int *l, unsigned int max);
++int afp_server_connect(struct afp_server *s, int full);
++
++struct afp_server * afp_server_complete_connection(
++	void * priv,
++	struct afp_server * server,
++	struct sockaddr_in * address, unsigned char * versions,
++	unsigned int uams, char * username, char * password,
++	unsigned int requested_version, unsigned int uam_mask);
++
++int afp_connect_volume(struct afp_volume * volume, struct afp_server * server,
++	char * mesg, unsigned int * l, unsigned int max);
++int something_is_mounted(struct afp_server * server);
++
++int add_cache_entry(struct afp_file_info * file) ;
++struct afp_file_info * get_cache_by_name(char * name);
++struct afp_server * find_server_by_address(struct sockaddr_in * address);
++struct afp_server * find_server_by_signature(char * signature);
++struct afp_server * find_server_by_name(char * name);
++int server_still_valid(struct afp_server * server);
++
++
++struct afp_server * get_server_base(void);
++int afp_server_remove(struct afp_server * server);
++
++int afp_unmount_volume(struct afp_volume * volume);
++int afp_unmount_all_volumes(struct afp_server * server);
++
++#define volume_is_readonly(x) (((x)->attributes&kReadOnly) || \
++	((x)->extra_flags & VOLUME_EXTRA_FLAGS_READONLY))
++
++int afp_opendt(struct afp_volume *volume, unsigned short * refnum);
++
++int afp_closedt(struct afp_server * server, unsigned short * refnum);
++
++int afp_getcomment(struct afp_volume *volume, unsigned int did,
++        const char * pathname, struct afp_comment * comment);
++
++int afp_addcomment(struct afp_volume *volume, unsigned int did,
++        const char * pathname, char * comment,uint64_t *size);
++
++int afp_geticon(struct afp_volume * volume, unsigned int filecreator,
++        unsigned int filetype, unsigned char icontype, 
++	unsigned short length, struct afp_icon * icon);
++
++/* Things you want to do to a server */
++
++int afp_getsrvrmsg(struct afp_server *server, unsigned short messagetype,unsigned char utf8, unsigned char block, char * mesg);
++
++int afp_login(struct afp_server *server, char * uaname,
++        char * userauthinfo, unsigned int userauthinfo_len,
++	struct afp_rx_buffer *rx);
++
++int afp_changepassword(struct afp_server *server, char * uaname,
++        char * userauthinfo, unsigned int userauthinfo_len,
++	struct afp_rx_buffer *rx);
++
++int afp_logincont(struct afp_server *server, unsigned short id,
++        char * userauthinfo, unsigned int userauthinfo_len,
++	struct afp_rx_buffer *rx);
++
++int afp_getsessiontoken(struct afp_server * server, int type,
++        unsigned int timestamp, struct afp_token *outgoing_token,
++        struct afp_token * incoming_token);
++
++int afp_getsrvrparms(struct afp_server *server);
++
++int afp_logout(struct afp_server *server,unsigned char wait);
++
++int afp_mapname(struct afp_server * server, unsigned char subfunction,
++        char * name, unsigned int * id);
++
++int afp_mapid(struct afp_server * server, unsigned char subfunction,
++	unsigned int id, char *name);
++
++int afp_getuserinfo(struct afp_server * server, int thisuser,
++	unsigned int userid, unsigned short bitmap, 
++	unsigned int *newuid, unsigned int *newgid);
++
++int afp_zzzzz(struct afp_server *server);
++
++int afp_volopen(struct afp_volume * volume, 
++		unsigned short bitmap, char * password);
++
++int afp_flush(struct afp_volume * volume);
++
++int afp_getfiledirparms(struct afp_volume *volume, unsigned int did, 
++	unsigned int filebitmap, unsigned int dirbitmap, const char * pathname,
++	struct afp_file_info *fp);
++
++int afp_enumerate(struct afp_volume * volume, 
++	unsigned int dirid, 
++	unsigned int filebitmap, unsigned int dirbitmap, 
++        unsigned short reqcount,
++        unsigned short startindex,
++        char * path,
++	struct afp_file_info ** file_p);
++
++int afp_enumerateext2(struct afp_volume * volume, 
++	unsigned int dirid, 
++	unsigned int filebitmap, unsigned int dirbitmap, 
++        unsigned short reqcount,
++        unsigned long startindex,
++        char * path,
++	struct afp_file_info ** file_p);
++
++int afp_openfork(struct afp_volume * volume,
++        unsigned char forktype,
++        unsigned int dirid,
++        unsigned short accessmode,
++        char * filename, 
++	struct afp_file_info *fp);
++
++int afp_read(struct afp_volume * volume, unsigned short forkid,
++                uint32_t offset,
++                uint32_t count, struct afp_rx_buffer * rx);
++
++int afp_readext(struct afp_volume * volume, unsigned short forkid,
++                uint64_t offset,
++                uint64_t count, struct afp_rx_buffer * rx);
++
++int afp_getvolparms(struct afp_volume * volume, unsigned short bitmap);
++
++
++int afp_createdir(struct afp_volume * volume, unsigned int dirid, const char * pathname, unsigned int *did_p);
++
++int afp_delete(struct afp_volume * volume,
++        unsigned int dirid, char * pathname);
++
++
++int afp_createfile(struct afp_volume * volume, unsigned char flag,
++        unsigned int did, char * pathname);
++
++int afp_write(struct afp_volume * volume, unsigned short forkid,
++        uint32_t offset, uint32_t reqcount,
++        char * data, uint32_t * written);
++
++int afp_writeext(struct afp_volume * volume, unsigned short forkid,
++        uint64_t offset, uint64_t reqcount,
++        char * data, uint64_t * written);
++
++int afp_flushfork(struct afp_volume * volume, unsigned short forkid);
++
++int afp_closefork(struct afp_volume * volume, unsigned short forkid);
++int afp_setfileparms(struct afp_volume * volume,
++        unsigned int dirid, const char * pathname, unsigned short bitmap,
++        struct afp_file_info *fp);
++int afp_setfiledirparms(struct afp_volume * volume, 
++        unsigned int dirid, const char * pathname, unsigned short bitmap,
++        struct afp_file_info *fp);
++
++int afp_setdirparms(struct afp_volume * volume,
++        unsigned int dirid, const char * pathname, unsigned short bitmap,
++        struct afp_file_info *fp);
++
++int afp_volclose(struct afp_volume * volume);
++
++
++int afp_setforkparms(struct afp_volume *volume,
++        unsigned short forkid, unsigned short bitmap, unsigned long len);
++
++int afp_byterangelock(struct afp_volume * volume,
++        unsigned char flag,
++        unsigned short forkid,
++        uint32_t offset,
++        uint32_t len, uint32_t *generated_offset);
++
++int afp_byterangelockext(struct afp_volume * volume,
++        unsigned char flag,
++        unsigned short forkid,
++        uint64_t offset,
++        uint64_t len, uint64_t *generated_offset);
++
++int afp_moveandrename(struct afp_volume *volume,
++	unsigned int src_did,
++	unsigned int dst_did,
++	char * src_path, char * dst_path, char *new_name);
++
++int afp_rename(struct afp_volume * volume,
++        unsigned int dirid,
++        char * path_from, char * path_to);
++
++int afp_listextattr(struct afp_volume * volume,
++        unsigned int dirid, unsigned short bitmap,
++        char * pathname, struct afp_extattr_info * info);
++
++/* This is a currently undocumented command */
++int afp_newcommand76(struct afp_volume * volume, unsigned int dlen, char * data);
++
++/* For debugging */
++char * afp_get_command_name(char code);
++
++
++#endif
+diff -Naur afpfs-ng-0.8.1/include/afpfs-ng/afp_protocol.h afpfs-ng-0.8.1.patch/include/afpfs-ng/afp_protocol.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/afp_protocol.h	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afpfs-ng/afp_protocol.h	2011-09-10 12:13:50.112124505 +0200
+@@ -0,0 +1,361 @@
++
++#ifndef _AFP_PROTOCOL_H_
++#define _AFP_PROTOCOL_H_
++
++#include <sys/types.h>
++#include <stddef.h>
++#include <unistd.h>
++#include <stdint.h>
++
++/* This file defines constants for the Apple File Protocol.
++   All page references are from "Apple Filing Protocol Programming" version 3.2.
++   except where noted.
++*/
++
++#define AFP_SERVER_NAME_LEN 33
++#define AFP_SERVER_NAME_UTF8_LEN 255
++#define AFP_VOLUME_NAME_LEN 33
++#define AFP_VOLUME_NAME_UTF8_LEN 33
++#define AFP_SIGNATURE_LEN 16
++#define AFP_MACHINETYPE_LEN 33
++#define AFP_LOGINMESG_LEN 200
++#define AFP_VOLPASS_LEN 8
++#define AFP_HOSTNAME_LEN 255
++/* This is actually just a guess, and only used for appletalk */
++#define AFP_ZONE_LEN 255
++
++#define AFP_SERVER_ICON_LEN 256
++
++
++#define AFP_MAX_USERNAME_LEN 127
++#define AFP_MAX_PASSWORD_LEN 127
++
++
++/* This is the maximum length of any UAM string */
++#define AFP_UAM_LENGTH 24
++
++/* This is the maximum length of any path description */
++#define AFP_MAX_PATH 768
++
++#define AFP_VOL_FLAT 1
++#define AFP_VOL_FIXED 2
++#define AFP_VOL_VARIABLE 3
++
++/* The root directory ID, p.26 */
++
++#define AFP_ROOT_DID 2
++
++/* Path type constants, p.249 */
++
++enum {
++kFPShortName = 1,
++kFPLongName = 2,
++kFPUTF8Name = 3
++};
++
++/* fork types */
++
++#define AFP_FORKTYPE_DATA 0x0
++#define AFP_FORKTYPE_RESOURCE 0x80
++
++/* openfork access modes, from p.196 */
++
++#define AFP_OPENFORK_ALLOWREAD 1
++#define AFP_OPENFORK_ALLOWWRITE 2
++#define AFP_OPENFORK_DENYREAD 0x10
++#define AFP_OPENFORK_DENYWRITE 0x20
++
++/* Message type for getsrvmesg, p. 169*/
++
++typedef enum {
++  AFPMESG_LOGIN = 0,
++  AFPMESG_SERVER = 1
++} afpmessage_t;
++
++/* Message bitmap for getsrvrmsg */
++
++#define AFP_GETSRVRMSG_UTF8 0x2
++#define AFP_GETSRVRMSG_GETMSG 0x1
++
++
++/* Maximum Version length, p.17 */
++#define AFP_MAX_VERSION_LENGTH 16
++
++/* Maximum length of a token, this is undocumented */
++#define AFP_TOKEN_MAX_LEN 256
++
++/* The maximum size of a file for AFP 2 */
++#define AFP_MAX_AFP2_FILESIZE (4294967296)
++
++/* Unix privs, p.240 */
++
++struct afp_unixprivs {
++	uint32_t uid __attribute__((__packed__));
++	uint32_t gid __attribute__((__packed__));
++	uint32_t permissions __attribute__((__packed__));
++	uint32_t ua_permissions __attribute__((__packed__));
++
++};
++
++
++/* AFP Volume attributes bitmap, p.241 */
++
++enum {
++    kReadOnly = 0x01,
++    kHasVolumePassword = 0x02,
++    kSupportsFileIDs = 0x04,
++    kSupportsCatSearch = 0x08,
++    kSupportsBlankAccessPrivs = 0x10,
++    kSupportsUnixPrivs = 0x20,
++    kSupportsUTF8Names = 0x40,
++    kNoNetworkUserIDs = 0x80,
++    kDefaultPrivsFromParent = 0x100,
++    kNoExchangeFiles = 0x200,
++    kSupportsExtAttrs = 0x400,
++    kSupportsACLs=0x800
++};
++
++/* AFP file creation constantes, p.250 */
++enum {
++kFPSoftCreate = 0,
++kFPHardCreate = 0x80
++};
++
++/* AFP Directory attributes, taken from the protocol guide p.236 */
++
++enum {
++    kFPAttributeBit = 0x1,
++    kFPParentDirIDBit = 0x2,
++    kFPCreateDateBit = 0x4,
++    kFPModDateBit = 0x8,
++    kFPBackupDateBit = 0x10,
++    kFPFinderInfoBit = 0x20,
++    kFPLongNameBit = 0x40,
++    kFPShortNameBit = 0x80,
++    kFPNodeIDBit = 0x100,
++    kFPOffspringCountBit = 0x0200,
++    kFPOwnerIDBit = 0x0400,
++    kFPGroupIDBit = 0x0800,
++    kFPAccessRightsBit = 0x1000,
++    kFPProDOSInfoBit = 0x2000, // AFP version 2.2 and earlier
++    kFPUTF8NameBit = 0x2000, // AFP version 3.0 and later
++    kFPUnixPrivsBit = 0x8000 // AFP version 3.0 and later
++};
++
++/* AFP File bitmap, p.238.  These are the ones not in the AFP Directory
++   attributes map. */
++
++enum {
++	kFPDataForkLenBit = 0x0200,
++	kFPRsrcForkLenBit = 0x0400,
++	kFPExtDataForkLenBit = 0x0800, // AFP version 3.0 and later
++	kFPLaunchLimitBit = 0x1000,
++	kFPExtRsrcForkLenBit = 0x4000, // AFP version 3.0 and later
++};
++
++/* AFP Extended Attributes Bitmap, p.238  */
++
++enum {
++	kXAttrNoFollow = 0x1,
++	kXAttrCreate = 0x2,
++	kXAttrREplace=0x4
++};
++
++
++/* AFP function codes */
++enum AFPFunction
++{
++        afpByteRangeLock = 1, afpCloseVol, afpCloseDir, afpCloseFork,
++        afpCopyFile, afpCreateDir, afpCreateFile,
++        afpDelete, afpEnumerate, afpFlush, afpFlushFork,
++        afpGetForkParms = 14, afpGetSrvrInfo, afpGetSrvrParms,
++        afpGetVolParms, afpLogin, afpLoginCont, afpLogout, afpMapID,
++        afpMapName, afpMoveAndRename, afpOpenVol, afpOpenDir, afpOpenFork,
++        afpRead, afpRename, afpSetDirParms, afpSetFileParms,
++        afpSetForkParms, afpSetVolParms, afpWrite, afpGetFileDirParms,
++	afpSetFileDirParms, afpChangePassword,
++        afpGetUserInfo=37,afpGetSrvrMsg = 38,
++	afpOpenDT=48,
++	afpCloseDT=49,
++	afpGetIcon=51, afpGetIconInfo=52,
++	afpAddComment=56, afpRemoveComment=57, afpGetComment=58,
++	afpByteRangeLockExt=59, afpReadExt, afpWriteExt,
++	afpGetAuthMethods=62,
++	afp_LoginExt=63,
++	afpGetSessionToken=64,
++	afpDisconnectOldSession=65,
++	afpEnumerateExt=66,
++	afpCatSearchExt = 67,
++	afpEnumerateExt2 = 68, afpGetExtAttr, afpSetExtAttr, 
++	afpRemoveExtAttr , afpListExtAttrs,
++	afpZzzzz = 122,
++	afpAddIcon=192,
++};
++
++/* AFP Volume bitmap.  Take from 242 of the protocol guide. */
++enum {
++	kFPBadVolPre222Bitmap = 0xFe00,
++	kFPBadVolBitmap = 0xF000,
++	kFPVolAttributeBit = 0x1,
++	kFPVolSignatureBit = 0x2,
++	kFPVolCreateDateBit = 0x4,
++	kFPVolModDateBit = 0x8,
++	kFPVolBackupDateBit = 0x10,
++	kFPVolIDBit = 0x20,
++	kFPVolBytesFreeBit = 0x40,
++	kFPVolBytesTotalBit = 0x80,
++	kFPVolNameBit = 0x100,
++	kFPVolExtBytesFreeBit = 0x200,
++	kFPVolExtBytesTotalBit = 0x400,
++	kFPVolBlockSizeBit = 0x800
++};
++
++/* AFP Attention Codes -- 4 bits */
++#define AFPATTN_SHUTDOWN     (1 << 15)            /* shutdown/disconnect */
++#define AFPATTN_CRASH        (1 << 14)            /* server crashed */
++#define AFPATTN_MESG         (1 << 13)            /* server has message */
++#define AFPATTN_NORECONNECT  (1 << 12)            /* don't reconnect */
++/* server notification */
++#define AFPATTN_NOTIFY       (AFPATTN_MESG | AFPATTN_NORECONNECT) 
++
++/* extended bitmap -- 12 bits. volchanged is only useful w/ a server
++ * notification, and time is only useful for shutdown. */
++#define AFPATTN_VOLCHANGED   (1 << 0)             /* volume has changed */
++#define AFPATTN_TIME(x)      ((x) & 0xfff)        /* time in minutes */
++
++#define kFPNoErr 0
++
++/* AFP result codes, p252 */
++#define kASPSessClosed -1072
++#define kFPAccessDenied -5000
++#define kFPAuthContinue -5001
++#define kFPBadUAM -5002
++#define kFPBadVersNum -5003
++#define kFPBitmapErr -5004
++#define kFPCantMove -5005
++#define kFPDenyConflict -5006
++#define kFPDirNotEmpty -5007
++#define kFPDiskFull -5008
++#define kFPEOFErr -5009
++#define kFPFileBusy -5010
++#define kFPFlatVol -5011
++#define kFPItemNotFound -5012
++#define kFPLockErr -5013
++#define kFPMiscErr -5014
++#define kFPNoMoreLocks -5015
++#define kFPNoServer -5016
++#define kFPObjectExists -5017
++#define kFPObjectNotFound -5018
++#define kFPParamErr -5019
++#define kFPRangeNotLocked -5020
++#define kFPRangeOverlap -5021
++#define kFPSessClosed -5022
++#define kFPUserNotAuth -5023
++#define kFPCallNotSupported -5024
++#define kFPObjectTypeErr -5025
++#define kFPTooManyFilesOpen -5026
++#define kFPServerGoingDown -5027
++#define kFPCantRename -5028
++#define kFPDirNotFound -5029
++#define kFPIconTypeError -5030
++#define kFPVolLocked -5031
++#define kFPObjectLocked -5032
++#define kFPContainsSharedErr -5033
++#define kFPIDNotFound -5034
++#define kFPIDExists -5035
++#define kFPDiffVolErr  -5036
++#define kFPCatalogChanged -5037
++#define kFPSameObjectErr -5038
++#define kFPBadIDErr -5039
++#define kFPPwdSameErr -5040
++#define kFPPwdTooShortErr -5041
++#define kFPPwdExpiredErr -5042
++#define kFPInsideSharedErr -5043
++#define kFPInsideTrashErr -5044
++#define kFPPwdNeedsChangeErr -5045
++#define kFPPwdPolicyErr -5046
++#define kFPDiskQuotaExceeded –5047 
++
++
++
++/* These flags determine to lock or unlock in ByteRangeLock(Ext) */
++
++enum {
++ByteRangeLock_Lock = 0,
++ByteRangeLock_Unlock = 1
++};
++
++/* These flags are used in volopen and getsrvrparm replies, p.171 */
++
++#define HasConfigInfo 0x1
++#define HasPassword 0x80
++
++/* These are the subfunction for kFPMapID, as per p.248 */
++
++enum {
++kUserIDToName = 1,
++kGroupIDToName = 2,
++kUserIDToUTF8Name = 3,
++kGroupIDToUTF8Name = 4,
++kUserUUIDToUTF8Name = 5,
++kGroupUUIDToUTF8Name = 6
++};
++
++
++/* These are the subfunction flags described in the FPMapName command, p.286.
++   Note that this is different than what's described on p. 186. */
++
++enum {
++kNameToUserID = 1,
++kNameToGroupID = 2,
++kUTF8NameToUserID = 3,
++kUTF8NameToGroupID = 4,
++kUTF8NameToUserUUID = 5,
++kUTF8NameToGroupUUID = 6
++};
++
++/* These are bits for FPGetUserInfo, p.173. */
++#define kFPGetUserInfo_USER_ID 1
++#define kFPGetUserInfo_PRI_GROUPID 2
++
++/* Flags for the replies of GetSrvrInfo and DSI GetStatus, p.240 */
++
++enum {
++	kSupportsCopyfile = 0x01,
++	kSupportsChgPwd = 0x02,
++	kDontAllowSavePwd = 0x04,
++	kSupportsSrvrMsg = 0x08,
++	kSrvrSig = 0x10,
++	kSupportsTCP = 0x20,
++	kSupportsSrvrNotify = 0x40,
++	kSupportsReconnect = 0x80,
++	kSupportsDirServices = 0x100,
++	kSupportsUTF8SrvrName = 0x200,
++	kSupportsUUIDs = 0x400,
++	kSupportsSuperClient = 0x8000
++};
++
++
++/* p.247 */
++
++enum {
++	kLoginWithoutID = 0,
++	kLoginWithID = 1,
++	kReconnWithID = 2,
++	kLoginWithTimeAndID = 3,
++	kReconnWithTimeAndID = 4,
++	kRecon1Login = 5,
++	kRecon1ReconnectLogin = 6,
++	kRecon1Refresh = 7, kGetKerberosSessionKey = 8
++};
++
++
++#define AFP_CHMOD_ALLOWED_BITS_22 \
++	(S_IRUSR |S_IWUSR | S_IRGRP | S_IWGRP |S_IROTH | S_IWOTH | S_IFREG )
++
++
++#endif
++
++
++
++
+diff -Naur afpfs-ng-0.8.1/include/afpfs-ng/codepage.h afpfs-ng-0.8.1.patch/include/afpfs-ng/codepage.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/codepage.h	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afpfs-ng/codepage.h	2011-09-10 12:13:50.113124518 +0200
+@@ -0,0 +1,11 @@
++#ifndef __CODE_PAGE_H_
++#define __CODE_PAGE_H_
++int convert_utf8dec_to_utf8pre(const char *src, int src_len,
++	char * dest, int dest_len);
++int convert_utf8pre_to_utf8dec(const char * src, int src_len, 
++	char * dest, int dest_len);
++int convert_path_to_unix(char encoding, char * dest, 
++	char * src, int dest_len);
++int convert_path_to_afp(char encoding, char * dest, 
++	char * src, int dest_len);
++#endif
+diff -Naur afpfs-ng-0.8.1/include/afpfs-ng/dsi.h afpfs-ng-0.8.1.patch/include/afpfs-ng/dsi.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/dsi.h	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afpfs-ng/dsi.h	2011-09-10 12:13:50.115124544 +0200
+@@ -0,0 +1,33 @@
++
++#ifndef __DSI_H_
++#define __DSI_H_
++
++#include "afpfs-ng/afp.h"
++
++struct dsi_request
++{
++	unsigned short requestid;
++	unsigned char subcommand;
++	void * other;
++	unsigned char wait;
++	pthread_cond_t  condition_cond;
++	struct dsi_request * next;
++	int return_code;
++};
++
++int dsi_receive(struct afp_server * server, void * data, int size);
++int dsi_getstatus(struct afp_server * server);
++
++int dsi_opensession(struct afp_server *server);
++
++int dsi_send(struct afp_server *server, char * msg, int size,int wait,unsigned char subcommand, void ** other);
++struct dsi_session * dsi_create(struct afp_server *server);
++int dsi_restart(struct afp_server *server);
++int dsi_recv(struct afp_server * server);
++
++#define DSI_BLOCK_TIMEOUT -1
++#define DSI_DONT_WAIT 0
++#define DSI_DEFAULT_TIMEOUT 5
++
++
++#endif
+diff -Naur afpfs-ng-0.8.1/include/afpfs-ng/libafpclient.h afpfs-ng-0.8.1.patch/include/afpfs-ng/libafpclient.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/libafpclient.h	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afpfs-ng/libafpclient.h	2011-09-10 12:13:50.115124544 +0200
+@@ -0,0 +1,50 @@
++
++#ifndef __CLIENT_H_
++#define __CLIENT_H_
++
++#include <unistd.h>
++#include <syslog.h>
++
++#define MAX_CLIENT_RESPONSE 2048
++
++
++enum loglevels {
++        AFPFSD,
++};
++
++struct afp_server;
++struct afp_volume;
++
++struct libafpclient {
++        int (*unmount_volume) (struct afp_volume * volume);
++	void (*log_for_client)(void * priv,
++        	enum loglevels loglevel, int logtype, const char *message);
++	void (*forced_ending_hook)(void);
++	int (*scan_extra_fds)(int command_fd,fd_set *set, int * max_fd);
++	void (*loop_started)(void);
++} ;
++
++extern struct libafpclient * libafpclient;
++
++void libafpclient_register(struct libafpclient * tmpclient);
++
++
++void signal_main_thread(void);
++
++/* These are logging functions */
++
++#define MAXLOGSIZE 2048
++
++#define LOG_METHOD_SYSLOG 1
++#define LOG_METHOD_STDOUT 2
++
++void set_log_method(int m);
++
++
++void log_for_client(void * priv,
++        enum loglevels loglevel, int logtype, char * message,...);
++
++void stdout_log_for_client(void * priv,
++	enum loglevels loglevel, int logtype, const char *message);
++
++#endif
+diff -Naur afpfs-ng-0.8.1/include/afpfs-ng/Makefile.am afpfs-ng-0.8.1.patch/include/afpfs-ng/Makefile.am
+--- afpfs-ng-0.8.1/include/afpfs-ng/Makefile.am	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afpfs-ng/Makefile.am	2011-09-10 12:13:50.115124544 +0200
+@@ -0,0 +1,6 @@
++## Process this file with automake to produce Makefile.in
++
++afpfsincludedir = $(includedir)/afpfs-ng
++
++afpfsinclude_HEADERS = afp.h afp_protocol.h libafpclient.h
++nodist_afpfsinclude_HEADERS =  codepage.h dsi.h  map_def.h midlevel.h uams_def.h utils.h
+diff -Naur afpfs-ng-0.8.1/include/afpfs-ng/map_def.h afpfs-ng-0.8.1.patch/include/afpfs-ng/map_def.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/map_def.h	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afpfs-ng/map_def.h	2011-09-10 12:13:50.116124557 +0200
+@@ -0,0 +1,15 @@
++#ifndef __MAP_H_
++#define __MAP_H_
++
++#include "afpfs-ng/afp.h"
++
++#define AFP_MAPPING_UNKNOWN 0
++#define AFP_MAPPING_COMMON 1
++#define AFP_MAPPING_LOGINIDS 2
++#define AFP_MAPPING_NAME 3
++
++unsigned int map_string_to_num(char * name);
++char * get_mapping_name(struct afp_volume * volume);
++
++
++#endif
+diff -Naur afpfs-ng-0.8.1/include/afpfs-ng/midlevel.h afpfs-ng-0.8.1.patch/include/afpfs-ng/midlevel.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/midlevel.h	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afpfs-ng/midlevel.h	2011-09-10 12:13:50.116124557 +0200
+@@ -0,0 +1,64 @@
++#ifndef __MIDLEVEL_H_
++#define __MIDLEVEL_H_ 
++
++#include <utime.h>
++#include "afpfs-ng/afp.h"
++
++int ml_open(struct afp_volume * volume, const char *path, int flags, 
++        struct afp_file_info **newfp);
++
++int ml_creat(struct afp_volume * volume, const char *path,mode_t mode);
++
++int ml_readdir(struct afp_volume * volume, 
++	const char *path, 
++	struct afp_file_info **base);
++
++int ml_read(struct afp_volume * volume, const char *path,
++	char *buf, size_t size, off_t offset,
++	struct afp_file_info *fp, int * eof);
++
++int ml_chmod(struct afp_volume * vol, const char * path, mode_t mode);
++
++int ml_unlink(struct afp_volume * vol, const char *path);
++
++int ml_mkdir(struct afp_volume * vol, const char * path, mode_t mode);
++
++int ml_close(struct afp_volume * volume, const char * path,
++        struct afp_file_info * fp);
++
++int ml_getattr(struct afp_volume * volume, const char *path, 
++	struct stat *stbuf);
++
++int ml_write(struct afp_volume * volume, const char * path, 
++	const char *data, size_t size, off_t offset,
++	struct afp_file_info * fp, uid_t uid,
++	gid_t gid);
++
++int ml_readlink(struct afp_volume * vol, const char * path,
++        char *buf, size_t size);
++
++int ml_rmdir(struct afp_volume * vol, const char *path);
++
++int ml_chown(struct afp_volume * vol, const char * path,   
++        uid_t uid, gid_t gid);
++
++int ml_truncate(struct afp_volume * vol, const char * path, off_t offset);
++
++int ml_utime(struct afp_volume * vol, const char * path,
++	struct utimbuf * timebuf);
++
++int ml_symlink(struct afp_volume *vol, const char * path1, const char * path2);
++
++int ml_rename(struct afp_volume * vol,
++	const char * path_from, const char * path_to);
++
++int ml_statfs(struct afp_volume * vol, const char *path, struct statvfs *stat);
++
++void afp_ml_filebase_free(struct afp_file_info **filebase);
++
++int ml_passwd(struct afp_server *server,
++                char * username, char * oldpasswd, char * newpasswd);
++
++
++
++#endif
+diff -Naur afpfs-ng-0.8.1/include/afpfs-ng/uams_def.h afpfs-ng-0.8.1.patch/include/afpfs-ng/uams_def.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/uams_def.h	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afpfs-ng/uams_def.h	2011-09-10 12:13:50.116124557 +0200
+@@ -0,0 +1,16 @@
++#ifndef __UAM_DEFS_H_
++#define __UAM_DEFS_H_
++
++#define UAM_NOUSERAUTHENT 0x1
++#define UAM_CLEARTXTPASSWRD 0x2
++#define UAM_RANDNUMEXCHANGE 0x4
++#define UAM_2WAYRANDNUM 0x8
++#define UAM_DHCAST128 0x10
++#define UAM_CLIENTKRB 0x20
++#define UAM_DHX2 0x40
++#define UAM_RECON1 0x80
++
++int uam_string_to_bitmap(char * name);
++char * uam_bitmap_to_string(unsigned int bitmap);
++
++#endif
+diff -Naur afpfs-ng-0.8.1/include/afpfs-ng/utils.h afpfs-ng-0.8.1.patch/include/afpfs-ng/utils.h
+--- afpfs-ng-0.8.1/include/afpfs-ng/utils.h	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afpfs-ng/utils.h	2011-09-10 12:13:50.116124557 +0200
+@@ -0,0 +1,43 @@
++#ifndef __UTILS_H_
++#define __UTILS_H_
++#include <stdio.h>
++
++#include "afpfs-ng/afp.h"
++
++#if BYTE_ORDER == BIG_ENDIAN
++#define hton64(x)       (x)
++#define ntoh64(x)       (x)
++#else /* BYTE_ORDER == BIG_ENDIAN */
++#define hton64(x)       ((u_int64_t) (htonl(((x) >> 32) & 0xffffffffLL)) | \
++                         (u_int64_t) ((htonl(x) & 0xffffffffLL) << 32))
++#define ntoh64(x)       (hton64(x))
++#endif /* BYTE_ORDER == BIG_ENDIAN */
++
++#define min(a,b) (((a)<(b)) ? (a) : (b))
++#define max(a,b) (((a)>(b)) ? (a) : (b))
++
++
++
++unsigned char unixpath_to_afppath(
++        struct afp_server * server,
++        char * buf);
++
++unsigned char sizeof_path_header(struct afp_server * server);
++
++
++
++unsigned char copy_from_pascal(char *dest, char *pascal,unsigned int max_len) ;
++unsigned short copy_from_pascal_two(char *dest, char *pascal,unsigned int max_len);
++
++unsigned char copy_to_pascal(char *dest, const char *src);
++unsigned short copy_to_pascal_two(char *dest, const char *src);
++
++void copy_path(struct afp_server * server, char * dest, const char * pathname, unsigned char len);
++
++
++char * create_path(struct afp_server * server, char * pathname, unsigned short * len);
++
++
++int invalid_filename(struct afp_server * server, const char * filename);
++
++#endif
+diff -Naur afpfs-ng-0.8.1/include/afp.h afpfs-ng-0.8.1.patch/include/afp.h
+--- afpfs-ng-0.8.1/include/afp.h	2008-03-08 17:08:18.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afp.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,533 +0,0 @@
+-
+-#ifndef _AFP_H_
+-#define _AFP_H_
+-
+-#include <arpa/inet.h>
+-#include <pthread.h>
+-#include <netdb.h>
+-#include <sys/statvfs.h>
+-#include <pwd.h>
+-#include <afp_protocol.h>
+-#include <libafpclient.h>
+-#include <sys/types.h>
+-#include <sys/stat.h>
+-#include <unistd.h>
+-#include <netinet/in.h>
+-
+-
+-#define AFPFS_VERSION "0.8.1"
+-
+-/* This is the maximum AFP version this library supports */
+-#define AFP_MAX_SUPPORTED_VERSION 32
+-
+-/* afp_url is used to pass locations around */
+-struct afp_url {
+-	enum {TCPIP,AT} protocol;
+-	char username[AFP_MAX_USERNAME_LEN];
+-	char uamname[50];
+-	char password[AFP_MAX_PASSWORD_LEN];
+-	char servername[AFP_SERVER_NAME_UTF8_LEN];
+-	int port;
+-	char volumename[AFP_VOLUME_NAME_UTF8_LEN];
+-	char path[AFP_MAX_PATH];
+-
+-	int requested_version;
+-	char zone[AFP_ZONE_LEN]; /* Only used for Appletalk */
+-	char volpassword[9];;
+-};
+-
+-struct afp_token {
+-	unsigned int length;
+-	char data[AFP_TOKEN_MAX_LEN];
+-};
+-
+-#define SERVER_MAX_VERSIONS 10
+-#define SERVER_MAX_UAMS 10
+-
+-struct afp_rx_buffer {
+-	unsigned int size;
+-	unsigned int maxsize;
+-	char * data;
+-	int errorcode;
+-};
+-
+-
+-struct afp_file_info {
+-	unsigned short attributes;
+-	unsigned int did;
+-	unsigned int creation_date;
+-	unsigned int modification_date;
+-	unsigned int backup_date;
+-	unsigned int fileid;
+-	unsigned short offspring;
+-	char sync;
+-	char finderinfo[32];
+-	char name[AFP_MAX_PATH];
+-	char basename[AFP_MAX_PATH];
+-	char translated_name[AFP_MAX_PATH];
+-	struct afp_unixprivs unixprivs;
+-	unsigned int accessrights;
+-	struct afp_file_info * next;
+-	struct afp_file_info * largelist_next;
+-	unsigned char isdir;
+-	unsigned long long size;
+-	unsigned short resourcesize;
+-	unsigned int resource;
+-	unsigned short forkid;
+-	struct afp_icon * icon;
+-	int eof;
+-};
+-
+-
+-#define VOLUME_EXTRA_FLAGS_VOL_CHMOD_KNOWN 0x1
+-#define VOLUME_EXTRA_FLAGS_VOL_CHMOD_BROKEN 0x2
+-#define VOLUME_EXTRA_FLAGS_SHOW_APPLEDOUBLE 0x4
+-#define VOLUME_EXTRA_FLAGS_VOL_SUPPORTS_UNIX 0x8
+-#define VOLUME_EXTRA_FLAGS_NO_LOCKING 0x10
+-#define VOLUME_EXTRA_FLAGS_IGNORE_UNIXPRIVS 0x20
+-#define VOLUME_EXTRA_FLAGS_READONLY 0x40
+-
+-#define AFP_VOLUME_UNMOUNTED 0
+-#define AFP_VOLUME_MOUNTED 1
+-#define AFP_VOLUME_UNMOUNTING 2
+-
+-struct afp_volume {
+-	unsigned short volid;
+-	char flags;  /* This is from afpGetSrvrParms */
+-	unsigned short attributes; /* This is from VolOpen */
+-	unsigned short signature;  /* This is fixed or variable */
+-	unsigned int creation_date;
+-	unsigned int modification_date;
+-	unsigned int backup_date;
+-	struct statvfs stat;
+-	unsigned char mounted;
+-	char mountpoint[255];
+-	struct afp_server * server;
+-	char volume_name[AFP_VOLUME_NAME_LEN];
+-	char volume_name_printable[AFP_VOLUME_NAME_UTF8_LEN];
+-	unsigned short dtrefnum;
+-	char volpassword[AFP_VOLPASS_LEN];
+-	unsigned int extra_flags; /* This is an afpfs-ng specific field */
+-
+-	/* Our directory ID cache */
+-	struct did_cache_entry * did_cache_base;
+-	pthread_mutex_t did_cache_mutex;
+-
+-	/* Our journal of open forks */
+-	struct afp_file_info * open_forks;
+-	pthread_mutex_t open_forks_mutex;
+-
+-	/* Used to trigger startup */
+-        pthread_cond_t  startup_condition_cond;
+-
+-	struct {
+-		uint64_t hits;
+-		uint64_t misses;
+-		uint64_t expired;
+-		uint64_t force_removed;
+-	} did_cache_stats;
+-
+-	void * priv;  /* This is a private structure for fuse/cmdline, etc */
+-	pthread_t thread; /* This is the per-volume thread */
+-
+-	int mapping;
+-
+-};
+-
+-#define SERVER_STATE_CONNECTED 1
+-#define SERVER_STATE_DISCONNECTED 2
+-
+-enum server_type{
+-	AFPFS_SERVER_TYPE_UNKNOWN,
+-	AFPFS_SERVER_TYPE_NETATALK,
+-	AFPFS_SERVER_TYPE_AIRPORT,
+-	AFPFS_SERVER_TYPE_MACINTOSH,
+-};
+-
+-#define is_netatalk(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_NETATALK )
+-#define is_airport(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_AIRPORT )
+-#define is_macintosh(x) ( (x)->machine_type == AFPFS_SERVER_TYPE_MACINTOSH )
+-
+-
+-
+-struct afp_versions {
+-        char        *av_name;
+-        int         av_number;
+-};
+-extern struct afp_versions afp_versions[];
+-
+-struct afp_server {
+-
+-	/* Our buffer sizes */
+-	unsigned int tx_quantum;
+-	unsigned int rx_quantum;
+-
+-	unsigned int tx_delay;
+-
+-	/* Connection information */
+-	struct sockaddr_in address;
+-	int fd;
+-
+-	/* Some stats, for information only */
+-	struct {
+-		uint64_t runt_packets;
+-		uint64_t incoming_dsi;
+-		uint64_t rx_bytes;
+-		uint64_t tx_bytes;
+-		uint64_t requests_pending;
+-	} stats;
+-
+-	/* General information */
+-	char server_name[AFP_SERVER_NAME_LEN];
+-	char server_name_utf8[AFP_SERVER_NAME_UTF8_LEN];
+-        char server_name_printable[AFP_SERVER_NAME_UTF8_LEN];
+-
+-	char machine_type[17];
+-	char icon[256];
+-	char signature[16];
+-	unsigned short flags;
+-	int connect_state;
+-	enum server_type server_type;
+-
+-	/* This is the time we connected */
+-	time_t connect_time;
+-
+-	/* UAMs */
+-	unsigned int supported_uams;
+-	unsigned int using_uam;
+-
+-	/* Authentication */
+-	char username[AFP_MAX_USERNAME_LEN];
+-	char password[AFP_MAX_PASSWORD_LEN];
+-
+-	/* Session */
+-	struct afp_token token;
+-	char need_resume;
+-
+-	/* Versions */
+-	unsigned char requested_version;
+-	unsigned char versions[SERVER_MAX_VERSIONS];
+-	struct afp_versions *using_version;
+-
+-	/* Volumes */
+-	unsigned char num_volumes;
+-	struct afp_volume * volumes;
+-
+-	void * dsi;
+-	unsigned int exit_flag;
+-
+-	/* Our DSI request queue */
+-	pthread_mutex_t requestid_mutex;
+-	pthread_mutex_t request_queue_mutex;
+-	unsigned short lastrequestid;
+-	unsigned short expectedrequestid;
+-	struct dsi_request * command_requests;
+-
+-
+-	char loginmesg[200];
+-	char servermesg[200];
+-	char path_encoding;
+-
+-	/* This is the data for the incoming buffer */
+-	char * incoming_buffer;
+-	int data_read;
+-	int bufsize;
+-
+-	/* And this is for the outgoing queue */
+-	pthread_mutex_t send_mutex;
+-
+-	/* This is for user mapping */
+-	struct passwd passwd;
+-	unsigned int server_uid, server_gid;
+-	int server_gid_valid;
+-
+-	struct afp_server *next;
+-
+-	/* These are for DSI attention packets */
+-	unsigned int attention_quantum;
+-	unsigned int attention_len;
+-	char * attention_buffer;
+-
+-};
+-
+-struct afp_extattr_info {
+-	unsigned int maxsize;
+-	unsigned int size;
+-	char data[1024];
+-};
+-struct afp_comment {
+-	unsigned int maxsize;
+-	unsigned int size;
+-	char *data;
+-};
+-
+-struct afp_icon {
+-	unsigned int maxsize;
+-	unsigned int size;
+-	char *data;
+-};
+-
+-#define AFP_DEFAULT_ATTENTION_QUANTUM 1024
+-
+-void afp_unixpriv_to_stat(struct afp_file_info *fp,
+-	struct stat *stat);
+-
+-int init_uams(void) ;
+-
+-unsigned int find_uam_by_name(const char * name);
+-char * uam_bitmap_to_string(unsigned int bitmap);
+-
+-
+-char * get_uam_names_list(void);
+-
+-unsigned int default_uams_mask(void);
+-
+-struct afp_volume * find_volume_by_name(struct afp_server * server,
+-        const char * volname);
+-
+-struct afp_connection_request {
+-        unsigned int uam_mask;
+-	struct afp_url url;
+-};
+-
+-void afp_default_url(struct afp_url *url);
+-int afp_parse_url(struct afp_url * url, const char * toparse, int verbose);
+-void afp_print_url(struct afp_url * url);
+-int afp_url_validate(char * url_string, struct afp_url * valid_url);
+-
+-int afp_list_volnames(struct afp_server * server, char * names, int max);
+-
+-/* User mapping */
+-int afp_detect_mapping(struct afp_volume * volume);
+-
+-/* These are some functions that help with simple status text generation */
+-
+-int afp_status_header(char * text, int * len);
+-int afp_status_server(struct afp_server * s,char * text, int * len);
+-
+-
+-struct afp_server * afp_server_full_connect(void * priv, struct afp_connection_request * req);
+-
+-void * just_end_it_now(void *other);
+-void add_fd_and_signal(int fd);
+-void loop_disconnect(struct afp_server *s);
+-void afp_wait_for_started_loop(void);
+-
+-
+-struct afp_versions * pick_version(unsigned char *versions,
+-	unsigned char requested) ;
+-int pick_uam(unsigned int u1, unsigned int u2);
+-
+-int afp_server_login(struct afp_server *server,
+-        char * mesg, unsigned int *l, unsigned int max);
+-
+-
+-int afp_dologin(struct afp_server *server,
+-	unsigned int uam, char * username, char * passwd);
+-
+-void afp_free_server(struct afp_server **server);
+-
+-struct afp_server * afp_server_init(struct sockaddr_in * address);
+-int afp_get_address(void * priv, const char * hostname, unsigned int port,
+-	struct sockaddr_in * address);
+-
+-
+-int afp_main_loop(int command_fd);
+-int afp_main_quick_startup(pthread_t * thread);
+-
+-int afp_server_destroy(struct afp_server *s) ;
+-int afp_server_reconnect(struct afp_server * s, char * mesg,
+-        unsigned int *l, unsigned int max);
+-int afp_server_connect(struct afp_server *s, int full);
+-
+-struct afp_server * afp_server_complete_connection(
+-	void * priv,
+-	struct afp_server * server,
+-	struct sockaddr_in * address, unsigned char * versions,
+-	unsigned int uams, char * username, char * password,
+-	unsigned int requested_version, unsigned int uam_mask);
+-
+-int afp_connect_volume(struct afp_volume * volume, struct afp_server * server,
+-	char * mesg, unsigned int * l, unsigned int max);
+-int something_is_mounted(struct afp_server * server);
+-
+-int add_cache_entry(struct afp_file_info * file) ;
+-struct afp_file_info * get_cache_by_name(char * name);
+-struct afp_server * find_server_by_address(struct sockaddr_in * address);
+-struct afp_server * find_server_by_signature(char * signature);
+-struct afp_server * find_server_by_name(char * name);
+-int server_still_valid(struct afp_server * server);
+-
+-
+-struct afp_server * get_server_base(void);
+-int afp_server_remove(struct afp_server * server);
+-
+-int afp_unmount_volume(struct afp_volume * volume);
+-int afp_unmount_all_volumes(struct afp_server * server);
+-
+-#define volume_is_readonly(x) (((x)->attributes&kReadOnly) || \
+-	((x)->extra_flags & VOLUME_EXTRA_FLAGS_READONLY))
+-
+-int afp_opendt(struct afp_volume *volume, unsigned short * refnum);
+-
+-int afp_closedt(struct afp_server * server, unsigned short * refnum);
+-
+-int afp_getcomment(struct afp_volume *volume, unsigned int did,
+-        const char * pathname, struct afp_comment * comment);
+-
+-int afp_addcomment(struct afp_volume *volume, unsigned int did,
+-        const char * pathname, char * comment,uint64_t *size);
+-
+-int afp_geticon(struct afp_volume * volume, unsigned int filecreator,
+-        unsigned int filetype, unsigned char icontype, 
+-	unsigned short length, struct afp_icon * icon);
+-
+-/* Things you want to do to a server */
+-
+-int afp_getsrvrmsg(struct afp_server *server, unsigned short messagetype,unsigned char utf8, unsigned char block, char * mesg);
+-
+-int afp_login(struct afp_server *server, char * uaname,
+-        char * userauthinfo, unsigned int userauthinfo_len,
+-	struct afp_rx_buffer *rx);
+-
+-int afp_changepassword(struct afp_server *server, char * uaname,
+-        char * userauthinfo, unsigned int userauthinfo_len,
+-	struct afp_rx_buffer *rx);
+-
+-int afp_logincont(struct afp_server *server, unsigned short id,
+-        char * userauthinfo, unsigned int userauthinfo_len,
+-	struct afp_rx_buffer *rx);
+-
+-int afp_getsessiontoken(struct afp_server * server, int type,
+-        unsigned int timestamp, struct afp_token *outgoing_token,
+-        struct afp_token * incoming_token);
+-
+-int afp_getsrvrparms(struct afp_server *server);
+-
+-int afp_logout(struct afp_server *server,unsigned char wait);
+-
+-int afp_mapname(struct afp_server * server, unsigned char subfunction,
+-        char * name, unsigned int * id);
+-
+-int afp_mapid(struct afp_server * server, unsigned char subfunction,
+-	unsigned int id, char *name);
+-
+-int afp_getuserinfo(struct afp_server * server, int thisuser,
+-	unsigned int userid, unsigned short bitmap, 
+-	unsigned int *newuid, unsigned int *newgid);
+-
+-int afp_zzzzz(struct afp_server *server);
+-
+-int afp_volopen(struct afp_volume * volume, 
+-		unsigned short bitmap, char * password);
+-
+-int afp_flush(struct afp_volume * volume);
+-
+-int afp_getfiledirparms(struct afp_volume *volume, unsigned int did, 
+-	unsigned int filebitmap, unsigned int dirbitmap, const char * pathname,
+-	struct afp_file_info *fp);
+-
+-int afp_enumerate(struct afp_volume * volume, 
+-	unsigned int dirid, 
+-	unsigned int filebitmap, unsigned int dirbitmap, 
+-        unsigned short reqcount,
+-        unsigned short startindex,
+-        char * path,
+-	struct afp_file_info ** file_p);
+-
+-int afp_enumerateext2(struct afp_volume * volume, 
+-	unsigned int dirid, 
+-	unsigned int filebitmap, unsigned int dirbitmap, 
+-        unsigned short reqcount,
+-        unsigned long startindex,
+-        char * path,
+-	struct afp_file_info ** file_p);
+-
+-int afp_openfork(struct afp_volume * volume,
+-        unsigned char forktype,
+-        unsigned int dirid,
+-        unsigned short accessmode,
+-        char * filename, 
+-	struct afp_file_info *fp);
+-
+-int afp_read(struct afp_volume * volume, unsigned short forkid,
+-                uint32_t offset,
+-                uint32_t count, struct afp_rx_buffer * rx);
+-
+-int afp_readext(struct afp_volume * volume, unsigned short forkid,
+-                uint64_t offset,
+-                uint64_t count, struct afp_rx_buffer * rx);
+-
+-int afp_getvolparms(struct afp_volume * volume, unsigned short bitmap);
+-
+-
+-int afp_createdir(struct afp_volume * volume, unsigned int dirid, const char * pathname, unsigned int *did_p);
+-
+-int afp_delete(struct afp_volume * volume,
+-        unsigned int dirid, char * pathname);
+-
+-
+-int afp_createfile(struct afp_volume * volume, unsigned char flag,
+-        unsigned int did, char * pathname);
+-
+-int afp_write(struct afp_volume * volume, unsigned short forkid,
+-        uint32_t offset, uint32_t reqcount,
+-        char * data, uint32_t * written);
+-
+-int afp_writeext(struct afp_volume * volume, unsigned short forkid,
+-        uint64_t offset, uint64_t reqcount,
+-        char * data, uint64_t * written);
+-
+-int afp_flushfork(struct afp_volume * volume, unsigned short forkid);
+-
+-int afp_closefork(struct afp_volume * volume, unsigned short forkid);
+-int afp_setfileparms(struct afp_volume * volume,
+-        unsigned int dirid, const char * pathname, unsigned short bitmap,
+-        struct afp_file_info *fp);
+-int afp_setfiledirparms(struct afp_volume * volume, 
+-        unsigned int dirid, const char * pathname, unsigned short bitmap,
+-        struct afp_file_info *fp);
+-
+-int afp_setdirparms(struct afp_volume * volume,
+-        unsigned int dirid, const char * pathname, unsigned short bitmap,
+-        struct afp_file_info *fp);
+-
+-int afp_volclose(struct afp_volume * volume);
+-
+-
+-int afp_setforkparms(struct afp_volume *volume,
+-        unsigned short forkid, unsigned short bitmap, unsigned long len);
+-
+-int afp_byterangelock(struct afp_volume * volume,
+-        unsigned char flag,
+-        unsigned short forkid,
+-        uint32_t offset,
+-        uint32_t len, uint32_t *generated_offset);
+-
+-int afp_byterangelockext(struct afp_volume * volume,
+-        unsigned char flag,
+-        unsigned short forkid,
+-        uint64_t offset,
+-        uint64_t len, uint64_t *generated_offset);
+-
+-int afp_moveandrename(struct afp_volume *volume,
+-	unsigned int src_did,
+-	unsigned int dst_did,
+-	char * src_path, char * dst_path, char *new_name);
+-
+-int afp_rename(struct afp_volume * volume,
+-        unsigned int dirid,
+-        char * path_from, char * path_to);
+-
+-int afp_listextattr(struct afp_volume * volume,
+-        unsigned int dirid, unsigned short bitmap,
+-        char * pathname, struct afp_extattr_info * info);
+-
+-/* This is a currently undocumented command */
+-int afp_newcommand76(struct afp_volume * volume, unsigned int dlen, char * data);
+-
+-/* For debugging */
+-char * afp_get_command_name(char code);
+-
+-
+-#endif
+diff -Naur afpfs-ng-0.8.1/include/afp_protocol.h afpfs-ng-0.8.1.patch/include/afp_protocol.h
+--- afpfs-ng-0.8.1/include/afp_protocol.h	2008-02-18 04:33:43.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/afp_protocol.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,361 +0,0 @@
+-
+-#ifndef _AFP_PROTOCOL_H_
+-#define _AFP_PROTOCOL_H_
+-
+-#include <sys/types.h>
+-#include <stddef.h>
+-#include <unistd.h>
+-#include <stdint.h>
+-
+-/* This file defines constants for the Apple File Protocol.
+-   All page references are from "Apple Filing Protocol Programming" version 3.2.
+-   except where noted.
+-*/
+-
+-#define AFP_SERVER_NAME_LEN 33
+-#define AFP_SERVER_NAME_UTF8_LEN 255
+-#define AFP_VOLUME_NAME_LEN 33
+-#define AFP_VOLUME_NAME_UTF8_LEN 33
+-#define AFP_SIGNATURE_LEN 16
+-#define AFP_MACHINETYPE_LEN 33
+-#define AFP_LOGINMESG_LEN 200
+-#define AFP_VOLPASS_LEN 8
+-#define AFP_HOSTNAME_LEN 255
+-/* This is actually just a guess, and only used for appletalk */
+-#define AFP_ZONE_LEN 255
+-
+-#define AFP_SERVER_ICON_LEN 256
+-
+-
+-#define AFP_MAX_USERNAME_LEN 127
+-#define AFP_MAX_PASSWORD_LEN 127
+-
+-
+-/* This is the maximum length of any UAM string */
+-#define AFP_UAM_LENGTH 24
+-
+-/* This is the maximum length of any path description */
+-#define AFP_MAX_PATH 768
+-
+-#define AFP_VOL_FLAT 1
+-#define AFP_VOL_FIXED 2
+-#define AFP_VOL_VARIABLE 3
+-
+-/* The root directory ID, p.26 */
+-
+-#define AFP_ROOT_DID 2
+-
+-/* Path type constants, p.249 */
+-
+-enum {
+-kFPShortName = 1,
+-kFPLongName = 2,
+-kFPUTF8Name = 3
+-};
+-
+-/* fork types */
+-
+-#define AFP_FORKTYPE_DATA 0x0
+-#define AFP_FORKTYPE_RESOURCE 0x80
+-
+-/* openfork access modes, from p.196 */
+-
+-#define AFP_OPENFORK_ALLOWREAD 1
+-#define AFP_OPENFORK_ALLOWWRITE 2
+-#define AFP_OPENFORK_DENYREAD 0x10
+-#define AFP_OPENFORK_DENYWRITE 0x20
+-
+-/* Message type for getsrvmesg, p. 169*/
+-
+-typedef enum {
+-  AFPMESG_LOGIN = 0,
+-  AFPMESG_SERVER = 1
+-} afpmessage_t;
+-
+-/* Message bitmap for getsrvrmsg */
+-
+-#define AFP_GETSRVRMSG_UTF8 0x2
+-#define AFP_GETSRVRMSG_GETMSG 0x1
+-
+-
+-/* Maximum Version length, p.17 */
+-#define AFP_MAX_VERSION_LENGTH 16
+-
+-/* Maximum length of a token, this is undocumented */
+-#define AFP_TOKEN_MAX_LEN 256
+-
+-/* The maximum size of a file for AFP 2 */
+-#define AFP_MAX_AFP2_FILESIZE (4294967296)
+-
+-/* Unix privs, p.240 */
+-
+-struct afp_unixprivs {
+-	uint32_t uid __attribute__((__packed__));
+-	uint32_t gid __attribute__((__packed__));
+-	uint32_t permissions __attribute__((__packed__));
+-	uint32_t ua_permissions __attribute__((__packed__));
+-
+-};
+-
+-
+-/* AFP Volume attributes bitmap, p.241 */
+-
+-enum {
+-    kReadOnly = 0x01,
+-    kHasVolumePassword = 0x02,
+-    kSupportsFileIDs = 0x04,
+-    kSupportsCatSearch = 0x08,
+-    kSupportsBlankAccessPrivs = 0x10,
+-    kSupportsUnixPrivs = 0x20,
+-    kSupportsUTF8Names = 0x40,
+-    kNoNetworkUserIDs = 0x80,
+-    kDefaultPrivsFromParent = 0x100,
+-    kNoExchangeFiles = 0x200,
+-    kSupportsExtAttrs = 0x400,
+-    kSupportsACLs=0x800
+-};
+-
+-/* AFP file creation constantes, p.250 */
+-enum {
+-kFPSoftCreate = 0,
+-kFPHardCreate = 0x80
+-};
+-
+-/* AFP Directory attributes, taken from the protocol guide p.236 */
+-
+-enum {
+-    kFPAttributeBit = 0x1,
+-    kFPParentDirIDBit = 0x2,
+-    kFPCreateDateBit = 0x4,
+-    kFPModDateBit = 0x8,
+-    kFPBackupDateBit = 0x10,
+-    kFPFinderInfoBit = 0x20,
+-    kFPLongNameBit = 0x40,
+-    kFPShortNameBit = 0x80,
+-    kFPNodeIDBit = 0x100,
+-    kFPOffspringCountBit = 0x0200,
+-    kFPOwnerIDBit = 0x0400,
+-    kFPGroupIDBit = 0x0800,
+-    kFPAccessRightsBit = 0x1000,
+-    kFPProDOSInfoBit = 0x2000, // AFP version 2.2 and earlier
+-    kFPUTF8NameBit = 0x2000, // AFP version 3.0 and later
+-    kFPUnixPrivsBit = 0x8000 // AFP version 3.0 and later
+-};
+-
+-/* AFP File bitmap, p.238.  These are the ones not in the AFP Directory
+-   attributes map. */
+-
+-enum {
+-	kFPDataForkLenBit = 0x0200,
+-	kFPRsrcForkLenBit = 0x0400,
+-	kFPExtDataForkLenBit = 0x0800, // AFP version 3.0 and later
+-	kFPLaunchLimitBit = 0x1000,
+-	kFPExtRsrcForkLenBit = 0x4000, // AFP version 3.0 and later
+-};
+-
+-/* AFP Extended Attributes Bitmap, p.238  */
+-
+-enum {
+-	kXAttrNoFollow = 0x1,
+-	kXAttrCreate = 0x2,
+-	kXAttrREplace=0x4
+-};
+-
+-
+-/* AFP function codes */
+-enum AFPFunction
+-{
+-        afpByteRangeLock = 1, afpCloseVol, afpCloseDir, afpCloseFork,
+-        afpCopyFile, afpCreateDir, afpCreateFile,
+-        afpDelete, afpEnumerate, afpFlush, afpFlushFork,
+-        afpGetForkParms = 14, afpGetSrvrInfo, afpGetSrvrParms,
+-        afpGetVolParms, afpLogin, afpLoginCont, afpLogout, afpMapID,
+-        afpMapName, afpMoveAndRename, afpOpenVol, afpOpenDir, afpOpenFork,
+-        afpRead, afpRename, afpSetDirParms, afpSetFileParms,
+-        afpSetForkParms, afpSetVolParms, afpWrite, afpGetFileDirParms,
+-	afpSetFileDirParms, afpChangePassword,
+-        afpGetUserInfo=37,afpGetSrvrMsg = 38,
+-	afpOpenDT=48,
+-	afpCloseDT=49,
+-	afpGetIcon=51, afpGetIconInfo=52,
+-	afpAddComment=56, afpRemoveComment=57, afpGetComment=58,
+-	afpByteRangeLockExt=59, afpReadExt, afpWriteExt,
+-	afpGetAuthMethods=62,
+-	afp_LoginExt=63,
+-	afpGetSessionToken=64,
+-	afpDisconnectOldSession=65,
+-	afpEnumerateExt=66,
+-	afpCatSearchExt = 67,
+-	afpEnumerateExt2 = 68, afpGetExtAttr, afpSetExtAttr, 
+-	afpRemoveExtAttr , afpListExtAttrs,
+-	afpZzzzz = 122,
+-	afpAddIcon=192,
+-};
+-
+-/* AFP Volume bitmap.  Take from 242 of the protocol guide. */
+-enum {
+-	kFPBadVolPre222Bitmap = 0xFe00,
+-	kFPBadVolBitmap = 0xF000,
+-	kFPVolAttributeBit = 0x1,
+-	kFPVolSignatureBit = 0x2,
+-	kFPVolCreateDateBit = 0x4,
+-	kFPVolModDateBit = 0x8,
+-	kFPVolBackupDateBit = 0x10,
+-	kFPVolIDBit = 0x20,
+-	kFPVolBytesFreeBit = 0x40,
+-	kFPVolBytesTotalBit = 0x80,
+-	kFPVolNameBit = 0x100,
+-	kFPVolExtBytesFreeBit = 0x200,
+-	kFPVolExtBytesTotalBit = 0x400,
+-	kFPVolBlockSizeBit = 0x800
+-};
+-
+-/* AFP Attention Codes -- 4 bits */
+-#define AFPATTN_SHUTDOWN     (1 << 15)            /* shutdown/disconnect */
+-#define AFPATTN_CRASH        (1 << 14)            /* server crashed */
+-#define AFPATTN_MESG         (1 << 13)            /* server has message */
+-#define AFPATTN_NORECONNECT  (1 << 12)            /* don't reconnect */
+-/* server notification */
+-#define AFPATTN_NOTIFY       (AFPATTN_MESG | AFPATTN_NORECONNECT) 
+-
+-/* extended bitmap -- 12 bits. volchanged is only useful w/ a server
+- * notification, and time is only useful for shutdown. */
+-#define AFPATTN_VOLCHANGED   (1 << 0)             /* volume has changed */
+-#define AFPATTN_TIME(x)      ((x) & 0xfff)        /* time in minutes */
+-
+-#define kFPNoErr 0
+-
+-/* AFP result codes, p252 */
+-#define kASPSessClosed -1072
+-#define kFPAccessDenied -5000
+-#define kFPAuthContinue -5001
+-#define kFPBadUAM -5002
+-#define kFPBadVersNum -5003
+-#define kFPBitmapErr -5004
+-#define kFPCantMove -5005
+-#define kFPDenyConflict -5006
+-#define kFPDirNotEmpty -5007
+-#define kFPDiskFull -5008
+-#define kFPEOFErr -5009
+-#define kFPFileBusy -5010
+-#define kFPFlatVol -5011
+-#define kFPItemNotFound -5012
+-#define kFPLockErr -5013
+-#define kFPMiscErr -5014
+-#define kFPNoMoreLocks -5015
+-#define kFPNoServer -5016
+-#define kFPObjectExists -5017
+-#define kFPObjectNotFound -5018
+-#define kFPParamErr -5019
+-#define kFPRangeNotLocked -5020
+-#define kFPRangeOverlap -5021
+-#define kFPSessClosed -5022
+-#define kFPUserNotAuth -5023
+-#define kFPCallNotSupported -5024
+-#define kFPObjectTypeErr -5025
+-#define kFPTooManyFilesOpen -5026
+-#define kFPServerGoingDown -5027
+-#define kFPCantRename -5028
+-#define kFPDirNotFound -5029
+-#define kFPIconTypeError -5030
+-#define kFPVolLocked -5031
+-#define kFPObjectLocked -5032
+-#define kFPContainsSharedErr -5033
+-#define kFPIDNotFound -5034
+-#define kFPIDExists -5035
+-#define kFPDiffVolErr  -5036
+-#define kFPCatalogChanged -5037
+-#define kFPSameObjectErr -5038
+-#define kFPBadIDErr -5039
+-#define kFPPwdSameErr -5040
+-#define kFPPwdTooShortErr -5041
+-#define kFPPwdExpiredErr -5042
+-#define kFPInsideSharedErr -5043
+-#define kFPInsideTrashErr -5044
+-#define kFPPwdNeedsChangeErr -5045
+-#define kFPPwdPolicyErr -5046
+-#define kFPDiskQuotaExceeded –5047 
+-
+-
+-
+-/* These flags determine to lock or unlock in ByteRangeLock(Ext) */
+-
+-enum {
+-ByteRangeLock_Lock = 0,
+-ByteRangeLock_Unlock = 1
+-};
+-
+-/* These flags are used in volopen and getsrvrparm replies, p.171 */
+-
+-#define HasConfigInfo 0x1
+-#define HasPassword 0x80
+-
+-/* These are the subfunction for kFPMapID, as per p.248 */
+-
+-enum {
+-kUserIDToName = 1,
+-kGroupIDToName = 2,
+-kUserIDToUTF8Name = 3,
+-kGroupIDToUTF8Name = 4,
+-kUserUUIDToUTF8Name = 5,
+-kGroupUUIDToUTF8Name = 6
+-};
+-
+-
+-/* These are the subfunction flags described in the FPMapName command, p.286.
+-   Note that this is different than what's described on p. 186. */
+-
+-enum {
+-kNameToUserID = 1,
+-kNameToGroupID = 2,
+-kUTF8NameToUserID = 3,
+-kUTF8NameToGroupID = 4,
+-kUTF8NameToUserUUID = 5,
+-kUTF8NameToGroupUUID = 6
+-};
+-
+-/* These are bits for FPGetUserInfo, p.173. */
+-#define kFPGetUserInfo_USER_ID 1
+-#define kFPGetUserInfo_PRI_GROUPID 2
+-
+-/* Flags for the replies of GetSrvrInfo and DSI GetStatus, p.240 */
+-
+-enum {
+-	kSupportsCopyfile = 0x01,
+-	kSupportsChgPwd = 0x02,
+-	kDontAllowSavePwd = 0x04,
+-	kSupportsSrvrMsg = 0x08,
+-	kSrvrSig = 0x10,
+-	kSupportsTCP = 0x20,
+-	kSupportsSrvrNotify = 0x40,
+-	kSupportsReconnect = 0x80,
+-	kSupportsDirServices = 0x100,
+-	kSupportsUTF8SrvrName = 0x200,
+-	kSupportsUUIDs = 0x400,
+-	kSupportsSuperClient = 0x8000
+-};
+-
+-
+-/* p.247 */
+-
+-enum {
+-	kLoginWithoutID = 0,
+-	kLoginWithID = 1,
+-	kReconnWithID = 2,
+-	kLoginWithTimeAndID = 3,
+-	kReconnWithTimeAndID = 4,
+-	kRecon1Login = 5,
+-	kRecon1ReconnectLogin = 6,
+-	kRecon1Refresh = 7, kGetKerberosSessionKey = 8
+-};
+-
+-
+-#define AFP_CHMOD_ALLOWED_BITS_22 \
+-	(S_IRUSR |S_IWUSR | S_IRGRP | S_IWGRP |S_IROTH | S_IWOTH | S_IFREG )
+-
+-
+-#endif
+-
+-
+-
+-
+diff -Naur afpfs-ng-0.8.1/include/codepage.h afpfs-ng-0.8.1.patch/include/codepage.h
+--- afpfs-ng-0.8.1/include/codepage.h	2007-09-23 16:21:30.000000000 +0200
++++ afpfs-ng-0.8.1.patch/include/codepage.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,11 +0,0 @@
+-#ifndef __CODE_PAGE_H_
+-#define __CODE_PAGE_H_
+-int convert_utf8dec_to_utf8pre(const char *src, int src_len,
+-	char * dest, int dest_len);
+-int convert_utf8pre_to_utf8dec(const char * src, int src_len, 
+-	char * dest, int dest_len);
+-int convert_path_to_unix(char encoding, char * dest, 
+-	char * src, int dest_len);
+-int convert_path_to_afp(char encoding, char * dest, 
+-	char * src, int dest_len);
+-#endif
+diff -Naur afpfs-ng-0.8.1/include/dsi.h afpfs-ng-0.8.1.patch/include/dsi.h
+--- afpfs-ng-0.8.1/include/dsi.h	2008-02-18 04:33:24.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/dsi.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,33 +0,0 @@
+-
+-#ifndef __DSI_H_
+-#define __DSI_H_
+-
+-#include "afp.h"
+-
+-struct dsi_request
+-{
+-	unsigned short requestid;
+-	unsigned char subcommand;
+-	void * other;
+-	unsigned char wait;
+-	pthread_cond_t  condition_cond;
+-	struct dsi_request * next;
+-	int return_code;
+-};
+-
+-int dsi_receive(struct afp_server * server, void * data, int size);
+-int dsi_getstatus(struct afp_server * server);
+-
+-int dsi_opensession(struct afp_server *server);
+-
+-int dsi_send(struct afp_server *server, char * msg, int size,int wait,unsigned char subcommand, void ** other);
+-struct dsi_session * dsi_create(struct afp_server *server);
+-int dsi_restart(struct afp_server *server);
+-int dsi_recv(struct afp_server * server);
+-
+-#define DSI_BLOCK_TIMEOUT -1
+-#define DSI_DONT_WAIT 0
+-#define DSI_DEFAULT_TIMEOUT 5
+-
+-
+-#endif
+diff -Naur afpfs-ng-0.8.1/include/libafpclient.h afpfs-ng-0.8.1.patch/include/libafpclient.h
+--- afpfs-ng-0.8.1/include/libafpclient.h	2008-01-30 05:37:59.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/libafpclient.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,50 +0,0 @@
+-
+-#ifndef __CLIENT_H_
+-#define __CLIENT_H_
+-
+-#include <unistd.h>
+-#include <syslog.h>
+-
+-#define MAX_CLIENT_RESPONSE 2048
+-
+-
+-enum loglevels {
+-        AFPFSD,
+-};
+-
+-struct afp_server;
+-struct afp_volume;
+-
+-struct libafpclient {
+-        int (*unmount_volume) (struct afp_volume * volume);
+-	void (*log_for_client)(void * priv,
+-        	enum loglevels loglevel, int logtype, const char *message);
+-	void (*forced_ending_hook)(void);
+-	int (*scan_extra_fds)(int command_fd,fd_set *set, int * max_fd);
+-	void (*loop_started)(void);
+-} ;
+-
+-extern struct libafpclient * libafpclient;
+-
+-void libafpclient_register(struct libafpclient * tmpclient);
+-
+-
+-void signal_main_thread(void);
+-
+-/* These are logging functions */
+-
+-#define MAXLOGSIZE 2048
+-
+-#define LOG_METHOD_SYSLOG 1
+-#define LOG_METHOD_STDOUT 2
+-
+-void set_log_method(int m);
+-
+-
+-void log_for_client(void * priv,
+-        enum loglevels loglevel, int logtype, char * message,...);
+-
+-void stdout_log_for_client(void * priv,
+-	enum loglevels loglevel, int logtype, const char *message);
+-
+-#endif
+diff -Naur afpfs-ng-0.8.1/include/Makefile.am afpfs-ng-0.8.1.patch/include/Makefile.am
+--- afpfs-ng-0.8.1/include/Makefile.am	1970-01-01 01:00:00.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/Makefile.am	2011-09-10 12:13:50.126124692 +0200
+@@ -0,0 +1,3 @@
++## Process this file with automake to produce Makefile.in
++
++SUBDIRS = afpfs-ng
+diff -Naur afpfs-ng-0.8.1/include/map_def.h afpfs-ng-0.8.1.patch/include/map_def.h
+--- afpfs-ng-0.8.1/include/map_def.h	2008-01-17 05:55:46.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/map_def.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,15 +0,0 @@
+-#ifndef __MAP_H_
+-#define __MAP_H_
+-
+-#include "afp.h"
+-
+-#define AFP_MAPPING_UNKNOWN 0
+-#define AFP_MAPPING_COMMON 1
+-#define AFP_MAPPING_LOGINIDS 2
+-#define AFP_MAPPING_NAME 3
+-
+-unsigned int map_string_to_num(char * name);
+-char * get_mapping_name(struct afp_volume * volume);
+-
+-
+-#endif
+diff -Naur afpfs-ng-0.8.1/include/midlevel.h afpfs-ng-0.8.1.patch/include/midlevel.h
+--- afpfs-ng-0.8.1/include/midlevel.h	2007-12-24 20:39:25.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/midlevel.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,64 +0,0 @@
+-#ifndef __MIDLEVEL_H_
+-#define __MIDLEVEL_H_ 
+-
+-#include <utime.h>
+-#include "afp.h"
+-
+-int ml_open(struct afp_volume * volume, const char *path, int flags, 
+-        struct afp_file_info **newfp);
+-
+-int ml_creat(struct afp_volume * volume, const char *path,mode_t mode);
+-
+-int ml_readdir(struct afp_volume * volume, 
+-	const char *path, 
+-	struct afp_file_info **base);
+-
+-int ml_read(struct afp_volume * volume, const char *path,
+-	char *buf, size_t size, off_t offset,
+-	struct afp_file_info *fp, int * eof);
+-
+-int ml_chmod(struct afp_volume * vol, const char * path, mode_t mode);
+-
+-int ml_unlink(struct afp_volume * vol, const char *path);
+-
+-int ml_mkdir(struct afp_volume * vol, const char * path, mode_t mode);
+-
+-int ml_close(struct afp_volume * volume, const char * path,
+-        struct afp_file_info * fp);
+-
+-int ml_getattr(struct afp_volume * volume, const char *path, 
+-	struct stat *stbuf);
+-
+-int ml_write(struct afp_volume * volume, const char * path, 
+-	const char *data, size_t size, off_t offset,
+-	struct afp_file_info * fp, uid_t uid,
+-	gid_t gid);
+-
+-int ml_readlink(struct afp_volume * vol, const char * path,
+-        char *buf, size_t size);
+-
+-int ml_rmdir(struct afp_volume * vol, const char *path);
+-
+-int ml_chown(struct afp_volume * vol, const char * path,   
+-        uid_t uid, gid_t gid);
+-
+-int ml_truncate(struct afp_volume * vol, const char * path, off_t offset);
+-
+-int ml_utime(struct afp_volume * vol, const char * path,
+-	struct utimbuf * timebuf);
+-
+-int ml_symlink(struct afp_volume *vol, const char * path1, const char * path2);
+-
+-int ml_rename(struct afp_volume * vol,
+-	const char * path_from, const char * path_to);
+-
+-int ml_statfs(struct afp_volume * vol, const char *path, struct statvfs *stat);
+-
+-void afp_ml_filebase_free(struct afp_file_info **filebase);
+-
+-int ml_passwd(struct afp_server *server,
+-                char * username, char * oldpasswd, char * newpasswd);
+-
+-
+-
+-#endif
+diff -Naur afpfs-ng-0.8.1/include/uams_def.h afpfs-ng-0.8.1.patch/include/uams_def.h
+--- afpfs-ng-0.8.1/include/uams_def.h	2007-09-07 15:10:51.000000000 +0200
++++ afpfs-ng-0.8.1.patch/include/uams_def.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,16 +0,0 @@
+-#ifndef __UAM_DEFS_H_
+-#define __UAM_DEFS_H_
+-
+-#define UAM_NOUSERAUTHENT 0x1
+-#define UAM_CLEARTXTPASSWRD 0x2
+-#define UAM_RANDNUMEXCHANGE 0x4
+-#define UAM_2WAYRANDNUM 0x8
+-#define UAM_DHCAST128 0x10
+-#define UAM_CLIENTKRB 0x20
+-#define UAM_DHX2 0x40
+-#define UAM_RECON1 0x80
+-
+-int uam_string_to_bitmap(char * name);
+-char * uam_bitmap_to_string(unsigned int bitmap);
+-
+-#endif
+diff -Naur afpfs-ng-0.8.1/include/utils.h afpfs-ng-0.8.1.patch/include/utils.h
+--- afpfs-ng-0.8.1/include/utils.h	2008-02-18 04:33:58.000000000 +0100
++++ afpfs-ng-0.8.1.patch/include/utils.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,43 +0,0 @@
+-#ifndef __UTILS_H_
+-#define __UTILS_H_
+-#include <stdio.h>
+-
+-#include "afp.h"
+-
+-#if BYTE_ORDER == BIG_ENDIAN
+-#define hton64(x)       (x)
+-#define ntoh64(x)       (x)
+-#else /* BYTE_ORDER == BIG_ENDIAN */
+-#define hton64(x)       ((u_int64_t) (htonl(((x) >> 32) & 0xffffffffLL)) | \
+-                         (u_int64_t) ((htonl(x) & 0xffffffffLL) << 32))
+-#define ntoh64(x)       (hton64(x))
+-#endif /* BYTE_ORDER == BIG_ENDIAN */
+-
+-#define min(a,b) (((a)<(b)) ? (a) : (b))
+-#define max(a,b) (((a)>(b)) ? (a) : (b))
+-
+-
+-
+-unsigned char unixpath_to_afppath(
+-        struct afp_server * server,
+-        char * buf);
+-
+-unsigned char sizeof_path_header(struct afp_server * server);
+-
+-
+-
+-unsigned char copy_from_pascal(char *dest, char *pascal,unsigned int max_len) ;
+-unsigned short copy_from_pascal_two(char *dest, char *pascal,unsigned int max_len);
+-
+-unsigned char copy_to_pascal(char *dest, const char *src);
+-unsigned short copy_to_pascal_two(char *dest, const char *src);
+-
+-void copy_path(struct afp_server * server, char * dest, const char * pathname, unsigned char len);
+-
+-
+-char * create_path(struct afp_server * server, char * pathname, unsigned short * len);
+-
+-
+-int invalid_filename(struct afp_server * server, const char * filename);
+-
+-#endif
+diff -Naur afpfs-ng-0.8.1/lib/afp.c afpfs-ng-0.8.1.patch/lib/afp.c
+--- afpfs-ng-0.8.1/lib/afp.c	2008-03-08 03:44:16.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/afp.c	2011-09-10 12:13:50.131124759 +0200
+@@ -9,7 +9,7 @@
+ 
+ 
+ 
+-#include "afp.h"
++#include "afpfs-ng/afp.h"
+ #include <config.h>
+ 
+ #include <stdio.h>
+@@ -21,17 +21,17 @@
+ #include <sys/socket.h>
+ #include <errno.h>
+ 
+-#include "afp_protocol.h"
+-#include "libafpclient.h"
++#include "afpfs-ng/afp_protocol.h"
++#include "afpfs-ng/libafpclient.h"
+ #include "server.h"
+-#include "dsi.h"
++#include "afpfs-ng/dsi.h"
+ #include "dsi_protocol.h"
+-#include "utils.h"
++#include "afpfs-ng/utils.h"
+ #include "afp_replies.h"
+ #include "afp_internal.h"
+ #include "did.h"
+ #include "forklist.h"
+-#include "codepage.h"
++#include "afpfs-ng/codepage.h"
+ 
+ struct afp_versions      afp_versions[] = {
+             { "AFPVersion 1.1", 11 },
+diff -Naur afpfs-ng-0.8.1/lib/afp_internal.h afpfs-ng-0.8.1.patch/lib/afp_internal.h
+--- afpfs-ng-0.8.1/lib/afp_internal.h	2007-11-09 05:27:20.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/afp_internal.h	2011-09-10 12:13:50.132124772 +0200
+@@ -1,7 +1,7 @@
+ #ifndef _AFP_INTERNAL_H_
+ #define _AFP_INTERNAL_H_
+ 
+-#include "afp.h"
++#include "afpfs-ng/afp.h"
+ 
+ extern struct afp_versions afp_versions[];
+ 
+diff -Naur afpfs-ng-0.8.1/lib/afp_url.c afpfs-ng-0.8.1.patch/lib/afp_url.c
+--- afpfs-ng-0.8.1/lib/afp_url.c	2008-03-04 21:16:49.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/afp_url.c	2011-09-10 12:13:50.132124772 +0200
+@@ -3,7 +3,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <errno.h>
+-#include "afp.h"
++#include "afpfs-ng/afp.h"
+ 
+ void afp_default_url(struct afp_url *url)
+ {
+diff -Naur afpfs-ng-0.8.1/lib/client.c afpfs-ng-0.8.1.patch/lib/client.c
+--- afpfs-ng-0.8.1/lib/client.c	2008-02-18 04:36:30.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/client.c	2011-09-10 12:13:50.132124772 +0200
+@@ -1,5 +1,5 @@
+-#include <afp.h>
+-#include <libafpclient.h>
++#include <afpfs-ng/afp.h>
++#include <afpfs-ng/libafpclient.h>
+ 
+ 
+ struct libafpclient * libafpclient = NULL;
+diff -Naur afpfs-ng-0.8.1/lib/codepage.c afpfs-ng-0.8.1.patch/lib/codepage.c
+--- afpfs-ng-0.8.1/lib/codepage.c	2008-02-18 04:36:54.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/codepage.c	2011-09-10 12:13:50.133124786 +0200
+@@ -14,8 +14,8 @@
+ 
+ #include <string.h>
+ #include <stdlib.h>
+-#include "afp_protocol.h"
+-#include "utils.h"
++#include "afpfs-ng/afp_protocol.h"
++#include "afpfs-ng/utils.h"
+ #include "unicode.h"
+ 
+ int convert_utf8dec_to_utf8pre(const char *src, int src_len,
+diff -Naur afpfs-ng-0.8.1/lib/connect.c afpfs-ng-0.8.1.patch/lib/connect.c
+--- afpfs-ng-0.8.1/lib/connect.c	2008-02-18 04:38:59.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/connect.c	2011-09-10 12:13:50.133124786 +0200
+@@ -10,13 +10,13 @@
+ #include <string.h>
+ #include <sys/socket.h>
+ 
+-#include "afp.h"
+-#include "dsi.h"
+-#include "utils.h"
+-#include "uams_def.h"
+-#include "codepage.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/utils.h"
++#include "afpfs-ng/uams_def.h"
++#include "afpfs-ng/codepage.h"
+ #include "users.h"
+-#include "libafpclient.h"
++#include "afpfs-ng/libafpclient.h"
+ #include "server.h"
+ 
+ 
+diff -Naur afpfs-ng-0.8.1/lib/did.c afpfs-ng-0.8.1.patch/lib/did.c
+--- afpfs-ng-0.8.1/lib/did.c	2008-02-18 04:39:17.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/did.c	2011-09-10 12:13:50.133124786 +0200
+@@ -9,8 +9,8 @@
+ #include <string.h>
+ #include <stdio.h>
+ 
+-#include "afp.h"
+-#include "afp_protocol.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/afp_protocol.h"
+ 
+ #undef DID_CACHE_DISABLE
+ 
+diff -Naur afpfs-ng-0.8.1/lib/dsi.c afpfs-ng-0.8.1.patch/lib/dsi.c
+--- afpfs-ng-0.8.1/lib/dsi.c	2008-02-18 04:53:03.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/dsi.c	2011-09-10 12:13:50.134124800 +0200
+@@ -19,12 +19,12 @@
+ #include <signal.h>
+ #include <iconv.h>
+ 
+-#include "utils.h"
+-#include "dsi.h"
+-#include "afp.h"
+-#include "uams_def.h"
++#include "afpfs-ng/utils.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/uams_def.h"
+ #include "dsi_protocol.h"
+-#include "libafpclient.h"
++#include "afpfs-ng/libafpclient.h"
+ #include "afp_internal.h"
+ #include "afp_replies.h"
+ 
+diff -Naur afpfs-ng-0.8.1/lib/forklist.c afpfs-ng-0.8.1.patch/lib/forklist.c
+--- afpfs-ng-0.8.1/lib/forklist.c	2008-01-17 05:49:16.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/forklist.c	2011-09-10 12:13:50.135124814 +0200
+@@ -10,7 +10,7 @@
+ */
+ 
+ 
+-#include "afp.h"
++#include "afpfs-ng/afp.h"
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
+diff -Naur afpfs-ng-0.8.1/lib/log.c afpfs-ng-0.8.1.patch/lib/log.c
+--- afpfs-ng-0.8.1/lib/log.c	2008-01-30 05:37:58.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/log.c	2011-09-10 12:13:50.135124814 +0200
+@@ -3,7 +3,7 @@
+ #include <stdarg.h>
+ #include <string.h>
+ #include <stdlib.h>
+-#include "libafpclient.h"
++#include "afpfs-ng/libafpclient.h"
+ 
+ void log_for_client(void * priv,
+ 	enum loglevels loglevel, int logtype, char *format, ...) {
+diff -Naur afpfs-ng-0.8.1/lib/loop.c afpfs-ng-0.8.1.patch/lib/loop.c
+--- afpfs-ng-0.8.1/lib/loop.c	2008-02-18 04:40:11.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/loop.c	2011-09-10 12:13:50.135124814 +0200
+@@ -16,9 +16,9 @@
+ #include <sys/time.h>
+ #include <signal.h>
+ 
+-#include "afp.h"
+-#include "dsi.h"
+-#include "utils.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/utils.h"
+ 
+ #define SIGNAL_TO_USE SIGUSR2
+ 
+diff -Naur afpfs-ng-0.8.1/lib/lowlevel.c afpfs-ng-0.8.1.patch/lib/lowlevel.c
+--- afpfs-ng-0.8.1/lib/lowlevel.c	2008-02-20 02:33:17.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/lowlevel.c	2011-09-10 12:13:50.136124828 +0200
+@@ -19,10 +19,10 @@
+ #else
+ #include <fcntl.h>
+ #endif
+-#include "afp.h"
+-#include "afp_protocol.h"
+-#include "codepage.h"
+-#include "utils.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/afp_protocol.h"
++#include "afpfs-ng/codepage.h"
++#include "afpfs-ng/utils.h"
+ #include "did.h"
+ #include "users.h"
+ 
+diff -Naur afpfs-ng-0.8.1/lib/map_def.c afpfs-ng-0.8.1.patch/lib/map_def.c
+--- afpfs-ng-0.8.1/lib/map_def.c	2007-09-07 15:10:59.000000000 +0200
++++ afpfs-ng-0.8.1.patch/lib/map_def.c	2011-09-10 12:13:50.136124828 +0200
+@@ -1,6 +1,6 @@
+ #include <string.h>
+-#include "afp.h"
+-#include "map_def.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/map_def.h"
+ 
+ static char *afp_map_strings[] = {
+ 	"Unknown",
+diff -Naur afpfs-ng-0.8.1/lib/meta.c afpfs-ng-0.8.1.patch/lib/meta.c
+--- afpfs-ng-0.8.1/lib/meta.c	2008-01-04 04:52:44.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/meta.c	2011-09-10 12:13:50.137124841 +0200
+@@ -17,10 +17,10 @@
+ #include <unistd.h>
+ #include <sys/time.h>
+ 
+-#include "afp.h"
+-#include "dsi.h"
+-#include "afp_protocol.h"
+-#include "utils.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp_protocol.h"
++#include "afpfs-ng/utils.h"
+ 
+ 
+ int afp_meta_getattr(const char *path, struct stat *stbuf)
+diff -Naur afpfs-ng-0.8.1/lib/midlevel.c afpfs-ng-0.8.1.patch/lib/midlevel.c
+--- afpfs-ng-0.8.1/lib/midlevel.c	2008-03-08 17:08:18.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/midlevel.c	2011-09-10 12:13:50.160125150 +0200
+@@ -10,7 +10,7 @@
+ */
+ 
+ 
+-#include "afp.h"
++#include "afpfs-ng/afp.h"
+ 
+ #include <sys/stat.h>
+ #include <string.h>
+@@ -28,9 +28,9 @@
+ #include "users.h"
+ #include "did.h"
+ #include "resource.h"
+-#include "utils.h"
+-#include "codepage.h"
+-#include "midlevel.h"
++#include "afpfs-ng/utils.h"
++#include "afpfs-ng/codepage.h"
++#include "afpfs-ng/midlevel.h"
+ #include "afp_internal.h"
+ #include "forklist.h"
+ #include "uams.h"
+diff -Naur afpfs-ng-0.8.1/lib/proto_attr.c afpfs-ng-0.8.1.patch/lib/proto_attr.c
+--- afpfs-ng-0.8.1/lib/proto_attr.c	2008-01-30 05:37:58.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_attr.c	2011-09-10 12:13:50.168125257 +0200
+@@ -7,10 +7,10 @@
+ 
+ #include <string.h>
+ #include <stdlib.h>
+-#include "dsi.h"
+-#include "afp.h"
+-#include "utils.h"
+-#include "afp_protocol.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
++#include "afpfs-ng/afp_protocol.h"
+ #include "dsi_protocol.h"
+ 
+ /* This is a new command, function 76.  There are currently no docs, so this 
+diff -Naur afpfs-ng-0.8.1/lib/proto_desktop.c afpfs-ng-0.8.1.patch/lib/proto_desktop.c
+--- afpfs-ng-0.8.1/lib/proto_desktop.c	2008-02-18 04:44:11.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_desktop.c	2011-09-10 12:13:50.168125257 +0200
+@@ -9,10 +9,10 @@
+ #include <string.h>
+ #include <stdlib.h>
+ 
+-#include "dsi.h"
+-#include "afp.h"
+-#include "utils.h"
+-#include "afp_protocol.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
++#include "afpfs-ng/afp_protocol.h"
+ #include "dsi_protocol.h"
+ 
+ /* closedt, addicon, geticoninfo, addappl, removeappl */
+diff -Naur afpfs-ng-0.8.1/lib/proto_directory.c afpfs-ng-0.8.1.patch/lib/proto_directory.c
+--- afpfs-ng-0.8.1/lib/proto_directory.c	2008-02-19 03:39:29.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_directory.c	2011-09-10 12:13:50.168125257 +0200
+@@ -9,10 +9,10 @@
+ #include <string.h>
+ #include <stdlib.h>
+ 
+-#include "dsi.h"
+-#include "afp.h"
+-#include "utils.h"
+-#include "afp_protocol.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
++#include "afpfs-ng/afp_protocol.h"
+ #include "dsi_protocol.h"
+ #include "afp_replies.h"
+ 
+diff -Naur afpfs-ng-0.8.1/lib/proto_files.c afpfs-ng-0.8.1.patch/lib/proto_files.c
+--- afpfs-ng-0.8.1/lib/proto_files.c	2008-02-18 04:46:18.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_files.c	2011-09-10 12:13:50.169125270 +0200
+@@ -8,11 +8,11 @@
+ 
+ #include <stdlib.h>
+ #include <string.h>
+-#include "dsi.h"
+-#include "afp.h"
+-#include "utils.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
+ #include "dsi_protocol.h"
+-#include "afp_protocol.h"
++#include "afpfs-ng/afp_protocol.h"
+ #include "afp_internal.h"
+ 
+ /* afp_setfileparms, afp_setdirparms and afpsetfiledirparms are all remarkably
+diff -Naur afpfs-ng-0.8.1/lib/proto_fork.c afpfs-ng-0.8.1.patch/lib/proto_fork.c
+--- afpfs-ng-0.8.1/lib/proto_fork.c	2008-01-30 05:37:58.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_fork.c	2011-09-10 12:13:50.169125270 +0200
+@@ -9,11 +9,11 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-#include "dsi.h"
+-#include "afp.h"
+-#include "utils.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
+ #include "dsi_protocol.h"
+-#include "afp_protocol.h"
++#include "afpfs-ng/afp_protocol.h"
+ 
+ int afp_setforkparms(struct afp_volume * volume,
+ 	unsigned short forkid, unsigned short bitmap, unsigned long len)
+diff -Naur afpfs-ng-0.8.1/lib/proto_login.c afpfs-ng-0.8.1.patch/lib/proto_login.c
+--- afpfs-ng-0.8.1/lib/proto_login.c	2008-01-30 05:37:59.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_login.c	2011-09-10 12:13:50.169125270 +0200
+@@ -10,10 +10,10 @@
+ 
+ #include <stdlib.h>
+ #include <string.h>
+-#include "dsi.h"
++#include "afpfs-ng/dsi.h"
+ #include "dsi_protocol.h"
+-#include "afp.h"
+-#include "utils.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
+ #include "afp_internal.h"
+ 
+ 
+diff -Naur afpfs-ng-0.8.1/lib/proto_map.c afpfs-ng-0.8.1.patch/lib/proto_map.c
+--- afpfs-ng-0.8.1/lib/proto_map.c	2008-01-30 05:37:59.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_map.c	2011-09-10 12:13:50.170125283 +0200
+@@ -9,11 +9,11 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-#include "dsi.h"
+-#include "afp.h"
+-#include "utils.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
+ #include "dsi_protocol.h"
+-#include "afp_protocol.h"
++#include "afpfs-ng/afp_protocol.h"
+ 
+ /* This is used to pass the return values back from afp_getuserinfo_reply() */
+ struct uidgid {
+diff -Naur afpfs-ng-0.8.1/lib/proto_replyblock.c afpfs-ng-0.8.1.patch/lib/proto_replyblock.c
+--- afpfs-ng-0.8.1/lib/proto_replyblock.c	2008-02-18 04:46:19.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_replyblock.c	2011-09-10 12:13:50.170125283 +0200
+@@ -6,9 +6,9 @@
+  */
+ 
+ #include <string.h>
+-#include "dsi.h"
+-#include "afp.h"
+-#include "utils.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
+ #include "afp_internal.h"
+ 
+ 
+diff -Naur afpfs-ng-0.8.1/lib/proto_server.c afpfs-ng-0.8.1.patch/lib/proto_server.c
+--- afpfs-ng-0.8.1/lib/proto_server.c	2008-02-19 02:56:21.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_server.c	2011-09-10 12:13:50.170125283 +0200
+@@ -7,12 +7,12 @@
+  */
+ #include <stdlib.h>
+ #include <string.h>
+-#include "dsi.h"
+-#include "afp.h"
+-#include "utils.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
+ #include "dsi_protocol.h"
+-#include "afp_protocol.h"
+-#include "codepage.h"
++#include "afpfs-ng/afp_protocol.h"
++#include "afpfs-ng/codepage.h"
+ #include "afp_internal.h"
+ 
+ int afp_getsrvrparms(struct afp_server *server)
+diff -Naur afpfs-ng-0.8.1/lib/proto_session.c afpfs-ng-0.8.1.patch/lib/proto_session.c
+--- afpfs-ng-0.8.1/lib/proto_session.c	2008-02-18 04:46:19.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_session.c	2011-09-10 12:13:50.170125283 +0200
+@@ -8,10 +8,10 @@
+  */
+ #include <stdlib.h>
+ #include <string.h>
+-#include "dsi.h"
++#include "afpfs-ng/dsi.h"
+ #include "dsi_protocol.h"
+-#include "afp.h"
+-#include "utils.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
+ 
+ int afp_getsessiontoken(struct afp_server * server, int type, 
+ 	unsigned int timestamp, struct afp_token *outgoing_token, 
+diff -Naur afpfs-ng-0.8.1/lib/proto_volume.c afpfs-ng-0.8.1.patch/lib/proto_volume.c
+--- afpfs-ng-0.8.1/lib/proto_volume.c	2008-02-18 04:47:48.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/proto_volume.c	2011-09-10 12:13:50.171125296 +0200
+@@ -8,13 +8,13 @@
+ 
+ #include <string.h>
+ #include <stdlib.h>
+-#include "dsi.h"
+-#include "afp.h"
+-#include "utils.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
+ #include "dsi_protocol.h"
+-#include "afp_protocol.h"
++#include "afpfs-ng/afp_protocol.h"
+ #include "afp_internal.h"
+-#include "codepage.h"
++#include "afpfs-ng/codepage.h"
+ 
+ static int parse_volbitmap_reply(struct afp_server * server, 
+ 		struct afp_volume * tmpvol, 
+diff -Naur afpfs-ng-0.8.1/lib/resource.c afpfs-ng-0.8.1.patch/lib/resource.c
+--- afpfs-ng-0.8.1/lib/resource.c	2008-02-18 04:46:56.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/resource.c	2011-09-10 12:13:50.171125296 +0200
+@@ -3,11 +3,11 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <fcntl.h>
+-#include "afp.h"
++#include "afpfs-ng/afp.h"
+ #include "resource.h"
+ #include "lowlevel.h"
+ #include "did.h"
+-#include "midlevel.h"
++#include "afpfs-ng/midlevel.h"
+ 
+ #define appledouble ".AppleDouble"
+ #define finderinfo_string ".finderinfo"
+diff -Naur afpfs-ng-0.8.1/lib/server.c afpfs-ng-0.8.1.patch/lib/server.c
+--- afpfs-ng-0.8.1/lib/server.c	2008-02-19 02:56:21.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/server.c	2011-09-10 12:13:50.172125310 +0200
+@@ -8,15 +8,15 @@
+ #include <string.h>
+ #include <time.h>
+ 
+-#include "afp.h"
+-#include "dsi.h"
+-#include "utils.h"
+-#include "uams_def.h"
+-#include "codepage.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/utils.h"
++#include "afpfs-ng/uams_def.h"
++#include "afpfs-ng/codepage.h"
+ #include "users.h"
+-#include "libafpclient.h"
++#include "afpfs-ng/libafpclient.h"
+ #include "afp_internal.h"
+-#include "dsi.h"
++#include "afpfs-ng/dsi.h"
+ 
+ 
+ struct afp_server * afp_server_complete_connection(
+diff -Naur afpfs-ng-0.8.1/lib/status.c afpfs-ng-0.8.1.patch/lib/status.c
+--- afpfs-ng-0.8.1/lib/status.c	2008-03-08 17:08:38.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/status.c	2011-09-10 12:13:50.172125310 +0200
+@@ -1,8 +1,8 @@
+ #include <string.h>
+ #include <stdio.h>
+-#include "map_def.h"
+-#include "dsi.h"
+-#include "afp.h"
++#include "afpfs-ng/map_def.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
+ 
+ int afp_status_header(char * text, int * len) 
+ {
+diff -Naur afpfs-ng-0.8.1/lib/uams.c afpfs-ng-0.8.1.patch/lib/uams.c
+--- afpfs-ng-0.8.1/lib/uams.c	2008-01-04 04:52:44.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/uams.c	2011-09-10 12:13:50.173125324 +0200
+@@ -8,10 +8,10 @@
+ 
+ #include <string.h>
+ #include <stdlib.h>
+-#include "dsi.h"
+-#include "afp.h"
+-#include "utils.h"
+-#include "uams_def.h"
++#include "afpfs-ng/dsi.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
++#include "afpfs-ng/uams_def.h"
+ #include "config.h"
+ 
+ #ifdef HAVE_LIBGCRYPT
+diff -Naur afpfs-ng-0.8.1/lib/users.c afpfs-ng-0.8.1.patch/lib/users.c
+--- afpfs-ng-0.8.1/lib/users.c	2008-02-18 04:48:56.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/users.c	2011-09-10 12:13:50.174125338 +0200
+@@ -3,8 +3,8 @@
+ #include <grp.h>
+ #include <string.h>
+ 
+-#include "afp.h"
+-#include "map_def.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/map_def.h"
+ 
+ /* How mapping works
+  *
+diff -Naur afpfs-ng-0.8.1/lib/utils.c afpfs-ng-0.8.1.patch/lib/utils.c
+--- afpfs-ng-0.8.1/lib/utils.c	2008-02-18 04:53:37.000000000 +0100
++++ afpfs-ng-0.8.1.patch/lib/utils.c	2011-09-10 12:13:50.174125338 +0200
+@@ -8,10 +8,10 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
+-#include "afp.h"
+-#include "utils.h"
++#include "afpfs-ng/afp.h"
++#include "afpfs-ng/utils.h"
+ #include "afp_internal.h"
+-#include "afp_protocol.h"
++#include "afpfs-ng/afp_protocol.h"
+ 
+ struct afp_path_header_long {
+ 	unsigned char type;
+diff -Naur afpfs-ng-0.8.1/Makefile.am afpfs-ng-0.8.1.patch/Makefile.am
+--- afpfs-ng-0.8.1/Makefile.am	2008-02-18 04:24:14.000000000 +0100
++++ afpfs-ng-0.8.1.patch/Makefile.am	2011-09-10 12:13:50.176125365 +0200
+@@ -1,5 +1,5 @@
+ if HAVE_LIBFUSE
+-SUBDIRS = lib fuse cmdline docs
++SUBDIRS = lib fuse cmdline include docs
+ else
+-SUBDIRS = lib cmdline docs
++SUBDIRS = lib cmdline include docs
+ endif


### PR DESCRIPTION
This enables optional AFP support for linux by adding a Makefile + patches for building afpfs-ng/libafpclient manually. Basically this is the same approach like for libnfs and libshairport (airtunes).
