### PR TITLE
changed: enable zeroconf if airplay is being enabled. disable airplay if 

### DIFF
--- a/xbmc/network/Zeroconf.h
+++ b/xbmc/network/Zeroconf.h
@@ -91,6 +91,10 @@ protected:
   //removes all services (short hand for "for i in m_service_map doRemoveService(i)")
   virtual void doStop() = 0;
 
+#ifdef TARGET_WINDOWS
+  virtual bool IsServiceAvailable() = 0;
+#endif
+
 protected:
   //singleton: we don't want to get instantiated nor copied or deleted from outside
   CZeroconf();

--- a/xbmc/network/windows/ZeroconfWIN.cpp
+++ b/xbmc/network/windows/ZeroconfWIN.cpp
@@ -37,6 +37,13 @@ CZeroconfWIN::~CZeroconfWIN()
   doStop();
 }
 
+bool CZeroconfWIN::IsServiceAvailable()
+{
+  uint32_t version;
+  uint32_t size = sizeof(version);
+  DNSServiceErrorType err = DNSServiceGetProperty(kDNSServiceProperty_DaemonVersion, &version, &size);
+  return err == kDNSServiceErr_NoError;
+}
 
 //methods to implement for concrete implementations
 bool CZeroconfWIN::doPublishService(const std::string& fcr_identifier,

--- a/xbmc/network/windows/ZeroconfWIN.h
+++ b/xbmc/network/windows/ZeroconfWIN.h
@@ -43,6 +43,8 @@ protected:
 
   virtual void doStop();
 
+  virtual bool IsServiceAvailable();
+
 private:
 
   //returns the string that gets published (a.k.a. add the hostname)

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -1291,16 +1291,37 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
   {
 #ifdef HAS_ZEROCONF
     //ifdef zeroconf here because it's only found in guisettings if defined
-    CZeroconf::GetInstance()->Stop();
     if(g_guiSettings.GetBool("services.zeroconf"))
+    {
+      CZeroconf::GetInstance()->Stop();
       CZeroconf::GetInstance()->Start();
+    }
+#ifdef HAS_AIRPLAY
+    else
+    {
+      g_application.StopAirplayServer(true);
+      g_guiSettings.SetBool("services.airplay", false);
+      CZeroconf::GetInstance()->Stop();
+    }
+#endif
 #endif
   }
   else if (strSetting.Equals("services.airplay"))
   {  
 #ifdef HAS_AIRPLAY  
     if (g_guiSettings.GetBool("services.airplay"))
+    {
+#ifdef HAS_ZEROCONF
+      // AirPlay needs zeroconf
+      if(!g_guiSettings.GetBool("services.zeroconf"))
+      {
+        g_guiSettings.SetBool("services.zeroconf", true);
+        CZeroconf::GetInstance()->Stop();
+        CZeroconf::GetInstance()->Start();
+      }
+#endif //HAS_ZEROCONF
       g_application.StartAirplayServer();//will stop the server before internal
+    }
     else
       g_application.StopAirplayServer(true);//will stop the server before internal    
 #endif//HAS_AIRPLAY      


### PR DESCRIPTION
This PR enables zeroconf if airplay is being enabled and disables airplay if zeroconf is being disabled.

Latter one might be discussable but I think its better to have it in to not confuse the user.
