### PR TITLE
Updated metadata parsing for pictures

### DIFF
--- a/addons/skin.confluence/720p/SlideShow.xml
+++ b/addons/skin.confluence/720p/SlideShow.xml
@@ -27,6 +27,36 @@
 				<label>31043</label>
 			</control>
 		</control>
+
+		<!-- Picture infos -->
+		<control type="label">
+			<description>caption</description>
+			<posx>10r</posx>
+			<posy>88r</posy>
+			<width>1000</width>
+			<height>25</height>
+			<align>right</align>
+			<aligny>bottom</aligny>
+			<font>font13</font>
+			<textcolor>white</textcolor>
+			<shadowcolor>black</shadowcolor>
+			<label>$INFO[slideshow.exifdescription]$INFO[slideshow.city,[CR]]</label>
+		</control>
+
+		<control type="label">
+			<description>exif info</description>
+			<posx>10r</posx>
+			<posy>35r</posy>
+			<width>1000</width>
+			<height>25</height>
+			<align>right</align>
+			<aligny>bottom</aligny>
+			<font>font10</font>
+			<textcolor>white</textcolor>
+			<shadowcolor>black</shadowcolor>
+			<label>$INFO[slideshow.exposuretime] | $INFO[slideshow.apreture,f ] | $INFO[slideshow.isoequivalence,ISO ] | $INFO[slideshow.focallength] | $INFO[slideshow.filename]</label>
+		</control>
+
 		<!-- media infos -->
 		<control type="group">
 			<posx>20</posx>

--- a/configure.in
+++ b/configure.in
@@ -581,19 +581,19 @@ elif test "$use_arch" = "arm"; then
       [AC_LANG_SOURCE([int foo;])],
       [ CFLAGS="$SAVE_CFLAGS -Wno-psabi -Wa,-march=armv7a -mtune=cortex-a9 -mfpu=vfpv3-d16 -mthumb-interwork"
         CXXFLAGS="$CXXFLAGS -Wno-psabi -Wa,-march=armv7a -mtune=cortex-a9 -mfpu=vfpv3-d16 -mthumb-interwork"
-        FFMPEG_EXTRACFLAGS+=" -mtune=cortex-a9 -mfpu=vfpv3-d16"
+        FFMPEG_EXTRACFLAGS="$FFMPEG_EXTRACFLAGS -mtune=cortex-a9 -mfpu=vfpv3-d16"
         use_cpu=cortex-a9],
       [ CFLAGS="$SAVE_CFLAGS -Wa,-march=armv6 -mtune=cortex-a8 -mthumb-interwork"
         CXXFLAGS="$CXXFLAGS -Wa,-march=armv6 -mtune=cortex-a8 -mthumb-interwork"    
         use_cpu=cortex-a8])
   else
     # Compile for ARMv7a architecture, CortexA8 cpu and check for enabled NEON coprocessor
-    CFLAGS+=" -Wa,-march=armv7a -mcpu=cortex-a8"
-    CXXFLAGS+=" -Wa,-march=armv7a -mcpu=cortex-a8"
+    CFLAGS="$CFLAGS -Wa,-march=armv7a -mcpu=cortex-a8"
+    CXXFLAGS="$CXXFLAGS -Wa,-march=armv7a -mcpu=cortex-a8"
     if test "$use_neon" = "yes"; then 
-      CFLAGS+=" -mfpu=neon -mvectorize-with-neon-quad"
-      CXXFLAGS+=" -mfpu=neon -mvectorize-with-neon-quad"
-      FFMPEG_EXTRACFLAGS+=" -mfpu=neon"
+      CFLAGS="$CFLAGS -mfpu=neon -mvectorize-with-neon-quad"
+      CXXFLAGS="$CXXFLAGS -mfpu=neon -mvectorize-with-neon-quad"
+      FFMPEG_EXTRACFLAGS="$FFMPEG_EXTRACFLAGS -mfpu=neon"
     fi
   fi
 fi
@@ -1888,7 +1888,7 @@ OUTPUT_FILES="Makefile \
     xbmc/peripherals/devices/Makefile"
 
 if test "$use_skin_touched" = "yes"; then
-OUTPUT_FILES+=" addons/skin.touched/media/Makefile"
+OUTPUT_FILES="$OUTPUT_FILES addons/skin.touched/media/Makefile"
 fi
 
 # Line below is used so we can use AM_INIT_AUTOMAKE. The corresponding

--- a/configure.in
+++ b/configure.in
@@ -123,8 +123,10 @@ libudev_not_found="== Could not find libudev. Will use polling to check for devi
 libudev_disabled="== udev support disabled. Will use polling to check for device changes. =="
 libusb_not_found="== Could not find libusb. Plug and play USB device support will not be available. =="
 libusb_disabled="== libusb disabled. Plug and play USB device support will not be available. =="
+libusb_disabled_udev_found="== libusb disabled. =="
 libcec_enabled="== libcec enabled. =="
 libcec_disabled="== libcec disabled. CEC adapter support will not be available. =="
+libcec_disabled_missing_libs="== libcec disabled because both libudev and libusb are not available. CEC adapter support will not be available. =="
 
 # External library message strings
 external_libraries_enabled="== Use of all supported external libraries enabled. =="
@@ -1105,66 +1107,69 @@ else
     PKG_CHECK_MODULES([UDEV],[libudev],,[use_libudev="no";AC_MSG_RESULT($libudev_not_found)])
   elif test "$use_libudev" = "yes" ; then
     PKG_CHECK_MODULES([UDEV],[libudev],,[use_libudev="no";AC_MSG_ERROR($libudev_not_found)])
+  else
+    AC_MSG_NOTICE($libudev_disabled)
   fi
+
   if test "x$use_libudev" != "xno"; then
     USE_LIBUDEV=1;INCLUDES="$INCLUDES $UDEV_CFLAGS";LIBS="$LIBS $UDEV_LIBS"
     AC_DEFINE([HAVE_LIBUDEV],[1],["Define to 1 if libudev is installed"])
-  else
-     AC_MSG_NOTICE($libudev_disabled)
   fi
 fi
 
 # libusb
 USE_LIBUSB=0
-if test "$host_vendor" = "apple" ; then
+
+# if libudev is available, we don't need libusb
+if test "x$use_libudev" != "xno"; then
   use_libusb="no"
-  AC_MSG_NOTICE($libusb_disabled)
+  AC_MSG_NOTICE($libusb_disabled_udev_found)
 else
-  # we can use either libudev or libusb but not both.
-  if test "x$use_libusb" != "xno" && test "x$use_libudev" == "xno"; then
-    if test "$host_vendor" = "apple" ; then
-      use_libusb="no"
-      AC_MSG_NOTICE($libusb_disabled)
+  if test "$host_vendor" = "apple" ; then
+    use_libusb="no"
+    AC_MSG_NOTICE($libusb_disabled)
+  else
+    if test "$use_libusb" = "auto"; then
+      PKG_CHECK_MODULES([USB],[libusb],,[use_libusb="no";AC_MSG_RESULT($libusb_not_found)])
+    elif test "$use_libusb" = "yes"; then
+      PKG_CHECK_MODULES([USB],[libusb],,[use_libusb="no";AC_MSG_ERROR($libusb_not_found)])
     else
-      if test "$use_libusb" = "auto"; then
-        PKG_CHECK_MODULES([USB],[libusb],,[use_libusb="no";AC_MSG_RESULT($libusb_not_found)])
-      elif test "$use_libusb" = "yes"; then
-        PKG_CHECK_MODULES([USB],[libusb],,[use_libusb="no";AC_MSG_ERROR($libusb_not_found)])
-      fi
+      AC_MSG_NOTICE($libusb_disabled)
     fi
+  
     if test "x$use_libusb" != "xno"; then
       USE_LIBUSB=1;INCLUDES="$INCLUDES $USB_CFLAGS";LIBS="$LIBS $USB_LIBS"
       AC_DEFINE([HAVE_LIBUSB],[1],["Define to 1 if libusb is installed"])
-    else
-       AC_MSG_NOTICE($libusb_disabled)
     fi
-  else
-    use_libusb="no"
   fi
 fi
 
 # libcec
 USE_LIBCEC=0
 if test "x$use_libcec" != "xno"; then
