### PR TITLE
Clean the font cache directory before playing. Helps with ticket 12023.

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -739,6 +739,19 @@ void CUtil::ClearSubtitles()
   }
 }
 
+void CUtil::ClearTempFonts()
+{
+  CFileItemList items;
+  CDirectory::GetDirectory("special://temp/fonts/", items, "", false, false, XFILE::DIR_CACHE_NEVER);
+
+  for (int i=0; i<items.Size(); ++i)
+  {
+    if (items[i]->m_bIsFolder)
+      continue;
+    CFile::Delete(items[i]->GetPath());
+  }
+}
+
 static const char * sub_exts[] = { ".utf", ".utf8", ".utf-8", ".sub", ".srt", ".smi", ".rt", ".txt", ".ssa", ".aqt", ".jss", ".ass", ".idx", NULL};
 
 int64_t CUtil::ToInt64(uint32_t high, uint32_t low)

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -79,6 +79,7 @@ public:
   static bool GetDirectoryName(const CStdString& strFileName, CStdString& strDescription);
   static void GetDVDDriveIcon( const CStdString& strPath, CStdString& strIcon );
   static void RemoveTempFiles();
+  static void ClearTempFonts();
 
   static void ClearSubtitles();
   static void ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CStdString>& vecSubtitles );

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -514,6 +514,7 @@ retry:
     g_settings.m_currentVideoSettings.m_SubtitleCached = true;
   }
 
+  CUtil::ClearTempFonts();
   SetAVDelay(g_settings.m_currentVideoSettings.m_AudioDelay);
   SetSubTitleDelay(g_settings.m_currentVideoSettings.m_SubtitleDelay);
   m_clock.Reset();

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -361,6 +361,8 @@ bool CDVDPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
     g_renderManager.PreInit();
 #endif
 	
+    CUtil::ClearTempFonts();
+
     Create();
     if(!m_ready.WaitMSec(100))
     {
@@ -514,7 +516,6 @@ retry:
     g_settings.m_currentVideoSettings.m_SubtitleCached = true;
   }
 
-  CUtil::ClearTempFonts();
   SetAVDelay(g_settings.m_currentVideoSettings.m_AudioDelay);
   SetSubTitleDelay(g_settings.m_currentVideoSettings.m_SubtitleDelay);
   m_clock.Reset();


### PR DESCRIPTION
The fonts embedded in an mkv are extracted every time a file is played and they accumulate over time in the special://temp/fonts directory. There doesn't seem to be a cleanup mechanism.

There are two issues:
- potential for conflicts with fonts extracted for a previous mkv file. The fonts are specified by name in ass scripts, not by file name. There could be (by accident or by malice) different fonts with the same name and different file names, and a font extracted earlier could be used instead of the font embedded in the file that's about to play. That seems to be the problem of ticket 12023.
- over time it could end up using a significant amount of disk space. Also takes slightly longer for libass to initialize if it has to search each font from a bunch of files, instead of just the few that came with the mkv.

This patch is simplistic and deletes all cached fonts when dvdplayer is initialized. The fonts are extracted from the mkv in dvdplayer::AddStream.

Chances are pretty good this is not the best place to put the fix and maybe the way to delete is also bad.
So please let me know what I did wrong :) I think this should be in Eden.
