### PR TITLE
Modify settings for SlideShow and Dim screensavers

### DIFF
--- a/addons/screensaver.xbmc.builtin.dim/resources/settings.xml
+++ b/addons/screensaver.xbmc.builtin.dim/resources/settings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <settings>
-  <setting label="30000" type="slider" id="level" range="20,1,100" default="20"/>
+  <setting label="30000" type="slider" id="level" range="20,1,100" option="percent" default="20"/>
 </settings>

--- a/addons/screensaver.xbmc.builtin.slideshow/resources/settings.xml
+++ b/addons/screensaver.xbmc.builtin.slideshow/resources/settings.xml
@@ -2,5 +2,5 @@
 <settings>
   <setting label="30000" type="enum" id="type" default="0" lvalues="30002|30003|30004"/>
   <setting label="30001" type="folder" source="pictures" id="path" default="" enable="eq(-1,2)"/>
-  <setting label="30005" type="slider" id="level" range="0,1,100" default="100"/>
+  <setting label="30005" type="slider" id="level" range="0,1,100" option="percent" default="100"/>
 </settings>


### PR DESCRIPTION
This PR updates the settings the use type="slider" to use the option "percent" to display a percentage instead of a floating point
