### PR TITLE
peripherals + cec fixes

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1137,7 +1137,7 @@ fi
 USE_LIBCEC=0
 if test "x$use_cec" != "xno"; then
   # libcec is dyloaded, so we need to check for its headers and link any depends.
-  PKG_CHECK_MODULES([CEC],[libcec = 0.6.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
+  PKG_CHECK_MODULES([CEC],[libcec = 0.7.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
   if test "x$use_libcec" != "xno" && test "$host_vendor" != "apple"; then
     # libcec has libudev as depends under linux and we also need usb headers.
     PKG_CHECK_MODULES([USB],[libusb],,[use_libcec="no";AC_MSG_RESULT($libusb_not_found)])

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2384,4 +2384,5 @@
   <string id="36012">Could not detect the CEC adapter.</string>
   <string id="36013">Unsupported libcec interface version. %d is greater than the version XBMC supports (%d)</string>
   <string id="36014">Put this PC in standby mode when the TV is switched off</string>
+  <string id="36015">HDMI port number</string>
 </strings>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2385,4 +2385,5 @@
   <string id="36013">Unsupported libcec interface version. %d is greater than the version XBMC supports (%d)</string>
   <string id="36014">Put this PC in standby mode when the TV is switched off</string>
   <string id="36015">HDMI port number</string>
+  <string id="36016">XBMC connected</string>
 </strings>

--- a/project/BuildDependencies/scripts/libcec_d.bat
+++ b/project/BuildDependencies/scripts/libcec_d.bat
@@ -7,7 +7,7 @@ CALL dlextract.bat libcec %FILES%
 
 cd %TMP_PATH%
 
-xcopy libcec\include\* "%CUR_PATH%\include\libcec" /E /Q /I /Y
+xcopy libcec\include\* "%CUR_PATH%\include" /E /Q /I /Y
 
 copy libcec\libcec.dll "%XBMC_PATH%\system\."
 copy libcec\pthreadVC2.dll "%XBMC_PATH%\system\."

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        mirror                                      source of the file
 
-libcec6.zip                       http://xbmc.opdenkamp.eu/                   http://packages.pulse-eight.net/
+libcec7.zip                       http://xbmc.opdenkamp.eu/                   http://packages.pulse-eight.net/

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -19,6 +19,7 @@
   <peripheral vendor="2548" product="1001" bus="usb" name="Pulse-Eight CEC Adaptor" mapTo="cec">
     <setting key="enabled" type="bool" value="1" label="305" />
     <setting key="port" type="string" value="" label="792" />
+    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="16" label="36015" />
     <setting key="cec_power_on_startup" type="bool" value="1" label="36007" />
     <setting key="cec_power_off_shutdown" type="bool" value="1" label="36008" />
     <setting key="cec_standby_screensaver" type="bool" value="1" label="36009" />

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -427,6 +427,9 @@ case TMSG_POWERDOWN:
       }
       break;
 
+    case TMSG_SETLANGUAGE:
+      g_guiSettings.SetLanguage(pMsg->strParam);
+      break;
     case TMSG_MEDIA_STOP:
       {
         // restore to previous window if needed
@@ -994,6 +997,13 @@ void CApplicationMessenger::PictureSlideShow(string pathname, bool bScreensaver 
   ThreadMessage tMsg = {dwMessage};
   tMsg.strParam = pathname;
   tMsg.dwParam1 = addTBN ? 1 : 0;
+  SendMessage(tMsg);
+}
+
+void CApplicationMessenger::SetGUILanguage(const std::string &strLanguage)
+{
+  ThreadMessage tMsg = {TMSG_SETLANGUAGE};
+  tMsg.strParam = strLanguage;
   SendMessage(tMsg);
 }
 

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -75,6 +75,7 @@ class CGUIWindow;
 #define TMSG_SWITCHTOFULLSCREEN   308
 #define TMSG_MINIMIZE             309
 #define TMSG_TOGGLEFULLSCREEN     310
+#define TMSG_SETLANGUAGE          311
 
 #define TMSG_HTTPAPI              400
 
@@ -164,6 +165,7 @@ public:
   void PlayFile(const CFileItem &item, bool bRestart = false); // thread safe version of g_application.PlayFile()
   void PictureShow(std::string filename);
   void PictureSlideShow(std::string pathname, bool bScreensaver = false, bool addTBN = false);
+  void SetGUILanguage(const std::string &strLanguage);
   void Shutdown();
   void Powerdown();
   void Quit();

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -400,8 +400,8 @@ void CPeripherals::GetSettingsFromMappingsFile(TiXmlElement *xmlNode, map<CStdSt
     {
       int iValue = currentNode->Attribute("value") ? atoi(currentNode->Attribute("value")) : 0;
       int iMin   = currentNode->Attribute("min") ? atoi(currentNode->Attribute("min")) : 0;
-      int iStep  = currentNode->Attribute("step") ? atoi(currentNode->Attribute("step")) : 0;
-      int iMax   = currentNode->Attribute("max") ? atoi(currentNode->Attribute("max")) : 0;
+      int iStep  = currentNode->Attribute("step") ? atoi(currentNode->Attribute("step")) : 1;
+      int iMax   = currentNode->Attribute("max") ? atoi(currentNode->Attribute("max")) : 255;
       CStdString strFormat(currentNode->Attribute("format"));
       setting = new CSettingInt(0, strKey, iLabelId, iValue, iMin, iStep, iMax, SPIN_CONTROL_INT, strFormat);
     }

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -196,6 +196,18 @@ int CPeripherals::GetPeripheralsWithFeature(vector<CPeripheral *> &results, cons
   return iReturn;
 }
 
+size_t CPeripherals::GetNumberOfPeripherals() const
+{
+  size_t iReturn(0);
+  CSingleLock lock(m_critSection);
+  for (unsigned int iBusPtr = 0; iBusPtr < m_busses.size(); iBusPtr++)
+  {
+    iReturn += m_busses.at(iBusPtr)->GetNumberOfPeripherals();
+  }
+
+  return iReturn;
+}
+
 bool CPeripherals::HasPeripheralWithFeature(const PeripheralFeature feature, PeripheralBusType busType /* = PERIPHERAL_BUS_UNKNOWN */) const
 {
   vector<CPeripheral *> dummy;

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -278,26 +278,22 @@ CPeripheral *CPeripherals::CreatePeripheral(CPeripheralBus &bus, const Periphera
   return peripheral;
 }
 
-void CPeripherals::OnDeviceAdded(const CPeripheralBus &bus, const CStdString &strLocation)
+void CPeripherals::OnDeviceAdded(const CPeripheralBus &bus, const CPeripheral &peripheral)
 {
   CGUIDialogPeripheralManager *dialog = (CGUIDialogPeripheralManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PERIPHERAL_MANAGER);
   if (dialog && dialog->IsActive())
     dialog->Update();
 
-  CPeripheral *peripheral = GetByPath(strLocation);
-  if (peripheral)
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35005), peripheral->DeviceName());
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35005), peripheral.DeviceName());
 }
 
-void CPeripherals::OnDeviceDeleted(const CPeripheralBus &bus, const CStdString &strLocation)
+void CPeripherals::OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral &peripheral)
 {
   CGUIDialogPeripheralManager *dialog = (CGUIDialogPeripheralManager *)g_windowManager.GetWindow(WINDOW_DIALOG_PERIPHERAL_MANAGER);
   if (dialog && dialog->IsActive())
     dialog->Update();
 
-  CPeripheral *peripheral = GetByPath(strLocation);
-  if (peripheral)
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35006), peripheral->DeviceName());
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35006), peripheral.DeviceName());
 }
 
 int CPeripherals::GetMappingForDevice(const CPeripheralBus &bus, const PeripheralType classType, int iVendorId, int iProductId) const

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -93,16 +93,16 @@ namespace PERIPHERALS
     /*!
      * @brief Called when a device has been added to a bus.
      * @param bus The bus the device was added to.
-     * @param strLocation The path of the fileitem.
+     * @param peripheral The peripheral that has been added.
      */
