### PR TITLE
Universal DB upgrade-via-copy support for sqlite and mysql.

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -268,64 +268,72 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   if ( dbSettings.type.Equals("mysql") )
   {
     // check we have all information before we cancel the fallback
-    if ( ! (dbSettings.host.IsEmpty() || dbSettings.name.IsEmpty() ||
+    if ( ! (dbSettings.host.IsEmpty() ||
             dbSettings.user.IsEmpty() || dbSettings.pass.IsEmpty()) )
       m_sqlite = false;
     else
-      CLog::Log(LOGINFO, "essential mysql database information is missing (eg. host, name, user, pass)");
+      CLog::Log(LOGINFO, "Essential mysql database information is missing. Require at least host, user and pass defined.");
   }
-
-  // always safely fallback to sqlite3, and use separate, versioned database
-  if (m_sqlite)
+  else
   {
     dbSettings.type = "sqlite3";
     dbSettings.host = _P(g_settings.GetDatabaseFolder());
-
-    int version = GetMinVersion();
-    CStdString latestDb;
-    latestDb.Format("%s%d.db", GetBaseDBName(), version);
-    while (version >= 0)
-    {
-      if (version)
-        dbSettings.name.Format("%s%d.db", GetBaseDBName(), version);
-      else
-        dbSettings.name.Format("%s.db", GetBaseDBName());
-      if (Connect(dbSettings, false))
-      { 
-        // Database exists, take a copy for our current version (if needed) and reopen that one
-        if (version < GetMinVersion())
-        {
-          CLog::Log(LOGNOTICE, "Old database found - updating from version %i to %i", version, GetMinVersion());
-          Close();
-          CStdString currentDb = URIUtils::AddFileToFolder(dbSettings.host, dbSettings.name);
-          CStdString newPath = URIUtils::AddFileToFolder(dbSettings.host, latestDb);
-          if (!XFILE::CFile::Cache(currentDb, newPath))
-          {
-            CLog::Log(LOGERROR, "Unable to copy old database %s to new version %s", dbSettings.name.c_str(), latestDb.c_str());
-            return false;
-          }
-          dbSettings.name = latestDb;
-          if (!Connect(dbSettings, false))
-          {
-            CLog::Log(LOGERROR, "Unable to open freshly copied database %s", dbSettings.name.c_str());
-            return false;
-          }
-        }
-        // yay - we have a copy of our db, now do our worst with it
-        if (UpdateVersion(dbSettings.name))
-          return true;
-        // update failed - loop around and see if we have another one available
-        Close();
-      }
-      // drop back to the previous version and try that
-      version--;
-    }
-    // unable to open any version fall through to create a new one
-    dbSettings.name = latestDb;
   }
+
+  // always safely fallback to sqlite3, and use separate, versioned database
+  int version = GetMinVersion();
+  CStdString latestDb;
+  latestDb.Format("%s%d", GetBaseDBName(), version);
+
+  while (version >= 0)
+  {
+    if (version)
+      dbSettings.name.Format("%s%d", GetBaseDBName(), version);
+    else
+      dbSettings.name.Format("%s", GetBaseDBName());
+
+    if (Connect(dbSettings, false))
+    {
+      // Database exists, take a copy for our current version (if needed) and reopen that one
+      if (version < GetMinVersion())
+      {
+        CLog::Log(LOGNOTICE, "Old database found - updating from version %i to %i", version, GetMinVersion());
+
+        if ( ! m_pDB->copy(latestDb) )
+        {
+          CLog::Log(LOGERROR, "Unable to copy old database %s to new version %s", dbSettings.name.c_str(), latestDb.c_str());
+          Close();
+          return false;
+        }
+
+        Close();
+
+        dbSettings.name = latestDb;
+        if (!Connect(dbSettings, false))
+        {
+          CLog::Log(LOGERROR, "Unable to open freshly copied database %s", dbSettings.name.c_str());
+          return false;
+        }
+      }
+
+      // yay - we have a copy of our db, now do our worst with it
+      if (UpdateVersion(dbSettings.name))
+        return true;
+
+      // update failed - loop around and see if we have another one available
+      Close();
+    }
+
+    // drop back to the previous version and try that
+    version--;
+  }
+
+  // unable to open any version fall through to create a new one
+  dbSettings.name = latestDb;
 
   if (Connect(dbSettings, true) && UpdateVersion(dbSettings.name))
     return true;
+
   // failed to update or open the database
   Close();
   CLog::Log(LOGERROR, "Unable to open database %s", dbSettings.name.c_str());
@@ -558,6 +566,8 @@ bool CDatabase::UpdateVersionNumber()
   {
     CStdString strSQL=PrepareSQL("UPDATE version SET idVersion=%i\n", GetMinVersion());
     m_pDS->exec(strSQL.c_str());
+
+    CommitTransaction();
   }
   catch(...)
   {

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -80,7 +80,7 @@ public:
   virtual ~Database();
   virtual Dataset *CreateDataset() const = 0;
 /* sets a new host name */
-  void setHostName(const char *newHost) { host = newHost; }
+  virtual void setHostName(const char *newHost) { host = newHost; }
 /* gets a host name */
   const char *getHostName(void) const { return host.c_str(); }
 /* sets a new port */
@@ -88,7 +88,7 @@ public:
 /* gets a port */
   const char *getPort(void) const { return port.c_str(); }
 /* sets a new database name */
-  void setDatabase(const char *newDb) { db = newDb; }
+  virtual void setDatabase(const char *newDb) { db = newDb; }
 /* gets a database name */
   const char *getDatabase(void) const { return db.c_str(); }
 /* sets a new login to database */
@@ -123,6 +123,9 @@ public:
   virtual int create(void) { return DB_COMMAND_OK; }
   virtual int drop(void) { return DB_COMMAND_OK; }
   virtual long nextid(const char* seq_name)=0;
+
+/* \brief copy database */
+  virtual int copy(const char *new_name) { return -1; }
 
   virtual bool exists(void) { return false; }
 

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -67,6 +67,9 @@ public:
 /* check if database exists (ie has tables/views defined) */
   virtual bool exists();
 
+/* \brief copy database */
+  virtual int copy(const char *backup_name);
+
   virtual long nextid(const char* seq_name);
 
 /* virtual methods for transaction */

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -61,8 +61,13 @@ public:
   virtual int setErr(int err_code,const char * qry);
 /* func. returns error message if error occurs */
   virtual const char *getErrorMsg();
-  
+/* sets a new host name */
+  virtual void setHostName(const char *newHost);
+/* sets a database name */
+  virtual void setDatabase(const char *newDb);
+
 /* func. connects to database-server */
+
   virtual int connect(bool create);
 /* func. disconnects from database-server */
   virtual void disconnect();
@@ -72,6 +77,9 @@ public:
   virtual int drop();
 /* check if database exists (ie has tables/views defined) */
   virtual bool exists();
+
+/* \brief copy database */
+  virtual int copy(const char *backup_name);
 
   virtual long nextid(const char* seq_name);
 
@@ -103,7 +111,7 @@ protected:
   result_set exec_res;
   bool autorefresh;
   char* errmsg;
-  
+
   sqlite3* handle();
 
 /* Makes direct queries to database */

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3134,6 +3134,8 @@ bool CMusicDatabase::UpdateOldVersion(int version)
   if (NULL == m_pDS.get()) return false;
   if (NULL == m_pDS2.get()) return false;
 
+  BeginTransaction();
+
   try
   {
     if (version < 16)
@@ -3226,9 +3228,12 @@ bool CMusicDatabase::UpdateOldVersion(int version)
       m_pDS->exec("CREATE INDEX idxSong4 ON song(idArtist)");
       m_pDS->exec("CREATE INDEX idxSong5 ON song(idGenre)");
       m_pDS->exec("CREATE INDEX idxSong6 ON song(idPath)");
-
-      CreateViews();
     }
+
+    // always recreate the views after any table change
+    CreateViews();
+
+    CommitTransaction();
   }
   catch (...)
   {


### PR DESCRIPTION
In summary this PR addresses the following:
1. aligns the DB upgrade procedure with sqlite
2. aligns music and db upgrade methods
3. minor cosmetics

Firstly, the DB upgrade procedure for sqlite was to copy the old versioned DB file to the new version DB file and then perform the upgrade on the new version DB file only. The benefit, if not obvious, was that the data was preserved in the event of a failure. This patchset now provides the same functionality for mysql users by creating a new db based on the old version schema and then performing the upgrade on the new DB only. What this does mean that the mysql credentials sufficient to "CREATE DATABASE".

Secondly, the music DB was not using a transaction for the db upgrade method, it was possible on sqlite systems that it could bail half way through an upgrade and leave it in an unknown state. Not so much an issue with the upgrade-via-copy capability, but it aligns with the video DB upgrade method.

Regards,
firnsy
