### PR TITLE
FIX: No files are returned from JSON-RPC Files.GetDirectory for http sources

### DIFF
--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -128,5 +128,15 @@ bool CHTTPDirectory::Exists(const char* strPath)
 {
   CFileCurl http;
   CURL url(strPath);
-  return http.Exists(url);
+  struct __stat64 buffer;
+
+  if( http.Stat(url, &buffer) != 0 )
+  {
+    return false;
+  }
+
+  if (buffer.st_mode == _S_IFDIR)
+	  return true;
+
+  return false;
 }


### PR DESCRIPTION
CHTTPDirectory::Exists is returning true not only for directories but also for files.

This breaks CFileOperations::GetDirectory for http as the item is rejected if it is a directory in CFileOperations::FillFileItem.
The result is that no files are returned from JSON-RPC for http sources.

This patch uses CFileCurl::Stat rather than CFileCurl::Exists.