-    virtual void OnDeviceAdded(const CPeripheralBus &bus, const CStdString &strLocation);
+    virtual void OnDeviceAdded(const CPeripheralBus &bus, const CPeripheral &peripheral);
 
     /*!
      * @brief Called when a device has been deleted from a bus.
      * @param bus The bus from which the device removed.
-     * @param strLocation The path of the fileitem.
+     * @param peripheral The peripheral that has been removed.
      */
-    virtual void OnDeviceDeleted(const CPeripheralBus &bus, const CStdString &strLocation);
+    virtual void OnDeviceDeleted(const CPeripheralBus &bus, const CPeripheral &peripheral);
 
     /*!
      * @brief Creates a new instance of a peripheral.

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -82,6 +82,8 @@ namespace PERIPHERALS
      */
     virtual int GetPeripheralsWithFeature(std::vector<CPeripheral *> &results, const PeripheralFeature feature, PeripheralBusType busType = PERIPHERAL_BUS_UNKNOWN) const;
 
+    size_t GetNumberOfPeripherals() const;
+
     /*!
      * @brief Check whether there is at least one device present with the given feature.
      * @param feature The feature to check for.

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -147,7 +147,7 @@ void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults &resul
       m_peripherals.erase(m_peripherals.begin() + iDevicePtr);
       lock.Leave();
 
-      m_manager->OnDeviceDeleted(*this, peripheral->FileLocation());
+      m_manager->OnDeviceDeleted(*this, *peripheral);
       delete peripheral;
     }
   }
@@ -282,7 +282,7 @@ void CPeripheralBus::Register(CPeripheral *peripheral)
     CLog::Log(LOGNOTICE, "%s - new %s device registered on %s->%s: %s (%s:%s)", __FUNCTION__, PeripheralTypeTranslator::TypeToString(peripheral->Type()), PeripheralTypeTranslator::BusTypeToString(m_type), peripheral->Location().c_str(), peripheral->DeviceName().c_str(), peripheral->VendorIdAsString(), peripheral->ProductIdAsString());
     lock.Leave();
 
-    m_manager->OnDeviceAdded(*this, peripheral->FileLocation());
+    m_manager->OnDeviceAdded(*this, *peripheral);
   }
 }
 

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -339,3 +339,8 @@ CPeripheral *CPeripheralBus::GetByPath(const CStdString &strPath) const
 
   return NULL;
 }
+
+size_t CPeripheralBus::GetNumberOfPeripherals() const
+{
+  return m_peripherals.size();
+}

--- a/xbmc/peripherals/bus/PeripheralBus.h
+++ b/xbmc/peripherals/bus/PeripheralBus.h
@@ -99,6 +99,8 @@ namespace PERIPHERALS
      */
     virtual int GetPeripheralsWithFeature(std::vector<CPeripheral *> &results, const PeripheralFeature feature) const;
 
