### PR TITLE
Xbmc restore volume

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1184,9 +1184,16 @@ bool CApplication::Initialize()
   CLog::Log(LOGINFO, "removing tempfiles");
   CUtil::RemoveTempFiles();
 
-  //  Show mute symbol
+  //  Restore volume
   if (g_settings.m_bMute)
+  {
+    SetVolume(g_settings.m_iPreMuteVolumeLevel);
     Mute();
+  }
+  else
+  {
+    SetVolume(g_settings.m_nVolumeLevel, false);
+  }
 
   // if the user shutoff the xbox during music scan
   // restore the settings

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -728,7 +728,9 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
   pElement = pRootElement->FirstChildElement("audio");
   if (pElement)
   {
+    XMLUtils::GetBoolean(pElement, "mute", m_bMute);
     GetInteger(pElement, "volumelevel", m_nVolumeLevel, VOLUME_MAXIMUM, VOLUME_MINIMUM, VOLUME_MAXIMUM);
+    GetInteger(pElement, "premutevolumelevel", m_iPreMuteVolumeLevel, 0, 0, 100);
     GetInteger(pElement, "dynamicrangecompression", m_dynamicRangeCompressionLevel, VOLUME_DRC_MINIMUM, VOLUME_DRC_MINIMUM, VOLUME_DRC_MAXIMUM);
   }
 
@@ -899,7 +901,9 @@ bool CSettings::SaveSettings(const CStdString& strSettingsFile, CGUISettings *lo
   TiXmlElement volumeNode("audio");
   pNode = pRoot->InsertEndChild(volumeNode);
   if (!pNode) return false;
+  XMLUtils::SetBoolean(pNode, "mute", m_bMute);
   XMLUtils::SetInt(pNode, "volumelevel", m_nVolumeLevel);
+  XMLUtils::SetInt(pNode, "premutevolumelevel", m_iPreMuteVolumeLevel);
   XMLUtils::SetInt(pNode, "dynamicrangecompression", m_dynamicRangeCompressionLevel);
 
   SaveCalibration(pRoot);


### PR DESCRIPTION
The sound volume is currently not restored correctly at system start. Added all relevant volume to user settings file. Restore volume at start up depending on the stored mute flag.
