### PR TITLE
Clip GUI element in overscan area

### DIFF
--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -128,11 +128,11 @@ void CGraphicContext::ClipRect(CRect &vertex, CRect &texture, CRect *texture2)
     CRect original(vertex);
     if (m_clipRegions.size())
     {
-    // intersect vertex with our clip region (moved to the same coordinate system)
-    CRect clipRegion(m_clipRegions.top());
-    if (m_origins.size())
-      clipRegion -= m_origins.top();
-    vertex.Intersect(clipRegion);
+      // intersect vertex with our clip region (moved to the same coordinate system)
+      CRect clipRegion(m_clipRegions.top());
+      if (m_origins.size())
+        clipRegion -= m_origins.top();
+      vertex.Intersect(clipRegion);
     }
     if (m_bNeedOverscanClip)
     {

--- a/xbmc/guilib/GraphicContext.h
+++ b/xbmc/guilib/GraphicContext.h
@@ -235,6 +235,9 @@ private:
   std::stack<TransformMatrix> m_groupTransform;
 
   CRect m_scissors;
+
+  bool m_bNeedOverscanClip;
+  CRect m_overscanRect;
 };
 
 /*!


### PR DESCRIPTION
This is proposed fix for http://trac.xbmc.org/ticket/12054. We still render GUI in overscan area (http://dl.dropbox.com/u/28792047/xbmc/screenshot048.png). With these commits it clips that area out (http://dl.dropbox.com/u/28792047/xbmc/screenshot047.png)