+    virtual size_t GetNumberOfPeripherals() const;
+
     /*!
      * @brief Get all features that are supported by devices on this bus.
      * @param features All features.

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -239,7 +239,7 @@ void CPeripheralCecAdapter::Process(void)
   m_cecAdapter->SetActiveView();
   FlushLog();
 
-  m_cecAdapter->SetOSDString(CECDEVICE_TV, CEC_DISPLAY_CONTROL_DISPLAY_FOR_DEFAULT_TIME, "XBMC connected");
+  m_cecAdapter->SetOSDString(CECDEVICE_TV, CEC_DISPLAY_CONTROL_DISPLAY_FOR_DEFAULT_TIME, g_localizeStrings.Get(36016).c_str());
 
   while (!m_bStop)
   {

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -237,6 +237,8 @@ void CPeripheralCecAdapter::Process(void)
   m_cecAdapter->SetActiveView();
   FlushLog();
 
+  m_cecAdapter->SetOSDString(CECDEVICE_TV, CEC_DISPLAY_CONTROL_DISPLAY_FOR_DEFAULT_TIME, "XBMC connected");
+
   while (!m_bStop)
   {
     FlushLog();

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -204,11 +204,8 @@ void CPeripheralCecAdapter::Process(void)
         CLog::Log(LOGDEBUG, "%s - multiple com ports found for device. taking the first one", __FUNCTION__);
       else
         CLog::Log(LOGDEBUG, "%s - autodetect com port '%s'", __FUNCTION__, dev->comm);
-      if (!strPort.Equals(dev->comm))
-      {
-        strPort = dev->comm;
-        SetSetting("port", strPort);
-      }
+
+      strPort = dev->comm;
     }
   }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -310,13 +310,11 @@ void CPeripheralCecAdapter::ProcessNextCommand(void)
     case CEC_OPCODE_STANDBY:
       /* a device was put in standby mode */
       CLog::Log(LOGDEBUG, "%s - device %d was put in standby mode", __FUNCTION__, command.initiator);
-      if (command.initiator == CECDEVICE_TV && GetSettingBool("standby_pc_on_tv_standby"))
+      if (command.initiator == CECDEVICE_TV && GetSettingBool("standby_pc_on_tv_standby") &&
+          (!m_screensaverLastActivated.IsValid() || CDateTime::GetCurrentDateTime() - m_screensaverLastActivated > CDateTimeSpan(0, 0, 0, SCREENSAVER_TIMEOUT)))
       {
-        if (!m_screensaverLastActivated.IsValid() || CDateTime::GetCurrentDateTime() - m_screensaverLastActivated > CDateTimeSpan(0, 0, 0, SCREENSAVER_TIMEOUT))
-        {
-          m_bStarted = false;
-          g_application.getApplicationMessenger().Suspend();
-        }
+        m_bStarted = false;
+        g_application.getApplicationMessenger().Suspend();
       }
       break;
     default:

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -209,6 +209,12 @@ void CPeripheralCecAdapter::Process(void)
     }
   }
 
+  // set the correct physical address
+  int iHdmiPort = GetSettingInt("cec_hdmi_port");
+  if (iHdmiPort <= 0 || iHdmiPort > 16)
+    iHdmiPort = 1;
+  m_cecAdapter->SetPhysicalAddress(iHdmiPort << 12);
+
   // open the CEC adapter
   CLog::Log(LOGDEBUG, "%s - opening a connection to the CEC adapter: %s", __FUNCTION__, strPort.c_str());
 
