### PR TITLE
Store context in skin variables

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1047,7 +1047,7 @@ TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const CStdString &format)
 CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
-    return GetSkinVariableString(info, contextWindow, false);
+    return GetSkinVariableString(info, false);
 
   CStdString strLabel;
   if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
@@ -2789,7 +2789,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
 CStdString CGUIInfoManager::GetImage(int info, int contextWindow)
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
-    return GetSkinVariableString(info, contextWindow, true);
+    return GetSkinVariableString(info, true);
 
   if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
   {
@@ -3770,7 +3770,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info)
   if (!item) return "";
 
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
-    return GetSkinVariableString(info, 0, false, item);
+    return GetSkinVariableString(info, false, item);
 
   if (info >= LISTITEM_PROPERTY_START && info - LISTITEM_PROPERTY_START < (int)m_listitemProperties.size())
   { // grab the property
@@ -4156,7 +4156,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info)
 CStdString CGUIInfoManager::GetItemImage(const CFileItem *item, int info)
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
-    return GetSkinVariableString(info, 0, true, item);
+    return GetSkinVariableString(info, true, item);
 
   switch (info)
   {
@@ -4518,13 +4518,13 @@ int CGUIInfoManager::TranslateSkinVariableString(const CStdString& name, int con
   return 0;
 }
 
-CStdString CGUIInfoManager::GetSkinVariableString(int info, int contextWindow, 
+CStdString CGUIInfoManager::GetSkinVariableString(int info,
                                                   bool preferImage /*= false*/,
                                                   const CGUIListItem *item /*= NULL*/)
 {
   info -= CONDITIONAL_LABEL_START;
   if (info >= 0 && info < (int)m_skinVariableStrings.size())
-    return m_skinVariableStrings[info].GetValue(contextWindow, preferImage, item);
+    return m_skinVariableStrings[info].GetValue(preferImage, item);
 
   return "";
 }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4496,14 +4496,14 @@ bool CGUIInfoManager::GetLibraryBool(int condition)
   return false;
 }
 
-int CGUIInfoManager::RegisterSkinVariableString(const CSkinVariableString& info)
+int CGUIInfoManager::RegisterSkinVariableString(const CSkinVariableString* info)
 {
-  CSingleLock lock(m_critInfo);
-  int id = TranslateSkinVariableString(info.GetName());
-  if (id != 0)
-    return id;
+  if (!info)
+    return 0;
 
-  m_skinVariableStrings.push_back(info);
+  CSingleLock lock(m_critInfo);
+  m_skinVariableStrings.push_back(*info);
+  delete info;
   return CONDITIONAL_LABEL_START + m_skinVariableStrings.size() - 1;
 }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4507,12 +4507,12 @@ int CGUIInfoManager::RegisterSkinVariableString(const CSkinVariableString* info)
   return CONDITIONAL_LABEL_START + m_skinVariableStrings.size() - 1;
 }
 
-int CGUIInfoManager::TranslateSkinVariableString(const CStdString& name)
+int CGUIInfoManager::TranslateSkinVariableString(const CStdString& name, int context)
 {
   for (vector<CSkinVariableString>::const_iterator it = m_skinVariableStrings.begin();
        it != m_skinVariableStrings.end(); ++it)
   {
-    if (it->GetName().Equals(name))
+    if (it->GetName().Equals(name) && it->GetContext() == context)
       return it - m_skinVariableStrings.begin() + CONDITIONAL_LABEL_START;
   }
   return 0;

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -678,7 +678,7 @@ public:
 
   int RegisterSkinVariableString(const INFO::CSkinVariableString* info);
   int TranslateSkinVariableString(const CStdString& name, int context);
-  CStdString GetSkinVariableString(int info, int contextWindow, bool preferImage = false, const CGUIListItem *item=NULL);
+  CStdString GetSkinVariableString(int info, bool preferImage = false, const CGUIListItem *item=NULL);
 protected:
   friend class INFO::InfoSingle;
   bool GetBool(int condition, int contextWindow = 0, const CGUIListItem *item=NULL);

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -676,7 +676,7 @@ public:
 
   int TranslateSingleString(const CStdString &strCondition);
 
-  int RegisterSkinVariableString(const INFO::CSkinVariableString& info);
+  int RegisterSkinVariableString(const INFO::CSkinVariableString* info);
   int TranslateSkinVariableString(const CStdString& name);
   CStdString GetSkinVariableString(int info, int contextWindow, bool preferImage = false, const CGUIListItem *item=NULL);
 protected:

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -677,7 +677,7 @@ public:
   int TranslateSingleString(const CStdString &strCondition);
 
   int RegisterSkinVariableString(const INFO::CSkinVariableString* info);
-  int TranslateSkinVariableString(const CStdString& name);
+  int TranslateSkinVariableString(const CStdString& name, int context);
   CStdString GetSkinVariableString(int info, int contextWindow, bool preferImage = false, const CGUIListItem *item=NULL);
 protected:
   friend class INFO::InfoSingle;

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -256,4 +256,9 @@ bool CSkinInfo::IsInUse() const
   return g_guiSettings.GetString("lookandfeel.skin") == ID();
 }
 
