### PR TITLE
libcmyth bug fix

### DIFF
--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -201,7 +201,7 @@ extern void cmyth_dbg(int level, char *fmt, ...);
  * Define a callback to use to send messages rather than using stderr
  * \param msgcb function pointer to pass a string to
  */
-extern void cmyth_set_dbg_msgcallback(void (*msgcb)(char *));
+extern void cmyth_set_dbg_msgcallback(void (*msgcb)(int level,char *));
 
 /*
  * -----------------------------------------------------------------

--- a/lib/cmyth/include/refmem/atomic.h
+++ b/lib/cmyth/include/refmem/atomic.h
@@ -63,7 +63,7 @@ __mvp_atomic_increment(mvp_atomic_t *valp)
 /**
  * Atomically decrement a reference count variable.
  * \param valp address of atomic variable
- * \return incremented reference count
+ * \return decremented reference count
  */
 static inline unsigned
 __mvp_atomic_decrement(mvp_atomic_t *valp)
@@ -72,7 +72,7 @@ __mvp_atomic_decrement(mvp_atomic_t *valp)
 #if defined __i486__ || defined __i586__ || defined __i686__
 	__asm__ __volatile__(
 		"lock xaddl %0, (%1);"
-		"     inc   %0;"
+		"     dec   %0;"
 		: "=r" (__val)
 		: "r" (valp), "0" (0x1)
 		: "cc", "memory"
@@ -113,7 +113,7 @@ __mvp_atomic_decrement(mvp_atomic_t *valp)
 	 * Don't know how to atomic decrement for a generic architecture
 	 * so punt and just decrement the value.
 	 */
-//#warning unknown architecture, atomic deccrement is not...
+//#warning unknown architecture, atomic decrement is not...
 	__val = --(*valp);
 #endif
 	return __val;

--- a/lib/cmyth/libcmyth/debug.c
+++ b/lib/cmyth/libcmyth/debug.c
@@ -116,7 +116,7 @@ cmyth_dbg(int level, char *fmt, ...)
 }
 
 void
-cmyth_set_dbg_msgcallback(void (*msgcb)(char *))
+cmyth_set_dbg_msgcallback(void (*msgcb)(int level,char *))
 {
 	cmyth_debug_ctx.msg_callback = msgcb;
 }

--- a/lib/cmyth/libcmyth/mythtv_mysql.c
+++ b/lib/cmyth/libcmyth/mythtv_mysql.c
@@ -936,7 +936,7 @@ cmyth_mythtv_remove_previos_recorded(cmyth_database_t db,char *query)
 
 int
 cmyth_mysql_testdb_connection(cmyth_database_t db,char **message) {
-	char buf[1000];
+	char *buf=malloc(sizeof(char)*1001);
 	int new_conn = 0;
 	if (db->mysql != NULL) {
 		if (mysql_stat(db->mysql) == NULL) {
@@ -949,21 +949,21 @@ cmyth_mysql_testdb_connection(cmyth_database_t db,char **message) {
 		new_conn = 1;
 		if(db->mysql == NULL) {
 			fprintf(stderr,"%s: mysql_init() failed, insufficient memory?", __FUNCTION__);
-			snprintf(buf, sizeof(buf), "mysql_init() failed, insufficient memory?");
+			snprintf(buf, 1000, "mysql_init() failed, insufficient memory?");
 			*message=buf;
 			return -1;
 		}
 		if (NULL == mysql_real_connect(db->mysql, db->db_host,db->db_user,db->db_pass,db->db_name,0,NULL,0)) {
 			fprintf(stderr,"%s: mysql_connect() failed: %s\n", __FUNCTION__,
 			mysql_error(db->mysql));
-			snprintf(buf, sizeof(buf), "%s",mysql_error(db->mysql));
+			snprintf(buf, 1000, "%s",mysql_error(db->mysql));
 			fprintf (stderr,"buf = %s\n",buf);
 			*message=buf;
 			cmyth_database_close(db);
 			return -1;
 		}
 	}
-	snprintf(buf, sizeof(buf), "All Test Successful\n");
+	snprintf(buf, 1000, "All Test Successful\n");
 	*message=buf;
 	return 1;
 }

--- a/lib/cmyth/librefmem/alloc.c
+++ b/lib/cmyth/librefmem/alloc.c
@@ -283,7 +283,8 @@ ref_realloc(void *p, size_t len)
 	refmem_dbg(REF_DBG_DEBUG, "%s(%d, ret = %p, ref = %p) {\n",
 		   __FUNCTION__, len, ret, ref);
 #ifdef DEBUG
-	assert(ref->magic == ALLOC_MAGIC);
+  if(p)
+	  assert(ref->magic == ALLOC_MAGIC);
 #endif /* DEBUG */
 	if (p && ret) {
 		memcpy(ret, p, ref->length);


### PR DESCRIPTION
Should fix the following bugs in libcmyth
- Wrong debug callback function
- Reference counting broken on linux
- cmyth_mysql_testdb_connection returns a pointer to a stack char[]
- ref_reallof derefence NULL pointer in debug build