@@ -290,6 +296,20 @@ bool CPeripheralCecAdapter::StartBootloader(void)
   {
     CLog::Log(LOGDEBUG, "%s - starting the bootloader", __FUNCTION__);
     bReturn = m_cecAdapter->StartBootloader();
+  }
+
+  return bReturn;
+}
+
+bool CPeripheralCecAdapter::SetHdmiPort(int iHdmiPort)
+{
+  bool bReturn(false);
+  if (m_cecAdapter && m_bIsReady)
+  {
+    if (iHdmiPort <= 0 || iHdmiPort > 16)
+      iHdmiPort = 1;
+    CLog::Log(LOGDEBUG, "%s - changing active HDMI port to %d", __FUNCTION__, iHdmiPort);
+    bReturn = m_cecAdapter->SetPhysicalAddress(iHdmiPort << 12);
   }
 
   return bReturn;
@@ -550,6 +570,10 @@ void CPeripheralCecAdapter::OnSettingChanged(const CStdString &strChangedSetting
       StopThread(true);
     else if (bEnabled && !m_cecAdapter && m_bStarted)
       InitialiseFeature(FEATURE_CEC);
+  }
+  else if (strChangedSetting.Equals("cec_hdmi_port"))
+  {
+    SetHdmiPort(GetSettingInt("cec_hdmi_port"));
   }
 }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -32,13 +32,13 @@
 #include "peripherals/bus/PeripheralBus.h"
 #include "utils/log.h"
 
-#include <libcec/CECExports.h>
+#include <cec.h>
 
 using namespace PERIPHERALS;
 using namespace ANNOUNCEMENT;
 using namespace CEC;
 