+const INFO::CSkinVariableString* CSkinInfo::CreateSkinVariable(const CStdString& name)
+{
+  return m_includes.CreateSkinVariable(name);
+}
+
 } /*namespace ADDON*/

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -256,9 +256,9 @@ bool CSkinInfo::IsInUse() const
   return g_guiSettings.GetString("lookandfeel.skin") == ID();
 }
 
-const INFO::CSkinVariableString* CSkinInfo::CreateSkinVariable(const CStdString& name)
+const INFO::CSkinVariableString* CSkinInfo::CreateSkinVariable(const CStdString& name, int context)
 {
-  return m_includes.CreateSkinVariable(name);
+  return m_includes.CreateSkinVariable(name, context);
 }
 
 } /*namespace ADDON*/

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -109,7 +109,7 @@ public:
 //  static bool Check(const CStdString& strSkinDir); // checks if everything is present and accounted for without loading the skin
   static double GetMinVersion();
   void LoadIncludes();
-  const INFO::CSkinVariableString* CreateSkinVariable(const CStdString& name);
+  const INFO::CSkinVariableString* CreateSkinVariable(const CStdString& name, int context);
 protected:
   /*! \brief Given a resolution, retrieve the corresponding directory name
    \param res RESOLUTION to translate

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -109,6 +109,7 @@ public:
 //  static bool Check(const CStdString& strSkinDir); // checks if everything is present and accounted for without loading the skin
   static double GetMinVersion();
   void LoadIncludes();
+  const INFO::CSkinVariableString* CreateSkinVariable(const CStdString& name);
 protected:
   /*! \brief Given a resolution, retrieve the corresponding directory name
    \param res RESOLUTION to translate

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -213,13 +213,13 @@ void CGUIButtonControl::SetInvalid()
 
 void CGUIButtonControl::SetLabel(const string &label)
 { // NOTE: No fallback for buttons at this point
-  m_info.SetLabel(label, "");
+  m_info.SetLabel(label, "", GetParentID());
   SetInvalid();
 }
 
 void CGUIButtonControl::SetLabel2(const string &label2)
 { // NOTE: No fallback for buttons at this point
-  m_info2.SetLabel(label2, "");
+  m_info2.SetLabel(label2, "", GetParentID());
   SetInvalid();
 }
 

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -74,7 +74,7 @@ public:
    */
   static bool GetDimension(const TiXmlNode* pRootNode, const char* strTag, float &value, float &min);
   static bool GetAspectRatio(const TiXmlNode* pRootNode, const char* strTag, CAspectRatio &aspectRatio);
-  static bool GetInfoTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo &image, CGUIInfoLabel &info);
+  static bool GetInfoTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo &image, CGUIInfoLabel &info, int parentID);
   static bool GetTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo &image);
   static bool GetAlignment(const TiXmlNode* pRootNode, const char* strTag, uint32_t& dwAlignment);
   static bool GetAlignmentY(const TiXmlNode* pRootNode, const char* strTag, uint32_t& dwAlignment);
@@ -90,9 +90,9 @@ public:
    \param infoLabel returned infoLabel
    \return true if a valid info label was read, false otherwise
    */
