### PR TITLE
Xbmc nav sound volume setting

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1373,6 +1373,7 @@
   <string id="15109">Skin default</string>
   <string id="15111">- Theme</string>
   <string id="15112">Default theme</string>
+  <string id="15113">Navigation volume</string>
 
   <string id="15200">Last.fm</string>
   <string id="15201">Submit songs to Last.fm</string>

--- a/language/German/strings.xml
+++ b/language/German/strings.xml
@@ -1406,6 +1406,7 @@
   <string id="15109">Vorgabe des Skins</string>
   <string id="15111">Theme</string>
   <string id="15112">Standardschema</string>
+  <string id="15113">Navigationslautstärke</string>
 
   <string id="15200">Last.fm</string>
   <string id="15201">Abgespielte Musiktitel an Last.fm übermitteln</string>

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -195,6 +195,7 @@ void CGUIAudioManager::PlayActionSound(const CAction& action)
     return;
   }
 
+  m_actionSound->SetVolume(m_iVolume);
   m_actionSound->Play();
 }
 
@@ -246,6 +247,7 @@ void CGUIAudioManager::PlayWindowSound(int id, WINDOW_SOUND event)
   }
 
   m_windowSounds.insert(pair<int, CGUISound*>(id, sound));
+  sound->SetVolume(m_iVolume);
   sound->Play();
 }
 
@@ -279,6 +281,7 @@ void CGUIAudioManager::PlayPythonSound(const CStdString& strFileName)
   }
 
   m_pythonSounds.insert(pair<CStdString, CGUISound*>(strFileName, sound));
+  sound->SetVolume(m_iVolume);
   sound->Play();
 }
 
@@ -423,16 +426,16 @@ void CGUIAudioManager::SetVolume(int iLevel)
 {
   CSingleLock lock(m_cs);
 
-  int vol = g_guiSettings.GetInt("lookandfeel.soundvol");
+  m_iVolume = iLevel * g_guiSettings.GetInt("lookandfeel.soundvol") / 100;
 
   if (m_actionSound)
-    m_actionSound->SetVolume(iLevel*vol/100);
+    m_actionSound->SetVolume(m_iVolume);
 
   windowSoundsMap::iterator it=m_windowSounds.begin();
   while (it!=m_windowSounds.end())
   {
     if (it->second)
-      it->second->SetVolume(iLevel*vol/100);
+      it->second->SetVolume(m_iVolume);
 
     ++it;
   }
@@ -441,7 +444,7 @@ void CGUIAudioManager::SetVolume(int iLevel)
   while (it1!=m_pythonSounds.end())
   {
     if (it1->second)
-      it1->second->SetVolume(iLevel*vol/100);
+      it1->second->SetVolume(m_iVolume);
 
     ++it1;
   }

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -423,14 +423,16 @@ void CGUIAudioManager::SetVolume(int iLevel)
 {
   CSingleLock lock(m_cs);
 
+  int vol = g_guiSettings.GetInt("lookandfeel.soundvol");
+
   if (m_actionSound)
-    m_actionSound->SetVolume(iLevel);
+    m_actionSound->SetVolume(iLevel*vol/100);
 
   windowSoundsMap::iterator it=m_windowSounds.begin();
   while (it!=m_windowSounds.end())
   {
     if (it->second)
-      it->second->SetVolume(iLevel);
+      it->second->SetVolume(iLevel*vol/100);
 
     ++it;
   }
@@ -439,7 +441,7 @@ void CGUIAudioManager::SetVolume(int iLevel)
   while (it1!=m_pythonSounds.end())
   {
     if (it1->second)
-      it1->second->SetVolume(iLevel);
+      it1->second->SetVolume(iLevel*vol/100);
 
     ++it1;
   }

--- a/xbmc/guilib/GUIAudioManager.h
+++ b/xbmc/guilib/GUIAudioManager.h
@@ -80,6 +80,7 @@ private:
   CStdString          m_strMediaDir;
   bool                m_bInitialized;
   bool                m_bEnabled;
+  int                 m_iVolume;
 
   CCriticalSection    m_cs;
 };

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -809,6 +809,7 @@ void CGUISettings::Initialize()
   AddInt(laf, "lookandfeel.skinzoom",20109, 0, -20, 2, 20, SPIN_CONTROL_INT, MASK_PERCENT);
   AddInt(laf, "lookandfeel.startupwindow",512,1, WINDOW_HOME, 1, WINDOW_PYTHON_END, SPIN_CONTROL_TEXT);
   AddString(laf, "lookandfeel.soundskin",15108,"SKINDEFAULT", SPIN_CONTROL_TEXT);
+  AddInt(laf, "lookandfeel.soundvol",15113,0, 0, 5, 100, SPIN_CONTROL_INT, MASK_PERCENT);
   AddSeparator(laf, "lookandfeel.sep2");
   AddBool(laf, "lookandfeel.enablerssfeeds",13305,  true);
   AddString(laf, "lookandfeel.rssedit", 21450, "", BUTTON_CONTROL_STANDARD);


### PR DESCRIPTION
Added setting to control navigation sound volume relative to master volume in percent.
The nav sounds are overwhelm with respect to video/music. The new setting allows the user to set the nav sound volume with respect to the global volume.
