### PR TITLE
Fix the GUISettingsSliderControl with dirty regions

### DIFF
--- a/xbmc/guilib/GUISettingsSliderControl.cpp
+++ b/xbmc/guilib/GUISettingsSliderControl.cpp
@@ -36,29 +36,36 @@ CGUISettingsSliderControl::~CGUISettingsSliderControl(void)
 
 void CGUISettingsSliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
+  m_buttonControl.SetFocus(HasFocus());
+  m_buttonControl.SetPulseOnSelect(m_pulseOnSelect);
+  m_buttonControl.SetEnabled(m_enabled);
   m_buttonControl.Process(currentTime, dirtyregions);
+  ProcessText();
   CGUISliderControl::Process(currentTime, dirtyregions);
 }
 
 void CGUISettingsSliderControl::Render()
 {
-  // make sure the button has focus if it should have...
-  m_buttonControl.SetFocus(HasFocus());
-  m_buttonControl.SetPulseOnSelect(m_pulseOnSelect);
-  m_buttonControl.SetEnabled(m_enabled);
   m_buttonControl.Render();
   CGUISliderControl::Render();
-
-  // now render our text
-  m_label.SetMaxRect(m_buttonControl.GetXPosition(), m_posY, m_posX - m_buttonControl.GetXPosition(), m_height);
-  m_label.SetText(CGUISliderControl::GetDescription());
-  if (IsDisabled())
-    m_label.SetColor(CGUILabel::COLOR_DISABLED);
-  else if (HasFocus())
-    m_label.SetColor(CGUILabel::COLOR_FOCUSED);
-  else
-    m_label.SetColor(CGUILabel::COLOR_TEXT);
   m_label.Render();
+}
+
+void CGUISettingsSliderControl::ProcessText()
+{
+  bool changed = false;
+
+  changed |= m_label.SetMaxRect(m_buttonControl.GetXPosition(), m_posY, m_posX - m_buttonControl.GetXPosition(), m_height);
+  changed |= m_label.SetText(CGUISliderControl::GetDescription());
+  if (IsDisabled())
+    changed |= m_label.SetColor(CGUILabel::COLOR_DISABLED);
+  else if (HasFocus())
+    changed |= m_label.SetColor(CGUILabel::COLOR_FOCUSED);
+  else
+    changed |= m_label.SetColor(CGUILabel::COLOR_TEXT);
+
+  if (changed)
+    MarkDirtyRegion();
 }
 
 bool CGUISettingsSliderControl::OnAction(const CAction &action)

--- a/xbmc/guilib/GUISettingsSliderControl.cpp
+++ b/xbmc/guilib/GUISettingsSliderControl.cpp
@@ -41,6 +41,8 @@ void CGUISettingsSliderControl::Process(unsigned int currentTime, CDirtyRegionLi
   m_buttonControl.SetEnabled(m_enabled);
   m_buttonControl.Process(currentTime, dirtyregions);
   ProcessText();
+  if (HasFocus() && m_pulseOnSelect)
+    MarkDirtyRegion();
   CGUISliderControl::Process(currentTime, dirtyregions);
 }
 

--- a/xbmc/guilib/GUISettingsSliderControl.h
+++ b/xbmc/guilib/GUISettingsSliderControl.h
@@ -70,7 +70,8 @@ public:
 
 protected:
   virtual bool UpdateColors();
-  
+  virtual void ProcessText();
+
 private:
   CGUIButtonControl m_buttonControl;
   CGUILabel m_label;


### PR DESCRIPTION
Takes care of problem described in ticket 11881: doesn't properly redraw when gaining/losing focus, doesn't pulse and the text value of the slider is not updated unless that makes the tick move.
To see that control: go to the configure screen of the Dim screensaver.

This is code shuffling for the most part, to mirror controls that actually work.

Note: I chickened out from converting GUILabel to dirty-regions. I'm too unfamiliar with that stuff. This should be done for more granular dirty regions. The GUIButtonControl did the same thing.