-  static bool GetInfoLabelFromElement(const TiXmlElement *element, CGUIInfoLabel &infoLabel);
-  static void GetInfoLabel(const TiXmlNode *pControlNode, const CStdString &labelTag, CGUIInfoLabel &infoLabel);
-  static void GetInfoLabels(const TiXmlNode *pControlNode, const CStdString &labelTag, std::vector<CGUIInfoLabel> &infoLabels);
+  static bool GetInfoLabelFromElement(const TiXmlElement *element, CGUIInfoLabel &infoLabel, int parentID);
+  static void GetInfoLabel(const TiXmlNode *pControlNode, const CStdString &labelTag, CGUIInfoLabel &infoLabel, int parentID);
+  static void GetInfoLabels(const TiXmlNode *pControlNode, const CStdString &labelTag, std::vector<CGUIInfoLabel> &infoLabels, int parentID);
   static bool GetColor(const TiXmlNode* pRootNode, const char* strTag, color_t &value);
   static bool GetInfoColor(const TiXmlNode* pRootNode, const char* strTag, CGUIInfoColor &value);
   static CStdString FilterLabel(const CStdString &label);

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -67,7 +67,7 @@ void CGUIFadeLabelControl::SetInfo(const vector<CGUIInfoLabel> &infoLabels)
 
 void CGUIFadeLabelControl::AddLabel(const string &label)
 {
-  m_infoLabels.push_back(CGUIInfoLabel(label));
+  m_infoLabels.push_back(CGUIInfoLabel(label, "", GetParentID()));
 }
 
 void CGUIFadeLabelControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -302,7 +302,7 @@ void CGUIImage::SetCrossFade(unsigned int time)
 void CGUIImage::SetFileName(const CStdString& strFileName, bool setConstant)
 {
   if (setConstant)
-    m_info.SetLabel(strFileName, "");
+    m_info.SetLabel(strFileName, "", GetParentID());
 
   if (m_crossFadeTime)
   {

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -85,6 +85,7 @@ void CGUIIncludes::ClearIncludes()
   m_includes.clear();
   m_defaults.clear();
   m_constants.clear();
+  m_skinvariables.clear();
   m_files.clear();
 }
 
@@ -153,6 +154,16 @@ bool CGUIIncludes::LoadIncludesFromXML(const TiXmlElement *root)
     node = node->NextSiblingElement("constant");
   }
 
+  node = root->FirstChildElement("variable");
+  while (node)
+  {
+    if (node->Attribute("name") && node->FirstChild())
+    {
+      CStdString tagName = node->Attribute("name");
+      m_skinvariables.insert(make_pair(tagName, *node));
+    }
+    node = node->NextSiblingElement("variable");
+  }
   INFO::CSkinVariable::LoadFromXML(root);
 
   return true;

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -284,10 +284,10 @@ CStdString CGUIIncludes::ResolveConstant(const CStdString &constant) const
   return value;
 }
 
-const INFO::CSkinVariableString* CGUIIncludes::CreateSkinVariable(const CStdString& name)
+const INFO::CSkinVariableString* CGUIIncludes::CreateSkinVariable(const CStdString& name, int context)
 {
   map<CStdString, TiXmlElement>::const_iterator it = m_skinvariables.find(name);
   if (it != m_skinvariables.end())
-    return INFO::CSkinVariable::CreateFromXML(it->second);
+    return INFO::CSkinVariable::CreateFromXML(it->second, context);
   return NULL;
 }

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -164,7 +164,6 @@ bool CGUIIncludes::LoadIncludesFromXML(const TiXmlElement *root)
     }
     node = node->NextSiblingElement("variable");
   }
-  INFO::CSkinVariable::LoadFromXML(root);
 
   return true;
 }
@@ -283,4 +282,12 @@ CStdString CGUIIncludes::ResolveConstant(const CStdString &constant) const
   CStdString value;
   StringUtils::JoinString(values, ",", value);
   return value;
+}
+
+const INFO::CSkinVariableString* CGUIIncludes::CreateSkinVariable(const CStdString& name)
+{
+  map<CStdString, TiXmlElement>::const_iterator it = m_skinvariables.find(name);
+  if (it != m_skinvariables.end())
+    return INFO::CSkinVariable::CreateFromXML(it->second);
+  return NULL;
 }

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -49,7 +49,7 @@ public:
    \param node an XML Element - all child elements are traversed.
    */
   void ResolveIncludes(TiXmlElement *node);
