### PR TITLE
[dvdplayer] only call IPlayerCallback::OnPlayBackSpeedChanged if the speed has actually changed

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2114,13 +2114,8 @@ void CDVDPlayer::HandleMessages()
           m_State.timestamp =  CDVDClock::GetAbsoluteClock();
         }
 
-        if (speed != DVD_PLAYSPEED_PAUSE)
-        {
-          if (m_playSpeed != DVD_PLAYSPEED_PAUSE)
-          {
-            m_callback.OnPlayBackSpeedChanged(speed / DVD_PLAYSPEED_NORMAL );
-          }
-        }
+        if (speed != DVD_PLAYSPEED_PAUSE && m_playSpeed != DVD_PLAYSPEED_PAUSE && speed != m_playSpeed)
+          m_callback.OnPlayBackSpeedChanged(speed / DVD_PLAYSPEED_NORMAL);
 
         // if playspeed is different then DVD_PLAYSPEED_NORMAL or DVD_PLAYSPEED_PAUSE
         // audioplayer, stops outputing audio to audiorendere, but still tries to


### PR DESCRIPTION
This change makes sure that IPlayerCallback::OnPlayBackSpeedChanged (specifically CApplication::OnPlayBackSpeedChanged) is only called when the playback speed in CDVDPlayer has actually changed.

What happens with the old code is that when stopping a playing video CDVDPlayer first calls IPlayerCallback::OnPlayBackSpeedChanged with a speed value of 1 (independant of whether the video was already playing at normal speed) and then calls IPlayerCallback::OnPlayBackStopped. As these methods also propagate HTTP-API broadcast, jsonrpc notifications and python callbacks it is a bit of an odd behaviour for 3rd party devs IMO.

But as I don't have any real clue about CDVDPlayer I'd appreciate it if someone with more insight could comment on whether this makes sense or not. Thanks