-#define CEC_LIB_SUPPORTED_VERSION 6
+#define CEC_LIB_SUPPORTED_VERSION 7
 
 class DllLibCECInterface
 {

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -72,6 +72,8 @@ CPeripheralCecAdapter::CPeripheralCecAdapter(const PeripheralType type, const Pe
   m_bHasButton(false),
   m_bIsReady(false)
 {
+  m_button.iButton = 0;
+  m_button.iDuration = 0;
   m_screensaverLastActivated.SetValid(false);
   m_dll = new DllLibCEC;
   if (m_dll->Load() && m_dll->IsLoaded())
@@ -413,154 +415,150 @@ void CPeripheralCecAdapter::ProcessNextCommand(void)
 bool CPeripheralCecAdapter::GetNextKey(void)
 {
   CSingleLock lock(m_critSection);
-  if (m_bHasButton)
+  if (m_bHasButton && m_button.iDuration > 0)
     return false;
 
   cec_keypress key;
-  if (!m_bIsReady || !(m_bHasButton = m_cecAdapter->GetNextKeypress(&key)))
+  if (!m_bIsReady || !m_cecAdapter->GetNextKeypress(&key))
     return false;
 
   CLog::Log(LOGDEBUG, "%s - received key %d", __FUNCTION__, key.keycode);
-  m_button.iButtonReleased = XbmcThreads::SystemClockMillis();
-  m_button.iButton        = 0;
-  m_button.iButtonPressed = m_button.iButtonReleased - key.duration;
+  DWORD iButton = 0;
 
   switch (key.keycode)
   {
   case CEC_USER_CONTROL_CODE_SELECT:
-    m_button.iButton = XINPUT_IR_REMOTE_SELECT;
+    iButton = XINPUT_IR_REMOTE_SELECT;
     break;
   case CEC_USER_CONTROL_CODE_UP:
-    m_button.iButton = XINPUT_IR_REMOTE_UP;
+    iButton = XINPUT_IR_REMOTE_UP;
     break;
   case CEC_USER_CONTROL_CODE_DOWN:
-    m_button.iButton = XINPUT_IR_REMOTE_DOWN;
+    iButton = XINPUT_IR_REMOTE_DOWN;
     break;
   case CEC_USER_CONTROL_CODE_LEFT:
   case CEC_USER_CONTROL_CODE_LEFT_UP:
   case CEC_USER_CONTROL_CODE_LEFT_DOWN:
-    m_button.iButton = XINPUT_IR_REMOTE_LEFT;
+    iButton = XINPUT_IR_REMOTE_LEFT;
     break;
   case CEC_USER_CONTROL_CODE_RIGHT:
   case CEC_USER_CONTROL_CODE_RIGHT_UP:
   case CEC_USER_CONTROL_CODE_RIGHT_DOWN:
-    m_button.iButton = XINPUT_IR_REMOTE_RIGHT;
+    iButton = XINPUT_IR_REMOTE_RIGHT;
     break;
   case CEC_USER_CONTROL_CODE_ROOT_MENU:
-    m_button.iButton = XINPUT_IR_REMOTE_MENU;
+    iButton = XINPUT_IR_REMOTE_MENU;
     break;
   case CEC_USER_CONTROL_CODE_EXIT:
-    m_button.iButton = XINPUT_IR_REMOTE_BACK;
+    iButton = XINPUT_IR_REMOTE_BACK;
     break;
   case CEC_USER_CONTROL_CODE_ENTER:
-    m_button.iButton = XINPUT_IR_REMOTE_ENTER;
+    iButton = XINPUT_IR_REMOTE_ENTER;
     break;
   case CEC_USER_CONTROL_CODE_CHANNEL_DOWN:
-    m_button.iButton = XINPUT_IR_REMOTE_CHANNEL_MINUS;
+    iButton = XINPUT_IR_REMOTE_CHANNEL_MINUS;
     break;
   case CEC_USER_CONTROL_CODE_CHANNEL_UP:
-    m_button.iButton = XINPUT_IR_REMOTE_CHANNEL_PLUS;
+    iButton = XINPUT_IR_REMOTE_CHANNEL_PLUS;
     break;
   case CEC_USER_CONTROL_CODE_PREVIOUS_CHANNEL:
-    m_button.iButton = XINPUT_IR_REMOTE_BACK;
+    iButton = XINPUT_IR_REMOTE_BACK;
     break;
   case CEC_USER_CONTROL_CODE_SOUND_SELECT:
-    m_button.iButton = XINPUT_IR_REMOTE_LANGUAGE;
+    iButton = XINPUT_IR_REMOTE_LANGUAGE;
     break;
   case CEC_USER_CONTROL_CODE_POWER:
-    m_button.iButton = XINPUT_IR_REMOTE_POWER;
+    iButton = XINPUT_IR_REMOTE_POWER;
     break;
   case CEC_USER_CONTROL_CODE_VOLUME_UP:
-    m_button.iButton = XINPUT_IR_REMOTE_VOLUME_PLUS;
+    iButton = XINPUT_IR_REMOTE_VOLUME_PLUS;
     break;
   case CEC_USER_CONTROL_CODE_VOLUME_DOWN:
-    m_button.iButton = XINPUT_IR_REMOTE_VOLUME_MINUS;
+    iButton = XINPUT_IR_REMOTE_VOLUME_MINUS;
     break;
   case CEC_USER_CONTROL_CODE_MUTE:
-    m_button.iButton = XINPUT_IR_REMOTE_MUTE;
+    iButton = XINPUT_IR_REMOTE_MUTE;
     break;
   case CEC_USER_CONTROL_CODE_PLAY:
-    m_button.iButton = XINPUT_IR_REMOTE_PLAY;
+    iButton = XINPUT_IR_REMOTE_PLAY;
     break;
   case CEC_USER_CONTROL_CODE_STOP:
-    m_button.iButton = XINPUT_IR_REMOTE_STOP;
+    iButton = XINPUT_IR_REMOTE_STOP;
     break;
   case CEC_USER_CONTROL_CODE_PAUSE:
-    m_button.iButton = XINPUT_IR_REMOTE_PAUSE;
+    iButton = XINPUT_IR_REMOTE_PAUSE;
     break;
   case CEC_USER_CONTROL_CODE_REWIND:
-    m_button.iButton = XINPUT_IR_REMOTE_REVERSE;
+    iButton = XINPUT_IR_REMOTE_REVERSE;
     break;
   case CEC_USER_CONTROL_CODE_FAST_FORWARD:
-    m_button.iButton = XINPUT_IR_REMOTE_FORWARD;
+    iButton = XINPUT_IR_REMOTE_FORWARD;
     break;
   case CEC_USER_CONTROL_CODE_NUMBER0:
-    m_button.iButton = XINPUT_IR_REMOTE_0;
+    iButton = XINPUT_IR_REMOTE_0;
     break;
   case CEC_USER_CONTROL_CODE_NUMBER1:
-    m_button.iButton = XINPUT_IR_REMOTE_1;
+    iButton = XINPUT_IR_REMOTE_1;
     break;
   case CEC_USER_CONTROL_CODE_NUMBER2:
-    m_button.iButton = XINPUT_IR_REMOTE_2;
+    iButton = XINPUT_IR_REMOTE_2;
     break;
   case CEC_USER_CONTROL_CODE_NUMBER3:
-    m_button.iButton = XINPUT_IR_REMOTE_3;
+    iButton = XINPUT_IR_REMOTE_3;
     break;
   case CEC_USER_CONTROL_CODE_NUMBER4:
-    m_button.iButton = XINPUT_IR_REMOTE_4;
+    iButton = XINPUT_IR_REMOTE_4;
     break;
   case CEC_USER_CONTROL_CODE_NUMBER5:
-    m_button.iButton = XINPUT_IR_REMOTE_5;
+    iButton = XINPUT_IR_REMOTE_5;
     break;
   case CEC_USER_CONTROL_CODE_NUMBER6:
-    m_button.iButton = XINPUT_IR_REMOTE_6;
+    iButton = XINPUT_IR_REMOTE_6;
     break;
   case CEC_USER_CONTROL_CODE_NUMBER7:
-    m_button.iButton = XINPUT_IR_REMOTE_7;
+    iButton = XINPUT_IR_REMOTE_7;
     break;
   case CEC_USER_CONTROL_CODE_NUMBER8:
-    m_button.iButton = XINPUT_IR_REMOTE_8;
+    iButton = XINPUT_IR_REMOTE_8;
     break;
   case CEC_USER_CONTROL_CODE_NUMBER9:
-    m_button.iButton = XINPUT_IR_REMOTE_9;
+    iButton = XINPUT_IR_REMOTE_9;
     break;
   case CEC_USER_CONTROL_CODE_RECORD:
-    m_button.iButton = XINPUT_IR_REMOTE_RECORD;
+    iButton = XINPUT_IR_REMOTE_RECORD;
     break;
   case CEC_USER_CONTROL_CODE_CLEAR:
-    m_button.iButton = XINPUT_IR_REMOTE_CLEAR;
+    iButton = XINPUT_IR_REMOTE_CLEAR;
     break;
   case CEC_USER_CONTROL_CODE_DISPLAY_INFORMATION:
-    m_button.iButton = XINPUT_IR_REMOTE_INFO;
+    iButton = XINPUT_IR_REMOTE_INFO;
     break;
   case CEC_USER_CONTROL_CODE_PAGE_UP:
-    m_button.iButton = XINPUT_IR_REMOTE_CHANNEL_PLUS;
+    iButton = XINPUT_IR_REMOTE_CHANNEL_PLUS;
     break;
   case CEC_USER_CONTROL_CODE_PAGE_DOWN:
-    m_button.iButton = XINPUT_IR_REMOTE_CHANNEL_MINUS;
-    break;
-  case CEC_USER_CONTROL_CODE_EJECT:
+    iButton = XINPUT_IR_REMOTE_CHANNEL_MINUS;
     break;
   case CEC_USER_CONTROL_CODE_FORWARD:
-    m_button.iButton = XINPUT_IR_REMOTE_SKIP_PLUS;
+    iButton = XINPUT_IR_REMOTE_SKIP_PLUS;
     break;
   case CEC_USER_CONTROL_CODE_BACKWARD:
-    m_button.iButton = XINPUT_IR_REMOTE_SKIP_MINUS;
-    break;
-  case CEC_USER_CONTROL_CODE_POWER_ON_FUNCTION:
+    iButton = XINPUT_IR_REMOTE_SKIP_MINUS;
     break;
   case CEC_USER_CONTROL_CODE_F1_BLUE:
-    m_button.iButton = XINPUT_IR_REMOTE_BLUE;
+    iButton = XINPUT_IR_REMOTE_BLUE;
     break;
   case CEC_USER_CONTROL_CODE_F2_RED:
-    m_button.iButton = XINPUT_IR_REMOTE_RED;
+    iButton = XINPUT_IR_REMOTE_RED;
     break;
   case CEC_USER_CONTROL_CODE_F3_GREEN:
-    m_button.iButton = XINPUT_IR_REMOTE_GREEN;
+    iButton = XINPUT_IR_REMOTE_GREEN;
     break;
   case CEC_USER_CONTROL_CODE_F4_YELLOW:
-    m_button.iButton = XINPUT_IR_REMOTE_YELLOW;
+    iButton = XINPUT_IR_REMOTE_YELLOW;
     break;
+  case CEC_USER_CONTROL_CODE_POWER_ON_FUNCTION:
+  case CEC_USER_CONTROL_CODE_EJECT:
   case CEC_USER_CONTROL_CODE_SETUP_MENU:
   case CEC_USER_CONTROL_CODE_CONTENTS_MENU:
   case CEC_USER_CONTROL_CODE_FAVORITE_MENU:
@@ -596,6 +594,17 @@ bool CPeripheralCecAdapter::GetNextKey(void)
     return false;
   }
 
+  if (!m_bHasButton && iButton == m_button.iButton && key.duration > 0)
+  {
+    /* released button of the previous keypress */
+    m_bHasButton = false;
+    return false;
+  }
+
+  m_bHasButton = true;
+  m_button.iDuration = key.duration;
+  m_button.iButton = iButton;
+
   return true;
 }
 
@@ -611,18 +620,10 @@ WORD CPeripheralCecAdapter::GetButton(void)
 unsigned int CPeripheralCecAdapter::GetHoldTime(void)
 {
   CSingleLock lock(m_critSection);
-  if (!m_bHasButton)
+  if (m_bHasButton && m_button.iDuration == 0)
     GetNextKey();
 
-  if (!m_bHasButton)
-    return 0;
-
-  if (m_button.iButtonPressed && m_button.iButtonReleased)
-    return m_button.iButtonReleased - m_button.iButtonPressed;
-  else if (m_button.iButtonPressed)
-    return XbmcThreads::SystemClockMillis() - m_button.iButtonPressed;
-
-  return 0;
+  return m_bHasButton ? m_button.iDuration : 0;
 }
 
 void CPeripheralCecAdapter::ResetButton(void)

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -30,6 +30,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/bus/PeripheralBus.h"
+#include "settings/GUISettings.h"
 #include "utils/log.h"
 
 #include <cec.h>
@@ -315,6 +316,64 @@ bool CPeripheralCecAdapter::SetHdmiPort(int iHdmiPort)
   return bReturn;
 }
 
+void CPeripheralCecAdapter::SetMenuLanguage(const char *strLanguage)
+{
+  CStdString strGuiLanguage;
+
+  if (!strcmp(strLanguage, "bul"))
+    strGuiLanguage = "Bulgarian";
+  else if (!strcmp(strLanguage, "hrv"))
+    strGuiLanguage = "Croatian";
+  else if (!strcmp(strLanguage, "cze"))
+    strGuiLanguage = "Czech";
+  else if (!strcmp(strLanguage, "dan"))
+    strGuiLanguage = "Danish";
+  else if (!strcmp(strLanguage, "dut"))
+    strGuiLanguage = "Dutch";
+  else if (!strcmp(strLanguage, "eng"))
+    strGuiLanguage = "English";
+  else if (!strcmp(strLanguage, "fin"))
+    strGuiLanguage = "Finnish";
+  else if (!strcmp(strLanguage, "fre"))
+    strGuiLanguage = "French";
+  else if (!strcmp(strLanguage, "ger"))
+    strGuiLanguage = "German";
+  else if (!strcmp(strLanguage, "gre"))
+    strGuiLanguage = "Greek";
+  else if (!strcmp(strLanguage, "hun"))
+    strGuiLanguage = "Hungarian";
+  else if (!strcmp(strLanguage, "ita"))
+    strGuiLanguage = "Italian";
+  else if (!strcmp(strLanguage, "nor"))
+    strGuiLanguage = "Norwegian";
+  else if (!strcmp(strLanguage, "pol"))
+    strGuiLanguage = "Polish";
+  else if (!strcmp(strLanguage, "por"))
+    strGuiLanguage = "Portuguese";
+  else if (!strcmp(strLanguage, "rum"))
+    strGuiLanguage = "Romanian";
+  else if (!strcmp(strLanguage, "rus"))
+    strGuiLanguage = "Russian";
+  else if (!strcmp(strLanguage, "srp"))
+    strGuiLanguage = "Serbian";
+  else if (!strcmp(strLanguage, "slo"))
+    strGuiLanguage = "Slovenian";
+  else if (!strcmp(strLanguage, "spa"))
+    strGuiLanguage = "Spanish";
+  else if (!strcmp(strLanguage, "swe"))
+    strGuiLanguage = "Swedish";
+  else if (!strcmp(strLanguage, "tur"))
+    strGuiLanguage = "Turkish";
+
+  if (!strGuiLanguage.IsEmpty())
+  {
+    g_application.getApplicationMessenger().SetGUILanguage(strGuiLanguage);
+    CLog::Log(LOGDEBUG, "%s - language set to '%s'", __FUNCTION__, strGuiLanguage.c_str());
+  }
+  else
+    CLog::Log(LOGWARNING, "%s - TV menu language set to unknown value '%s'", __FUNCTION__, strLanguage);
+}
+
 void CPeripheralCecAdapter::ProcessNextCommand(void)
 {
   cec_command command;
@@ -332,6 +391,15 @@ void CPeripheralCecAdapter::ProcessNextCommand(void)
       {
         m_bStarted = false;
         g_application.getApplicationMessenger().Suspend();
+      }
+      break;
+    case CEC_OPCODE_SET_MENU_LANGUAGE:
+      if (command.initiator == CECDEVICE_TV && command.parameters.size == 3)
+      {
+        char strNewLanguage[3];
+        for (int iPtr = 0; iPtr < 3; iPtr++)
+          strNewLanguage[iPtr] = command.parameters[iPtr];
+        SetMenuLanguage(strNewLanguage);
       }
       break;
     default:

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -76,6 +76,7 @@ namespace PERIPHERALS
     bool              m_bStarted;
     bool              m_bHasButton;
     bool              m_bIsReady;
+    CDateTime         m_screensaverLastActivated;
     CecButtonPress    m_button;
     CCriticalSection  m_critSection;
   };

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -69,6 +69,7 @@ namespace PERIPHERALS
     virtual bool InitialiseFeature(const PeripheralFeature feature);
     virtual void Process(void);
     virtual void ProcessNextCommand(void);
+    virtual void SetMenuLanguage(const char *strLanguage);
     static bool FindConfigLocation(CStdString &strString);
     static bool TranslateComPort(CStdString &strPort);
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -55,6 +55,7 @@ namespace PERIPHERALS
 
     virtual bool SendPing(void);
     virtual bool StartBootloader(void);
+    virtual bool SetHdmiPort(int iHdmiPort);
 
     virtual void OnSettingChanged(const CStdString &strChangedSetting);
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -38,8 +38,7 @@ namespace PERIPHERALS
   typedef struct
   {
     WORD         iButton;
-    unsigned int iButtonPressed;
-    unsigned int iButtonReleased;
+    unsigned int iDuration;
   } CecButtonPress;
 
 

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -41,6 +41,9 @@
 #include "cores/dvdplayer/DVDCodecs/Video/CrystalHD.h"
 #include "utils/PCMRemap.h"
 #include "guilib/GUIFont.h" // for FONT_STYLE_* definitions
+#include "guilib/GUIFontManager.h"
+#include "utils/Weather.h"
+#include "LangInfo.h"
 #if defined(__APPLE__)
   #include "osx/DarwinUtils.h"
 #endif
@@ -1383,4 +1386,41 @@ void CGUISettings::SetResolution(RESOLUTION res)
   }
   SetString("videoscreen.screenmode", mode);
   m_LookAndFeelResolution = res;
+}
+
+bool CGUISettings::SetLanguage(const CStdString &strLanguage)
+{
+  CStdString strPreviousLanguage = GetString("locale.language");
+  CStdString strNewLanguage = strLanguage;
+  if (strNewLanguage != strPreviousLanguage)
+  {
+    CStdString strLangInfoPath;
+    strLangInfoPath.Format("special://xbmc/language/%s/langinfo.xml", strNewLanguage.c_str());
+    if (!g_langInfo.Load(strLangInfoPath))
+      return false;
+
+    if (g_langInfo.ForceUnicodeFont() && !g_fontManager.IsFontSetUnicode())
+    {
+      CLog::Log(LOGINFO, "Language needs a ttf font, loading first ttf font available");
+      CStdString strFontSet;
+      if (g_fontManager.GetFirstFontSetUnicode(strFontSet))
+        strNewLanguage = strFontSet;
+      else
+        CLog::Log(LOGERROR, "No ttf font found but needed: %s", strFontSet.c_str());
+    }
+    SetString("locale.language", strNewLanguage);
+
+    g_charsetConverter.reset();
+
+    CStdString strLanguagePath;
+    strLanguagePath.Format("special://xbmc/language/%s/strings.xml", strNewLanguage.c_str());
+    if (!g_localizeStrings.Load(strLanguagePath))
+      return false;
+
+    // also tell our weather and skin to reload as these are localized
+    g_weatherManager.Refresh();
+    g_application.ReloadSkin();
+  }
+
+  return true;
 }

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -488,6 +488,7 @@ public:
   RESOLUTION GetResolution() const;
   static RESOLUTION GetResFromString(const CStdString &res);
   void SetResolution(RESOLUTION res);