-  const INFO::CSkinVariableString* CreateSkinVariable(const CStdString& name);
+  const INFO::CSkinVariableString* CreateSkinVariable(const CStdString& name, int context);
 
 private:
   void ResolveIncludesForNode(TiXmlElement *node);

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -28,6 +28,10 @@
 
 // forward definitions
 class TiXmlElement;
+namespace INFO
+{
+  class CSkinVariableString;
+}
 
 class CGUIIncludes
 {
@@ -45,6 +49,7 @@ public:
    \param node an XML Element - all child elements are traversed.
    */
   void ResolveIncludes(TiXmlElement *node);
+  const INFO::CSkinVariableString* CreateSkinVariable(const CStdString& name);
 
 private:
   void ResolveIncludesForNode(TiXmlElement *node);

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -52,6 +52,7 @@ private:
   bool HasIncludeFile(const CStdString &includeFile) const;
   std::map<CStdString, TiXmlElement> m_includes;
   std::map<CStdString, TiXmlElement> m_defaults;
+  std::map<CStdString, TiXmlElement> m_skinvariables;
   std::map<CStdString, CStdString> m_constants;
   std::vector<CStdString> m_files;
   typedef std::vector<CStdString>::const_iterator iFiles;

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -28,6 +28,7 @@
 #include "GUIColorManager.h"
 #include "GUIListItem.h"
 #include "utils/StringUtils.h"
+#include "addons/Skin.h"
 
 using namespace std;
 using ADDON::CAddonMgr;
@@ -303,10 +304,9 @@ void CGUIInfoLabel::Parse(const CStdString &label)
         {
           info = g_infoManager.TranslateSkinVariableString(params[0]);
           if (info == 0)
-          {
-            // we didn't register this conditional label yet!
-            CLog::Log(LOGWARNING, "Label Formating: $VAR[%s] is not yet defined", params[0].c_str());
-          }
+            info = g_infoManager.RegisterSkinVariableString(g_SkinInfo->CreateSkinVariable(params[0]));
+          if (info == 0) // skinner didn't define this conditional label!
+            CLog::Log(LOGWARNING, "Label Formating: $VAR[%s] is not defined", params[0].c_str());
         }
         else
           info = g_infoManager.TranslateString(params[0]);

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -119,15 +119,15 @@ CGUIInfoLabel::CGUIInfoLabel()
 {
 }
 
-CGUIInfoLabel::CGUIInfoLabel(const CStdString &label, const CStdString &fallback)
+CGUIInfoLabel::CGUIInfoLabel(const CStdString &label, const CStdString &fallback, int context)
 {
-  SetLabel(label, fallback);
+  SetLabel(label, fallback, context);
 }
 
-void CGUIInfoLabel::SetLabel(const CStdString &label, const CStdString &fallback)
+void CGUIInfoLabel::SetLabel(const CStdString &label, const CStdString &fallback, int context)
 {
   m_fallback = fallback;
-  Parse(label);
+  Parse(label, context);
 }
 
 CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage) const
@@ -261,7 +261,7 @@ const static infoformat infoformatmap[] = {{ "$INFO[",    FORMATINFO },
                                            { "$ESCINFO[", FORMATESCINFO},
                                            { "$VAR[",     FORMATVAR}};
 
