### PR TITLE
Allow mod="shift" to be used for function keys

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2186,8 +2186,14 @@ bool CApplication::OnKey(const CKey& key)
       CGUIControl *control = window->GetFocusedControl();
       if (control)
       {
-        if (control->GetControlType() == CGUIControl::GUICONTROL_EDIT ||
-           (control->IsContainer() && key.GetModifiers() == CKey::MODIFIER_SHIFT)) // shift and no other modifiers
+        // If this is an edit control set usekeyboard to true. This causes the
+        // keypress to be processed directly not through the key mappings.
+        if (control->GetControlType() == CGUIControl::GUICONTROL_EDIT)
+          useKeyboard = true;
+
+        // If the key pressed is shift-A to shift-Z set usekeyboard to true.
+        // This causes the keypress to be used for list navigation.
+        if (control->IsContainer() && key.GetModifiers() == CKey::MODIFIER_SHIFT && key.GetVKey() >= 'a' && key.GetVKey() <= 'z')
           useKeyboard = true;
       }
     }

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -29,6 +29,7 @@
 #include "windowing/XBMC_events.h"
 #include "utils/TimeUtils.h"
 #include "input/XBMC_keytable.h"
+#include "input/XBMC_vkeys.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/devices/PeripheralHID.h"
 
@@ -163,10 +164,14 @@ const CKey CKeyboardStat::ProcessKeyDown(XBMC_keysym& keysym)
     held = 0;
   }
 
-  // If the shift modifier is used alone, it is ignored unless it is
-  // combined with a - z
+  // For all shift-X keys except shift-A to shift-Z and shift-F1 to shift-F24 the
+  // shift modifier is ignored. This so that, for example, the * keypress (shift-8)
+  // is seen as <asterisk> not <asterisk mod="shift">.
+  // The A-Z keys are exempted because shift-A-Z is used for navigation in lists.
+  // The function keys are exempted because function keys have no shifted value and
+  // the Nyxboard remote uses keys like Shift-F3 for some buttons.
   if (modifiers == CKey::MODIFIER_SHIFT)
-    if ((unicode < 'A' || unicode > 'Z') && (unicode < 'a' || unicode > 'z'))
+    if ((unicode < 'A' || unicode > 'Z') && (unicode < 'a' || unicode > 'z') && (vkey < XBMCVK_F1 || vkey > XBMCVK_F24))
       modifiers = 0;
 
   // Create and return a CKey


### PR DESCRIPTION
The Nyxboard remote uses shifted function keys for some buttons e.g. Shift+F3, F4, F5, F6 for the colour keys, and these don't work because shift is reserved to mean navigation in lists. This pull works round this in as elegant a way as possible in the circumstances.

In CApplication::OnKey() the shift key is only used for navigation in lists for shift-A to shift-Z. For other shifted keys like shift-F3 the keypress is passed to the key mapping tables like all other keypresses.

In CKeyboardStat::ProcessKeyDown if the shift modifier is used alone (i.e. not ctrl-shift or alt-shift etc) it is ignored unless the key is A-Z or F1-F24.

This may seem a bit arbitrary, but it actually works very well. Shift-A to Z still work for list navigation, and <f3 mod="shift"> can be used in key mapping files so the Nyxboard remote will work. We need to ignore shift for other keys, for example on the French keyboard you get the digits using shift so to get "1" you press shift-&. If the shift modifier were processed in this case you'd need <one mod="shift"> instead of <one> in the keyboard.xml. Likewise the backslash key is shifted on some keyboards. The change proposed in this pull means everything works on all keyboards.
