### PR TITLE
replaced some strcpy's that were causing crashes, with strncpy's in unrarxlib

### DIFF
--- a/lib/UnrarXLib/extract.cpp
+++ b/lib/UnrarXLib/extract.cpp
@@ -5,6 +5,16 @@
 #include "XEventUtils.h"
 #endif
 
+// a cautious wrapper around strncpy
+char *strncpy_null_terminated(char *dest, const char *src, size_t n)
+{
+  char *result = strncpy(dest, src, n);
+  if(n>0) {
+    dest[n-1] = '\0';
+  }
+  return result;
+}
+
 CmdExtract::CmdExtract()
 {
   TotalFileCount=0;
@@ -90,7 +100,7 @@ void CmdExtract::ExtractArchiveInit(CommandData *Cmd,Archive &Arc)
 #endif
 
   if (*Cmd->Password!=0)
-    strncpy(Password,Cmd->Password, MAXPASSWORD);
+    strncpy_null_terminated(Password,Cmd->Password, MAXPASSWORD);
   PasswordAll=(*Cmd->Password!=0);
 
   DataIO.UnpVolume=false;
@@ -249,7 +259,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
   char ArcFileName[NM];
 
   IntToExt(Arc.NewLhd.FileName,Arc.NewLhd.FileName);
-  strncpy(ArcFileName,Arc.NewLhd.FileName, NM);
+  strncpy_null_terminated(ArcFileName,Arc.NewLhd.FileName, NM);
 
   wchar ArcFileNameW[NM];
   *ArcFileNameW=0;
@@ -297,7 +307,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
     char Name[NM];
     WideToChar(ArcFileNameW,Name);
     if (IsNameUsable(Name))
-      strncpy(ArcFileName,Name, NM);
+      strncpy_null_terminated(ArcFileName,Name, NM);
   }
 #endif
 
@@ -329,7 +339,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
   if ((Arc.NewLhd.Flags & (LHD_SPLIT_BEFORE/*|LHD_SOLID*/)) && FirstFile)
   {
     char CurVolName[NM];
-    strncpy(CurVolName,ArcName, NM);
+    strncpy_null_terminated(CurVolName,ArcName, NM);
 
     VolNameToFirstName(ArcName,ArcName,(Arc.NewMhd.Flags & MHD_NEWNUMBERING) != 0);
     if (stricomp(ArcName,CurVolName)!=0 && FileExist(ArcName))
@@ -351,7 +361,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
       }
     }
 #endif
-    strncpy(ArcName,CurVolName, NM);
+    strncpy_null_terminated(ArcName,CurVolName, NM);
   }
 #endif
 
@@ -393,7 +403,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
           if (Cmd->Callback==NULL ||
               Cmd->Callback(UCM_NEEDPASSWORD,Cmd->UserData,(LONG)Cmd->Password,sizeof(Cmd->Password))==-1)
             return(false);
-        strncpy(Password,Cmd->Password, MAXPASSWORD);
+        strncpy_null_terminated(Password,Cmd->Password, MAXPASSWORD);
 
 #else
         if (!GetPassword(PASSWORD_FILE,ArcFileName,Password,sizeof(Password)))
@@ -430,7 +440,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
       WideToChar(Cmd->ExtrPathW,DestFileName);
     else
 #endif
-      strncpy(DestFileName,Cmd->ExtrPath, NM);
+      strncpy_null_terminated(DestFileName,Cmd->ExtrPath, NM);
 
 
 #ifndef SFX_MODULE
@@ -551,7 +561,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
 #ifdef RARDLL
     if (*Cmd->DllDestName)
     {
-      strncpy(DestFileName,Cmd->DllDestName,sizeof(DestFileName));
+      strncpy_null_terminated(DestFileName,Cmd->DllDestName,sizeof(DestFileName));
       *DestFileNameW=0;
       if (Cmd->DllOpMode!=RAR_EXTRACT)
         ExtrFile=false;

--- a/lib/UnrarXLib/extract.cpp
+++ b/lib/UnrarXLib/extract.cpp
@@ -90,7 +90,7 @@ void CmdExtract::ExtractArchiveInit(CommandData *Cmd,Archive &Arc)
 #endif
 
   if (*Cmd->Password!=0)
-    strcpy(Password,Cmd->Password);
+    strncpy(Password,Cmd->Password, MAXPASSWORD);
   PasswordAll=(*Cmd->Password!=0);
 
   DataIO.UnpVolume=false;
@@ -249,7 +249,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
   char ArcFileName[NM];
 
   IntToExt(Arc.NewLhd.FileName,Arc.NewLhd.FileName);
-  strcpy(ArcFileName,Arc.NewLhd.FileName);
+  strncpy(ArcFileName,Arc.NewLhd.FileName, NM);
 
   wchar ArcFileNameW[NM];
   *ArcFileNameW=0;
@@ -297,7 +297,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
     char Name[NM];
     WideToChar(ArcFileNameW,Name);
     if (IsNameUsable(Name))
-    strcpy(ArcFileName,Name);
+      strncpy(ArcFileName,Name, NM);
   }
 #endif
 
@@ -329,7 +329,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
   if ((Arc.NewLhd.Flags & (LHD_SPLIT_BEFORE/*|LHD_SOLID*/)) && FirstFile)
   {
     char CurVolName[NM];
-    strcpy(CurVolName,ArcName);
+    strncpy(CurVolName,ArcName, NM);
 
     VolNameToFirstName(ArcName,ArcName,(Arc.NewMhd.Flags & MHD_NEWNUMBERING) != 0);
     if (stricomp(ArcName,CurVolName)!=0 && FileExist(ArcName))
@@ -351,7 +351,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
       }
     }
 #endif
-    strcpy(ArcName,CurVolName);
+    strncpy(ArcName,CurVolName, NM);
   }
 #endif
 
@@ -393,7 +393,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
           if (Cmd->Callback==NULL ||
               Cmd->Callback(UCM_NEEDPASSWORD,Cmd->UserData,(LONG)Cmd->Password,sizeof(Cmd->Password))==-1)
             return(false);
-        strcpy(Password,Cmd->Password);
+        strncpy(Password,Cmd->Password, MAXPASSWORD);
 
 #else
         if (!GetPassword(PASSWORD_FILE,ArcFileName,Password,sizeof(Password)))
@@ -430,7 +430,7 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
       WideToChar(Cmd->ExtrPathW,DestFileName);
     else
 #endif
-      strcpy(DestFileName,Cmd->ExtrPath);
+      strncpy(DestFileName,Cmd->ExtrPath, NM);
 
 
 #ifndef SFX_MODULE


### PR DESCRIPTION
As per the subject, xbmc was occasionally crashing for me while processing new files, and the back traces points to these strcpy's, so I figured out how long the target strings were and switched to strncpy. I've been using this patch for months with no problem.

I was motivated to submit this by the recent blog post on the web site, hopefully I've done it right.