-void CGUIInfoLabel::Parse(const CStdString &label)
+void CGUIInfoLabel::Parse(const CStdString &label, int context)
 {
   m_info.clear();
   // Step 1: Replace all $LOCALIZE[number] with the real string
@@ -302,9 +302,9 @@ void CGUIInfoLabel::Parse(const CStdString &label)
         int info;
         if (format == FORMATVAR)
         {
-          info = g_infoManager.TranslateSkinVariableString(params[0]);
+          info = g_infoManager.TranslateSkinVariableString(params[0], context);
           if (info == 0)
-            info = g_infoManager.RegisterSkinVariableString(g_SkinInfo->CreateSkinVariable(params[0]));
+            info = g_infoManager.RegisterSkinVariableString(g_SkinInfo->CreateSkinVariable(params[0], context));
           if (info == 0) // skinner didn't define this conditional label!
             CLog::Log(LOGWARNING, "Label Formating: $VAR[%s] is not defined", params[0].c_str());
         }
@@ -358,6 +358,6 @@ CStdString CGUIInfoLabel::CInfoPortion::GetLabel(const CStdString &info) const
 
 CStdString CGUIInfoLabel::GetLabel(const CStdString &label, int contextWindow, bool preferImage)
 { // translate the label
-  CGUIInfoLabel info(label, "");
+  CGUIInfoLabel info(label, "", contextWindow);
   return info.GetLabel(contextWindow, preferImage);
 }

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -72,9 +72,9 @@ class CGUIInfoLabel
 {
 public:
   CGUIInfoLabel();
-  CGUIInfoLabel(const CStdString &label, const CStdString &fallback = "");
+  CGUIInfoLabel(const CStdString &label, const CStdString &fallback = "", int context = 0);
 
-  void SetLabel(const CStdString &label, const CStdString &fallback);
+  void SetLabel(const CStdString &label, const CStdString &fallback, int context = 0);
   CStdString GetLabel(int contextWindow, bool preferImage = false) const;
   CStdString GetItemLabel(const CGUIListItem *item, bool preferImage = false) const;
   bool IsConstant() const;
@@ -99,7 +99,7 @@ public:
   static CStdString ReplaceAddonStrings(const CStdString &label);
 
 private:
-  void Parse(const CStdString &label);
+  void Parse(const CStdString &label, int context);
 
   class CInfoPortion
   {

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -142,7 +142,7 @@ bool CGUILabelControl::CanFocus() const
 
 void CGUILabelControl::SetLabel(const string &strLabel)
 {
-  m_infoLabel.SetLabel(strLabel, "");
+  m_infoLabel.SetLabel(strLabel, "", GetParentID());
   if (m_iCursorPos > (int)strLabel.size())
     m_iCursorPos = strLabel.size();
 

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -189,14 +189,14 @@ void CGUIListItemLayout::CreateListControlLayouts(float width, float height, boo
     m_group.AddControl(tex);
   }
   CGUIImage *image = new CGUIImage(0, 0, 8, 0, iconWidth, texHeight, CTextureInfo(""));
-  image->SetInfo(CGUIInfoLabel("$INFO[ListItem.Icon]"));
+  image->SetInfo(CGUIInfoLabel("$INFO[ListItem.Icon]", "", m_group.GetParentID()));
   image->SetAspectRatio(CAspectRatio::AR_KEEP);
   m_group.AddControl(image);
   float x = iconWidth + labelInfo.offsetX + 10;
-  CGUIListLabel *label = new CGUIListLabel(0, 0, x, labelInfo.offsetY, width - x - 18, height, labelInfo, CGUIInfoLabel("$INFO[ListItem.Label]"), false);
+  CGUIListLabel *label = new CGUIListLabel(0, 0, x, labelInfo.offsetY, width - x - 18, height, labelInfo, CGUIInfoLabel("$INFO[ListItem.Label]", "", m_group.GetParentID()), false);
   m_group.AddControl(label);
   x = labelInfo2.offsetX ? labelInfo2.offsetX : m_width - 16;
-  label = new CGUIListLabel(0, 0, x, labelInfo2.offsetY, x - iconWidth - 20, height, labelInfo2, CGUIInfoLabel("$INFO[ListItem.Label2]"), false);
+  label = new CGUIListLabel(0, 0, x, labelInfo2.offsetY, x - iconWidth - 20, height, labelInfo2, CGUIInfoLabel("$INFO[ListItem.Label2]", "", m_group.GetParentID()), false);
   m_group.AddControl(label);
 }
 //#endif

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -39,10 +39,10 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
   if (click && click->FirstChild())
   {
     CGUIInfoLabel label, label2, thumb, icon;
-    CGUIControlFactory::GetInfoLabel(item, "label", label);
-    CGUIControlFactory::GetInfoLabel(item, "label2", label2);
-    CGUIControlFactory::GetInfoLabel(item, "thumb", thumb);
-    CGUIControlFactory::GetInfoLabel(item, "icon", icon);
+    CGUIControlFactory::GetInfoLabel(item, "label", label, parentID);
+    CGUIControlFactory::GetInfoLabel(item, "label2", label2, parentID);
+    CGUIControlFactory::GetInfoLabel(item, "thumb", thumb, parentID);
+    CGUIControlFactory::GetInfoLabel(item, "icon", icon, parentID);
     const char *id = item->Attribute("id");
     CStdString condition;
     CGUIControlFactory::GetConditionalVisibility(item, condition);
@@ -63,7 +63,7 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
     {
       CStdString name = property->Attribute("name");
       CGUIInfoLabel prop;
-      if (!name.IsEmpty() && CGUIControlFactory::GetInfoLabelFromElement(property, prop))
+      if (!name.IsEmpty() && CGUIControlFactory::GetInfoLabelFromElement(property, prop, parentID))
       {
         SetProperty(name, prop.GetLabel(parentID, true).c_str());
         if (!prop.IsConstant())

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -244,7 +244,7 @@ bool CGUITextBox::OnMessage(CGUIMessage& message)
       m_scrollOffset = 0;
       ResetAutoScrolling();
       CGUITextLayout::Reset();
-      m_info.SetLabel(message.GetLabel(), "");
+      m_info.SetLabel(message.GetLabel(), "", GetParentID());
     }
 
     if (message.GetMessage() == GUI_MSG_LABEL_RESET)

--- a/xbmc/interfaces/info/SkinVariable.cpp
+++ b/xbmc/interfaces/info/SkinVariable.cpp
@@ -75,7 +75,7 @@ const CStdString& CSkinVariableString::GetName() const
   return m_name;
 }
 
-CStdString CSkinVariableString::GetValue(int contextWindow, bool preferImage /* = false*/, const CGUIListItem *item /* = NULL */)
+CStdString CSkinVariableString::GetValue(bool preferImage /* = false*/, const CGUIListItem *item /* = NULL */)
 {
   for (VECCONDITIONLABELPAIR::const_iterator it = m_conditionLabelPairs.begin() ; it != m_conditionLabelPairs.end(); it++)
   {

--- a/xbmc/interfaces/info/SkinVariable.cpp
+++ b/xbmc/interfaces/info/SkinVariable.cpp
@@ -28,44 +28,36 @@ using namespace INFO;
 
 #define DEFAULT_VALUE -1
 
-void CSkinVariable::LoadFromXML(const TiXmlElement *root)
+const CSkinVariableString* CSkinVariable::CreateFromXML(const TiXmlElement& node)
 {
-  const TiXmlElement* node = root->FirstChildElement("variable");
-  while (node)
+  const char* name = node.Attribute("name");
+  if (name)
   {
-    if (node->Attribute("name") && node->FirstChild())
+    CSkinVariableString* tmp = new CSkinVariableString;
+    tmp->m_name = name;
+    const TiXmlElement* valuenode = node.FirstChildElement("value");
+    while (valuenode)
     {
-      const char* type = node->Attribute("type");
-
-      // parameter type will be used in future for numeric and bool variables
-      if (!type || strnicmp(type, "text", 4) == 0)
+      if (valuenode->FirstChild())
       {
-        CSkinVariableString tmp;
-        tmp.m_name = node->Attribute("name");
-        const TiXmlElement* valuenode = node->FirstChildElement("value");
-        while (valuenode)
-        {
-          if (valuenode->FirstChild())
-          {
-            CSkinVariableString::ConditionLabelPair pair;
-            if (valuenode->Attribute("condition"))
-              pair.m_condition = g_infoManager.Register(valuenode->Attribute("condition"));
-            else
-              pair.m_condition = DEFAULT_VALUE;
+        CSkinVariableString::ConditionLabelPair pair;
+        if (valuenode->Attribute("condition"))
+          pair.m_condition = g_infoManager.Register(valuenode->Attribute("condition"));
+        else
+          pair.m_condition = DEFAULT_VALUE;
 
-            pair.m_label = CGUIInfoLabel(valuenode->FirstChild()->Value());
-            tmp.m_conditionLabelPairs.push_back(pair);
-            if (pair.m_condition == DEFAULT_VALUE)
-              break; // once we reach default value (without condition) break iterating
-          }
-          valuenode = valuenode->NextSiblingElement("value");
-        }
-        if (tmp.m_conditionLabelPairs.size() > 0)
-          g_infoManager.RegisterSkinVariableString(tmp);
+        pair.m_label = CGUIInfoLabel(valuenode->FirstChild()->Value());
+        tmp->m_conditionLabelPairs.push_back(pair);
+        if (pair.m_condition == DEFAULT_VALUE)
+          break; // once we reach default value (without condition) break iterating
       }
+      valuenode = valuenode->NextSiblingElement("value");
     }
-    node = node->NextSiblingElement("variable");
+    if (tmp->m_conditionLabelPairs.size() > 0)
+      return tmp;
+    delete tmp;
   }
+  return NULL;
 }
 
 CSkinVariableString::CSkinVariableString()

--- a/xbmc/interfaces/info/SkinVariable.cpp
+++ b/xbmc/interfaces/info/SkinVariable.cpp
@@ -28,13 +28,14 @@ using namespace INFO;
 
 #define DEFAULT_VALUE -1
 
-const CSkinVariableString* CSkinVariable::CreateFromXML(const TiXmlElement& node)
+const CSkinVariableString* CSkinVariable::CreateFromXML(const TiXmlElement& node, int context)
 {
   const char* name = node.Attribute("name");
   if (name)
   {
     CSkinVariableString* tmp = new CSkinVariableString;
     tmp->m_name = name;
+    tmp->m_context = context;
     const TiXmlElement* valuenode = node.FirstChildElement("value");
     while (valuenode)
     {
@@ -42,7 +43,7 @@ const CSkinVariableString* CSkinVariable::CreateFromXML(const TiXmlElement& node
       {
         CSkinVariableString::ConditionLabelPair pair;
         if (valuenode->Attribute("condition"))
-          pair.m_condition = g_infoManager.Register(valuenode->Attribute("condition"));
+          pair.m_condition = g_infoManager.Register(valuenode->Attribute("condition"), context);
         else
           pair.m_condition = DEFAULT_VALUE;
 
@@ -64,6 +65,11 @@ CSkinVariableString::CSkinVariableString()
 {
 }
 
+int CSkinVariableString::GetContext() const
+{
+  return m_context;
+}
+
 const CStdString& CSkinVariableString::GetName() const
 {
   return m_name;
@@ -78,7 +84,7 @@ CStdString CSkinVariableString::GetValue(int contextWindow, bool preferImage /* 
       if (item)
         return it->m_label.GetItemLabel(item, preferImage);
       else
-        return it->m_label.GetLabel(contextWindow, preferImage);
+        return it->m_label.GetLabel(m_context, preferImage);
     }
   }
   return "";

--- a/xbmc/interfaces/info/SkinVariable.h
+++ b/xbmc/interfaces/info/SkinVariable.h
@@ -39,7 +39,7 @@ class CSkinVariableString
 public:
   const CStdString& GetName() const;
   int GetContext() const;
-  CStdString GetValue(int contextWindow, bool preferImage = false, const CGUIListItem *item = NULL );
+  CStdString GetValue(bool preferImage = false, const CGUIListItem *item = NULL );
 private:
   CSkinVariableString();
 

--- a/xbmc/interfaces/info/SkinVariable.h
+++ b/xbmc/interfaces/info/SkinVariable.h
@@ -26,10 +26,12 @@ class TiXmlElement;
 
 namespace INFO
 {
+class CSkinVariableString;
+
 class CSkinVariable
 {
 public:
-  static void LoadFromXML(const TiXmlElement *root);
+  static const CSkinVariableString* CreateFromXML(const TiXmlElement& node);
 };
 
 class CSkinVariableString

--- a/xbmc/interfaces/info/SkinVariable.h
+++ b/xbmc/interfaces/info/SkinVariable.h
@@ -31,18 +31,20 @@ class CSkinVariableString;
 class CSkinVariable
 {
 public:
-  static const CSkinVariableString* CreateFromXML(const TiXmlElement& node);
+  static const CSkinVariableString* CreateFromXML(const TiXmlElement& node, int context);
 };
 
 class CSkinVariableString
 {
 public:
   const CStdString& GetName() const;
+  int GetContext() const;
   CStdString GetValue(int contextWindow, bool preferImage = false, const CGUIListItem *item = NULL );
 private:
   CSkinVariableString();
 
   CStdString m_name;
+  int m_context;
 
   struct ConditionLabelPair
   {


### PR DESCRIPTION
Currently skin variables are created without context info. This cause problems if boolean conditions need context info to return proper value (http://forum.xbmc.org/showpost.php?p=905703&postcount=70). This PR fix this issue by adding context information to skin variables.

Simple logic:
- create skin variable "definitions" when parsing includes.xml (no context info)
- create proper skin variables with context info (copy of definition with context aware conditions) when parsing window .xml

This is bugfix so I think this (after review) should go in before release.
