### PR TITLE
Fix compile against old libudev on eg. Ubuntu Karmic

### DIFF
--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
@@ -21,7 +21,9 @@
 
 #include "PeripheralBusUSBLibUdev.h"
 #include "peripherals/Peripherals.h"
+extern "C" {
 #include <libudev.h>
+}
 #include <usb.h>
 #include <poll.h>
 #include "utils/log.h"


### PR DESCRIPTION
libudev.h (147) on older Linux distros, like Karmic does not include extern "C" declarations and so doesn't compile against C++ code.
