### PR TITLE
Fix WindowXML includes

### DIFF
--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -180,6 +180,15 @@ void CSkinInfo::LoadIncludes()
   m_includes.LoadIncludes(includesPath);
 }
 
+void CSkinInfo::AddIncludes(const CSkinInfo &startedSkin)
+{
+  if (!startedSkin.m_includes.IsEmpty())
+  {
+    CStdString includesPath = PTH_IC(startedSkin.GetSkinPath("includes.xml"));
+    m_includes.LoadIncludes(includesPath);
+  }
+}
+
 void CSkinInfo::ResolveIncludes(TiXmlElement *node)
 {
   m_includes.ResolveIncludes(node);

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -93,6 +93,12 @@ public:
    */
   static bool TranslateResolution(const CStdString &name, RESOLUTION_INFO &res);
 
+  /*! \brief Add the includes loaded from another skin to the current includes.
+      \param startedSkin the skin (should have already been loaded via Start(), otherwise
+             nothing will happen)
+   */
+  void AddIncludes(const CSkinInfo &startedSkin);
+
   void ResolveIncludes(TiXmlElement *node);
 
   float GetEffectsSlowdown() const { return m_effectsSlowDown; };

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -38,6 +38,7 @@ public:
   void ClearIncludes();
   bool LoadIncludes(const CStdString &includeFile);
   bool LoadIncludesFromXML(const TiXmlElement *root);
+  bool IsEmpty() const {return !m_includes.size() && !m_defaults.size() && !m_constants.size();};
 
   /*! \brief Resolve <include>name</include> tags recursively for the given XML element
    Replaces any instances of <include file="foo">bar</include> with the value of the include

--- a/xbmc/interfaces/python/xbmcmodule/winxml.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/winxml.cpp
@@ -74,18 +74,27 @@ namespace PYXBMC
 
     if (!XFILE::CFile::Exists(strSkinPath))
     {
-      // Check for the matching folder for the skin in the fallback skins folder
+      CStdString str("none");
+      AddonProps props(str, ADDON_SKIN, "", "");
+      CSkinInfo::TranslateResolution(resolution, res);
+
       CStdString fallbackPath = URIUtils::AddFileToFolder(strFallbackPath, "resources");
       fallbackPath = URIUtils::AddFileToFolder(fallbackPath, "skins");
       CStdString basePath = URIUtils::AddFileToFolder(fallbackPath, g_SkinInfo->ID());
-      strSkinPath = g_SkinInfo->GetSkinPath(strXMLname, &res, basePath);
+
+      // Check for the matching folder for the skin in the fallback skins folder (if it exists)
+      if (XFILE::CFile::Exists(basePath))
+      {
+        props.path = basePath;
+        CSkinInfo skinInfo(props, res);
+        skinInfo.Start();
+        strSkinPath = skinInfo.GetSkinPath(strXMLname, &res);
+      }
+      
       if (!XFILE::CFile::Exists(strSkinPath))
       {
         // Finally fallback to the DefaultSkin as it didn't exist in either the XBMC Skin folder or the fallback skin folder
-        CStdString str("none");
-        AddonProps props(str, ADDON_SKIN, "", "");
         props.path = URIUtils::AddFileToFolder(fallbackPath, strDefault);
-        CSkinInfo::TranslateResolution(resolution, res);
         CSkinInfo skinInfo(props, res);
 
         skinInfo.Start();

--- a/xbmc/interfaces/python/xbmcmodule/winxml.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/winxml.cpp
@@ -83,23 +83,46 @@ namespace PYXBMC
       CStdString basePath = URIUtils::AddFileToFolder(fallbackPath, g_SkinInfo->ID());
 
       // Check for the matching folder for the skin in the fallback skins folder (if it exists)
+      bool bSkinPathFound = false; // avoid hitting fs twice
       if (XFILE::CFile::Exists(basePath))
       {
         props.path = basePath;
         CSkinInfo skinInfo(props, res);
-        skinInfo.Start();
+
+        // Load resolutions, fonts, strings and includes, IN THIS ORDER
+        skinInfo.Start(); // for resolutions
+        // additional strings can be loaded here
+        skinInfo.LoadIncludes();
+        // additional fonts can be loaded here
+
         strSkinPath = skinInfo.GetSkinPath(strXMLname, &res);
+        if (XFILE::CFile::Exists(strSkinPath))
+        {
+          // These includes are added to the skin's includes because the skin provided them
+          bSkinPathFound = true;
+          g_SkinInfo->AddIncludes(skinInfo);
+        }
       }
-      
-      if (!XFILE::CFile::Exists(strSkinPath))
+
+      if (!bSkinPathFound)
       {
         // Finally fallback to the DefaultSkin as it didn't exist in either the XBMC Skin folder or the fallback skin folder
         props.path = URIUtils::AddFileToFolder(fallbackPath, strDefault);
         CSkinInfo skinInfo(props, res);
 
-        skinInfo.Start();
+        // Load resolutions, fonts, strings and includes, IN THIS ORDER
+        skinInfo.Start(); // for resolutions
+        // additional strings can be loaded here
+        skinInfo.LoadIncludes();
+        // additional fonts can be loaded here
+
         strSkinPath = skinInfo.GetSkinPath(strXMLname, &res);
-        if (!XFILE::CFile::Exists(strSkinPath))
+        if (XFILE::CFile::Exists(strSkinPath))
+        {
+          // Add the addon's local includes to the main include namespace
+          g_SkinInfo->AddIncludes(skinInfo);
+        }
+        else
         {
           PyErr_SetString(PyExc_TypeError, "XML File for Window is missing");
           return NULL;

--- a/xbmc/interfaces/python/xbmcmodule/winxmldialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/winxmldialog.cpp
@@ -75,22 +75,31 @@ namespace PYXBMC
 
     if (!XFILE::CFile::Exists(strSkinPath))
     {
-      // Check for the matching folder for the skin in the fallback skins folder
+      CStdString str("none");
+      AddonProps props(str, ADDON_SKIN, "", "");
+      CSkinInfo::TranslateResolution(resolution, res);
+
       CStdString fallbackPath = URIUtils::AddFileToFolder(strFallbackPath, "resources");
       fallbackPath = URIUtils::AddFileToFolder(fallbackPath, "skins");
       CStdString basePath = URIUtils::AddFileToFolder(fallbackPath, g_SkinInfo->ID());
-      strSkinPath = g_SkinInfo->GetSkinPath(strXMLname, &res, basePath);
+
+      // Check for the matching folder for the skin in the fallback skins folder (if it exists)
+      if (XFILE::CFile::Exists(basePath))
+      {
+        props.path = basePath;
+        CSkinInfo skinInfo(props, res);
+        skinInfo.Start();
+        strSkinPath = skinInfo.GetSkinPath(strXMLname, &res);
+      }
+
       if (!XFILE::CFile::Exists(strSkinPath))
       {
         // Finally fallback to the DefaultSkin as it didn't exist in either the XBMC Skin folder or the fallback skin folder
-        CStdString str("none");
-        AddonProps props(str, ADDON_SKIN, "", "");
         props.path = URIUtils::AddFileToFolder(fallbackPath, strDefault);
-        CSkinInfo::TranslateResolution(resolution, res);
         CSkinInfo skinInfo(props, res);
 
         skinInfo.Start();
-        strSkinPath = skinInfo.GetSkinPath(strXMLname, &res);        
+        strSkinPath = skinInfo.GetSkinPath(strXMLname, &res);
         if (!XFILE::CFile::Exists(strSkinPath))
         {
           PyErr_SetString(PyExc_TypeError, "XML File for Window is missing");

--- a/xbmc/interfaces/python/xbmcmodule/winxmldialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/winxmldialog.cpp
@@ -84,23 +84,46 @@ namespace PYXBMC
       CStdString basePath = URIUtils::AddFileToFolder(fallbackPath, g_SkinInfo->ID());
 
       // Check for the matching folder for the skin in the fallback skins folder (if it exists)
+      bool bSkinPathFound = false; // avoid hitting fs twice
       if (XFILE::CFile::Exists(basePath))
       {
         props.path = basePath;
         CSkinInfo skinInfo(props, res);
-        skinInfo.Start();
+
+        // Load resolutions, fonts, strings and includes, IN THIS ORDER
+        skinInfo.Start(); // for resolutions
+        // additional strings can be loaded here
+        skinInfo.LoadIncludes();
+        // additional fonts can be loaded here
+
         strSkinPath = skinInfo.GetSkinPath(strXMLname, &res);
+        if (XFILE::CFile::Exists(strSkinPath))
+        {
+          // These includes are added to the skin's includes because the skin provided them
+          bSkinPathFound = true;
+          g_SkinInfo->AddIncludes(skinInfo);
+        }
       }
 
-      if (!XFILE::CFile::Exists(strSkinPath))
+      if (!bSkinPathFound)
       {
         // Finally fallback to the DefaultSkin as it didn't exist in either the XBMC Skin folder or the fallback skin folder
         props.path = URIUtils::AddFileToFolder(fallbackPath, strDefault);
         CSkinInfo skinInfo(props, res);
 
-        skinInfo.Start();
+        // Load resolutions, fonts, strings and includes, IN THIS ORDER
+        skinInfo.Start(); // for resolutions
+        // additional strings can be loaded here
+        skinInfo.LoadIncludes();
+        // additional fonts can be loaded here
+
         strSkinPath = skinInfo.GetSkinPath(strXMLname, &res);
-        if (!XFILE::CFile::Exists(strSkinPath))
+        if (XFILE::CFile::Exists(strSkinPath))
+        {
+          // Add the addon's local includes to the main include namespace
+          g_SkinInfo->AddIncludes(skinInfo);
+        }
+        else
         {
           PyErr_SetString(PyExc_TypeError, "XML File for Window is missing");
           return NULL;


### PR DESCRIPTION
XBMC complains if an addon script is missing includes.xml. Ironically, if this file exists, XBMC will silently ignore it.

This is fixed in two commits. First up is a fix for the following case: XBMC would skip skin fallback folders using a different resolution. For example, using NTSC, xbmc would completely ignore addon.id/skins/skin.id/720p/script-window.xml

Now that XBMC can locate the best xml file correctly under all cases, it will also look for an includes.xml in the same folder. If a (non-empty) includes.xml file is discovered, it will be merged with the current skin's so that the addon may use includes defined in both skin and local files.

Edge Cases (things to be considered):
- If the skin is reloaded (or changed) while the addon's window is open, the addon's includes will be lost until the addon window is reopened.
- An addon's local includes.xml can contain includes with the same name as a skin's. The behavior will be identical to the case where a skin provides two includes with the same name.
