### PR TITLE
trac#12028 : Keymap command for changing audio device

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -53,6 +53,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "Util.h"
+#include "osx/CoreAudio.h"
 
 #include "filesystem/PluginDirectory.h"
 #ifdef HAS_FILESYSTEM_RAR
@@ -206,6 +207,7 @@ const BUILT_IN commands[] = {
   { "LCD.Resume",                 false,  "Resumes LCDproc" },
 #endif
   { "VideoLibrary.Search",        false,  "Brings up a search dialog which will search the library" },
+  { "SetAudioOutputDevice",       true,   "Set XBMC audio output device" },
 };
 
 bool CBuiltins::HasCommand(const CStdString& execString)
@@ -1544,6 +1546,18 @@ int CBuiltins::Execute(const CStdString& execString)
   {
     CGUIMessage msg(GUI_MSG_SEARCH, 0, 0, 0);
     g_windowManager.SendMessage(msg, WINDOW_VIDEO_NAV);
+  }
+  else if (execute.Equals("setaudiooutputdevice"))
+  {
+#ifdef __APPLE__
+    AudioDeviceID device = CCoreAudioHardware::FindAudioDevice(strParameterCaseIntact);
+    if (device)
+    {
+      CLog::Log(LOGINFO, "Setting audio device: %s", strParameterCaseIntact.c_str());
+      g_guiSettings.SetString("audiooutput.audiodevice", strParameterCaseIntact);
+      //TODO: Bonus points-- switch current stream to new device
+    }
+#endif
   }
   else
     return -1;

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -53,7 +53,9 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "Util.h"
+#if defined(__APPLE__)
 #include "osx/CoreAudio.h"
+#endif
 
 #include "filesystem/PluginDirectory.h"
 #ifdef HAS_FILESYSTEM_RAR


### PR DESCRIPTION
This implements my feature request from trac ticket #12028

Allow changing XBMC's audio device on Mac via a keymap command. For example:

<F1>SetAudioOutputDevice(Built-in Output)</F1>

in the joystick.Harmony.xml keymap will change the output setting to "Built-in Output". Changes to this setting are picked up when a new stream is started.

I originally implemented this in Plex but I find myself using XBMC more and needed this feature so I ported it.