-  # libcec is dyloaded, so we need to check for its headers and link any depends.
-  PKG_CHECK_MODULES([CEC],[libcec = 0.7.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
-  if test "x$use_libcec" != "xno" && test "$host_vendor" != "apple"; then
-    # libcec has libudev as depends under linux.
-    PKG_CHECK_MODULES([UDEV],[libudev],,[use_libcec="no";AC_MSG_RESULT($libudev_not_found)])
-  fi
-  if test "x$use_libcec" != "xno"; then
-    if test "$host_vendor" != "apple"; then
-      # if linux, bring in udev cflags and add lib.
-      INCLUDES="$INCLUDES $UDEV_CFLAGS";LIBS="$LIBS $UDEV_LIBS"
-      USE_LIBUDEV=1;AC_DEFINE([HAVE_LIBUDEV],[1],["Define to 1 if libudev is installed"])
+  # libcec needs libudev or libusb under linux, or the device will never be detected.
+  if test "$host_vendor" != "apple" && test "$use_libusb" = "no" && test "$use_libudev" = "no"; then
+    if test "x$use_libcec" != "xauto"; then
+      AC_MSG_ERROR($libcec_disabled_missing_libs)
+    else
+      use_libcec="no"
+      AC_MSG_NOTICE($libcec_disabled_missing_libs)
     fi
-    INCLUDES="$INCLUDES $CEC_CFLAGS"
-    USE_LIBCEC=1;AC_DEFINE([HAVE_LIBCEC],[1],["Define to 1 if libcec is installed"])
-    XB_FIND_SONAME([LIBCEC],[cec],[use_libcec])
-    AC_MSG_NOTICE($libcec_enabled)
-  else
-    use_libcec="no"
-    AC_MSG_NOTICE($libcec_disabled)
+  fi
+
+  # libcec is dyloaded, so we need to check for its headers and link any depends.
+  if test "x$use_libcec" != "xno"; then
+    PKG_CHECK_MODULES([CEC],[libcec = 0.7.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
+
+    if test "x$use_libcec" != "xno"; then
+      INCLUDES="$INCLUDES $CEC_CFLAGS"
+      USE_LIBCEC=1;AC_DEFINE([HAVE_LIBCEC],[1],["Define to 1 if libcec is installed"])
+      XB_FIND_SONAME([LIBCEC],[cec],[use_libcec])
+      AC_MSG_NOTICE($libcec_enabled)
+    else
+      use_libcec="no"
+      AC_MSG_NOTICE($libcec_disabled)
+    fi
   fi
 else
   use_libcec="no"

--- a/configure.in
+++ b/configure.in
@@ -155,6 +155,12 @@ AC_ARG_WITH([cpu],
   [use_cpu=$withval],
   [use_cpu=no])
 
+AC_ARG_ENABLE([neon],
+  [AS_HELP_STRING([--enable-neon],
+  [enable neon passing to ffmpeg (default is no)])],
+  [use_neon=$enableval],
+  [use_neon=no])
+
 AC_ARG_ENABLE([optimizations],
   [AS_HELP_STRING([--enable-optimizations],
   [enable optimization (default is yes)])],
@@ -579,10 +585,14 @@ elif test "$use_arch" = "arm"; then
         CXXFLAGS="$CXXFLAGS -Wa,-march=armv6 -mtune=cortex-a8 -mthumb-interwork"    
         use_cpu=cortex-a8])
   else
-    # Compile for ARMv7a architecture, CortexA8 cpu and NEON coprocessor
-    CFLAGS+=" -Wa,-march=armv7a -mcpu=cortex-a8 -mfpu=neon -mvectorize-with-neon-quad"
-    CXXFLAGS+=" -Wa,-march=armv7a -mcpu=cortex-a8 -mfpu=neon -mvectorize-with-neon-quad"
-    FFMPEG_EXTRACFLAGS+=" -mfpu=neon"
+    # Compile for ARMv7a architecture, CortexA8 cpu and check for enabled NEON coprocessor
+    CFLAGS+=" -Wa,-march=armv7a -mcpu=cortex-a8"
+    CXXFLAGS+=" -Wa,-march=armv7a -mcpu=cortex-a8"
+    if test "$use_neon" = "yes"; then 
+      CFLAGS+=" -mfpu=neon -mvectorize-with-neon-quad"
+      CXXFLAGS+=" -mfpu=neon -mvectorize-with-neon-quad"
+      FFMPEG_EXTRACFLAGS+=" -mfpu=neon"
+    fi
   fi
 fi
 
@@ -1989,11 +1999,12 @@ XB_CONFIG_MODULE([lib/ffmpeg], [
       `if test "$use_arch" != "no"; then echo --enable-cross-compile; fi` \
       `if test "$use_arch" != "no"; then echo --arch=$use_arch; fi`\
       `if test "$use_cpu" != "no"; then echo --cpu=$use_cpu; fi`\
+      `if test "$use_arch" = "arm"; then echo --enable-pic; fi`\
+      `if test "$use_neon" = "yes"; then echo --enable-neon; else echo --disable-neon; fi`\
       --target-os=$(tolower $(uname -s)) \
       --disable-amd3dnow \
       --disable-armv5te \
       --disable-armv6t2 \
-      `if test "$use_arch" != "yes"; then echo --enable-neon; fi`\
       --disable-static \
       `if test "$use_debug" = "no"; then echo --disable-debug; fi` \
       --disable-muxers \
@@ -2034,6 +2045,7 @@ XB_CONFIG_MODULE([lib/ffmpeg], [
       `if test "$cross_compiling" = "yes"; then echo --enable-cross-compile; fi` \
       `if test "$use_arch" != "no"; then echo --arch=$use_arch; fi`\
       `if test "$use_cpu" != "no"; then echo --cpu=$use_cpu; fi`\
+      `if test "$use_neon" = "yes"; then echo --enable-neon; else echo --disable-neon; fi`\
       --target-os=$(tolower $(uname -s)) \
       --disable-muxers \
       --enable-muxer=spdif \

--- a/language/Catalan/strings.xml
+++ b/language/Catalan/strings.xml
@@ -811,6 +811,7 @@
   
   <string id="1270">Permet que l'XBMC rebi contingut de l'AirPlay</string>
   <string id="1271">Nom del dispositiu</string>
+  <string id="1272">- Utilitza protecció amb contrasenya</string>
 
   <string id="1300">Dispositiu d'àudio personalitzat</string>
   <string id="1301">Custom passthrough device</string>
@@ -1480,20 +1481,25 @@
   <string id="16020">Desentrellaçat</string>
   <string id="16021">Bob</string>
   <string id="16022">Bob (invertit)</string>
-  <string id="16023">Manejador entrellaçat</string>
+  <string id="16023"></string>
   <string id="16024">S'està cancel·lant...</string>
   <string id="16025">Introduïu el nom de l'artista</string>
   <string id="16026">La reproducció ha fallat</string>
   <string id="16027">Un o més ítems no s'han pogut reproduir.</string>
   <string id="16028">Introduïu el valor</string>
-  <string id="16029">Check the log file for details.</string>
+  <string id="16029">Comproveu el fitxer de registre per obtenir més detalls.</string>
   <string id="16030">Mode festa abortat.</string>
   <string id="16031">Sense cançons coincidents a la biblioteca</string>
   <string id="16032">No s'ha pogut inicialitzar la base de dades.</string>
   <string id="16033">No s'ha pogut obrir la base de dades.</string>
   <string id="16034">No s'han pogut obtenir les cançons de la base de dades.</string>
-  <string id="16035">Lllista de reproducció del mode festa</string>
+  <string id="16035">Llista de reproducció del mode festa</string>
   <string id="16036">Desentrellaçat (Half)</string>
+  <string id="16037">Deinterlace video</string>
+  <string id="16038">Mètode de desentrellaçat</string>
+  <string id="16039">Off</string>
+  <string id="16040">Auto</string>
+  <string id="16041">On</string>
 
   <string id="16100">Tots els vídeos</string>
   <string id="16101">No visualitzats</string>
@@ -1534,6 +1540,7 @@
   <string id="16321">DXVA Best</string>
   <string id="16322">Spline36</string>
   <string id="16323">Spline36 optimitzat</string>
+  <string id="16324">Software Blend</string>
 
   <string id="16400">Postprocessament</string>
 
@@ -1746,7 +1753,7 @@
   <string id="20258">Client de MythTV</string>
   <string id="20259">Network Filesystem (NFS)</string>
   <string id="20260">Secure Shell (SSH/SFTP)</string>
-  <string id="20261">Apple File Protocol (AFP)</string>
+  <string id="20261">Apple Filing Protocol (AFP)</string>
 
   <string id="20300">Directori del servidor web (HTTP)</string>
   <string id="20301">Directori dels servidor web (HTTPS)</string>
@@ -1911,16 +1918,16 @@
   <string id="21336">S'està connectant a: %s</string>
   <string id="21337">Unitat de TuxBox</string>
   <!-- up to 21355 is reserved for the TuxBox Client!! !-->
-
+  
   <string id="21359">Afegeix recurs compartit...</string>
   <string id="21360">Comparteix les biblioteques de vídeo i música a través de UPnP</string>
-
+  
   <string id="21364">Edita recurs compartit</string>
   <string id="21365">Elimina recurs compartit</string>
   <string id="21366">Carpeta del subtítol</string>
   <string id="21367">Movie &amp; alternate subtitle directory</string>
-
-  <string id="21369">Activa el ratolí</string>
+  
+  <string id="21369">Activa el suport de ratolí i pantalla tàctil</string>
   <string id="21370">Reprodueix els sons de navegació durant la reproducció</string>
   <string id="21371">Miniatura</string>
   <string id="21372">Força la regió del reproductor DVD</string>
@@ -2223,6 +2230,7 @@
   <string id="24073">No s'ha pogut connectar</string>
   <string id="24074">És necessari reiniciar</string>
   <string id="24075">Desactiva</string>
+  <string id="24076">Complement necessari</string>
   <string id="24080">Voleu tornar a provar de connectar?</string>
   <string id="24089">Reinicia el complement</string>
   <string id="24090">Bloqueja el gestor de complements</string>
@@ -2233,6 +2241,8 @@
   <string id="24097">Voleu desactivar-lo en el sistema?</string>
   <string id="24098">Trencat</string>
   <string id="24099">Voleu canviar a aquesta aparença?</string>
+  <string id="24100">Per utilitzar aquesta funció cal descarregar un complement:</string>
+  <string id="24101">Voleu descarregar aquest complement?</string>
   <string id="25000">Notificacions</string>
 
   <!-- strings 29800 thru 29998 reserved strings used only in the default Project Mayhem III skin and not c++ code -->
@@ -2345,4 +2355,39 @@
   
   <string id="34201">Can't find a next item to play</string>
   <string id="34202">Can't find a previous item to play</string>
+  
+  <string id="35000">Perifèrics</string>
+  <string id="35001">Generic HID device</string>
+  <string id="35002">Adaptador de xarxa genèric</string>
+  <string id="35003">Disc genèric</string>
+  <string id="35004">No hi ha opcions disponibles&#10;per aquest perifèric.</string>
+  <string id="35005">Nou dispositiu configurat</string>
+  <string id="35006">Dispositiu eliminat</string>
+  <string id="35007">Keymap to use for this device</string>
+  <string id="35008">Mapa de teclat activat</string>
+  
+  <string id="35500">Ubicació</string>
+  <string id="35501">Classe</string>
+  <string id="35502">Nom</string>
+  <string id="35503">Venedor</string>
+  <string id="35504">Product ID</string>
+  
+  <string id="36000">Pulse-Eight CEC adapter</string>
+  <string id="36001">Pulse-Eight Nyxboard</string>
+  <string id="36002">Switch to keyboard side command</string>
+  <string id="36003">Switch to remote side command</string>
+  <string id="36004">Press "user" button command</string>
+  <string id="36005">Enable switch side commands</string>
+  <string id="36006">Could not open the adapter</string>
+  <string id="36007">Power on the TV when starting XBMC</string>
+  <string id="36008">Power off devices when stopping XBMC</string>
+  <string id="36009">Put devices in standby mode when activating screensaver</string>
+  <string id="36010">Set as inactive source when stopping XBMC</string>
+  <string id="36011">Could not detect the CEC port. Set it up manually.</string>
+  <string id="36012">Could not detect the CEC adapter.</string>
+  <string id="36013">Unsupported libcec interface version. %d is greater than the version XBMC supports (%d)</string>
+  <string id="36014">Put this PC in standby mode when the TV is switched off</string>
+  <string id="36015">Número de port HDMI</string>
+  <string id="36016">XBMC connectat</string>
+  <string id="36017">S'ha trobat un adaptador, però la libcec no està disponible</string>
 </strings>

--- a/language/German/strings.xml
+++ b/language/German/strings.xml
@@ -881,12 +881,18 @@
   <string id="10019">Einstellungen-&gt;Darstellung</string>
   <string id="10020">Skripte</string>
   <string id="10021">Webbrowser</string>
+  <string id="10022">Videos/Schauspieler</string>
+  <string id="10023">Videos/Jahr</string>
+  <string id="10024">Videos/Dateien</string>
+  <string id="10025">Videos/Datenbank</string>
 
   <string id="10028">Videos/Playlisten</string>
   <string id="10034">Einstellungen-&gt;Profile</string>
 
   <string id="10100">Ja/Nein Dialog</string>
   <string id="10101">Fortschrittsanzeige</string>
+  
+  <string id="10106">Entscheidung</string>
 
   <string id="10210">Suche nach Untertiteln...</string>
   <string id="10211">Zwischenspeichern der Untertitel...</string>

--- a/lib/libexif/ExifParse.cpp
+++ b/lib/libexif/ExifParse.cpp
@@ -413,7 +413,13 @@ void CExifParse::ProcessDir(const unsigned char* const DirStart,
     // Extract useful components of tag
     switch(Tag)
     {
-//      case TAG_DESCRIPTION:       strncpy(m_ExifInfo->Description, ValuePtr, 5);    break;
+      case TAG_DESCRIPTION:
+      {
+        int length = max(ByteCount, 0);
+        length = min(length, 2000);
+        strncpy(m_ExifInfo->Description, (char *)ValuePtr, length);
+        break;
+      }
       case TAG_MAKE:              strncpy(m_ExifInfo->CameraMake, (char *)ValuePtr, 32);    break;
       case TAG_MODEL:             strncpy(m_ExifInfo->CameraModel, (char *)ValuePtr, 40);    break;
 //      case TAG_SOFTWARE:          strncpy(m_ExifInfo->Software, ValuePtr, 5);    break;

--- a/lib/libexif/IptcParse.cpp
+++ b/lib/libexif/IptcParse.cpp
@@ -37,6 +37,7 @@
 #include "ExifParse.h"
 
 // Supported IPTC entry types
+#define IPTC_RECORD_VERSION         0x00
 #define IPTC_SUPLEMENTAL_CATEGORIES 0x14
 #define IPTC_KEYWORDS               0x19
 #define IPTC_CAPTION                0x78
@@ -58,6 +59,9 @@
 #define IPTC_COPYRIGHT              0x0A
 #define IPTC_COUNTRY_CODE           0x64
 #define IPTC_REFERENCE_SERVICE      0x2D
+#define IPTC_TIME_CREATED           0x3C
+#define IPTC_SUB_LOCATION           0x5C
+#define IPTC_IMAGE_TYPE             0x82
 
 
 //--------------------------------------------------------------------------
@@ -89,66 +93,103 @@ bool CIptcParse::Process (const unsigned char* const Data, const unsigned short 
 
   // Check IPTC signatures
   char* pos = (char*)(Data + sizeof(short));  // position data pointer after length field
+  char* maxpos = (char*)(Data+itemlen);
+  unsigned char headerLen = 0;
+  unsigned char dataLen = 0;
+  memset(info, 0, sizeof(IPTCInfo_t));
 
-  if (memcmp(pos, IptcSignature1, strlen(IptcSignature1)) != 0) return false;
-  pos += strlen(IptcSignature1) + 1;          // move data pointer to the next field
+  if (itemlen < 25) return false;
 
-  if (memcmp(pos, IptcSignature2, strlen(IptcSignature2)) != 0) return false;
-  pos += strlen(IptcSignature2);              // move data pointer to the next field
+  if (memcmp(pos, IptcSignature1, strlen(IptcSignature1)-1) != 0) return false;
+  pos += sizeof(IptcSignature1);          // move data pointer to the next field
 
-  if (memcmp(pos, IptcSignature3, sizeof(IptcSignature3)) != 0) return false;
-  pos += sizeof(IptcSignature3);              // move data pointer to the next field
+  if (memcmp(pos, IptcSignature2, strlen(IptcSignature2)-1) != 0) return false;
+  pos += sizeof(IptcSignature2)-1;              // move data pointer to the next field
+
+  while (memcmp(pos, IptcSignature3, sizeof(IptcSignature3)) != 0) { // loop on valid Photoshop blocks
+
+    pos += sizeof(IptcSignature3); // move data pointer to the Header Length
+    // Skip header
+    headerLen = *pos; // get header length and move data pointer to the next field
+    pos += (headerLen & 0xfe) + 2; // move data pointer to the next field (Header is padded to even length, counting the length byte)
+
+    pos += 3; // move data pointer to length, assume only one byte, TODO: use all 4 bytes
+
+    dataLen = *pos++;
+    pos += dataLen; // skip data section
+
+    if (memcmp(pos, IptcSignature2, sizeof(IptcSignature2) - 1) != 0) return false;
+    pos += sizeof(IptcSignature2) - 1; // move data pointer to the next field
+  }
+
+  pos += sizeof(IptcSignature3);          // move data pointer to the next field
+  if (pos >= maxpos) return false;
 
   // IPTC section found
 
   // Skip header
-  unsigned char headerLen = *pos++;           // get header length and move data pointer to the next field
+  headerLen = *pos++;           // get header length and move data pointer to the next field
   pos += headerLen + 1 - (headerLen % 2);     // move data pointer to the next field (Header is padded to even length, counting the length byte)
 
+  if (pos + 4 >= maxpos) return false;
+
   // Get length (Motorola format)
-  unsigned long length = CExifParse::Get32(pos);
+  //unsigned long length = CExifParse::Get32(pos);
+
   pos += sizeof(long);                        // move data pointer to the next field
 
   // Now read IPTC data
   while (pos < (char*)(Data + itemlen-5))
   {
+    if (pos + 5 > maxpos) return false;
+
     short signature = (*pos << 8) + (*(pos+1));
 
     pos += sizeof(short);
-    if (signature != 0x1C02)
+    if (signature != 0x1C01 && signature != 0x1C02)
       break;
 
     unsigned char  type = *pos++;
     unsigned short length  = (*pos << 8) + (*(pos+1));
     pos += sizeof(short);                   // Skip tag length
+
+    if (pos + length > maxpos) return false;
+
     // Process tag here
     char *tag = NULL;
-    switch (type)
+    if (signature == 0x1C02)
     {
-      case IPTC_SUPLEMENTAL_CATEGORIES:   tag = info->SupplementalCategories;  break;
-      case IPTC_KEYWORDS:                 tag = info->Keywords;                break;
-      case IPTC_CAPTION:                  tag = info->Caption;                 break;
-      case IPTC_AUTHOR:                   tag = info->Author;                  break;
-      case IPTC_HEADLINE:                 tag = info->Headline;                break;
-      case IPTC_SPECIAL_INSTRUCTIONS:     tag = info->SpecialInstructions;     break;
-      case IPTC_CATEGORY:                 tag = info->Category;                break;
-      case IPTC_BYLINE:                   tag = info->Byline;                  break;
-      case IPTC_BYLINE_TITLE:             tag = info->BylineTitle;             break;
-      case IPTC_CREDIT:                   tag = info->Credit;                  break;
-      case IPTC_SOURCE:                   tag = info->Source;                  break;
-      case IPTC_COPYRIGHT_NOTICE:         tag = info->CopyrightNotice;         break;
-      case IPTC_OBJECT_NAME:              tag = info->ObjectName;              break;
-      case IPTC_CITY:                     tag = info->City;                    break;
-      case IPTC_STATE:                    tag = info->State;                   break;
-      case IPTC_COUNTRY:                  tag = info->Country;                 break;
-      case IPTC_TRANSMISSION_REFERENCE:   tag = info->TransmissionReference;   break;
-      case IPTC_DATE:                     tag = info->Date;                    break;
-      case IPTC_COPYRIGHT:                tag = info->Copyright;               break;
-      case IPTC_REFERENCE_SERVICE:        tag = info->ReferenceService;        break;
-      case IPTC_COUNTRY_CODE:             tag = info->CountryCode;             break;
-      default:
-        printf("IptcParse: Unrecognised IPTC tag: 0x%02x", type);
-      break;
+      switch (type)
+      {
+        case IPTC_RECORD_VERSION:           tag = info->RecordVersion;           break;
+        case IPTC_SUPLEMENTAL_CATEGORIES:   tag = info->SupplementalCategories;  break;
+        case IPTC_KEYWORDS:                 tag = info->Keywords;                break;
+        case IPTC_CAPTION:                  tag = info->Caption;                 break;
+        case IPTC_AUTHOR:                   tag = info->Author;                  break;
+        case IPTC_HEADLINE:                 tag = info->Headline;                break;
+        case IPTC_SPECIAL_INSTRUCTIONS:     tag = info->SpecialInstructions;     break;
+        case IPTC_CATEGORY:                 tag = info->Category;                break;
+        case IPTC_BYLINE:                   tag = info->Byline;                  break;
+        case IPTC_BYLINE_TITLE:             tag = info->BylineTitle;             break;
+        case IPTC_CREDIT:                   tag = info->Credit;                  break;
+        case IPTC_SOURCE:                   tag = info->Source;                  break;
+        case IPTC_COPYRIGHT_NOTICE:         tag = info->CopyrightNotice;         break;
+        case IPTC_OBJECT_NAME:              tag = info->ObjectName;              break;
+        case IPTC_CITY:                     tag = info->City;                    break;
+        case IPTC_STATE:                    tag = info->State;                   break;
+        case IPTC_COUNTRY:                  tag = info->Country;                 break;
+        case IPTC_TRANSMISSION_REFERENCE:   tag = info->TransmissionReference;   break;
+        case IPTC_DATE:                     tag = info->Date;                    break;
+        case IPTC_COPYRIGHT:                tag = info->Copyright;               break;
+        case IPTC_REFERENCE_SERVICE:        tag = info->ReferenceService;        break;
+        case IPTC_COUNTRY_CODE:             tag = info->CountryCode;             break;
+        case IPTC_TIME_CREATED:             tag = info->TimeCreated;             break;
+        case IPTC_SUB_LOCATION:             tag = info->SubLocation;             break;
+        case IPTC_IMAGE_TYPE:               tag = info->ImageType;               break;
+        default:
+          printf("IptcParse: Unrecognised IPTC tag: 0x%02x", type);
+          break;
+      }
     }
 
     if (tag)

--- a/lib/libexif/IptcParse.cpp
+++ b/lib/libexif/IptcParse.cpp
@@ -136,7 +136,7 @@ bool CIptcParse::Process (const unsigned char* const Data, const unsigned short 
   // Get length (Motorola format)
   //unsigned long length = CExifParse::Get32(pos);
 
-  pos += sizeof(long);                        // move data pointer to the next field
+  pos += 4;                         // move data pointer to the next field
 
   // Now read IPTC data
   while (pos < (char*)(Data + itemlen-5))

--- a/lib/libexif/libexif.h
+++ b/lib/libexif/libexif.h
@@ -98,6 +98,7 @@ typedef struct {
     int   ISOequivalent;
     int   LightSource;
     char  Comments[MAX_COMMENT];
+    char  Description[MAX_COMMENT];
 
     unsigned ThumbnailOffset;          // Exif offset to thumbnail
     unsigned ThumbnailSize;            // Size of thumbnail.

--- a/lib/libexif/libexif.h
+++ b/lib/libexif/libexif.h
@@ -48,6 +48,7 @@ extern "C" {
 #define MAX_IPTC_STRING 256
 
 typedef struct {
+  char RecordVersion[MAX_IPTC_STRING];
   char SupplementalCategories[MAX_IPTC_STRING];
   char Keywords[MAX_IPTC_STRING];
   char Caption[MAX_IPTC_STRING];
@@ -69,6 +70,9 @@ typedef struct {
   char Copyright[MAX_IPTC_STRING];
   char ReferenceService[MAX_IPTC_STRING];
   char CountryCode[MAX_IPTC_STRING];
+  char TimeCreated[MAX_IPTC_STRING];
+  char SubLocation[MAX_IPTC_STRING];
+  char ImageType[MAX_IPTC_STRING];
 } IPTCInfo_t;
 
 #define MAX_COMMENT 2000

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -239,7 +239,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\;..\..\xbmc\;..\..\xbmc\win32\;..\..\xbmc\cores\dvdplayer;..\..\lib;..\..\lib\ffmpeg;..\..\lib\ffmpeg\include-xbmc-win32;..\..\lib\liblame\include;..\..\lib\libUPnP\Platinum\Source\Devices\MediaRenderer;..\..\lib\libUPnP\Platinum\Source\Devices\MediaConnect;..\..\lib\libUPnP\Platinum\Source\Devices\MediaServer;..\..\lib\libUPnP\Platinum\Source\Platinum;..\..\lib\libUPnP\Platinum\Source\Core;..\..\lib\libUPnP\Neptune\Source\Core;..\..\lib\libUPnP\Neptune\Source\System\Win32;..\..\lib\win32\pcre;..\..\lib\win32</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>TARGET_WINDOWS;_WINDOWS;_MSVC;WIN32;_DEBUG;_WIN32_WINNT=0x0501;NTDDI_VERSION=0x05010300;NOMINMAX;_USE_32BIT_TIME_T;HAS_GL;__STDC_CONSTANT_MACROS;HAVE_LIBCEC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TARGET_WINDOWS;_WINDOWS;_MSVC;WIN32;_DEBUG;_WIN32_WINNT=0x0501;NTDDI_VERSION=0x05010300;NOMINMAX;_USE_32BIT_TIME_T;HAS_GL;__STDC_CONSTANT_MACROS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <ExceptionHandling>Async</ExceptionHandling>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -279,6 +279,7 @@ public:
   bool IsPresentFrame();
 
   void Minimize();
+  float NavigationIdleTime();
   bool ToggleDPMS(bool manual);
 
   float GetDimScreenSaverLevel() const;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -362,7 +362,6 @@ protected:
   bool ProcessHTTPApiButtons();
   bool ProcessJoystickEvent(const std::string& joystickName, int button, bool isAxis, float fAmount);
 
-  float NavigationIdleTime();
   static bool AlwaysProcess(const CAction& action);
 
   void SaveCurrentFileSettings();

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -42,6 +42,7 @@
 #include "guilib/GUIDialog.h"
 #include "windowing/WindowingFactory.h"
 #include "GUIInfoManager.h"
+#include "cores/VideoRenderers/RenderManager.h"
 
 #include "powermanagement/PowerManager.h"
 
@@ -230,6 +231,10 @@ void CApplicationMessenger::ProcessMessage(ThreadMessage *pMsg)
 
           case POWERSTATE_MINIMIZE:
             Minimize();
+            break;
+
+          case TMSG_RENDERER_FLUSH:
+            g_renderManager.Flush();
             break;
         }
       }

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -76,6 +76,7 @@ class CGUIWindow;
 #define TMSG_MINIMIZE             309
 #define TMSG_TOGGLEFULLSCREEN     310
 #define TMSG_SETLANGUAGE          311
+#define TMSG_RENDERER_FLUSH       312
 
 #define TMSG_HTTPAPI              400
 

--- a/xbmc/addons/Visualisation.cpp
+++ b/xbmc/addons/Visualisation.cpp
@@ -31,6 +31,10 @@
 #include <dlfcn.h>
 #include "filesystem/SpecialProtocol.h"
 #endif
+#ifdef HAS_LCD
+#include "settings/AdvancedSettings.h"
+#include "utils/LCDFactory.h"
+#endif
 
 using namespace std;
 using namespace MUSIC_INFO;
@@ -313,10 +317,22 @@ void CVisualisation::OnAudioData(const unsigned char* pAudioData, int iAudioData
 
     // Transfer data to our visualisation
     AudioData(ptrAudioBuffer->Get(), AUDIO_BUFFER_SIZE, m_fFreq, AUDIO_BUFFER_SIZE);
+#ifdef HAS_LCD
+    if (g_advancedSettings.m_lcdSpectrumAnalyzer)
+    {
+      g_lcd->SetSpectrumAnalyzerAudioData(ptrAudioBuffer->Get(), AUDIO_BUFFER_SIZE, m_fFreq, AUDIO_BUFFER_SIZE);
+    }
+#endif
   }
   else
   { // Transfer data to our visualisation
     AudioData(ptrAudioBuffer->Get(), AUDIO_BUFFER_SIZE, NULL, 0);
+#ifdef HAS_LCD
+    if (g_advancedSettings.m_lcdSpectrumAnalyzer)
+    {
+      g_lcd->SetSpectrumAnalyzerAudioData(ptrAudioBuffer->Get(), AUDIO_BUFFER_SIZE, NULL, 0);
+    }
+#endif
   }
   return ;
 }

--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -64,6 +64,7 @@ public:
   float GetAspectRatio() const;
 
   virtual bool AddVideoPicture(DVDVideoPicture* picture) { return false; }
+  virtual void Flush() {};
 
   virtual unsigned int GetProcessorSize() { return 0; }
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -554,6 +554,20 @@ void CLinuxRendererGL::Reset()
   }
 }
 
+void CLinuxRendererGL::Flush()
+{
+  if (!m_bValidated)
+    return;
+
+  glFinish();
+
+  for (int i = 0 ; i < m_NumYV12Buffers ; i++)
+    (this->*m_textureDelete)(i);
+
+  glFinish();
+  m_bValidated = false;
+}
+
 void CLinuxRendererGL::Update(bool bPauseDrawing)
 {
   if (!m_bConfigured) return;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -1049,6 +1049,8 @@ void CLinuxRendererGL::UnInit()
   CLog::Log(LOGDEBUG, "LinuxRendererGL: Cleaning up GL resources");
   CSingleLock lock(g_graphicsContext);
 
+  glFinish();
+
   if (m_rgbPbo)
   {
     glDeleteBuffersARB(1, &m_rgbPbo);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -140,6 +140,7 @@ public:
   virtual unsigned int PreInit();
   virtual void         UnInit();
   virtual void         Reset(); /* resets renderer after seek for example */
+  virtual void         Flush();
 
 #ifdef HAVE_LIBVDPAU
   virtual void         AddProcessor(CVDPAU* vdpau);

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -76,6 +76,7 @@ public:
   void FlipPage(volatile bool& bStop, double timestamp = 0.0, int source = -1, EFIELDSYNC sync = FS_NONE);
   unsigned int PreInit();
   void UnInit();
+  bool Flush();
 
   void AddOverlay(CDVDOverlay* o, double pts)
   {
@@ -227,6 +228,7 @@ protected:
   EPRESENTSTEP     m_presentstep;
   int        m_presentsource;
   CEvent     m_presentevent;
+  CEvent     m_flushEvent;
 
 
   OVERLAY::CRenderer m_overlays;

--- a/xbmc/cores/VideoRenderers/VideoShaders/YUV2RGBShader.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/YUV2RGBShader.cpp
@@ -239,7 +239,7 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
 #if HAS_GLES == 2
   glUniformMatrix4fv(m_hProj,  1, GL_FALSE, m_proj);
   glUniformMatrix4fv(m_hModel, 1, GL_FALSE, m_model);
-  glUniform1i(m_hAlpha, m_alpha);
+  glUniform1f(m_hAlpha, m_alpha);
 #endif
   VerifyGLState();
   return true;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -77,6 +77,7 @@ protected:
   int  FilterOpen(const CStdString& filters);
   void FilterClose();
   int  FilterProcess(AVFrame* frame);
+  void ReopenCodec();
 
   AVFrame* m_pFrame;
   AVCodecContext* m_pCodecContext;
@@ -88,6 +89,7 @@ protected:
   AVFilterContext* m_pFilterIn;
   AVFilterContext* m_pFilterOut;
   AVFilterLink*    m_pFilterLink;
+  AVCodec*         m_pCodec;
 
   int m_iPictureWidth;
   int m_iPictureHeight;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -387,6 +387,8 @@ int CVDPAU::Check(AVCodecContext* avctx)
 
   if (state == VDPAU_LOST)
   {
+    FiniVDPAUOutput();
+    FiniVDPAUProcs();
     if (!m_DisplayEvent.WaitMSec(2000))
     {
       CLog::Log(LOGERROR, "CVDPAU::Check - device didn't reset in reasonable time");

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -1533,8 +1533,6 @@ bool CVDPAU::CheckStatus(VdpStatus vdp_st, int line)
   {
     CLog::Log(LOGERROR, " (VDPAU) Error: %s(%d) at %s:%d\n", vdp_get_error_string(vdp_st), vdp_st, __FILE__, line);
 
-    vdp_device = VDP_INVALID_HANDLE;
-
     if(m_DisplayState == VDPAU_OPEN)
       m_DisplayState = VDPAU_RESET;
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -387,8 +387,10 @@ int CVDPAU::Check(AVCodecContext* avctx)
 
   if (state == VDPAU_LOST)
   {
+    CLog::Log(LOGNOTICE,"------------ clear down");
     FiniVDPAUOutput();
     FiniVDPAUProcs();
+    CLog::Log(LOGNOTICE,"------------ enter wait");
     if (!m_DisplayEvent.WaitMSec(2000))
     {
       CLog::Log(LOGERROR, "CVDPAU::Check - device didn't reset in reasonable time");

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -102,7 +102,6 @@ public:
   void InitCSCMatrix(int Height);
   bool CheckStatus(VdpStatus vdp_st, int line);
 
-  bool CheckRecover(bool force = false);
   void CheckFeatures();
   void SetColor();
   void SetNoiseReduction();
@@ -111,7 +110,6 @@ public:
   void SetHWUpscaling();
 
   pictureAge picAge;
-  bool       recover;
   vdpau_render_state *past[2], *current, *future;
   int        tmpDeintMode, tmpDeintGUI, tmpDeint;
   float      tmpNoiseReduction, tmpSharpness;
@@ -226,6 +224,9 @@ public:
 
   std::vector<vdpau_render_state*> m_videoSurfaces;
 
+  // OnLostDevice triggers transition from all states to LOST
+  // internal errors trigger transition from OPEN to RESET
+  // OnResetDevice triggers transition from LOST to RESET
   enum EDisplayState
   { VDPAU_OPEN
   , VDPAU_RESET

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -87,15 +87,12 @@ public:
   PFNGLXRELEASETEXIMAGEEXTPROC glXReleaseTexImageEXT;
   GLXPixmap  m_glPixmap;
   Pixmap  m_Pixmap;
-  GLXContext m_glContext;
 
   static void             FFReleaseBuffer(AVCodecContext *avctx, AVFrame *pic);
   static void             FFDrawSlice(struct AVCodecContext *s,
                                const AVFrame *src, int offset[4],
                                int y, int type, int height);
   static int              FFGetBuffer(AVCodecContext *avctx, AVFrame *pic);
-
-  static void             VDPPreemptionCallbackFunction(VdpDevice device, void* context);
 
   void Present();
   bool ConfigVDPAU(AVCodecContext *avctx, int ref_frames);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -21,6 +21,7 @@
  *
  */
 
+#include "DllAvUtil.h"
 #include "DVDVideoCodec.h"
 #include "DVDVideoCodecFFmpeg.h"
 #include "libavcodec/vdpau.h"
@@ -223,6 +224,7 @@ public:
                           , VdpChromaType     &chroma_type);
 
   std::vector<vdpau_render_state*> m_videoSurfaces;
+  DllAvUtil   m_dllAvUtil;
 
   // OnLostDevice triggers transition from all states to LOST
   // internal errors trigger transition from OPEN to RESET

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -134,6 +134,8 @@ public:
   void      InitVDPAUProcs();
   void      FiniVDPAUProcs();
   void      FiniVDPAUOutput();
+  bool      ConfigOutputMethod(AVCodecContext *avctx, AVFrame *pFrame);
+  bool      FiniOutputMethod();
 
   VdpDevice                            vdp_device;
   VdpGetProcAddress *                  vdp_get_proc_address;
@@ -222,6 +224,15 @@ public:
 
   std::vector<vdpau_render_state*> m_videoSurfaces;
   DllAvUtil   m_dllAvUtil;
+
+  enum VDPAUOutputMethod
+  {
+    OUTPUT_NONE,
+    OUTPUT_PIXMAP,
+    OUTPUT_GL_INTEROP_RGB,
+    OUTPUT_GL_INTEROP_YUV
+  };
+  VDPAUOutputMethod m_vdpauOutputMethod;
 
   // OnLostDevice triggers transition from all states to LOST
   // internal errors trigger transition from OPEN to RESET

--- a/xbmc/cores/paplayer/BXAcodec.cpp
+++ b/xbmc/cores/paplayer/BXAcodec.cpp
@@ -102,7 +102,8 @@ int BXACodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
     return READ_SUCCESS;
   }
 
-  return READ_ERROR;
+  *actualsize = 0;
+  return READ_EOF;
 }
 
 bool BXACodec::CanInit()

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -286,12 +286,12 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   int version = GetMinVersion();
   CStdString baseDBName = (dbSettings.name.IsEmpty() ? GetBaseDBName() : dbSettings.name.c_str());
   CStdString latestDb;
-  latestDb.Format("%s%d", GetBaseDBName(), version);
+  latestDb.Format("%s%d", baseDBName, version);
 
   while (version >= 0)
   {
     if (version)
-      dbSettings.name.Format("%s%d", GetBaseDBName(), version);
+      dbSettings.name.Format("%s%d", baseDBName, version);
     else
       dbSettings.name.Format("%s", baseDBName);
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -454,6 +454,11 @@ bool CDatabase::UpdateVersion(const CStdString &dbName)
     CLog::Log(LOGERROR, "Can't open the database %s as it is a NEWER version than what we were expecting?", dbName.c_str());
     return false;
   }
+  else
+  {
+    // we're at the same version so we need to recreate views which are not copied for mysql
+    CreateViews();
+  }
   return true;
 }
 

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -112,6 +112,7 @@ protected:
 
   virtual bool Open();
   virtual bool CreateTables();
+  virtual void CreateViews() {};
   virtual bool UpdateOldVersion(int version) { return true; };
 
   virtual int GetMinVersion() const=0;

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -214,19 +214,14 @@ int MysqlDatabase::copy(const char *backup_name) {
   char sql[512];
   int ret;
 
-  // create the new database
-  sprintf(sql, "CREATE DATABASE `%s`", backup_name);
-  if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
-    throw DbErrors("Can't create database for copy: '%s' (%d)", db.c_str(), ret);
-
   // ensure we're connected to the db we are about to copy
   if ( (ret=mysql_select_db(conn, db.c_str())) != MYSQL_OK )
-    throw DbErrors("Can't connect to master database: '%s'",db.c_str());
+    throw DbErrors("Can't connect to source database: '%s'",db.c_str());
 
   // grab a list of base tables only (no views)
   sprintf(sql, "SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'");
   if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
-    throw DbErrors("Can't determine base tables");
+    throw DbErrors("Can't determine base tables for copy.");
 
   // get list of all tables from old DB
   MYSQL_RES* res = mysql_store_result(conn);
@@ -236,8 +231,13 @@ int MysqlDatabase::copy(const char *backup_name) {
     if (mysql_num_rows(res) == 0)
     {
       mysql_free_result(res);
-      throw DbErrors("The source DB was unexpectedly empty.");
+      throw DbErrors("The source database was unexpectedly empty.");
     }
+
+    // create the new database
+    sprintf(sql, "CREATE DATABASE `%s`", backup_name);
+    if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+      throw DbErrors("Can't create database for copy: '%s' (%d)", db.c_str(), ret);
 
     MYSQL_ROW row;
 
@@ -248,15 +248,15 @@ int MysqlDatabase::copy(const char *backup_name) {
       sprintf(sql, "CREATE TABLE %s.%s LIKE %s",
               backup_name, row[0], row[0]);
 
-      if (query_with_reconnect(sql))
-        throw DbErrors("Can't copy schema for table '%s'\nError: %s", db.c_str(), strerror(errno));
+      if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+        throw DbErrors("Can't copy schema for table '%s'\nError: %s", db.c_str(), ret);
 
       // copy the table data
       sprintf(sql, "INSERT INTO %s.%s SELECT * FROM %s",
               backup_name, row[0], row[0]);
 
-      if (query_with_reconnect(sql))
-        throw DbErrors("Can't copy data for table '%s'\nError: %s", db.c_str(), strerror(errno));
+      if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+        throw DbErrors("Can't copy data for table '%s'\nError: %s", db.c_str(), ret);
     }
   }
 

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -139,13 +139,13 @@ int MysqlDatabase::connect(bool create_new) {
       }
       else if (create_new)
       {
-        CLog::Log(LOGDEBUG, "Creating new db becuase you asked me.");
-
         char sqlcmd[512];
+        int ret;
+
         sprintf(sqlcmd, "CREATE DATABASE `%s`", db.c_str());
-        if ( query_with_reconnect(sqlcmd) )
+        if ( (ret=query_with_reconnect(sqlcmd)) != MYSQL_OK )
         {
-          throw DbErrors("Can't create database: '%s'\nError: %s", db.c_str(), strerror(errno));
+          throw DbErrors("Can't create new database: '%s' (%d)", db.c_str(), ret);
         }
       }
 
@@ -197,10 +197,11 @@ int MysqlDatabase::drop() {
   if (!active)
     throw DbErrors("Can't drop database: no active connection...");
   char sqlcmd[512];
+  int ret;
   sprintf(sqlcmd,"DROP DATABASE `%s`", db.c_str());
-  if ( query_with_reconnect(sqlcmd) )
+  if ( (ret=query_with_reconnect(sqlcmd)) != MYSQL_OK )
   {
-    throw DbErrors("Can't drop database: '%s'\nError: %s", db.c_str(), strerror(errno));
+    throw DbErrors("Can't drop database: '%s' (%d)", db.c_str(), ret);
   }
   disconnect();
   return DB_COMMAND_OK;
@@ -211,19 +212,20 @@ int MysqlDatabase::copy(const char *backup_name) {
     throw DbErrors("Can't copy database: no active connection...");
 
   char sql[512];
+  int ret;
 
   // create the new database
   sprintf(sql, "CREATE DATABASE `%s`", backup_name);
-  if ( query_with_reconnect(sql) )
-    throw DbErrors("Can't create database for copy: '%s'\nError: %s", db.c_str(), strerror(errno));
+  if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
+    throw DbErrors("Can't create database for copy: '%s' (%d)", db.c_str(), ret);
 
   // ensure we're connected to the db we are about to copy
-  if (mysql_select_db(conn, db.c_str()))
+  if ( (ret=mysql_select_db(conn, db.c_str())) != MYSQL_OK )
     throw DbErrors("Can't connect to master database: '%s'",db.c_str());
 
   // grab a list of base tables only (no views)
   sprintf(sql, "SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'");
-  if ( query_with_reconnect(sql) )
+  if ( (ret=query_with_reconnect(sql)) != MYSQL_OK )
     throw DbErrors("Can't determine base tables");
 
   // get list of all tables from old DB
@@ -234,7 +236,7 @@ int MysqlDatabase::copy(const char *backup_name) {
     if (mysql_num_rows(res) == 0)
     {
       mysql_free_result(res);
-      return -1; // EMPTY DB
+      throw DbErrors("The source DB was unexpectedly empty.");
     }
 
     MYSQL_ROW row;

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -267,7 +267,8 @@ int SqliteDatabase::create() {
 }
 
 int SqliteDatabase::copy(const char *backup_name) {
-  if (active == false) throw DbErrors("Can't copy database: no active connection...");
+  if (active == false)
+    throw DbErrors("Can't copy database: no active connection...");
 
   CLog::Log(LOGDEBUG, "Copying from %s to %s at %s", backup_name, db.c_str(), host.c_str());
 
@@ -304,6 +305,9 @@ int SqliteDatabase::copy(const char *backup_name) {
   }
 
   (void)sqlite3_close(pFile);
+
+  if( rc != SQLITE_OK )
+    throw DbErrors("Can't copy database. (%d)", rc);
 
   return rc;
 }

--- a/xbmc/filesystem/FilePipe.cpp
+++ b/xbmc/filesystem/FilePipe.cpp
@@ -123,8 +123,8 @@ void CFilePipe::Close()
 {
   if (m_pipe)
   {
-    PipesManager::GetInstance().ClosePipe(m_pipe);
     m_pipe->RemoveListener(this);
+    PipesManager::GetInstance().ClosePipe(m_pipe);    
   }
   m_pipe = NULL;
 }

--- a/xbmc/filesystem/MythSession.cpp
+++ b/xbmc/filesystem/MythSession.cpp
@@ -210,7 +210,9 @@ void CMythSession::SetFileItemMetaData(CFileItem &item, cmyth_proginfo_t program
      * within the OSD.
      */
     CStdString name = GetValue(m_dll->proginfo_chansign(program));
-    if (!name.IsEmpty())
+    if (tag->m_strTitle.IsEmpty())
+      tag->m_strTitle += name; 
+    else if (!name.IsEmpty())
       tag->m_strTitle += " - " + name;
 
     /*

--- a/xbmc/guilib/DispResource.h
+++ b/xbmc/guilib/DispResource.h
@@ -1,0 +1,33 @@
+/*
+*      Copyright (C) 2005-2008 Team XBMC
+*      http://www.xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#pragma once
+
+#ifdef HAS_GLX
+class IDispResource
+{
+public:
+  virtual ~IDispResource() {};
+  virtual void OnLostDevice() {};
+  virtual void OnResetDevice() {};
+};
+
+#endif

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -446,12 +446,12 @@ bool CGUIControlFactory::GetColor(const TiXmlNode *control, const char *strTag, 
   return false;
 }
 
-bool CGUIControlFactory::GetInfoColor(const TiXmlNode *control, const char *strTag, CGUIInfoColor &value)
+bool CGUIControlFactory::GetInfoColor(const TiXmlNode *control, const char *strTag, CGUIInfoColor &value,int parentID)
 {
   const TiXmlElement* node = control->FirstChildElement(strTag);
   if (node && node->FirstChild())
   {
-    value.Parse(node->FirstChild()->Value());
+    value.Parse(node->FirstChild()->Value(), parentID);
     return true;
   }
   return false;
@@ -737,7 +737,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   }
   XMLUtils::GetInt(pControlNode, "pagecontrol", pageControl);
 
-  GetInfoColor(pControlNode, "colordiffuse", colorDiffuse);
+  GetInfoColor(pControlNode, "colordiffuse", colorDiffuse, parentID);
 
   GetConditionalVisibility(pControlNode, visibleCondition, allowHiddenFocus);
   XMLUtils::GetString(pControlNode, "enable", enableCondition);
@@ -745,11 +745,11 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   CRect animRect(posX, posY, posX + width, posY + height);
   GetAnimations(pControlNode, animRect, parentID, animations);
 
-  GetInfoColor(pControlNode, "textcolor", labelInfo.textColor);
-  GetInfoColor(pControlNode, "focusedcolor", labelInfo.focusedColor);
-  GetInfoColor(pControlNode, "disabledcolor", labelInfo.disabledColor);
-  GetInfoColor(pControlNode, "shadowcolor", labelInfo.shadowColor);
-  GetInfoColor(pControlNode, "selectedcolor", labelInfo.selectedColor);
+  GetInfoColor(pControlNode, "textcolor", labelInfo.textColor, parentID);
+  GetInfoColor(pControlNode, "focusedcolor", labelInfo.focusedColor, parentID);
+  GetInfoColor(pControlNode, "disabledcolor", labelInfo.disabledColor, parentID);
+  GetInfoColor(pControlNode, "shadowcolor", labelInfo.shadowColor, parentID);
+  GetInfoColor(pControlNode, "selectedcolor", labelInfo.selectedColor, parentID);
   XMLUtils::GetFloat(pControlNode, "textoffsetx", labelInfo.offsetX);
   XMLUtils::GetFloat(pControlNode, "textoffsety", labelInfo.offsetY);
   int angle = 0;  // use the negative angle to compensate for our vertically flipped cartesian plane
@@ -795,7 +795,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GetTexture(pControlNode, "textureleftfocus", textureLeftFocus);
   GetTexture(pControlNode, "texturerightfocus", textureRightFocus);
 
-  GetInfoColor(pControlNode, "spincolor", spinInfo.textColor);
+  GetInfoColor(pControlNode, "spincolor", spinInfo.textColor, parentID);
   if (XMLUtils::GetString(pControlNode, "spinfont", strFont))
     spinInfo.font = g_fontManager.GetFont(strFont);
   if (!spinInfo.font) spinInfo.font = labelInfo.font;
@@ -824,8 +824,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
   XMLUtils::GetString(pControlNode, "title", strTitle);
   XMLUtils::GetString(pControlNode, "tagset", strRSSTags);
-  GetInfoColor(pControlNode, "headlinecolor", headlineColor);
-  GetInfoColor(pControlNode, "titlecolor", textColor3);
+  GetInfoColor(pControlNode, "headlinecolor", headlineColor, parentID);
+  GetInfoColor(pControlNode, "titlecolor", textColor3, parentID);
 
   if (XMLUtils::GetString(pControlNode, "subtype", strSubType))
   {

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -94,7 +94,7 @@ public:
   static void GetInfoLabel(const TiXmlNode *pControlNode, const CStdString &labelTag, CGUIInfoLabel &infoLabel, int parentID);
   static void GetInfoLabels(const TiXmlNode *pControlNode, const CStdString &labelTag, std::vector<CGUIInfoLabel> &infoLabels, int parentID);
   static bool GetColor(const TiXmlNode* pRootNode, const char* strTag, color_t &value);
-  static bool GetInfoColor(const TiXmlNode* pRootNode, const char* strTag, CGUIInfoColor &value);
+  static bool GetInfoColor(const TiXmlNode* pRootNode, const char* strTag, CGUIInfoColor &value, int parentID);
   static CStdString FilterLabel(const CStdString &label);
   static bool GetConditionalVisibility(const TiXmlNode* control, CStdString &condition);
   static bool GetActions(const TiXmlNode* pRootNode, const char* strTag, CGUIAction& actions);

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -100,12 +100,21 @@ bool CGUIInfoColor::Update()
     return false;
 }
 
-void CGUIInfoColor::Parse(const CStdString &label)
+void CGUIInfoColor::Parse(const CStdString &label, int context)
 {
   // Check for the standard $INFO[] block layout, and strip it if present
   CStdString label2 = label;
   if (label.Equals("-", false))
     return;
+
+  if (label.Left(4).Equals("$VAR", false))
+  {
+    label2 = label.Mid(5, label.length() - 6);
+    m_info = g_infoManager.TranslateSkinVariableString(label2, context);
+    if (!m_info)
+      m_info = g_infoManager.RegisterSkinVariableString(g_SkinInfo->CreateSkinVariable(label2, context));
+    return;
+  }
 
   if (label.Left(5).Equals("$INFO", false))
     label2 = label.Mid(6, label.length()-7);

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -60,7 +60,7 @@ public:
   operator color_t() const { return m_color; };
 
   bool Update();
-  void Parse(const CStdString &label);
+  void Parse(const CStdString &label, int context);
 
 private:
   color_t GetColor() const;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -143,7 +143,7 @@ bool CGUIWindow::Load(TiXmlDocument &xmlDoc)
   // now load in the skin file
   SetDefaults();
 
-  CGUIControlFactory::GetInfoColor(pRootElement, "backgroundcolor", m_clearBackground);
+  CGUIControlFactory::GetInfoColor(pRootElement, "backgroundcolor", m_clearBackground, GetID());
   CGUIControlFactory::GetActions(pRootElement, "onload", m_loadActions);
   CGUIControlFactory::GetActions(pRootElement, "onunload", m_unloadActions);
   CGUIControlFactory::GetHitRect(pRootElement, m_hitRect);

--- a/xbmc/linux/Makefile.in
+++ b/xbmc/linux/Makefile.in
@@ -14,6 +14,8 @@ SRCS=ConvUtils.cpp \
      XFileUtils.cpp \
      XHandle.cpp \
      XLCDproc.cpp \
+	 XLCDProc_imon.cpp \
+	 XLCDProc_mdm166a.cpp \
      XMemUtils.cpp \
      XSyncUtils.cpp \
      XTimeUtils.cpp \

--- a/xbmc/linux/XLCDProc_imon.cpp
+++ b/xbmc/linux/XLCDProc_imon.cpp
@@ -1,0 +1,416 @@
+#ifndef __XLCDProc_imon_CPP__
+#define __XLCDProc_imon_CPP__
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "XLCDProc_imon.h"
+#include "../utils/log.h"
+
+XLCDProc_imon::XLCDProc_imon()
+{
+  m_outputTimer.StartZero();
+}
+
+XLCDProc_imon::~XLCDProc_imon(void)
+{
+}
+
+bool XLCDProc_imon::SendIconStatesToDisplay()
+{
+  char cmd[64];
+
+  if (outputValue != outputValueOld || isOutputValuesTurn())
+  {
+    // A tweak for the imon-lcd-driver: There is no icon for this bit.
+    // Needed because the driver sets ALL symbols (icons and progress bars) to "off", if there is an outputValue == 0
+    outputValue |= 1 << 30;
+    outputValueOld = outputValue;
+    sprintf(cmd, "output %d\n", outputValue);
+  }
+  else if (outputValueProgressBars != outputValueProgressBarsOld)
+  {
+    outputValueProgressBarsOld = outputValueProgressBars;
+    sprintf(cmd, "output %d\n", outputValueProgressBars);
+  }
+  else
+    return true;
+
+  ResetModeIcons();
+
+  if (write(m_sockfd, cmd, strlen(cmd)) < 0)
+  {
+    CLog::Log(
+        LOGERROR,
+        "XLCDproc::%s - Unable to write 'outputValue' to socket, LCDd not running?",
+        __FUNCTION__);
+  }
+
+  return true;
+}
+
+void XLCDProc_imon::ResetModeIcons(void)
+{
+  outputValue &= ~(7 << IMON_OUTPUT_TOP_ROW); // reset entire row
+  outputValue &= ~(7 << IMON_OUTPUT_BL_ICONS); // reset entire row
+  outputValue &= ~(7 << IMON_OUTPUT_BM_ICONS); // reset entire row
+  outputValue &= ~(7 << IMON_OUTPUT_BR_ICONS); // reset entire row
+  outputValue &= ~(3 << IMON_OUTPUT_SPKR); // reset entire block
+}
+
+void XLCDProc_imon::SetIconMovie(bool on)
+{
+  if (on)
+    outputValue |= 2 << IMON_OUTPUT_TOP_ROW;
+  else
+    outputValue &= ~(2 << IMON_OUTPUT_TOP_ROW);
+}
+
+void XLCDProc_imon::SetIconMusic(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_TOP_ROW;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_TOP_ROW);
+}
+
+void XLCDProc_imon::SetIconWeather(bool on)
+{
+  if (on)
+    outputValue |= 7 << IMON_OUTPUT_TOP_ROW;
+  else
+    outputValue &= ~(7 << IMON_OUTPUT_TOP_ROW);
+}
+
+void XLCDProc_imon::SetIconTV(bool on)
+{
+  if (on)
+    outputValue |= 5 << IMON_OUTPUT_TOP_ROW;
+  else
+    outputValue &= ~(5 << IMON_OUTPUT_TOP_ROW);
+}
+
+void XLCDProc_imon::SetIconPhoto(bool on)
+{
+  if (on)
+    outputValue |= 3 << IMON_OUTPUT_TOP_ROW;
+  else
+    outputValue &= ~(3 << IMON_OUTPUT_TOP_ROW);
+}
+
+void XLCDProc_imon::SetIconResolution(ILCD::LCD_RESOLUTION resolution)
+{
+  // reset both icons to avoid that they may be lit at the same time
+  outputValue &= ~(1 << IMON_OUTPUT_TV);
+  outputValue &= ~(1 << IMON_OUTPUT_HDTV);
+
+  if (resolution == LCD_RESOLUTION_SD)
+    outputValue |= 1 << IMON_OUTPUT_TV;
+  else if (resolution == LCD_RESOLUTION_HD)
+    outputValue |= 1 << IMON_OUTPUT_HDTV;
+}
+
+void XLCDProc_imon::SetProgressBar1(double progress)
+{
+  XLCDproc::outputValueProgressBars = progressBar(
+      XLCDproc::outputValueProgressBars, progress);
+}
+
+void XLCDProc_imon::SetProgressBar2(double volume)
+{
+  XLCDproc::outputValueProgressBars = volumeBar(
+      XLCDproc::outputValueProgressBars, volume);
+}
+
+inline int XLCDProc_imon::volumeBar(int oldValue, double newValue)
+{
+  oldValue &= ~0x00FC0000;
+  oldValue |= ((int) (32 * (newValue / 100)) << 18) & 0x00FC0000;
+  oldValue |= 1 << IMON_OUTPUT_PBARS;
+  return oldValue;
+}
+
+inline int XLCDProc_imon::progressBar(int oldValue, double newValue)
+{
+  oldValue &= ~0x00000FC0;
+  oldValue |= ((int) (32 * (newValue / 100)) << 6) & 0x00000FC0;
+  oldValue |= 1 << IMON_OUTPUT_PBARS;
+  return oldValue;
+}
+
+bool XLCDProc_imon::isOutputValuesTurn()
+{
+  if (m_outputTimer.GetElapsedMilliseconds() > 1000)
+  {
+    m_outputTimer.Reset();
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+void XLCDProc_imon::SetIconMute(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_imon::SetIconPlaying(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_DISC;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_DISC);
+}
+
+void XLCDProc_imon::SetIconPause(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_imon::SetIconRepeat(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_REP;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_REP);
+}
+
+void XLCDProc_imon::SetIconShuffle(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_SFL;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_SFL);
+}
+
+void XLCDProc_imon::SetIconAlarm(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_ALARM;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_ALARM);
+}
+
+void XLCDProc_imon::SetIconRecord(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_REC;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_REC);
+}
+
+void XLCDProc_imon::SetIconVolume(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_VOL;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_VOL);
+}
+
+void XLCDProc_imon::SetIconTime(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_TIME;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_TIME);
+}
+
+void XLCDProc_imon::SetIconSPDIF(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_SPDIF;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_SPDIF);
+}
+
+void XLCDProc_imon::SetIconDiscIn(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_DISK_IN;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_DISK_IN);
+}
+
+void XLCDProc_imon::SetIconSource(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_SRC;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_SRC);
+}
+
+void XLCDProc_imon::SetIconFit(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_FIT;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_FIT);
+}
+
+void XLCDProc_imon::SetIconSCR1(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_SCR1;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_SCR1);
+}
+
+void XLCDProc_imon::SetIconSCR2(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_SCR2;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_SCR2);
+}
+
+// codec icons - video: video stream format ###################################
+void XLCDProc_imon::SetIconMPEG(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_BL_ICONS;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_BL_ICONS);
+}
+
+void XLCDProc_imon::SetIconDIVX(bool on)
+{
+  if (on)
+    outputValue |= 2 << IMON_OUTPUT_BL_ICONS;
+  else
+    outputValue &= ~(2 << IMON_OUTPUT_BL_ICONS);
+}
+
+void XLCDProc_imon::SetIconXVID(bool on)
+{
+  if (on)
+    outputValue |= 3 << IMON_OUTPUT_BL_ICONS;
+  else
+    outputValue &= ~(3 << IMON_OUTPUT_BL_ICONS);
+}
+
+void XLCDProc_imon::SetIconWMV(bool on)
+{
+  if (on)
+    outputValue |= 4 << IMON_OUTPUT_BL_ICONS;
+  else
+    outputValue &= ~(4 << IMON_OUTPUT_BL_ICONS);
+}
+// codec icons - video: audio stream format #################################
+void XLCDProc_imon::SetIconMPGA(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_BM_ICONS;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_BM_ICONS);
+}
+
+void XLCDProc_imon::SetIconAC3(bool on)
+{
+  if (on)
+    outputValue |= 2 << IMON_OUTPUT_BM_ICONS;
+  else
+    outputValue &= ~(2 << IMON_OUTPUT_BM_ICONS);
+}
+
+void XLCDProc_imon::SetIconDTS(bool on)
+{
+  if (on)
+    outputValue |= 3 << IMON_OUTPUT_BM_ICONS;
+  else
+    outputValue &= ~(3 << IMON_OUTPUT_BM_ICONS);
+}
+
+void XLCDProc_imon::SetIconVWMA(bool on)
+{
+  if (on)
+    outputValue |= 4 << IMON_OUTPUT_BM_ICONS;
+  else
+    outputValue &= ~(4 << IMON_OUTPUT_BM_ICONS);
+}
+// codec icons - audio format ###############################################
+void XLCDProc_imon::SetIconMP3(bool on)
+{
+  if (on)
+    outputValue |= 1 << IMON_OUTPUT_BR_ICONS;
+  else
+    outputValue &= ~(1 << IMON_OUTPUT_BR_ICONS);
+}
+
+void XLCDProc_imon::SetIconOGG(bool on)
+{
+  if (on)
+    outputValue |= 2 << IMON_OUTPUT_BR_ICONS;
+  else
+    outputValue &= ~(2 << IMON_OUTPUT_BR_ICONS);
+}
+
+void XLCDProc_imon::SetIconAWMA(bool on)
+{
+  if (on)
+    outputValue |= 3 << IMON_OUTPUT_BR_ICONS;
+  else
+    outputValue &= ~(3 << IMON_OUTPUT_BR_ICONS);
+}
+
+void XLCDProc_imon::SetIconWAV(bool on)
+{
+  if (on)
+    outputValue |= 4 << IMON_OUTPUT_BR_ICONS;
+  else
+    outputValue &= ~(4 << IMON_OUTPUT_BR_ICONS);
+}
+
+void XLCDProc_imon::SetIconAudioChannels(int channels)
+{
+  switch (channels)
+  {
+  case 1:
+  case 2:
+  case 3:
+    outputValue |= 1 << IMON_OUTPUT_SPKR;
+    break;
+  case 5:
+  case 6:
+    outputValue |= 2 << IMON_OUTPUT_SPKR;
+    break;
+  case 7:
+  case 8:
+    outputValue |= 3 << IMON_OUTPUT_SPKR;
+    break;
+  default:
+    outputValue &= ~(3 << IMON_OUTPUT_SPKR);
+    break;
+  }
+}
+
+void XLCDProc_imon::InitializeSpectrumAnalyzer()
+{
+  // no need to do anything here
+}
+
+void XLCDProc_imon::SetSpectrumAnalyzerData()
+{
+  // no need to do anything here
+}
+
+#endif // __XLCDProc_imon_CPP__

--- a/xbmc/linux/XLCDProc_imon.h
+++ b/xbmc/linux/XLCDProc_imon.h
@@ -1,0 +1,158 @@
+#ifndef __XLCDProc_imon_H__
+#define __XLCDProc_imon_H__
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <SDL/SDL_thread.h>
+#include "../utils/LCD.h"
+#include "XLCDproc.h"
+#include "../utils/Stopwatch.h"
+
+#define IMON_OUTPUT_DISC        0
+#define IMON_OUTPUT_TOP_ROW     1
+#define IMON_OUTPUT_SPKR        4
+#define IMON_OUTPUT_SPDIF       6
+#define IMON_OUTPUT_SRC         7
+#define IMON_OUTPUT_FIT         8
+#define IMON_OUTPUT_TV          9
+#define IMON_OUTPUT_HDTV        10
+#define IMON_OUTPUT_SCR1        11
+#define IMON_OUTPUT_SCR2        12
+#define IMON_OUTPUT_BR_ICONS    13
+#define IMON_OUTPUT_BM_ICONS    16
+#define IMON_OUTPUT_BL_ICONS    19
+#define IMON_OUTPUT_VOL         22
+#define IMON_OUTPUT_TIME        23
+#define IMON_OUTPUT_ALARM       24
+#define IMON_OUTPUT_REC         25
+#define IMON_OUTPUT_REP         26
+#define IMON_OUTPUT_SFL         27
+#define IMON_OUTPUT_PBARS       28
+#define IMON_OUTPUT_DISK_IN     29
+
+/**
+ * Sets the "output state" for the device. We use this to control the icons around the outside the
+ * display. The bits in \c outputValue correspond to the icons as follows:
+ *
+ * Bit     : Icon/Function
+ * 0       : disc icon (0=off, 1='spin') , if Toprow==4, use CD-animation, else use "HDD-recording-animation"
+ * 1,2,3   : top row (0=none, 1=music, 2=movie, 3=photo, 4=CD/DVD, 5=TV, 6=Web, 7=News/Weather)
+ * 4,5     : 'speaker' icons (0=off, 1=L+R, 2=5.1ch, 3=7.1ch)
+ * 6       : S/PDIF icon
+ * 7       : 'SRC'
+ * 8       : 'FIT'
+ * 9       : 'TV'
+ * 10      : 'HDTV'
+ * 11      : 'SRC1'
+ * 12      : 'SRC2'
+ * 13,14,15: bottom-right icons (0=off, 1=MP3, 2=OGG, 3=WMA, 4=WAV)
+ * 16,17,18: bottom-middle icons (0=off, 1=MPG, 2=AC3, 3=DTS, 4=WMA)
+ * 19,20,21: bottom-left icons (0=off, 1=MPG, 2=DIVX, 3=XVID, 4=WMV)
+ * 22      : 'VOL' (volume)
+ * 23      : 'TIME'
+ * 24      : 'ALARM'
+ * 25      : 'REC' (recording)
+ * 26      : 'REP' (repeat)
+ * 27      : 'SFL' (shuffle)
+ * 28      : Abuse this for progress bars (if set to 1), lower bits represent
+ *               the length (6 bits each: P|6xTP|6xTL|6xBL|6xBP with P = bit 28,
+ *               TP=Top Progress, TL = Top Line, BL = Bottom Line, BP = Bottom Progress).
+ *               If bit 28 is set to 1, lower bits are interpreted as
+ *               lengths; otherwise setting the symbols as usual.
+ *               0 <= length <= 32, bars extend from left to right.
+ *               length > 32, bars extend from right to left, length is counted
+ *               from 32 up (i.e. 35 means a length of 3).
+ *
+ *     Remember: There are two kinds of calls!
+ *               With bit 28 set to 1: Set all bars (leaving the symbols as is),
+ *               with bit 28 set to 0: Set the symbols (leaving the bars as is).
+ *     Beware:   TODO: May become a race condition, if both calls are executed
+ *                     before the display gets updated. Keep this in mind in your
+ *                     client-code.
+ * 29      : 'disc-in icon' - half ellipsoid under the disc symbols (0=off, 1=on)
+ */
+
+class XLCDProc_imon: public XLCDproc
+{
+public:
+  XLCDProc_imon();
+  virtual ~XLCDProc_imon(void);
+
+  // States whether this device sends the icon-information by itself.
+  // Returns true, if the caller does not have to care about sending the information.
+  virtual bool SendIconStatesToDisplay();
+
+  virtual void ResetModeIcons(void);
+  virtual void SetIconMovie(bool on);
+  virtual void SetIconMusic(bool on);
+  virtual void SetIconWeather(bool on);
+  virtual void SetIconTV(bool on);
+  virtual void SetIconPhoto(bool on);
+  virtual void SetIconResolution(ILCD::LCD_RESOLUTION resolution);
+  virtual void SetProgressBar1(double progress); // range from 0 - 100
+  virtual void SetProgressBar2(double volume); // range from 0 - 100
+  virtual void SetIconMute(bool on);
+  virtual void SetIconPlaying(bool on);
+  virtual void SetIconPause(bool on);
+  virtual void SetIconRepeat(bool on);
+  virtual void SetIconShuffle(bool on);
+  virtual void SetIconAlarm(bool on);
+  virtual void SetIconRecord(bool on);
+  virtual void SetIconVolume(bool on);
+  virtual void SetIconTime(bool on);
+  virtual void SetIconSPDIF(bool on);
+  virtual void SetIconDiscIn(bool on);
+  virtual void SetIconSource(bool on);
+  virtual void SetIconFit(bool on);
+  virtual void SetIconSCR1(bool on);
+  virtual void SetIconSCR2(bool on);
+
+  // codec icons - video: video stream format
+  virtual void SetIconMPEG(bool on);
+  virtual void SetIconDIVX(bool on);
+  virtual void SetIconXVID(bool on);
+  virtual void SetIconWMV(bool on);
+  // codec icons - video: audio stream format
+  virtual void SetIconMPGA(bool on);
+  virtual void SetIconAC3(bool on);
+  virtual void SetIconDTS(bool on);
+  virtual void SetIconVWMA(bool on);
+  // codec icons - audio format
+  virtual void SetIconMP3(bool on);
+  virtual void SetIconOGG(bool on);
+  virtual void SetIconAWMA(bool on);
+  virtual void SetIconWAV(bool on);
+
+  virtual void SetIconAudioChannels(int channels);
+
+  virtual void InitializeSpectrumAnalyzer(void);
+  virtual void SetSpectrumAnalyzerData(void);
+
+private:
+  CStopWatch m_outputTimer;
+
+  int volumeBar(int oldValue, double newValue);
+  int progressBar(int oldValue, double newValue);
+  bool isOutputValuesTurn();
+};
+
+#endif // __XLCDProc_imon_H__

--- a/xbmc/linux/XLCDProc_mdm166a.cpp
+++ b/xbmc/linux/XLCDProc_mdm166a.cpp
@@ -1,0 +1,310 @@
+#ifndef __XLCDProc_mdm166a_CPP__
+#define __XLCDProc_mdm166a_CPP__
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "XLCDProc_mdm166a.h"
+#include "../utils/log.h"
+
+XLCDProc_mdm166a::XLCDProc_mdm166a()
+{
+}
+
+XLCDProc_mdm166a::~XLCDProc_mdm166a(void)
+{
+}
+
+bool XLCDProc_mdm166a::SendIconStatesToDisplay()
+{
+  char cmd[64];
+
+  if (outputValue != outputValueOld)
+  {
+    outputValueOld = outputValue;
+    sprintf(cmd, "output %d\n", outputValue);
+  }
+  else
+    return true;
+
+  ResetModeIcons();
+
+  if (write(m_sockfd, cmd, strlen(cmd)) < 0)
+  {
+    CLog::Log(
+        LOGERROR,
+        "XLCDproc::%s - Unable to write 'outputValue' to socket, LCDd not running?",
+        __FUNCTION__);
+  }
+
+  return true;
+}
+
+void XLCDProc_mdm166a::ResetModeIcons(void)
+{
+  outputValue &= ~(3 << MDM166A_OUTPUT_WLAN_STR); // reset entire block
+}
+
+void XLCDProc_mdm166a::SetIconMovie(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconMusic(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconWeather(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconTV(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconPhoto(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconResolution(ILCD::LCD_RESOLUTION resolution)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetProgressBar1(double progress)
+{
+  outputValue = progressBar(outputValue, progress);
+}
+
+void XLCDProc_mdm166a::SetProgressBar2(double volume)
+{
+  outputValue = volumeBar(outputValue, volume);
+}
+
+inline int XLCDProc_mdm166a::volumeBar(int oldValue, double newValue)
+{
+  oldValue &= ~0x1F00;
+  oldValue |= ((int) (28 * (newValue / 100)) << MDM166A_OUTPUT_VOLUME) & 0x1F00;
+  return oldValue;
+}
+
+inline int XLCDProc_mdm166a::progressBar(int oldValue, double newValue)
+{
+  oldValue &= ~0x3F8000;
+  oldValue |= ((int) (96 * (newValue / 100)) << MDM166A_OUTPUT_PROGRESS) & 0x3F8000;
+  return oldValue;
+}
+
+void XLCDProc_mdm166a::SetIconMute(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_MUTE;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_MUTE);
+}
+
+void XLCDProc_mdm166a::SetIconPlaying(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_PLAY;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_PLAY);
+}
+
+void XLCDProc_mdm166a::SetIconPause(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_PAUSE;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_PAUSE);
+}
+
+void XLCDProc_mdm166a::SetIconRepeat(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconShuffle(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconAlarm(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_ALARM;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_ALARM);
+}
+
+void XLCDProc_mdm166a::SetIconRecord(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_REC;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_REC);
+}
+
+void XLCDProc_mdm166a::SetIconVolume(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_VOL;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_VOL);
+}
+
+void XLCDProc_mdm166a::SetIconTime(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconSPDIF(bool on)
+{
+  if (on)
+    outputValue |= 1 << MDM166A_OUTPUT_WLAN_ANT;
+  else
+    outputValue &= ~(1 << MDM166A_OUTPUT_WLAN_ANT);
+}
+
+void XLCDProc_mdm166a::SetIconDiscIn(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconSource(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconFit(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconSCR1(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconSCR2(bool on)
+{
+  // icon not supported by display
+}
+
+// codec icons - video: video stream format ###################################
+void XLCDProc_mdm166a::SetIconMPEG(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconDIVX(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconXVID(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconWMV(bool on)
+{
+  // icon not supported by display
+}
+// codec icons - video: audio stream format #################################
+void XLCDProc_mdm166a::SetIconMPGA(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconAC3(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconDTS(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconVWMA(bool on)
+{
+  // icon not supported by display
+}
+// codec icons - audio format ###############################################
+void XLCDProc_mdm166a::SetIconMP3(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconOGG(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconAWMA(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconWAV(bool on)
+{
+  // icon not supported by display
+}
+
+void XLCDProc_mdm166a::SetIconAudioChannels(int channels)
+{
+  switch (channels)
+  {
+  case 1:
+  case 2:
+  case 3:
+    outputValue |= 1 << MDM166A_OUTPUT_WLAN_STR;
+    break;
+  case 5:
+  case 6:
+    outputValue |= 2 << MDM166A_OUTPUT_WLAN_STR;
+    break;
+  case 7:
+  case 8:
+    outputValue |= 3 << MDM166A_OUTPUT_WLAN_STR;
+    break;
+  default:
+    outputValue &= ~(3 << MDM166A_OUTPUT_WLAN_STR);
+    break;
+  }
+}
+
+void XLCDProc_mdm166a::InitializeSpectrumAnalyzer()
+{
+  // no need to do anything here
+}
+
+void XLCDProc_mdm166a::SetSpectrumAnalyzerData()
+{
+  // no need to do anything here
+}
+
+#endif // __XLCDProc_mdm166a_CPP__

--- a/xbmc/linux/XLCDProc_mdm166a.h
+++ b/xbmc/linux/XLCDProc_mdm166a.h
@@ -1,0 +1,120 @@
+#ifndef __XLCDProc_mdm166a_H__
+#define __XLCDProc_mdm166a_H__
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <SDL/SDL_thread.h>
+#include "../utils/LCD.h"
+#include "XLCDproc.h"
+#include "../utils/Stopwatch.h"
+
+#define MDM166A_OUTPUT_PLAY     0
+#define MDM166A_OUTPUT_PAUSE    1
+#define MDM166A_OUTPUT_REC      2
+#define MDM166A_OUTPUT_ALARM    3
+#define MDM166A_OUTPUT_AT       4
+#define MDM166A_OUTPUT_MUTE     5
+#define MDM166A_OUTPUT_WLAN_ANT 6
+#define MDM166A_OUTPUT_VOL      7
+#define MDM166A_OUTPUT_VOLUME   8
+#define MDM166A_OUTPUT_WLAN_STR 13
+#define MDM166A_OUTPUT_PROGRESS 15
+
+/**
+ * Sets the "output state" for the device. We use this to control the icons around the outside the
+ * display. The bits in \c outputValue correspond to the icons as follows:
+ *
+ * Bit     : Icon/Function
+ * 0       : Play
+ * 1       : Pause
+ * 2       : Record
+ * 3       : Message
+ * 4       : @ (in the envelope (=Message symbol))
+ * 5       : Mute
+ * 6       : WLAN tower
+ * 7       : Volume (the word "Vol.")
+ * 8...12  : Volume value (which may be 0-28)
+ * 13...14 : WLAN signal strength (which may be 0-3)
+ */
+
+class XLCDProc_mdm166a: public XLCDproc
+{
+public:
+  XLCDProc_mdm166a();
+  virtual ~XLCDProc_mdm166a(void);
+
+  // States whether this device sends the icon-information by itself.
+  // Returns true, if the caller does not have to care about sending the information.
+  virtual bool SendIconStatesToDisplay();
+
+  virtual void ResetModeIcons(void);
+  virtual void SetIconMovie(bool on);
+  virtual void SetIconMusic(bool on);
+  virtual void SetIconWeather(bool on);
+  virtual void SetIconTV(bool on);
+  virtual void SetIconPhoto(bool on);
+  virtual void SetIconResolution(ILCD::LCD_RESOLUTION resolution);
+  virtual void SetProgressBar1(double progress); // range from 0 - 100
+  virtual void SetProgressBar2(double volume); // range from 0 - 100
+  virtual void SetIconMute(bool on);
+  virtual void SetIconPlaying(bool on);
+  virtual void SetIconPause(bool on);
+  virtual void SetIconRepeat(bool on);
+  virtual void SetIconShuffle(bool on);
+  virtual void SetIconAlarm(bool on);
+  virtual void SetIconRecord(bool on);
+  virtual void SetIconVolume(bool on);
+  virtual void SetIconTime(bool on);
+  virtual void SetIconSPDIF(bool on);
+  virtual void SetIconDiscIn(bool on);
+  virtual void SetIconSource(bool on);
+  virtual void SetIconFit(bool on);
+  virtual void SetIconSCR1(bool on);
+  virtual void SetIconSCR2(bool on);
+
+  // codec icons - video: video stream format
+  virtual void SetIconMPEG(bool on);
+  virtual void SetIconDIVX(bool on);
+  virtual void SetIconXVID(bool on);
+  virtual void SetIconWMV(bool on);
+  // codec icons - video: audio stream format
+  virtual void SetIconMPGA(bool on);
+  virtual void SetIconAC3(bool on);
+  virtual void SetIconDTS(bool on);
+  virtual void SetIconVWMA(bool on);
+  // codec icons - audio format
+  virtual void SetIconMP3(bool on);
+  virtual void SetIconOGG(bool on);
+  virtual void SetIconAWMA(bool on);
+  virtual void SetIconWAV(bool on);
+
+  virtual void SetIconAudioChannels(int channels);
+
+  virtual void InitializeSpectrumAnalyzer(void);
+  virtual void SetSpectrumAnalyzerData(void);
+
+private:
+  int volumeBar(int oldValue, double newValue);
+  int progressBar(int oldValue, double newValue);
+};
+
+#endif // __XLCDProc_mdm166a_H__

--- a/xbmc/linux/XLCDproc.cpp
+++ b/xbmc/linux/XLCDproc.cpp
@@ -26,6 +26,9 @@
 #include "../utils/TimeUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
+#include "XLCDProc_imon.h"
+#include "XLCDProc_mdm166a.h"
+#include <math.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -34,6 +37,13 @@
 
 #define SCROLL_SPEED_IN_MSEC 250
 
+// initialize class variables
+int XLCDproc::outputValue = 0;
+int XLCDproc::outputValueProgressBars = 0;
+int XLCDproc::outputValueOld = 1; // for correct icon-initialization this needs to be different to the actual value
+int XLCDproc::outputValueProgressBarsOld = 1; // for correct icon-initialization this needs to be different to the actual value
+int XLCDproc::m_sockfd = -1;
+int XLCDproc::saChanger = 0;
 
 XLCDproc::XLCDproc()
 {
@@ -41,20 +51,24 @@ XLCDproc::XLCDproc()
   m_iBackLight   = 32;
   m_iLCDContrast = 50;
   m_bStop        = true;
-  m_sockfd       = -1;
+//  m_sockfd       = -1;
   m_lastInitAttempt = 0;
   m_initRetryInterval = INIT_RETRY_INTERVAL;
   m_used = true;
+  m_lcdprocIconDevice = NULL;
+  scale = 1.0 / log(256.0);
+  audioDataBeforeDisplaying = 1;
 }
 
 XLCDproc::~XLCDproc()
 {
+  delete m_lcdprocIconDevice;
 }
 
 void XLCDproc::Initialize()
 {
   if (!m_used || !g_guiSettings.GetBool("videoscreen.haslcd"))
-    return ;//nothing to do
+    return;//nothing to do
 
   // don't try to initialize too often
   int now = XbmcThreads::SystemClockMillis();
@@ -70,6 +84,8 @@ void XLCDproc::Initialize()
     m_initRetryInterval = INIT_RETRY_INTERVAL;
 
     m_bStop = false;
+
+    RecognizeAndSetDriver();
   }
   else
   {
@@ -131,6 +147,8 @@ bool XLCDproc::Connect()
     return false;
   }
 
+  usleep(msWaitTime); // wait for the answer
+
   // Receive LCDproc data to determine row and column information
   char reply[1024];
   if (read(m_sockfd,reply,1024) == -1)
@@ -141,8 +159,19 @@ bool XLCDproc::Connect()
 
   unsigned int i=0;
   while ((strncmp("lcd",reply + i,3) != 0 ) && (i < (strlen(reply) - 5))) i++;
-  if(sscanf(reply+i,"lcd wid %u hgt %u", &m_iColumns, &m_iRows))
-    CLog::Log(LOGDEBUG, "XLCDproc::%s - LCDproc data: Columns %i - Rows %i.", __FUNCTION__, m_iColumns, m_iRows);
+//  if(sscanf(reply+i,"lcd wid %u hgt %u", &m_iColumns, &m_iRows))
+//    CLog::Log(LOGDEBUG, "XLCDproc::%s - LCDproc data: Columns %i - Rows %i.", __FUNCTION__, m_iColumns, m_iRows);
+  if (sscanf(reply + i, "lcd wid %u hgt %u cellwid %u cellhgt %u", &m_iColumns,
+        &m_iRows, &m_iCellWidth, &m_iCellHeight))
+  {
+    CLog::Log(
+      LOGDEBUG,
+      "XLCDproc::%s - LCDproc data: Columns %i - Rows %i - Cellheight %i - Cellwidth %i.",
+      __FUNCTION__, m_iColumns, m_iRows, m_iCellHeight, m_iCellWidth);
+    // we found the number of rows and columns - override the advanced settings with it to get the progress bar working correctly
+    g_advancedSettings.m_lcdColumns = m_iColumns;
+    g_advancedSettings.m_lcdRows = m_iRows;
+  }
 
   //Build command to setup screen
   CStdString cmd;
@@ -181,6 +210,57 @@ void XLCDproc::CloseSocket()
     shutdown(m_sockfd, SHUT_RDWR);
     close(m_sockfd);
     m_sockfd = -1;
+  }
+}
+
+void XLCDproc::RecognizeAndSetDriver()
+{
+  // Receive LCDproc data to determine the driver
+  char reply[1024];
+
+  // Get information about the driver
+  CStdString info;
+  info = "info\n";
+
+  writeSocketAndLog(info, __FUNCTION__);
+
+  for (unsigned int ms = 0; ms < msTimeout; ms += msWaitTime)
+  {
+    usleep(msWaitTime); // wait for the answer
+
+    // Receive server's reply
+    if (read(m_sockfd, reply, 1024) < 0)
+    {
+      CLog::Log(LOGERROR, "XLCDproc::%s - Unable to read from socket",
+          __FUNCTION__);
+    }
+    else
+    {
+      CLog::Log(LOGINFO, "XLCDproc::%s - Plain driver name is: %s",
+          __FUNCTION__, reply);
+    }
+
+    // to support older and newer versions of the lcdproc driver for the imon-lcd:
+    CStdString driverStringImonLcd = "SoundGraph iMON";
+    CStdString driverStringImonLcd2 = "LCD";
+
+    CStdString driverStringMdm166a = "mdm166a";
+
+    if ((strstr(reply, driverStringImonLcd.c_str()) != NULL) && (strstr(reply,
+        driverStringImonLcd2.c_str()) != NULL))
+    {
+      CLog::Log(LOGINFO, "XLCDproc::%s - Driver is: %s", __FUNCTION__,
+          "SoundGraph iMON LCD driver");
+      m_lcdprocIconDevice = new XLCDProc_imon();
+      break;
+    } else if (strstr(reply, driverStringMdm166a.c_str()) != NULL)
+    {
+      CLog::Log(LOGINFO, "XLCDproc::%s - Driver is: %s", __FUNCTION__,
+                "Targa USB Graphic Vacuum Fluorescent Display (mdm166a)");
+      m_lcdprocIconDevice = new XLCDProc_mdm166a();
+      break;
+    }
+    //    CLog::Log(LOGERROR, "XLCDproc::%s - Driver is: %s", __FUNCTION__, reply);
   }
 }
 
@@ -253,6 +333,11 @@ void XLCDproc::SetContrast(int iContrast)
 
 void XLCDproc::Stop()
 {
+  // clear any icons
+  outputValue = 0;
+  SendIconStatesToDisplay();
+  usleep(10000); // we have to wait a bit until the message has been sent to the display
+
   CloseSocket();
   m_bStop = true;
 }
@@ -308,24 +393,53 @@ void XLCDproc::SetLine(int iLine, const CStdString& strLine)
     strLineLong.append(m_iColumns - strLineLong.size(), ' ');
   //else if the string doesn't fit the display, lcdproc will scroll it, so we need a space
   else if (strLineLong.size() > m_iColumns)
-    strLineLong += " ";
+    strLineLong += " * ";
 
   if (strLineLong != m_strLine[iLine])
   {
     CStdString cmd;
     int ln = iLine + 1;
 
-    if (g_advancedSettings.m_lcdScrolldelay != 0)
-      cmd.Format("widget_set xbmc line%i 1 %i %i %i m %i \"%s\"\n", ln, ln, m_iColumns, ln, g_advancedSettings.m_lcdScrolldelay, strLineLong.c_str());
-    else
-      cmd.Format("widget_set xbmc line%i 1 %i \"%s\"\n", ln, ln, strLineLong.c_str());
+//    if (g_advancedSettings.m_lcdScrolldelay != 0)
+//      cmd.Format("widget_set xbmc line%i 1 %i %i %i m %i \"%s\"\n", ln, ln, m_iColumns, ln, g_advancedSettings.m_lcdScrolldelay, strLineLong.c_str());
+//    else
+//      cmd.Format("widget_set xbmc line%i 1 %i \"%s\"\n", ln, ln, strLineLong.c_str());
+//
+//    if (write(m_sockfd, cmd.c_str(), cmd.size()) == -1)
+//    {
+//      CLog::Log(LOGERROR, "XLCDproc::%s - Unable to write to socket", __FUNCTION__);
+//      CloseSocket();
+//      return;
+//    }
 
-    if (write(m_sockfd, cmd.c_str(), cmd.size()) == -1)
-    {
-      CLog::Log(LOGERROR, "XLCDproc::%s - Unable to write to socket", __FUNCTION__);
-      CloseSocket();
-      return;
-    }
+	if (g_advancedSettings.m_lcdScrolldelay != 0)
+	{
+	  if (GetIsSpectrumAnalyzerWorking() && ln == 1) // needed in order to allow navigation while playing back music
+	  { // unfortunately this is needed. If this is not active, the first line (its content) is missing when playing back a song the very first time
+		cmd.Format("widget_set xbmc SaScroller 1 %i %i %i m %i \"%s\"\n", ln,
+			m_iColumns, ln, g_advancedSettings.m_lcdScrolldelay,
+			strLineLong.c_str());
+		//    	  cmd.Format("widget_set xbmc line%i 1 %i %i %i m %i \"%s\"\n", ln, ln, m_iColumns, ln, g_advancedSettings.m_lcdScrolldelay, strLineLong.c_str());
+	  }
+	  else if (!GetIsSpectrumAnalyzerWorking())
+	  {
+		cmd.Format("widget_set xbmc line%i 1 %i %i %i m %i \"%s\"\n", ln, ln,
+			m_iColumns, ln, g_advancedSettings.m_lcdScrolldelay,
+			strLineLong.c_str());
+	  }
+	}
+	else
+	  cmd.Format("widget_set xbmc line%i 1 %i \"%s\"\n", ln, ln,
+		  strLineLong.c_str());
+
+	if (write(m_sockfd, cmd.c_str(), cmd.size()) < 0)
+	{
+	  m_bStop = true;
+	  CLog::Log(LOGERROR,
+		  "XLCDproc::%s - Unable to write to socket, LCDd not running?",
+		  __FUNCTION__);
+	  return;
+	}
     m_bUpdate[iLine] = true;
     m_strLine[iLine] = strLineLong;
     m_event.Set();
@@ -336,3 +450,387 @@ void XLCDproc::Process()
 {
 }
 
+bool XLCDproc::SendIconStatesToDisplay()
+{
+  CStdString cmd = "";
+
+  if ((m_lcdprocIconDevice != NULL)
+      && (!m_lcdprocIconDevice->SendIconStatesToDisplay()))
+  {
+    outputValueOld = outputValue;
+    cmd.Format("output %d\n", outputValue);
+
+    writeSocketAndLog(cmd, __FUNCTION__);
+
+    return true;
+  }
+  return false;
+}
+
+void XLCDproc::SetIconMovie(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconMovie(on);
+}
+
+void XLCDproc::SetIconMusic(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconMusic(on);
+}
+
+void XLCDproc::SetIconWeather(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconWeather(on);
+}
+
+void XLCDproc::SetIconTV(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconTV(on);
+}
+
+void XLCDproc::SetIconPhoto(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconPhoto(on);
+}
+
+void XLCDproc::SetIconResolution(LCD_RESOLUTION resolution)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconResolution(resolution);
+}
+
+void XLCDproc::SetProgressBar1(double progress)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetProgressBar1(progress);
+}
+
+void XLCDproc::SetProgressBar2(double volume)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetProgressBar2(volume);
+}
+
+void XLCDproc::SetIconMute(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+      m_lcdprocIconDevice->SetIconMute(on);
+}
+
+void XLCDproc::SetIconPlaying(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconPlaying(on);
+}
+
+void XLCDproc::SetIconPause(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconPause(on);
+}
+
+void XLCDproc::SetIconRepeat(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconRepeat(on);
+}
+
+void XLCDproc::SetIconShuffle(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconShuffle(on);
+}
+
+void XLCDproc::SetIconAlarm(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconAlarm(on);
+}
+
+void XLCDproc::SetIconRecord(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconRecord(on);
+}
+
+void XLCDproc::SetIconVolume(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconVolume(on);
+}
+
+void XLCDproc::SetIconTime(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconTime(on);
+}
+
+void XLCDproc::SetIconSPDIF(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconSPDIF(on);
+}
+
+void XLCDproc::SetIconDiscIn(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconDiscIn(on);
+}
+
+void XLCDproc::SetIconSource(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconSource(on);
+}
+
+void XLCDproc::SetIconFit(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconFit(on);
+}
+
+void XLCDproc::SetIconSCR1(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconSCR1(on);
+}
+
+void XLCDproc::SetIconSCR2(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconSCR2(on);
+}
+
+// codec icons - video: video stream format ###################################
+void XLCDproc::SetIconMPEG(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconMPEG(on);
+}
+
+void XLCDproc::SetIconDIVX(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconDIVX(on);
+}
+
+void XLCDproc::SetIconXVID(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconXVID(on);
+}
+
+void XLCDproc::SetIconWMV(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconWMV(on);
+}
+// codec icons - video: audio stream format #################################
+void XLCDproc::SetIconMPGA(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconMPGA(on);
+}
+
+void XLCDproc::SetIconAC3(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconAC3(on);
+}
+
+void XLCDproc::SetIconDTS(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconDTS(on);
+}
+
+void XLCDproc::SetIconVWMA(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconVWMA(on);
+}
+// codec icons - audio format ###############################################
+void XLCDproc::SetIconMP3(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconMP3(on);
+}
+
+void XLCDproc::SetIconOGG(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconOGG(on);
+}
+
+void XLCDproc::SetIconAWMA(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconAWMA(on);
+}
+
+void XLCDproc::SetIconWAV(bool on)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconWAV(on);
+}
+
+void XLCDproc::SetIconAudioChannels(int channels)
+{
+  if (m_lcdprocIconDevice != NULL)
+    m_lcdprocIconDevice->SetIconAudioChannels(channels);
+}
+
+bool XLCDproc::writeSocketAndLog(CStdString & cmd, const char *functionName)
+{
+  // Send to server
+  if (!m_bStop)
+  {
+    if (write(m_sockfd, cmd.c_str(), cmd.size()) < 0)
+    {
+      CLog::Log(LOGERROR, "XLCDproc::%s - Unable to write to socket", functionName);
+      return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+void XLCDproc::InitializeSpectrumAnalyzer()
+{
+  CStdString cmd = ""; // for the SpAn-Bars
+  unsigned int i = 0;
+  CLog::Log(LOGINFO, "XLCDproc::%s!", __FUNCTION__);
+
+  cmd.append("widget_del xbmc line1\n");
+  cmd.append("widget_del xbmc line2\n");
+  cmd.append("widget_del xbmc line3\n");
+  cmd.append("widget_del xbmc line4\n");
+  writeSocketAndLog(cmd, __FUNCTION__);
+
+  for (i = 0; i < m_iColumns; i++)
+  {
+    cmd.Format("widget_add xbmc SaBar%d vbar\n", i + 1);
+    writeSocketAndLog(cmd, __FUNCTION__);
+  }
+
+  cmd.Format("widget_add xbmc SaScroller scroller\n");
+  writeSocketAndLog(cmd, __FUNCTION__);
+}
+
+void XLCDproc::RemoveSpectrumAnalyzer()
+{
+  char reply[1024];
+  CStdString cmd; // for the SpAn-Bars
+  unsigned int i = 0;
+
+  for (i = 0; i < m_iColumns; i++)
+  {
+    cmd.Format("widget_del xbmc SaBar%d\n", i + 1);
+    writeSocketAndLog(cmd, __FUNCTION__);
+    if (!m_bStop)
+      read(m_sockfd, reply, 1024);
+  }
+
+  cmd.Format("widget_del xbmc SaScroller\n");
+  writeSocketAndLog(cmd, __FUNCTION__);
+
+  cmd = "";
+  if (!g_advancedSettings.m_lcdHeartbeat)
+    cmd.append("screen_set xbmc -heartbeat off\n");
+  if (g_advancedSettings.m_lcdScrolldelay != 0)
+  {
+    cmd.append("widget_add xbmc line1 scroller\n");
+    cmd.append("widget_add xbmc line2 scroller\n");
+    cmd.append("widget_add xbmc line3 scroller\n");
+    cmd.append("widget_add xbmc line4 scroller\n");
+  }
+  else
+  {
+    cmd.append("widget_add xbmc line1 string\n");
+    cmd.append("widget_add xbmc line2 string\n");
+    cmd.append("widget_add xbmc line3 string\n");
+    cmd.append("widget_add xbmc line4 string\n");
+  }
+
+  writeSocketAndLog(cmd, __FUNCTION__);
+}
+
+void XLCDproc::SetSpectrumAnalyzerData()
+{
+  unsigned int i = 0;
+  CStdString cmd = "";
+  //  CLog::Log(LOGINFO, "XLCDproc::%s!", __FUNCTION__);
+
+  saChanger = (saChanger + 1) % 10;
+
+  for (i = 0; i < m_iColumns; i++)
+  {
+    cmd.Format("widget_set xbmc SaBar%d %d %d %d\n", i + 1, i + 1, m_iRows,
+        (int) ((m_iCellHeight * (m_iRows / 2)/*1 or 2 lines high*/)
+            * /*barHeights[i]*/((heights[i] * 30.0f
+                / (float) audioDataBeforeDisplaying))) / 100);
+
+    //      CLog::Log(LOGINFO, "XLCDproc::%s %s f%f", __FUNCTION__, cmd.c_str(), heights[i]);
+
+    writeSocketAndLog(cmd, __FUNCTION__);
+  }
+  audioDataBeforeDisplaying = 1;
+}
+
+void XLCDproc::SetSpectrumAnalyzerAudioData(const short* psAudioData,
+    int piAudioDataLength, float *pfFreqData, int piFreqDataLength)
+{
+  unsigned int i = 0;
+  int c = 0, y = 0;
+  float val;
+  int* xscale;
+
+  // scaling for the spectrum analyzer
+  if (m_iColumns == 16)
+  {
+    // for 16 char-displays
+    int scales[] =
+    { 0, 1, 2, 3, 5, 7, 10, 14, 20, 28, 40, 54, 74, 101, 137, 187, 255 };
+    xscale = scales;
+  }
+  else if (m_iColumns == 20)
+  {
+    // for 20 char-displays
+    int scales[] =
+    { 0, 1, 3, 5, 9, 13, 19, 26, 34, 43, 53, 64, 76, 89, 105, 120, 140, 160,
+        187, 220, 255 };
+    xscale = scales;
+  }
+
+  //  CLog::Log(LOGINFO, "XLCDproc::%s", __FUNCTION__);
+
+  for (i = 0; i < m_iColumns; i++)
+  {
+    for (c = xscale[i], y = 0; c < xscale[i + 1]; c++)
+    {
+      if (c < piAudioDataLength)
+      {
+        if (psAudioData[c] > y)
+          y = (int) psAudioData[c];
+      }
+      else
+        continue;
+    }
+    y >>= 7;
+    if (y > 0)
+      val = (logf(y) * scale);
+    else
+      val = 0;
+    if (audioDataBeforeDisplaying == 1)
+      heights[i] = val;
+    else
+      heights[i] += val;
+
+    //    CLog::Log(LOGINFO, "XLCDproc::%s y=%d f%f, i=%d", __FUNCTION__, y, heights[i], i);
+  }
+  audioDataBeforeDisplaying++;
+}

--- a/xbmc/linux/XLCDproc.h
+++ b/xbmc/linux/XLCDproc.h
@@ -28,7 +28,7 @@
 #define INIT_RETRY_INTERVAL 2000
 #define INIT_RETRY_INTERVAL_MAX 60000
 
-class XLCDproc : public ILCD
+class XLCDproc: public ILCD
 {
 public:
   XLCDproc();
@@ -41,18 +41,64 @@ public:
   virtual void SetBackLight(int iLight);
   virtual void SetContrast(int iContrast);
 
+  bool SendIconStatesToDisplay();
+  void SetIconMovie(bool on);
+  void SetIconMusic(bool on);
+  void SetIconWeather(bool on);
+  void SetIconTV(bool on);
+  void SetIconPhoto(bool on);
+  void SetIconResolution(LCD_RESOLUTION resolution);
+  void SetProgressBar1(double progress);
+  void SetProgressBar2(double volume);
+  void SetIconMute(bool on);
+  void SetIconPlaying(bool on);
+  void SetIconPause(bool on);
+  void SetIconRepeat(bool on);
+  void SetIconShuffle(bool on);
+  void SetIconAlarm(bool on);
+  void SetIconRecord(bool on);
+  void SetIconVolume(bool on);
+  void SetIconTime(bool on);
+  void SetIconSPDIF(bool on);
+  void SetIconDiscIn(bool on);
+  void SetIconSource(bool on);
+  void SetIconFit(bool on);
+  void SetIconSCR1(bool on);
+  void SetIconSCR2(bool on);
+  void SetIconMPEG(bool on);
+  void SetIconDIVX(bool on);
+  void SetIconXVID(bool on);
+  void SetIconWMV(bool on);
+  void SetIconMPGA(bool on);
+  void SetIconAC3(bool on);
+  void SetIconDTS(bool on);
+  void SetIconVWMA(bool on);
+  void SetIconMP3(bool on);
+  void SetIconOGG(bool on);
+  void SetIconAWMA(bool on);
+  void SetIconWAV(bool on);
+  void SetIconAudioChannels(int channels);
+  void InitializeSpectrumAnalyzer();
+  void RemoveSpectrumAnalyzer();
+  void SetSpectrumAnalyzerData();
+  virtual void SetSpectrumAnalyzerAudioData(const short* psAudioData,
+  int piAudioDataLength, float *pfFreqData, int piFreqDataLength);
+
 protected:
   virtual void Process();
   virtual void SetLine(int iLine, const CStdString& strLine);
   bool         Connect();
   void         CloseSocket();
+  void RecognizeAndSetDriver();
   unsigned int m_iColumns;        // display columns for each line
   unsigned int m_iRows;           // total number of rows
+  unsigned int m_iCellWidth;
+  unsigned int m_iCellHeight;
   unsigned int m_iRow1adr;
   unsigned int m_iRow2adr;
   unsigned int m_iRow3adr;
   unsigned int m_iRow4adr;
-  unsigned int m_iActualpos;      // actual cursor possition
+  unsigned int m_iActualpos;      // actual cursor position
   int          m_iBackLight;
   int          m_iLCDContrast;
   bool         m_bUpdate[MAX_ROWS];
@@ -60,12 +106,23 @@ protected:
   int          m_iPos[MAX_ROWS];
   DWORD        m_dwSleep[MAX_ROWS];
   CEvent       m_event;
-  int          m_sockfd;
+  static int   m_sockfd;
+  static int outputValue;
+  static int outputValueProgressBars;
+  static int outputValueOld;
+  static int outputValueProgressBarsOld;
+  static int saChanger;
+  static const unsigned int msWaitTime = 10000;
+  static const unsigned int msTimeout = 250000;
+  bool writeSocketAndLog(CStdString &cmd, const char *functionName);
 
 private:
+  XLCDproc *m_lcdprocIconDevice;
   int          m_lastInitAttempt;
   int          m_initRetryInterval;
   bool         m_used; //set to false when trying to connect has failed
+  float heights[20], scale;
+  int audioDataBeforeDisplaying;
 };
 
 #endif

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -231,7 +231,7 @@ protected:
 private:
   /*! \brief (Re)Create the generic database views for songs and albums
    */
-  void CreateViews();
+  virtual void CreateViews();
 
   void SplitString(const CStdString &multiString, std::vector<CStdString> &vecStrings, CStdString &extraStrings);
   CSong GetSongFromDataset(bool bWithMusicDbPath=false);

--- a/xbmc/osx/atv2/XBMCAppliance.m
+++ b/xbmc/osx/atv2/XBMCAppliance.m
@@ -95,7 +95,7 @@
   // and there is an overlap of some UIKit and AppleTV methods.
   // This voodoo seems to clear up the wonkiness. :)
   Class cls = NSClassFromString(@"ATVVersionInfo");
-  if (cls != nil && [[cls currentOSVersion] isEqualToString:@"5.0"])
+  if (cls != nil && [[cls currentOSVersion] rangeOfString:@"5."].location != NSNotFound)
   {
     id cd = nil;
 

--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -155,16 +155,14 @@ namespace PERIPHERALS
       return iVal;
     };
 
-    static char *IntToHexString(int iVal)
+    static void FormatHexString(int iVal, CStdString &strHexString)
     {
       if (iVal < 0)
         iVal = 0;
       if (iVal > 65536)
         iVal = 65536;
 
-      char *buf = new char[4];
-      sprintf(buf, "%04X", iVal);
-      return buf;
+      strHexString.Format("%04X", iVal);
     };
   };
 }

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -111,6 +111,9 @@ void CPeripherals::Clear(void)
   /* reset class state */
   m_bIsStarted   = false;
   m_bInitialised = false;
+#if !defined(HAVE_LIBCEC)
+  m_bMissingLibCecWarningDisplayed = false;
+#endif
 }
 
 void CPeripherals::TriggerDeviceScan(const PeripheralBusType type /* = PERIPHERAL_BUS_UNKNOWN */)
@@ -263,8 +266,12 @@ CPeripheral *CPeripherals::CreatePeripheral(CPeripheralBus &bus, const Periphera
 #if defined(HAVE_LIBCEC)
     peripheral = new CPeripheralCecAdapter(type, bus.Type(), strLocation, strDeviceName, iVendorId, iProductId);
 #else
-    CLog::Log(LOGWARNING, "%s - libCEC support has not been compiled in, so the CEC adapter cannot be used.", __FUNCTION__);
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(36000), g_localizeStrings.Get(36017));
+    if (!m_bMissingLibCecWarningDisplayed)
+    {
+      m_bMissingLibCecWarningDisplayed = true;
+      CLog::Log(LOGWARNING, "%s - libCEC support has not been compiled in, so the CEC adapter cannot be used.", __FUNCTION__);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(36000), g_localizeStrings.Get(36017));
+    }
 #endif
     break;
 

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -324,7 +324,10 @@ int CPeripherals::GetMappingForDevice(const CPeripheralBus &bus, const Periphera
 
     if (bBusMatch && bVendorMatch && bProductMatch && bClassMatch)
     {
-      CLog::Log(LOGDEBUG, "%s - device (%s:%s) mapped to %s (type = %s)", __FUNCTION__, PeripheralTypeTranslator::IntToHexString(iVendorId), PeripheralTypeTranslator::IntToHexString(iProductId), mapping.m_strDeviceName.c_str(), PeripheralTypeTranslator::TypeToString(mapping.m_mappedTo));
+      CStdString strVendorId, strProductId;
+      PeripheralTypeTranslator::FormatHexString(iVendorId, strVendorId);
+      PeripheralTypeTranslator::FormatHexString(iProductId, strProductId);
+      CLog::Log(LOGDEBUG, "%s - device (%s:%s) mapped to %s (type = %s)", __FUNCTION__, strVendorId.c_str(), strProductId.c_str(), mapping.m_strDeviceName.c_str(), PeripheralTypeTranslator::TypeToString(mapping.m_mappedTo));
       return iMappingPtr;
     }
   }

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -155,6 +155,9 @@ namespace PERIPHERALS
 
     bool                                 m_bInitialised;
     bool                                 m_bIsStarted;
+#if !defined(HAVE_LIBCEC)
+    bool                                 m_bMissingLibCecWarningDisplayed;
+#endif
     std::vector<CPeripheralBus *>        m_busses;
     std::vector<PeripheralDeviceMapping> m_mappings;
     CSettingsCategory *                  m_settings;

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -37,13 +37,13 @@ CPeripheral::CPeripheral(const PeripheralType type, const PeripheralBusType busT
   m_strDeviceName(strDeviceName),
   m_strFileLocation(StringUtils::EmptyString),
   m_iVendorId(iVendorId),
-  m_strVendorId(PeripheralTypeTranslator::IntToHexString(iVendorId)),
   m_iProductId(iProductId),
-  m_strProductId(PeripheralTypeTranslator::IntToHexString(iProductId)),
   m_bInitialised(false),
   m_bHidden(false),
   m_bError(false)
 {
+  PeripheralTypeTranslator::FormatHexString(iVendorId, m_strVendorId);
+  PeripheralTypeTranslator::FormatHexString(iProductId, m_strProductId);
   m_strFileLocation.Format("peripherals://%s/%s.dev", PeripheralTypeTranslator::BusTypeToString(busType), strLocation.c_str());
 }
 
@@ -54,9 +54,9 @@ CPeripheral::CPeripheral(void) :
   m_strDeviceName(StringUtils::EmptyString),
   m_strFileLocation(StringUtils::EmptyString),
   m_iVendorId(0),
-  m_strVendorId(PeripheralTypeTranslator::IntToHexString(0)),
+  m_strVendorId("0000"),
   m_iProductId(0),
-  m_strProductId(PeripheralTypeTranslator::IntToHexString(0)),
+  m_strProductId("0000"),
   m_bInitialised(false),
   m_bHidden(false)
 {
@@ -135,7 +135,7 @@ bool CPeripheral::Initialise(void)
     return bReturn;
 
   g_peripherals.GetSettingsFromMapping(*this);
-  m_strSettingsFile.Format("special://profile/peripheral_data/%s_%s_%s.xml", PeripheralTypeTranslator::BusTypeToString(m_busType), m_strVendorId, m_strProductId);
+  m_strSettingsFile.Format("special://profile/peripheral_data/%s_%s_%s.xml", PeripheralTypeTranslator::BusTypeToString(m_busType), m_strVendorId.c_str(), m_strProductId.c_str());
   LoadPersistedSettings();
 
   for (unsigned int iFeaturePtr = 0; iFeaturePtr < m_features.size(); iFeaturePtr++)

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -45,9 +45,9 @@ namespace PERIPHERALS
     const CStdString &FileLocation(void) const     { return m_strFileLocation; }
     const CStdString &Location(void) const         { return m_strLocation; }
     int VendorId(void) const                       { return m_iVendorId; }
-    const char *VendorIdAsString(void) const       { return m_strVendorId; }
+    const char *VendorIdAsString(void) const       { return m_strVendorId.c_str(); }
     int ProductId(void) const                      { return m_iProductId; }
-    const char *ProductIdAsString(void) const      { return m_strProductId; }
+    const char *ProductIdAsString(void) const      { return m_strProductId.c_str(); }
     const PeripheralType Type(void) const          { return m_type; }
     const PeripheralBusType GetBusType(void) const { return m_busType; };
     const CStdString &DeviceName(void) const       { return m_strDeviceName; }
@@ -159,9 +159,9 @@ namespace PERIPHERALS
     CStdString                       m_strSettingsFile;
     CStdString                       m_strFileLocation;
     int                              m_iVendorId;
-    char *                           m_strVendorId;
+    CStdString                       m_strVendorId;
     int                              m_iProductId;
-    char *                           m_strProductId;
+    CStdString                       m_strProductId;
     bool                             m_bInitialised;
     bool                             m_bHidden;
     bool                             m_bError;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -406,6 +406,23 @@ void CPeripheralCecAdapter::ProcessNextCommand(void)
         SetMenuLanguage(strNewLanguage);
       }
       break;
+    case CEC_OPCODE_DECK_CONTROL:
+      if (command.initiator == CECDEVICE_TV &&
+          command.parameters.size == 1 &&
+          command.parameters[0] == CEC_DESK_CONTROL_MODE_STOP)
+      {
+        g_application.getApplicationMessenger().MediaStop(false);
+      }
+      break;
+    case CEC_OPCODE_PLAY:
+      if (command.initiator == CECDEVICE_TV &&
+          command.parameters.size == 1)
+      {
+        if (command.parameters[0] == CEC_PLAY_MODE_PLAY_FORWARD ||
+            command.parameters[0] == CEC_PLAY_MODE_PLAY_STILL)
+          g_application.getApplicationMessenger().MediaPause();
+      }
+      break;
     default:
       break;
     }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -411,7 +411,7 @@ void CPeripheralCecAdapter::ProcessNextCommand(void)
           command.parameters.size == 1 &&
           command.parameters[0] == CEC_DESK_CONTROL_MODE_STOP)
       {
-        g_application.getApplicationMessenger().MediaStop(false);
+        g_application.getApplicationMessenger().MediaStop();
       }
       break;
     case CEC_OPCODE_PLAY:

--- a/xbmc/peripherals/devices/PeripheralHID.cpp
+++ b/xbmc/peripherals/devices/PeripheralHID.cpp
@@ -73,7 +73,7 @@ bool CPeripheralHID::InitialiseFeature(const PeripheralFeature feature)
       }
     }
 
-    CLog::Log(LOGDEBUG, "%s - initialised HID device (%s:%s)", __FUNCTION__, m_strVendorId, m_strProductId);
+    CLog::Log(LOGDEBUG, "%s - initialised HID device (%s:%s)", __FUNCTION__, m_strVendorId.c_str(), m_strProductId.c_str());
   }
 
   return CPeripheral::InitialiseFeature(feature);

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -66,6 +66,7 @@ void CPictureInfoTag::Archive(CArchive& ar)
     ar << CStdString(m_exifInfo.CameraModel);
     ar << m_exifInfo.CCDWidth;
     ar << CStdString(m_exifInfo.Comments);
+    ar << CStdString(m_exifInfo.Description);
     ar << CStdString(m_exifInfo.DateTime);
     for (int i = 0; i < 10; i++)
       ar << m_exifInfo.DateTimeOffsets[i];
@@ -128,6 +129,7 @@ void CPictureInfoTag::Archive(CArchive& ar)
     GetStringFromArchive(ar, m_exifInfo.CameraModel, sizeof(m_exifInfo.CameraModel));
     ar >> m_exifInfo.CCDWidth;
     GetStringFromArchive(ar, m_exifInfo.Comments, sizeof(m_exifInfo.Comments));
+    GetStringFromArchive(ar, m_exifInfo.Description, sizeof(m_exifInfo.Description));
     GetStringFromArchive(ar, m_exifInfo.DateTime, sizeof(m_exifInfo.DateTime));
     for (int i = 0; i < 10; i++)
       ar >> m_exifInfo.DateTimeOffsets[i];
@@ -191,6 +193,7 @@ void CPictureInfoTag::Serialize(CVariant& value)
   value["cameramodel"] = CStdString(m_exifInfo.CameraModel);
   value["ccdwidth"] = m_exifInfo.CCDWidth;
   value["comments"] = CStdString(m_exifInfo.Comments);
+  value["description"] = CStdString(m_exifInfo.Description);
   value["datetime"] = CStdString(m_exifInfo.DateTime);
   for (int i = 0; i < 10; i++)
     value["datetimeoffsets"][i] = m_exifInfo.DateTimeOffsets[i];
@@ -311,9 +314,9 @@ const CStdString CPictureInfoTag::GetInfo(int info) const
       value = date.GetAsLocalizedDateTime();
     }
     break;
-//  case SLIDE_EXIF_DESCRIPTION:
-//    value = m_exifInfo.Description;
-//    break;
+  case SLIDE_EXIF_DESCRIPTION:
+    value = m_exifInfo.Description;
+    break;
   case SLIDE_EXIF_CAMERA_MAKE:
     value = m_exifInfo.CameraMake;
     break;

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -345,9 +345,9 @@ const CStdString CPictureInfoTag::GetInfo(int info) const
   case SLIDE_EXIF_FOCAL_LENGTH:
     if (m_exifInfo.FocalLength)
     {
-      value.Format("%4.2fmm", m_exifInfo.FocalLength);
+      value.Format("%2.0fmm", m_exifInfo.FocalLength);
       if (m_exifInfo.FocalLength35mmEquiv != 0)
-        value.AppendFormat("  (35mm Equivalent = %umm)", m_exifInfo.FocalLength35mmEquiv);
+        value.AppendFormat(" (%umm)", m_exifInfo.FocalLength35mmEquiv);
     }
     break;
   case SLIDE_EXIF_FOCUS_DIST:
@@ -372,12 +372,10 @@ const CStdString CPictureInfoTag::GetInfo(int info) const
   case SLIDE_EXIF_EXPOSURE_TIME:
     if (m_exifInfo.ExposureTime)
     {
-      if (m_exifInfo.ExposureTime < 0.010f)
-        value.Format("%6.4fs", m_exifInfo.ExposureTime);
-      else
-        value.Format("%5.3fs", m_exifInfo.ExposureTime);
       if (m_exifInfo.ExposureTime <= 0.5)
-        value.AppendFormat(" (1/%d)", (int)(0.5 + 1/m_exifInfo.ExposureTime));
+        value.Format("1/%ds", (int)(0.5 + 1/m_exifInfo.ExposureTime));
+      else
+        value.Format("%2.0fs", m_exifInfo.ExposureTime);
     }
     break;
   case SLIDE_EXIF_EXPOSURE_BIAS:

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -124,6 +124,8 @@ void CAdvancedSettings::Initialize()
   m_lcdDimOnScreenSave = false;
   m_lcdScrolldelay = 1;
   m_lcdHostName = "localhost";
+  m_lcdSpectrumAnalyzer = true;
+  m_lcdRefreshRate = 8; // in Hertz
 
   m_autoDetectPingTime = 30;
 
@@ -604,6 +606,8 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement, "dimonscreensave", m_lcdDimOnScreenSave);
     XMLUtils::GetInt(pElement, "scrolldelay", m_lcdScrolldelay, -8, 8);
     XMLUtils::GetString(pElement, "hostname", m_lcdHostName);
+    XMLUtils::GetBoolean(pElement, "spectrumanalyzer", m_lcdSpectrumAnalyzer);
+    XMLUtils::GetInt(pElement, "refreshrate", m_lcdRefreshRate, 1, 20);
   }
   pElement = pRootElement->FirstChildElement("network");
   if (pElement)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -147,6 +147,8 @@ class CAdvancedSettings
     bool m_lcdDimOnScreenSave;
     int m_lcdScrolldelay;
     CStdString m_lcdHostName;
+    bool m_lcdSpectrumAnalyzer;
+    int m_lcdRefreshRate;
 
     int m_autoDetectPingTime;
 

--- a/xbmc/utils/LCD.h
+++ b/xbmc/utils/LCD.h
@@ -51,6 +51,11 @@ public:
                         CUSTOM_CHARSET_BIGCHAR,
                         CUSTOM_CHARSET_MAX
                 };
+  enum LCD_RESOLUTION {
+                        LCD_RESOLUTION_NONE = 0,
+                        LCD_RESOLUTION_SD,
+                        LCD_RESOLUTION_HD
+    };
   virtual void Initialize();
   virtual bool IsConnected();
   virtual void Stop() = 0;
@@ -66,6 +71,8 @@ public:
   void LoadSkin(const CStdString &xmlFile);
   void Reset();
   void Render(LCD_MODE mode);
+  bool GetIsSpectrumAnalyzerWorking();
+  virtual void SetSpectrumAnalyzerAudioData(const short* psAudioData, int piAudioDataLength, float *pfFreqData, int piFreqDataLength) =0;
   ILCD() : m_disableOnPlay(DISABLE_ON_PLAY_NONE), 
            m_eCurrentCharset(CUSTOM_CHARSET_DEFAULT) {}
 protected:
@@ -73,11 +80,64 @@ protected:
   void StringToLCDCharSet(CStdString& strText);
   unsigned char GetLCDCharsetCharacter( UINT _nCharacter, int _nCharset=-1);
   void LoadMode(TiXmlNode *node, LCD_MODE mode);
+  void RenderIcons();
+  virtual bool SendIconStatesToDisplay(void) =0;
+  virtual void SetIconMovie(bool on) =0;
+  virtual void SetIconMusic(bool on) =0;
+  virtual void SetIconWeather(bool on) =0;
+  virtual void SetIconTV(bool on) =0;
+  virtual void SetIconPhoto(bool on) =0;
+  virtual void SetIconResolution(LCD_RESOLUTION resolution) =0;
+  virtual void SetProgressBar1(double progress) =0;
+  virtual void SetProgressBar2(double volume) =0;
+  virtual void SetIconMute(bool on) =0;
+  virtual void SetIconPlaying(bool on) =0;
+  virtual void SetIconPause(bool on) =0;
+  virtual void SetIconRepeat(bool on) =0;
+  virtual void SetIconShuffle(bool on) =0;
+  virtual void SetIconAlarm(bool on) =0;
+  virtual void SetIconRecord(bool on) =0;
+  virtual void SetIconVolume(bool on) =0;
+  virtual void SetIconTime(bool on) =0;
+  virtual void SetIconSPDIF(bool on) =0;
+  virtual void SetIconDiscIn(bool on) =0;
+  virtual void SetIconSource(bool on) =0;
+  virtual void SetIconFit(bool on) =0;
+  virtual void SetIconSCR1(bool on) =0;
+  virtual void SetIconSCR2(bool on) =0;
+  // codec icons - video: video stream format
+  virtual void SetIconMPEG(bool on) =0;
+  virtual void SetIconDIVX(bool on) =0;
+  virtual void SetIconXVID(bool on) =0;
+  virtual void SetIconWMV(bool on) =0;
+  // codec icons - video: audio stream format
+  virtual void SetIconMPGA(bool on) =0;
+  virtual void SetIconAC3(bool on) =0;
+  virtual void SetIconDTS(bool on) =0;
+  virtual void SetIconVWMA(bool on) =0;
+  // codec icons - audio format
+  virtual void SetIconMP3(bool on) =0;
+  virtual void SetIconOGG(bool on) =0;
+  virtual void SetIconAWMA(bool on) =0;
+  virtual void SetIconWAV(bool on) =0;
+
+  virtual void SetIconAudioChannels(int channels) =0;
+
+  virtual void InitializeSpectrumAnalyzer(void) =0;
+  virtual void RemoveSpectrumAnalyzer(void) =0;
+  virtual void SetSpectrumAnalyzerData(void) =0;
+
+  void SetIsSpectrumAnalyzerWorking(bool working);
 
 private:
   int m_disableOnPlay;
 
   std::vector<CGUIInfoLabel> m_lcdMode[LCD_MODE_MAX];
   UINT m_eCurrentCharset;
+
+  bool m_bIsSpectrumAnalyzerWorking;
+
+  void SetCodecInformationIcons();
+  void ResetCodecIcons();
 };
 extern ILCD* g_lcd;

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -245,10 +245,12 @@ CStdString StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
   if (format == TIME_FORMAT_GUESS)
     format = (hh >= 1) ? TIME_FORMAT_HH_MM_SS : TIME_FORMAT_MM_SS;
   CStdString strHMS;
-  if (format & TIME_FORMAT_HH)
-    strHMS.AppendFormat("%02.2i", hh);
-  else if (format & TIME_FORMAT_H)
-    strHMS.AppendFormat("%i", hh);
+  if (format & TIME_FORMAT_HH) {
+   if (hh < 10)
+     strHMS.AppendFormat("%01.1i", hh);
+   else
+     strHMS.AppendFormat("%02.2i", hh);
+  }
   if (format & TIME_FORMAT_MM)
     strHMS.AppendFormat(strHMS.IsEmpty() ? "%02.2i" : ":%02.2i", mm);
   if (format & TIME_FORMAT_SS)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -688,7 +688,7 @@ private:
   /*! \brief (Re)Create the generic database views for movies, tvshows,
      episodes and music videos
    */
-  void CreateViews();
+  virtual void CreateViews();
 
   /*! \brief Run a query on the main dataset and return the number of rows
    If no rows are found we close the dataset and return 0.

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -27,9 +27,18 @@
 #include "WinSystemX11.h"
 #include "settings/Settings.h"
 #include "guilib/Texture.h"
+#include "guilib/DispResource.h"
 #include "utils/log.h"
 #include "XRandR.h"
 #include <vector>
+#include "threads/SingleLock.h"
+#include <X11/Xlib.h>
+#include "cores/VideoRenderers/RenderManager.h"
+#include "utils/TimeUtils.h"
+
+#if defined(HAS_XRANDR)
+#include <X11/extensions/Xrandr.h>
+#endif
 
 using namespace std;
 
@@ -42,6 +51,7 @@ CWinSystemX11::CWinSystemX11() : CWinSystemBase()
   m_glWindow = 0;
   m_wmWindow = 0;
   m_bWasFullScreenBeforeMinimize = false;
+  m_dpyLostTime = 0;
 }
 
 CWinSystemX11::~CWinSystemX11()
@@ -126,6 +136,13 @@ bool CWinSystemX11::CreateNewWindow(const CStdString& name, bool fullScreen, RES
   SDL_WM_SetIcon(SDL_CreateRGBSurfaceFrom(iconTexture.GetPixels(), iconTexture.GetWidth(), iconTexture.GetHeight(), 32, iconTexture.GetPitch(), 0xff0000, 0x00ff00, 0x0000ff, 0xff000000L), NULL);
   SDL_WM_SetCaption("XBMC Media Center", NULL);
 
+  // register XRandR Events
+#if defined(HAS_XRANDR)
+  int iReturn;
+  XRRQueryExtension(m_dpy, &m_RREventBase, &iReturn);
+  XRRSelectInput(m_dpy, m_wmWindow, RRScreenChangeNotifyMask);
+#endif
+
   m_bWindowCreated = true;
   return true;
 }
@@ -175,7 +192,10 @@ bool CWinSystemX11::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   mode.id  = res.strId;
  
   if(m_bFullScreen)
+  {
+    OnLostDevice();
     g_xrandr.SetMode(out, mode);
+  }
   else
     g_xrandr.RestoreState();
 #endif
@@ -444,4 +464,74 @@ bool CWinSystemX11::Show(bool raise)
   XSync(m_dpy, False);
   return true;
 }
+
+void CWinSystemX11::CheckDisplayEvents()
+{
+#if defined(HAS_XRANDR)
+  bool bGotEvent(false);
+  bool bTimeout(false);
+  XEvent Event;
+  while (XCheckTypedEvent(m_dpy, m_RREventBase + RRScreenChangeNotify, &Event))
+  {
+    if (Event.type == m_RREventBase + RRScreenChangeNotify)
+    {
+      CLog::Log(LOGDEBUG, "%s: Received RandR event %i", __FUNCTION__, Event.type);
+      bGotEvent = true;
+    }
+    XRRUpdateConfiguration(&Event);
+  }
+
+  // check fail safe timer
+  if (m_dpyLostTime && CurrentHostCounter() - m_dpyLostTime > (uint64_t)3 * CurrentHostFrequency())
+  {
+    CLog::Log(LOGERROR, "%s - no display event after 3 seconds", __FUNCTION__);
+    bTimeout = true;
+  }
+
+  if (bGotEvent || bTimeout)
+  {
+    CLog::Log(LOGDEBUG, "%s - notify display reset event", __FUNCTION__);
+
+    CSingleLock lock(m_resourceSection);
+
+    // tell any shared resources
+    for (vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); i++)
+      (*i)->OnResetDevice();
+
+    // reset fail safe timer
+    m_dpyLostTime = 0;
+  }
+#endif
+}
+
+void CWinSystemX11::OnLostDevice()
+{
+  CLog::Log(LOGDEBUG, "%s - notify display change event", __FUNCTION__);
+
+  { CSingleLock lock(m_resourceSection);
+    for (vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); i++)
+      (*i)->OnLostDevice();
+  }
+
+  // make sure renderer has no invalid references
+  g_renderManager.Flush();
+
+  // fail safe timer
+  m_dpyLostTime = CurrentHostCounter();
+}
+
+void CWinSystemX11::Register(IDispResource *resource)
+{
+  CSingleLock lock(m_resourceSection);
+  m_resources.push_back(resource);
+}
+
+void CWinSystemX11::Unregister(IDispResource* resource)
+{
+  CSingleLock lock(m_resourceSection);
+  vector<IDispResource*>::iterator i = find(m_resources.begin(), m_resources.end(), resource);
+  if (i != m_resources.end())
+    m_resources.erase(i);
+}
+
 #endif

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -26,6 +26,9 @@
 #include "windowing/WinSystem.h"
 #include "utils/Stopwatch.h"
 #include <GL/glx.h>
+#include "threads/CriticalSection.h"
+
+class IDispResource;
 
 class CWinSystemX11 : public CWinSystemBase
 {
@@ -51,6 +54,8 @@ public:
   virtual bool Restore() ;
   virtual bool Hide();
   virtual bool Show(bool raise = true);
+  virtual void Register(IDispResource *resource);
+  virtual void Unregister(IDispResource *resource);
 
   // Local to WinSystemX11 only
   Display*  GetDisplay() { return m_dpy; }
@@ -58,6 +63,8 @@ public:
 
 protected:
   bool RefreshGlxContext();
+  void CheckDisplayEvents();
+  void OnLostDevice();
 
   SDL_Surface* m_SDLSurface;
   GLXContext   m_glContext;
@@ -65,6 +72,10 @@ protected:
   Window       m_wmWindow;
   Display*     m_dpy;
   bool         m_bWasFullScreenBeforeMinimize;
+  int          m_RREventBase;
+  CCriticalSection             m_resourceSection;
+  std::vector<IDispResource*>  m_resources;
+  uint64_t                     m_dpyLostTime;
 
 private:
   bool IsSuitableVisual(XVisualInfo *vInfo);

--- a/xbmc/windowing/X11/WinSystemX11GL.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GL.cpp
@@ -43,6 +43,8 @@ CWinSystemX11GL::~CWinSystemX11GL()
 
 bool CWinSystemX11GL::PresentRenderImpl(const CDirtyRegionList& dirty)
 {
+  CheckDisplayEvents();
+
   if(m_iVSyncMode == 3)
   {
     glFinish();


### PR DESCRIPTION
IptcParser: Updated the iptc parser code (from the public domain software jhead). IPTC data that commercial tools (like Adobe PS and Lightroom) produce were not readable by xbmc. This improved parser now supports recent IPTC versions. 

ExifParser: Added support for the exif tag ImageDescription. The code that presents the info to the ui was already there; only a few lines in the parser were missing.
