### PR TITLE
Fix reading compressed codec private data from mkv files

### DIFF
--- a/lib/ffmpeg/libavformat/matroskadec.c
+++ b/lib/ffmpeg/libavformat/matroskadec.c
@@ -1220,7 +1220,7 @@ static int matroska_read_header(AVFormatContext *s, AVFormatParameters *ap)
     for (i=0; i < matroska->tracks.nb_elem; i++) {
         MatroskaTrack *track = &tracks[i];
         enum CodecID codec_id = CODEC_ID_NONE;
-        EbmlList *encodings_list = &tracks->encodings;
+        EbmlList *encodings_list = &track->encodings;
         MatroskaTrackEncoding *encodings = encodings_list->elem;
         uint8_t *extradata = NULL;
         int extradata_size = 0;


### PR DESCRIPTION
This is a backport of ffmpeg commit dc6c36ce46d4c4d7cb63503afc2ee44f00bf3725 on 2011-08-17

It fixes a bitmap sub color problem exposed by mkclean --optimize foo.mkv.
The compressed private data could not be extracted, resulting in a bad color palette and wrong colors on screen.

The problem was described in forum thread http://forum.xbmc.org/showthread.php?t=108942