+  bool SetLanguage(const CStdString &strLanguage);
 
   //m_LookAndFeelResolution holds the real gui resolution
   RESOLUTION m_LookAndFeelResolution;

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -1485,32 +1485,7 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
     CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(pSettingControl->GetID());
     CStdString strLanguage = pControl->GetCurrentLabel();
     if (strLanguage != ".svn" && strLanguage != pSettingString->GetData())
-    {
-      CStdString strLangInfoPath;
-      strLangInfoPath.Format("special://xbmc/language/%s/langinfo.xml", strLanguage.c_str());
-      g_langInfo.Load(strLangInfoPath);
-
-      if (g_langInfo.ForceUnicodeFont() && !g_fontManager.IsFontSetUnicode())
-      {
-        CLog::Log(LOGINFO, "Language needs a ttf font, loading first ttf font available");
-        CStdString strFontSet;
-        if (g_fontManager.GetFirstFontSetUnicode(strFontSet))
-          strLanguage = strFontSet;
-        else
-          CLog::Log(LOGERROR, "No ttf font found but needed: %s", strFontSet.c_str());
-      }
-      g_guiSettings.SetString("locale.language", strLanguage);
-
-      g_charsetConverter.reset();
-
-      CStdString strLanguagePath;
-      strLanguagePath.Format("special://xbmc/language/%s/strings.xml", strLanguage.c_str());
-      g_localizeStrings.Load(strLanguagePath);
-
-      // also tell our weather and skin to reload as these are localized
-      g_weatherManager.Refresh();
-      g_application.ReloadSkin();
-    }
+      g_guiSettings.SetLanguage(strLanguage);
   }
   else if (strSetting.Equals("lookandfeel.skintheme"))
   { //a new Theme was chosen

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -947,6 +947,12 @@ void CGUIWindowSettingsCategory::UpdateSettings()
           pControl->SetEnabled(addon->HasSettings());
       }
     }
