### PR TITLE
Various DXVA fixes

### DIFF
--- a/lib/ffmpeg/libavcodec/dxva2.h
+++ b/lib/ffmpeg/libavcodec/dxva2.h
@@ -65,6 +65,7 @@ struct dxva_context {
      * Private to the FFmpeg AVHWAccel implementation
      */
     unsigned report_id;
+    unsigned last_slice_count;
 };
 
 #endif /* AVCODEC_DXVA_H */

--- a/lib/ffmpeg/libavcodec/dxva2_h264.c
+++ b/lib/ffmpeg/libavcodec/dxva2_h264.c
@@ -430,6 +430,14 @@ static int end_frame(AVCodecContext *avctx)
 
     if (ctx_pic->slice_count <= 0 || ctx_pic->bitstream_size <= 0)
         return -1;
+
+    // Wait for an I-frame before start decoding. Workaround for ATI UVD and UVD+ GPUs
+    if (!h->got_first_iframe) {
+        if (!(ctx_pic->pp.wBitFields & (1 << 15)))
+            return -1;
+        h->got_first_iframe = 1;
+    }
+
     return ff_dxva2_common_end_frame(avctx, s,
                                      &ctx_pic->pp, sizeof(ctx_pic->pp),
                                      &ctx_pic->qm, sizeof(ctx_pic->qm),

--- a/lib/ffmpeg/libavcodec/dxva2_mpeg2.c
+++ b/lib/ffmpeg/libavcodec/dxva2_mpeg2.c
@@ -22,12 +22,12 @@
 
 #include "dxva2_internal.h"
 
-#define MAX_SLICES (SLICE_MAX_START_CODE - SLICE_MIN_START_CODE + 1)
 struct dxva2_picture_context {
     DXVA_PictureParameters pp;
     DXVA_QmatrixData       qm;
     unsigned               slice_count;
-    DXVA_SliceInfo         slice[MAX_SLICES];
+    DXVA_SliceInfo         *slice;
+    unsigned int           slice_alloc;
 
     const uint8_t          *bitstream;
     unsigned               bitstream_size;
@@ -220,6 +220,8 @@ static int start_frame(AVCodecContext *avctx,
     fill_quantization_matrices(avctx, ctx, s, &ctx_pic->qm);
 
     ctx_pic->slice_count    = 0;
+    ctx_pic->slice          = NULL;
+    ctx_pic->slice_alloc    = 0;
     ctx_pic->bitstream_size = 0;
     ctx_pic->bitstream      = NULL;
     return 0;
@@ -232,9 +234,14 @@ static int decode_slice(AVCodecContext *avctx,
     struct dxva2_picture_context *ctx_pic =
         s->current_picture_ptr->hwaccel_picture_private;
     unsigned position;
+    DXVA_SliceInfo* slice;
 
-    if (ctx_pic->slice_count >= MAX_SLICES)
+    slice = av_fast_realloc(ctx_pic->slice,
+                            &ctx_pic->slice_alloc,
+                            (ctx_pic->slice_count + 1) * sizeof(DXVA_SliceInfo));
+    if (!slice)
         return -1;
+    ctx_pic->slice = slice;
 
     if (!ctx_pic->bitstream)
         ctx_pic->bitstream = buffer;
@@ -258,6 +265,7 @@ static int end_frame(AVCodecContext *avctx)
                                      &ctx_pic->pp, sizeof(ctx_pic->pp),
                                      &ctx_pic->qm, sizeof(ctx_pic->qm),
                                      commit_bitstream_and_slice_buffer);
+    av_freep(ctx_pic->slice);
 }
 
 AVHWAccel ff_mpeg2_dxva2_hwaccel = {

--- a/lib/ffmpeg/libavcodec/dxva2_vc1.c
+++ b/lib/ffmpeg/libavcodec/dxva2_vc1.c
@@ -103,7 +103,10 @@ static void fill_picture_parameters(AVCodecContext *avctx,
                                   (v->rangered       << 3) |
                                   (s->max_b_frames       );
     pp->bPicExtrapolation       = (!v->interlace || v->fcm == 0x00) ? 1 : 2;
-    pp->bPicDeblocked           = ((v->profile != PROFILE_ADVANCED && v->rangeredfrm) << 5) |
+    pp->bPicDeblocked           = ((v->overlap == 1 &&
+                                  pp->bPicBackwardPrediction == 0 &&
+                                  ctx->cfg->ConfigResidDiffHost == 0)                 << 6) |
+                                  ((v->profile != PROFILE_ADVANCED && v->rangeredfrm) << 5) |
                                   (s->loop_filter                                     << 1);
     pp->bPicDeblockConfined     = (v->postprocflag             << 7) |
                                   (v->broadcast                << 6) |

--- a/lib/ffmpeg/libavcodec/dxva2_vc1.c
+++ b/lib/ffmpeg/libavcodec/dxva2_vc1.c
@@ -38,15 +38,17 @@ static void fill_picture_parameters(AVCodecContext *avctx,
 {
     const MpegEncContext *s = &v->s;
     const Picture *current_picture = s->current_picture_ptr;
+    BYTE bPicIntra = s->pict_type == FF_I_TYPE || v->bi_type == 1;
+    BYTE bPicBackwardPrediction = s->pict_type == FF_B_TYPE && v->bi_type == 0;
 
     memset(pp, 0, sizeof(*pp));
     pp->wDecodedPictureIndex    =
     pp->wDeblockedPictureIndex  = ff_dxva2_get_surface_index(ctx, current_picture);
-    if (s->pict_type != FF_I_TYPE)
-        pp->wForwardRefPictureIndex = ff_dxva2_get_surface_index(ctx, &s->last_picture);
-    else
+    if (bPicIntra)
         pp->wForwardRefPictureIndex = 0xffff;
-    if (s->pict_type == FF_B_TYPE)
+    else
+        pp->wForwardRefPictureIndex = ff_dxva2_get_surface_index(ctx, &s->last_picture);
+    if (bPicBackwardPrediction)
         pp->wBackwardRefPictureIndex = ff_dxva2_get_surface_index(ctx, &s->next_picture);
     else
         pp->wBackwardRefPictureIndex = 0xffff;
@@ -69,8 +71,8 @@ static void fill_picture_parameters(AVCodecContext *avctx,
     if (s->picture_structure & PICT_BOTTOM_FIELD)
         pp->bPicStructure      |= 0x02;
     pp->bSecondField            = v->interlace && v->fcm != 0x03 && !s->first_field;
-    pp->bPicIntra               = s->pict_type == FF_I_TYPE;
-    pp->bPicBackwardPrediction  = s->pict_type == FF_B_TYPE;
+    pp->bPicIntra               = bPicIntra;
+    pp->bPicBackwardPrediction  = bPicBackwardPrediction;
     pp->bBidirectionalAveragingMode = (1                                           << 7) |
                                       ((ctx->cfg->ConfigIntraResidUnsigned != 0)   << 6) |
                                       ((ctx->cfg->ConfigResidDiffAccelerator != 0) << 5) |
@@ -108,7 +110,7 @@ static void fill_picture_parameters(AVCodecContext *avctx,
                                   (v->interlace                << 5) |
                                   (v->tfcntrflag               << 4) |
                                   (v->finterpflag              << 3) |
-                                  ((s->pict_type != FF_B_TYPE) << 2) |
+                                  ((s->pict_type != FF_B_TYPE) << 2) | //includes BI
                                   (v->psf                      << 1) |
                                   (v->extended_dmv                 );
     if (s->pict_type != FF_I_TYPE)

--- a/lib/ffmpeg/libavcodec/h264.c
+++ b/lib/ffmpeg/libavcodec/h264.c
@@ -2568,7 +2568,7 @@ static int decode_slice(struct AVCodecContext *avctx, void *arg){
                 return 0;
             }
             if( ret < 0 || h->cabac.bytestream > h->cabac.bytestream_end + 2) {
-                av_log(h->s.avctx, AV_LOG_ERROR, "error while decoding MB %d %d, bytestream (%td)\n", s->mb_x, s->mb_y, h->cabac.bytestream_end - h->cabac.bytestream);
+                av_log(h->s.avctx, AV_LOG_ERROR, "error while decoding MB %d %d, bytestream (%u)\n", s->mb_x, s->mb_y, h->cabac.bytestream_end - h->cabac.bytestream);
                 ff_er_add_slice(s, s->resync_mb_x, s->resync_mb_y, s->mb_x, s->mb_y, (AC_ERROR|DC_ERROR|MV_ERROR)&part_mask);
                 return -1;
             }

--- a/lib/ffmpeg/libavcodec/h264.c
+++ b/lib/ffmpeg/libavcodec/h264.c
@@ -1479,6 +1479,7 @@ static void flush_dpb(AVCodecContext *avctx){
             h->delayed_pic[i]->reference= 0;
         h->delayed_pic[i]= NULL;
     }
+    h->got_first_iframe = 0;
     h->outputed_poc= INT_MIN;
     h->prev_interlaced_frame = 1;
     idr(h);
@@ -1848,6 +1849,7 @@ static int decode_slice_header(H264Context *h, H264Context *h0){
             return -1;
         s->first_field = 0;
         h->prev_interlaced_frame = 1;
+        h->got_first_iframe = 0;
 
         init_scan_tables(h);
         ff_h264_alloc_tables(h);

--- a/lib/ffmpeg/libavcodec/h264.h
+++ b/lib/ffmpeg/libavcodec/h264.h
@@ -587,6 +587,8 @@ typedef struct H264Context{
     int luma_weight_flag[2];   ///< 7.4.3.2 luma_weight_lX_flag
     int chroma_weight_flag[2]; ///< 7.4.3.2 chroma_weight_lX_flag
 
+    int got_first_iframe;
+
     // Timestamp stuff
     int sei_buffering_period_present;  ///< Buffering period SEI flag
     int initial_cpb_removal_delay[32]; ///< Initial timestamps for CPBs

--- a/lib/ffmpeg/patches/0051-dxva-mpeg2-Allocate-slices-array-dynamically-fixes-v.patch
+++ b/lib/ffmpeg/patches/0051-dxva-mpeg2-Allocate-slices-array-dynamically-fixes-v.patch
@@ -1,0 +1,74 @@
+From 87abcf002b55c8a26b6640ee55a56d3b79dd4740 Mon Sep 17 00:00:00 2001
+From: CrystalP <CrystalP@xbmc.org>
+Date: Wed, 5 Oct 2011 12:38:30 -0400
+Subject: [PATCH 1/6] dxva-mpeg2 Allocate slices array dynamically - fixes videos with > 175 slices.
+ They used to result in images with a black bottom.
+
+sample on team ftp samples/PR471/too_many_slices.ts
+
+Inspired by the vaapi code to reallocate the slices array for each new slice.
+Could be more efficient if the array could be preserved for all frames and
+freed only at the end of the video, but there doesn't seem to be anywhere
+appropriate to free the memory at the end.
+
+Alternative is to allocate the proper size straight away for a new frame,
+instead of realloc'ing for each slice.
+---
+ lib/ffmpeg/libavcodec/dxva2_mpeg2.c |   14 +++++++++++---
+ 1 files changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/lib/ffmpeg/libavcodec/dxva2_mpeg2.c b/lib/ffmpeg/libavcodec/dxva2_mpeg2.c
+index 780542a..9ac2d17 100644
+--- a/lib/ffmpeg/libavcodec/dxva2_mpeg2.c
++++ b/lib/ffmpeg/libavcodec/dxva2_mpeg2.c
+@@ -22,12 +22,12 @@
+ 
+ #include "dxva2_internal.h"
+ 
+-#define MAX_SLICES (SLICE_MAX_START_CODE - SLICE_MIN_START_CODE + 1)
+ struct dxva2_picture_context {
+     DXVA_PictureParameters pp;
+     DXVA_QmatrixData       qm;
+     unsigned               slice_count;
+-    DXVA_SliceInfo         slice[MAX_SLICES];
++    DXVA_SliceInfo         *slice;
++    unsigned int           slice_alloc;
+ 
+     const uint8_t          *bitstream;
+     unsigned               bitstream_size;
+@@ -220,6 +220,8 @@ static int start_frame(AVCodecContext *avctx,
+     fill_quantization_matrices(avctx, ctx, s, &ctx_pic->qm);
+ 
+     ctx_pic->slice_count    = 0;
++    ctx_pic->slice          = NULL;
++    ctx_pic->slice_alloc    = 0;
+     ctx_pic->bitstream_size = 0;
+     ctx_pic->bitstream      = NULL;
+     return 0;
+@@ -232,9 +234,14 @@ static int decode_slice(AVCodecContext *avctx,
+     struct dxva2_picture_context *ctx_pic =
+         s->current_picture_ptr->hwaccel_picture_private;
+     unsigned position;
++    DXVA_SliceInfo* slice;
+ 
+-    if (ctx_pic->slice_count >= MAX_SLICES)
++    slice = av_fast_realloc(ctx_pic->slice,
++                            &ctx_pic->slice_alloc,
++                            (ctx_pic->slice_count + 1) * sizeof(DXVA_SliceInfo));
++    if (!slice)
+         return -1;
++    ctx_pic->slice = slice;
+ 
+     if (!ctx_pic->bitstream)
+         ctx_pic->bitstream = buffer;
+@@ -258,6 +265,7 @@ static int end_frame(AVCodecContext *avctx)
+                                      &ctx_pic->pp, sizeof(ctx_pic->pp),
+                                      &ctx_pic->qm, sizeof(ctx_pic->qm),
+                                      commit_bitstream_and_slice_buffer);
++    av_freep(ctx_pic->slice);
+ }
+ 
+ AVHWAccel ff_mpeg2_dxva2_hwaccel = {
+-- 
+1.7.3.1.msysgit.0
+

--- a/lib/ffmpeg/patches/0052-dxva-mpeg2-speed-up-slice-allocation.patch
+++ b/lib/ffmpeg/patches/0052-dxva-mpeg2-speed-up-slice-allocation.patch
@@ -1,0 +1,74 @@
+From 191bc00c62691c4e365ae8b56ed36a9002295961 Mon Sep 17 00:00:00 2001
+From: CrystalP <CrystalP@xbmc.org>
+Date: Mon, 10 Oct 2011 19:42:50 -0400
+Subject: [PATCH 2/6] dxva-mpeg2 speed up slice allocation
+
+The number of slices is not very likely to change from frame to frame, so
+at the beginning of a new frame, allocate memory for the amount of slices of
+the previous frame. Saves a lot of reallocation, for some TV capture samples
+there are over 200 slices.
+
+There wasn't anywhere really appropriate to store last_slice_count (needs to
+live from first frame to last frame), so this is likely to cause discussion to
+merge upstream.
+Adding members to dxva_context breaks ABI, which we don't care too much about
+since on Windows we don't support external ffmpeg.
+dxva mpeg2 code also has access to MpegEncContext, but adding there would
+likely break ABI as well.
+---
+ lib/ffmpeg/libavcodec/dxva2.h       |    1 +
+ lib/ffmpeg/libavcodec/dxva2_mpeg2.c |   12 ++++++++++++
+ 2 files changed, 13 insertions(+), 0 deletions(-)
+
+diff --git a/lib/ffmpeg/libavcodec/dxva2.h b/lib/ffmpeg/libavcodec/dxva2.h
+index 6eb494b..12dce47 100644
+--- a/lib/ffmpeg/libavcodec/dxva2.h
++++ b/lib/ffmpeg/libavcodec/dxva2.h
+@@ -65,6 +65,7 @@ struct dxva_context {
+      * Private to the FFmpeg AVHWAccel implementation
+      */
+     unsigned report_id;
++    unsigned last_slice_count;
+ };
+ 
+ #endif /* AVCODEC_DXVA_H */
+diff --git a/lib/ffmpeg/libavcodec/dxva2_mpeg2.c b/lib/ffmpeg/libavcodec/dxva2_mpeg2.c
+index 9ac2d17..2482c2f 100644
+--- a/lib/ffmpeg/libavcodec/dxva2_mpeg2.c
++++ b/lib/ffmpeg/libavcodec/dxva2_mpeg2.c
+@@ -224,6 +224,16 @@ static int start_frame(AVCodecContext *avctx,
+     ctx_pic->slice_alloc    = 0;
+     ctx_pic->bitstream_size = 0;
+     ctx_pic->bitstream      = NULL;
++
++    if (ctx->last_slice_count > 0)
++    {
++        ctx_pic->slice = av_fast_realloc(NULL,
++                                         &ctx_pic->slice_alloc,
++                                         ctx->last_slice_count * sizeof(DXVA_SliceInfo));
++        if (!ctx_pic->slice)
++            return -1;
++    }
++
+     return 0;
+ }
+ 
+@@ -258,6 +268,7 @@ static int end_frame(AVCodecContext *avctx)
+     struct MpegEncContext *s = avctx->priv_data;
+     struct dxva2_picture_context *ctx_pic =
+         s->current_picture_ptr->hwaccel_picture_private;
++    struct dxva_context *ctx = avctx->hwaccel_context;
+ 
+     if (ctx_pic->slice_count <= 0 || ctx_pic->bitstream_size <= 0)
+         return -1;
+@@ -266,6 +277,7 @@ static int end_frame(AVCodecContext *avctx)
+                                      &ctx_pic->qm, sizeof(ctx_pic->qm),
+                                      commit_bitstream_and_slice_buffer);
+     av_freep(ctx_pic->slice);
++    ctx->last_slice_count = ctx_pic->slice_count;
+ }
+ 
+ AVHWAccel ff_mpeg2_dxva2_hwaccel = {
+-- 
+1.7.3.1.msysgit.0
+

--- a/lib/ffmpeg/patches/0053-dxva-vc1-Take-BI-into-account-for-forward-and-backwa.patch
+++ b/lib/ffmpeg/patches/0053-dxva-vc1-Take-BI-into-account-for-forward-and-backwa.patch
@@ -1,0 +1,59 @@
+From 9afd569e13e9c0a823e11f4dd68ba9cb5e3ad3f1 Mon Sep 17 00:00:00 2001
+From: CrystalP <CrystalP@xbmc.org>
+Date: Wed, 5 Oct 2011 12:53:38 -0400
+Subject: [PATCH 3/6] dxva-vc1 Take BI into account for forward and backward pictures
+
+See ticket #11643, sample on team ftp, samples/11643/vc-1 test.wmv
+---
+ lib/ffmpeg/libavcodec/dxva2_vc1.c |   16 +++++++++-------
+ 1 files changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/lib/ffmpeg/libavcodec/dxva2_vc1.c b/lib/ffmpeg/libavcodec/dxva2_vc1.c
+index 2b9a690..86cdf2f 100644
+--- a/lib/ffmpeg/libavcodec/dxva2_vc1.c
++++ b/lib/ffmpeg/libavcodec/dxva2_vc1.c
+@@ -38,15 +38,17 @@ static void fill_picture_parameters(AVCodecContext *avctx,
+ {
+     const MpegEncContext *s = &v->s;
+     const Picture *current_picture = s->current_picture_ptr;
++    BYTE bPicIntra = s->pict_type == FF_I_TYPE || v->bi_type == 1;
++    BYTE bPicBackwardPrediction = s->pict_type == FF_B_TYPE && v->bi_type == 0;
+ 
+     memset(pp, 0, sizeof(*pp));
+     pp->wDecodedPictureIndex    =
+     pp->wDeblockedPictureIndex  = ff_dxva2_get_surface_index(ctx, current_picture);
+-    if (s->pict_type != FF_I_TYPE)
+-        pp->wForwardRefPictureIndex = ff_dxva2_get_surface_index(ctx, &s->last_picture);
+-    else
++    if (bPicIntra)
+         pp->wForwardRefPictureIndex = 0xffff;
+-    if (s->pict_type == FF_B_TYPE)
++    else
++        pp->wForwardRefPictureIndex = ff_dxva2_get_surface_index(ctx, &s->last_picture);
++    if (bPicBackwardPrediction)
+         pp->wBackwardRefPictureIndex = ff_dxva2_get_surface_index(ctx, &s->next_picture);
+     else
+         pp->wBackwardRefPictureIndex = 0xffff;
+@@ -69,8 +71,8 @@ static void fill_picture_parameters(AVCodecContext *avctx,
+     if (s->picture_structure & PICT_BOTTOM_FIELD)
+         pp->bPicStructure      |= 0x02;
+     pp->bSecondField            = v->interlace && v->fcm != 0x03 && !s->first_field;
+-    pp->bPicIntra               = s->pict_type == FF_I_TYPE;
+-    pp->bPicBackwardPrediction  = s->pict_type == FF_B_TYPE;
++    pp->bPicIntra               = bPicIntra;
++    pp->bPicBackwardPrediction  = bPicBackwardPrediction;
+     pp->bBidirectionalAveragingMode = (1                                           << 7) |
+                                       ((ctx->cfg->ConfigIntraResidUnsigned != 0)   << 6) |
+                                       ((ctx->cfg->ConfigResidDiffAccelerator != 0) << 5) |
+@@ -108,7 +110,7 @@ static void fill_picture_parameters(AVCodecContext *avctx,
+                                   (v->interlace                << 5) |
+                                   (v->tfcntrflag               << 4) |
+                                   (v->finterpflag              << 3) |
+-                                  ((s->pict_type != FF_B_TYPE) << 2) |
++                                  ((s->pict_type != FF_B_TYPE) << 2) | //includes BI
+                                   (v->psf                      << 1) |
+                                   (v->extended_dmv                 );
+     if (s->pict_type != FF_I_TYPE)
+-- 
+1.7.3.1.msysgit.0
+

--- a/lib/ffmpeg/patches/0054-dxva-vc1-Pass-overlapping-transforms-hint.patch
+++ b/lib/ffmpeg/patches/0054-dxva-vc1-Pass-overlapping-transforms-hint.patch
@@ -1,0 +1,29 @@
+From 537d5999337500cac1c521f45de0a921b9aab5ac Mon Sep 17 00:00:00 2001
+From: CrystalP <CrystalP@xbmc.org>
+Date: Thu, 6 Oct 2011 20:23:31 -0400
+Subject: [PATCH 4/6] dxva-vc1 Pass overlapping transforms hint
+
+see ticket #11643
+---
+ lib/ffmpeg/libavcodec/dxva2_vc1.c |    5 ++++-
+ 1 files changed, 4 insertions(+), 1 deletions(-)
+
+diff --git a/lib/ffmpeg/libavcodec/dxva2_vc1.c b/lib/ffmpeg/libavcodec/dxva2_vc1.c
+index 86cdf2f..eca587a 100644
+--- a/lib/ffmpeg/libavcodec/dxva2_vc1.c
++++ b/lib/ffmpeg/libavcodec/dxva2_vc1.c
+@@ -103,7 +103,10 @@ static void fill_picture_parameters(AVCodecContext *avctx,
+                                   (v->rangered       << 3) |
+                                   (s->max_b_frames       );
+     pp->bPicExtrapolation       = (!v->interlace || v->fcm == 0x00) ? 1 : 2;
+-    pp->bPicDeblocked           = ((v->profile != PROFILE_ADVANCED && v->rangeredfrm) << 5) |
++    pp->bPicDeblocked           = ((v->overlap == 1 &&
++                                  pp->bPicBackwardPrediction == 0 &&
++                                  ctx->cfg->ConfigResidDiffHost == 0)                 << 6) |
++                                  ((v->profile != PROFILE_ADVANCED && v->rangeredfrm) << 5) |
+                                   (s->loop_filter                                     << 1);
+     pp->bPicDeblockConfined     = (v->postprocflag             << 7) |
+                                   (v->broadcast                << 6) |
+-- 
+1.7.3.1.msysgit.0
+

--- a/lib/ffmpeg/patches/0055-dxva-h264-Fix-dxva-playback-of-streams-that-don-t-st.patch
+++ b/lib/ffmpeg/patches/0055-dxva-h264-Fix-dxva-playback-of-streams-that-don-t-st.patch
@@ -1,0 +1,74 @@
+From 6328fc9c25a19f1cba3fae56eeff1eaf69ec6d50 Mon Sep 17 00:00:00 2001
+From: CrystalP <CrystalP@xbmc.org>
+Date: Wed, 5 Oct 2011 13:13:25 -0400
+Subject: [PATCH 5/6] dxva-h264 Fix dxva playback of streams that don't start with an I-Frame.
+
+GPUs with ATI UVDa and UVD+ have trouble when decoding doesn't start on an
+I-Frame, and they don't recover on later I-Frames.
+
+The variable to track the first I-Frame is in H264Context so that it can be
+reset by code in h264 when initializing the context or flushing.
+
+credits isidrogar, see ticket #11772.
+sample on team ftp, samples/11772/CSI_ New York - TV3 - 2008-09-16_1.ts
+---
+ lib/ffmpeg/libavcodec/dxva2_h264.c |    8 ++++++++
+ lib/ffmpeg/libavcodec/h264.c       |    2 ++
+ lib/ffmpeg/libavcodec/h264.h       |    2 ++
+ 3 files changed, 12 insertions(+), 0 deletions(-)
+
+diff --git a/lib/ffmpeg/libavcodec/dxva2_h264.c b/lib/ffmpeg/libavcodec/dxva2_h264.c
+index 4e3370c..2954b89 100644
+--- a/lib/ffmpeg/libavcodec/dxva2_h264.c
++++ b/lib/ffmpeg/libavcodec/dxva2_h264.c
+@@ -430,6 +430,14 @@ static int end_frame(AVCodecContext *avctx)
+ 
+     if (ctx_pic->slice_count <= 0 || ctx_pic->bitstream_size <= 0)
+         return -1;
++
++    // Wait for an I-frame before start decoding. Workaround for ATI UVD and UVD+ GPUs
++    if (!h->got_first_iframe) {
++        if (!(ctx_pic->pp.wBitFields & (1 << 15)))
++            return -1;
++        h->got_first_iframe = 1;
++    }
++
+     return ff_dxva2_common_end_frame(avctx, s,
+                                      &ctx_pic->pp, sizeof(ctx_pic->pp),
+                                      &ctx_pic->qm, sizeof(ctx_pic->qm),
+diff --git a/lib/ffmpeg/libavcodec/h264.c b/lib/ffmpeg/libavcodec/h264.c
+index b84430a..a4d35ae 100644
+--- a/lib/ffmpeg/libavcodec/h264.c
++++ b/lib/ffmpeg/libavcodec/h264.c
+@@ -1479,6 +1479,7 @@ static void flush_dpb(AVCodecContext *avctx){
+             h->delayed_pic[i]->reference= 0;
+         h->delayed_pic[i]= NULL;
+     }
++    h->got_first_iframe = 0;
+     h->outputed_poc= INT_MIN;
+     h->prev_interlaced_frame = 1;
+     idr(h);
+@@ -1848,6 +1849,7 @@ static int decode_slice_header(H264Context *h, H264Context *h0){
+             return -1;
+         s->first_field = 0;
+         h->prev_interlaced_frame = 1;
++        h->got_first_iframe = 0;
+ 
+         init_scan_tables(h);
+         ff_h264_alloc_tables(h);
+diff --git a/lib/ffmpeg/libavcodec/h264.h b/lib/ffmpeg/libavcodec/h264.h
+index b403968..bdca237 100644
+--- a/lib/ffmpeg/libavcodec/h264.h
++++ b/lib/ffmpeg/libavcodec/h264.h
+@@ -587,6 +587,8 @@ typedef struct H264Context{
+     int luma_weight_flag[2];   ///< 7.4.3.2 luma_weight_lX_flag
+     int chroma_weight_flag[2]; ///< 7.4.3.2 chroma_weight_lX_flag
+ 
++    int got_first_iframe;
++
+     // Timestamp stuff
+     int sei_buffering_period_present;  ///< Buffering period SEI flag
+     int initial_cpb_removal_delay[32]; ///< Initial timestamps for CPBs
+-- 
+1.7.3.1.msysgit.0
+

--- a/lib/ffmpeg/patches/0056-Changed-format-string-td-not-supported-by-our-MingW-.patch
+++ b/lib/ffmpeg/patches/0056-Changed-format-string-td-not-supported-by-our-MingW-.patch
@@ -1,0 +1,25 @@
+From a584fbd0039270ae30ce08603ef6e819c61c908a Mon Sep 17 00:00:00 2001
+From: CrystalP <CrystalP@xbmc.org>
+Date: Thu, 6 Oct 2011 13:25:28 -0400
+Subject: [PATCH 6/6] Changed format string - %td not supported by our MingW environment.
+
+---
+ lib/ffmpeg/libavcodec/h264.c |    2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/lib/ffmpeg/libavcodec/h264.c b/lib/ffmpeg/libavcodec/h264.c
+index a4d35ae..31d43df 100644
+--- a/lib/ffmpeg/libavcodec/h264.c
++++ b/lib/ffmpeg/libavcodec/h264.c
+@@ -2568,7 +2568,7 @@ static int decode_slice(struct AVCodecContext *avctx, void *arg){
+                 return 0;
+             }
+             if( ret < 0 || h->cabac.bytestream > h->cabac.bytestream_end + 2) {
+-                av_log(h->s.avctx, AV_LOG_ERROR, "error while decoding MB %d %d, bytestream (%td)\n", s->mb_x, s->mb_y, h->cabac.bytestream_end - h->cabac.bytestream);
++                av_log(h->s.avctx, AV_LOG_ERROR, "error while decoding MB %d %d, bytestream (%u)\n", s->mb_x, s->mb_y, h->cabac.bytestream_end - h->cabac.bytestream);
+                 ff_er_add_slice(s, s->resync_mb_x, s->resync_mb_y, s->mb_x, s->mb_y, (AC_ERROR|DC_ERROR|MV_ERROR)&part_mask);
+                 return -1;
+             }
+-- 
+1.7.3.1.msysgit.0
+


### PR DESCRIPTION
Those fixes have been floating around the forums for months but are not in official ffmpeg for various reasons.
- The VC-1 was thought to merged in ffmpeg, but I can't find it there and we're not merging ffmpeg for Eden anyway
- The mpeg2 and H264 fix the problem they tackle, but are maybe not good enough for official ffmpeg.

I'd like them in Eden because they fix problems that will become more visible now that we have deinterlacing, which will encourage more fans of TV to use XBMC. The mpeg2 and H264 fixes are geared towards playback of captured streams, which are typically interlaced.
I checked on my ATI and nVidia cards that they actually fix things and don't seem to introduce regressions.

If accepted, I will create the patch files to add to our list of ffmpeg patches. This PR is mostly for elupus' attention.

for fun I also checked for fixes in ffmpeg that we don't have. There is only one, and it creates problems in my testing so I didn't even consider it.
