### PR TITLE
Fix creation of db views on migration from custom named db to versioned db names

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -454,6 +454,12 @@ bool CDatabase::UpdateVersion(const CStdString &dbName)
     CLog::Log(LOGERROR, "Can't open the database %s as it is a NEWER version than what we were expecting?", dbName.c_str());
     return false;
   }
+  else//versions are same - but we where called. 
+      //This normally happens after copying a DB from custom name to new versioned DB name sheme.
+      //In that case recreate views because they don't get copied...
+  {
+    CreateViews();
+  }
   return true;
 }
 

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -112,6 +112,7 @@ protected:
 
   virtual bool Open();
   virtual bool CreateTables();
+  virtual void CreateViews(){};
   virtual bool UpdateOldVersion(int version) { return true; };
 
   virtual int GetMinVersion() const=0;

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -231,7 +231,7 @@ protected:
 private:
   /*! \brief (Re)Create the generic database views for songs and albums
    */
-  void CreateViews();
+  virtual void CreateViews();
 
   void SplitString(const CStdString &multiString, std::vector<CStdString> &vecStrings, CStdString &extraStrings);
   CSong GetSongFromDataset(bool bWithMusicDbPath=false);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -688,7 +688,7 @@ private:
   /*! \brief (Re)Create the generic database views for movies, tvshows,
      episodes and music videos
    */
-  void CreateViews();
+  virtual void CreateViews();
 
   /*! \brief Run a query on the main dataset and return the number of rows
    If no rows are found we close the dataset and return 0.


### PR DESCRIPTION
This PR should be reviewed and taken into account by firnsy (and might be closed unmerged if firnsy fixes it in another one). 

@firnsy
I know you are still working on this but i just want to be sure that with whatever changes you'll make the views get created.

In the special case where the DB update copys a custom named mysql db (e.x. xbmc_video) to the new name scheme MyVideos56 the views wheren't created because the UpdateVersion function didn't do anything (because the version wasn't bumped, but stayed on 56).

This PR fixes it by creating the views in Database::UpdateVersion whenever the versions are equal (UpdateVersion only gets called with equal version in the above use case).