+    else if (strSetting.Equals("input.peripherals"))
+    {
+      CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
+      if (pControl)
+        pControl->SetEnabled(g_peripherals.GetNumberOfPeripherals() > 0);
+    }
 #if defined(_LINUX) && !defined(__APPLE__)
     else if (strSetting.Equals("audiooutput.custompassthrough"))
     {


### PR DESCRIPTION
definite fix for trac 12043, some fixes and additions to the CEC adapter code and the general peripherals code:
- updated to use the v0.7 name of the libcec headers (CECExports.h -> cec.h)
- fixed: with both the options to put the TV in standby when the screensaver is activated and the option to put the pc in standby when the TV is put in standby or switched off, it would put the pc in standby a few seconds after the screensaver becomes active. fixed by adding a timeout to ignore standby commands of the TV, default 10 seconds
- fixed: don't store the com port in peripheralsettings when it was autodetected, or it won't be picked up when it's assigned another port number
- add setting 'HDMI port'
- fixed: peripherals - set default step to 1 and default max to 255 of int settings
- move set GUI language code to GUISettings and add SetGUILanguage() to applicationmessenger
- set XBMC's GUI language to match the language set up in the tv
- display a message on the TV when XBMC is connected (not supported by all tvs)
- handle key presses and key releases properly. fixes 500ms keypress delay and some keypresses not being handled
- spiff's patch: disable the peripherals dialog if no peripherals are registered
