### PR TITLE
Small amendment to the scan exclude list

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -144,8 +144,8 @@ void CAdvancedSettings::Initialize()
   m_videoCleanStringRegExps.push_back("(\\[.*\\])");
 
   m_moviesExcludeFromScanRegExps.push_back("-trailer");
-  m_moviesExcludeFromScanRegExps.push_back("[-._ \\\\/]sample[-._ \\\\/]");
-  m_tvshowExcludeFromScanRegExps.push_back("[-._ \\\\/]sample[-._ \\\\/]");
+  m_moviesExcludeFromScanRegExps.push_back("[!-._ \\\\/]sample[-._ \\\\/]");
+  m_tvshowExcludeFromScanRegExps.push_back("[!-._ \\\\/]sample[-._ \\\\/]");
 
   m_folderStackRegExps.push_back("((cd|dvd|dis[ck])[0-9]+)$");
 


### PR DESCRIPTION
Many of my movies come with the sample file named "!sample.mkv" (without quotes of course). XBMC's default regexp doesn't recognize this so the sample gets scanned on library updates, leading to duplicate entries. This simple commit modifies to exclusion regexp to also ignore !sample\* files.
