### PR TITLE
Support passthrough via pulseaudio

### DIFF
--- a/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/ALSADirectSound.cpp
@@ -49,7 +49,7 @@ CALSADirectSound::CALSADirectSound()
   m_bIsAllocated = false;
 }
 
-bool CALSADirectSound::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, bool bPassthrough)
+bool CALSADirectSound::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, EEncoded encoded)
 {
   enum PCMChannels *outLayout;
 
@@ -67,7 +67,7 @@ bool CALSADirectSound::Initialize(IAudioCallback* pCallback, const CStdString& d
   m_uiDataChannels = iChannels;
   m_remap.Reset();
 
-  if (!bPassthrough && channelMap)
+  if (encoded == ENCODED_NONE && channelMap)
   {
     /* set the input format, and get the channel layout so we know what we need to open */
     outLayout = m_remap.SetInputFormat (iChannels, channelMap, uiBitsPerSample / 8, uiSamplesPerSec);
@@ -105,7 +105,7 @@ bool CALSADirectSound::Initialize(IAudioCallback* pCallback, const CStdString& d
   m_uiChannels = iChannels;
   m_uiSamplesPerSec = uiSamplesPerSec;
   m_uiBitsPerSample = uiBitsPerSample;
-  m_bPassthrough = bPassthrough;
+  m_bPassthrough = encoded != ENCODED_NONE;
   m_drc = 0;
 
   m_nCurrentVolume = g_settings.m_nVolumeLevel;

--- a/xbmc/cores/AudioRenderers/ALSADirectSound.h
+++ b/xbmc/cores/AudioRenderers/ALSADirectSound.h
@@ -50,7 +50,7 @@ public:
   virtual float GetCacheTime();
   virtual float GetCacheTotal();
   CALSADirectSound();
-  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, bool bPassthrough = false);
+  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, EEncoded encoded = IAudioRenderer::ENCODED_NONE);
   virtual ~CALSADirectSound();
 
   virtual unsigned int AddPackets(const void* data, unsigned int len);

--- a/xbmc/cores/AudioRenderers/AudioRendererFactory.cpp
+++ b/xbmc/cores/AudioRenderers/AudioRendererFactory.cpp
@@ -45,7 +45,7 @@
 
 #define ReturnOnValidInitialize(rendererName)    \
 {                                                \
-  if (audioSink->Initialize(pCallback, device, iChannels, channelMap, uiSamplesPerSec, uiBitsPerSample, bResample, bIsMusic, bPassthrough)) \
+  if (audioSink->Initialize(pCallback, device, iChannels, channelMap, uiSamplesPerSec, uiBitsPerSample, bResample, bIsMusic, encoded)) \
   {                                              \
     CLog::Log(LOGDEBUG, "%s::Initialize"         \
       " - Channels: %i"                          \
@@ -53,7 +53,7 @@
       " - SampleBit: %i"                         \
       " - Resample %s"                           \
       " - IsMusic %s"                            \
-      " - IsPassthrough %s"                      \
+      " - IsPassthrough %d"                      \
       " - audioDevice: %s",                      \
       rendererName,                              \
       iChannels,                                 \
@@ -61,7 +61,7 @@
       uiBitsPerSample,                           \
       bResample ? "true" : "false",              \
       bIsMusic ? "true" : "false",               \
-      bPassthrough ? "true" : "false",           \
+      encoded,                                   \
       device.c_str()                             \
     ); \
     return audioSink;                      \
@@ -86,13 +86,13 @@
   return new rendererClass(); \
 }
 
-IAudioRenderer* CAudioRendererFactory::Create(IAudioCallback* pCallback, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, bool bPassthrough)
+IAudioRenderer* CAudioRendererFactory::Create(IAudioCallback* pCallback, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, IAudioRenderer::EEncoded encoded)
 {
   IAudioRenderer* audioSink = NULL;
   CStdString renderer;
 
   CStdString deviceString, device;
-  if (bPassthrough)
+  if (encoded)
   {
 #if defined(_LINUX) && !defined(__APPLE__)
     deviceString = g_guiSettings.GetString("audiooutput.passthroughdevice");

--- a/xbmc/cores/AudioRenderers/AudioRendererFactory.h
+++ b/xbmc/cores/AudioRenderers/AudioRendererFactory.h
@@ -31,7 +31,7 @@
 class CAudioRendererFactory
 {
 public:
-  static IAudioRenderer *Create(IAudioCallback* pCallback, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, bool bPassthrough);
+  static IAudioRenderer *Create(IAudioCallback* pCallback, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, IAudioRenderer::EEncoded encoded = IAudioRenderer::ENCODED_NONE);
   static void EnumerateAudioSinks(AudioSinkList& vAudioSinks, bool passthrough);
 private:
   static IAudioRenderer *CreateFromUri(const CStdString &soundsystem, CStdString &renderer);

--- a/xbmc/cores/AudioRenderers/CoreAudioRenderer.cpp
+++ b/xbmc/cores/AudioRenderers/CoreAudioRenderer.cpp
@@ -439,7 +439,7 @@ CCoreAudioRenderer::~CCoreAudioRenderer()
 if (!m_Initialized) \
 return x
 
-bool CCoreAudioRenderer::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic /*Useless Legacy Parameter*/, bool bPassthrough)
+bool CCoreAudioRenderer::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic /*Useless Legacy Parameter*/, EEncoded bPassthrough)
 {
   // Have to clean house before we start again.
   // TODO: Should we return failure instead?

--- a/xbmc/cores/AudioRenderers/CoreAudioRenderer.h
+++ b/xbmc/cores/AudioRenderers/CoreAudioRenderer.h
@@ -125,7 +125,7 @@ public:
   virtual ~CCoreAudioRenderer();
   virtual unsigned int GetChunkLen();
   virtual float GetDelay();
-  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, bool bPassthrough = false);
+  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, bool bPassthrough = false, EEncoded encoded = IAudioRenderer::ENCODED_NONE);
   virtual bool Deinitialize();
   virtual unsigned int AddPackets(const void* data, unsigned int len);
   virtual unsigned int GetSpace();

--- a/xbmc/cores/AudioRenderers/IAudioRenderer.h
+++ b/xbmc/cores/AudioRenderers/IAudioRenderer.h
@@ -41,9 +41,18 @@ typedef std::vector<AudioSink> AudioSinkList;
 class IAudioRenderer
 {
 public:
+  enum EEncoded {
+    ENCODED_NONE = 0,
+    ENCODED_IEC61937_AC3,
+    ENCODED_IEC61937_EAC3,
+    ENCODED_IEC61937_DTS,
+    ENCODED_IEC61937_MPEG,
+    ENCODED_IEC61937_UNKNOWN,
+  };
+
   IAudioRenderer() {};
   virtual ~IAudioRenderer() {};
-  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, bool bPassthrough = false) = 0;
+  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, EEncoded encoded = ENCODED_NONE) = 0;
   virtual void UnRegisterAudioCallback() = 0;
   virtual void RegisterAudioCallback(IAudioCallback* pCallback) = 0;
   virtual float GetDelay() = 0;

--- a/xbmc/cores/AudioRenderers/IOSAudioRenderer.cpp
+++ b/xbmc/cores/AudioRenderers/IOSAudioRenderer.cpp
@@ -55,7 +55,7 @@ CIOSAudioRenderer::~CIOSAudioRenderer()
 // Initialization
 //***********************************************************************************************
 
-bool CIOSAudioRenderer::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic /*Useless Legacy Parameter*/, bool bPassthrough)
+bool CIOSAudioRenderer::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic /*Useless Legacy Parameter*/, EEncoded bPassthrough)
 {
   // Limit to 2.0. It is only used for anloge audio.
   static enum PCMChannels IOSChannelMap[2] =

--- a/xbmc/cores/AudioRenderers/IOSAudioRenderer.h
+++ b/xbmc/cores/AudioRenderers/IOSAudioRenderer.h
@@ -35,7 +35,7 @@ class CIOSAudioRenderer : public IAudioRenderer
     virtual ~CIOSAudioRenderer();
     virtual unsigned int GetChunkLen();
     virtual float GetDelay();
-    virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, bool bPassthrough = false);
+    virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, EEncoded encoded = IAudioRenderer::ENCODED_NONE);
     virtual bool Deinitialize();
     virtual void Flush();
     virtual unsigned int AddPackets(const void* data, unsigned int len);

--- a/xbmc/cores/AudioRenderers/NullDirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/NullDirectSound.cpp
@@ -42,7 +42,7 @@ void CNullDirectSound::DoWork()
 CNullDirectSound::CNullDirectSound()
 {
 }
-bool CNullDirectSound::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, bool bPassthrough)
+bool CNullDirectSound::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, EEncoded encoded)
 {
   CLog::Log(LOGERROR,"Creating a Null Audio Renderer, Check your audio settings as this should not happen");
   if (iChannels == 0)

--- a/xbmc/cores/AudioRenderers/NullDirectSound.h
+++ b/xbmc/cores/AudioRenderers/NullDirectSound.h
@@ -41,7 +41,7 @@ public:
   virtual float GetDelay();
   virtual float GetCacheTime();
   CNullDirectSound();
-  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, bool bPassthrough = false);
+  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, EEncoded encoded = IAudioRenderer::ENCODED_NONE);
   virtual ~CNullDirectSound();
 
   virtual unsigned int AddPackets(const void* data, unsigned int len);

--- a/xbmc/cores/AudioRenderers/PulseAudioDirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/PulseAudioDirectSound.cpp
@@ -252,9 +252,9 @@ bool CPulseAudioDirectSound::Initialize(IAudioCallback* pCallback, const CStdStr
     }
   }
   else
-    pa_channel_map_init_auto(&map, m_SampleSpec.channels, PA_CHANNEL_MAP_ALSA); 
+    pa_channel_map_init_auto(&map, m_uiChannels, PA_CHANNEL_MAP_ALSA);
 
-  pa_cvolume_reset(&m_Volume, m_SampleSpec.channels);
+  pa_cvolume_reset(&m_Volume, m_uiChannels);
 
   if ((m_Stream = pa_stream_new(m_Context, "audio stream", &m_SampleSpec, &map)) == NULL)
   {
@@ -478,9 +478,9 @@ bool CPulseAudioDirectSound::SetCurrentVolume(long nVolume)
   pa_threaded_mainloop_lock(m_MainLoop);
   pa_volume_t volume = pa_sw_volume_from_dB((float)nVolume*1.5f / 200.0f);
   if ( nVolume <= VOLUME_MINIMUM )
-    pa_cvolume_mute(&m_Volume, m_SampleSpec.channels);
+    pa_cvolume_mute(&m_Volume, m_uiChannels);
   else
-    pa_cvolume_set(&m_Volume, m_SampleSpec.channels, volume);
+    pa_cvolume_set(&m_Volume, m_uiChannels, volume);
   pa_operation *op = pa_context_set_sink_input_volume(m_Context, pa_stream_get_index(m_Stream), &m_Volume, NULL, NULL);
   if (op == NULL)
     CLog::Log(LOGERROR, "PulseAudio: Failed to set volume");

--- a/xbmc/cores/AudioRenderers/PulseAudioDirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/PulseAudioDirectSound.cpp
@@ -144,13 +144,13 @@ CPulseAudioDirectSound::CPulseAudioDirectSound()
 {
 }
 
-bool CPulseAudioDirectSound::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels* channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, bool bPassthrough)
+bool CPulseAudioDirectSound::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels* channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, EEncoded encoded)
 {
   m_remap.Reset();
   m_uiDataChannels = iChannels;
   enum PCMChannels* outLayout = NULL;
 
-  if (!bPassthrough && channelMap)
+  if (encoded == ENCODED_NONE && channelMap)
   {
     /* set the input format, and get the channel layout so we know what we need to open */
     outLayout = m_remap.SetInputFormat(iChannels, channelMap, uiBitsPerSample / 8, uiSamplesPerSec);
@@ -179,7 +179,7 @@ bool CPulseAudioDirectSound::Initialize(IAudioCallback* pCallback, const CStdStr
   m_uiSamplesPerSec = uiSamplesPerSec;
   m_uiBufferSize = 0;
   m_uiBitsPerSample = uiBitsPerSample;
-  m_bPassthrough = bPassthrough;
+  m_bPassthrough = encoded == ENCODED_NONE ? false : true;
   m_uiBytesPerSecond = uiSamplesPerSec * (uiBitsPerSample / 8) * iChannels;
   m_drc = 0;
 

--- a/xbmc/cores/AudioRenderers/PulseAudioDirectSound.h
+++ b/xbmc/cores/AudioRenderers/PulseAudioDirectSound.h
@@ -91,7 +91,6 @@ private:
   bool m_bPassthrough;
 
   pa_stream *m_Stream;
-  pa_sample_spec m_SampleSpec;
   pa_cvolume m_Volume;
 
   pa_context *m_Context;

--- a/xbmc/cores/AudioRenderers/PulseAudioDirectSound.h
+++ b/xbmc/cores/AudioRenderers/PulseAudioDirectSound.h
@@ -46,7 +46,7 @@ public:
   virtual float GetCacheTime();
   virtual float GetCacheTotal();
   CPulseAudioDirectSound();
-  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, bool bPassthrough = false);
+  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, EEncoded encoded = IAudioRenderer::ENCODED_NONE);
   virtual ~CPulseAudioDirectSound();
 
   virtual unsigned int AddPackets(const void* data, unsigned int len);

--- a/xbmc/cores/AudioRenderers/Win32DirectSound.cpp
+++ b/xbmc/cores/AudioRenderers/Win32DirectSound.cpp
@@ -83,7 +83,7 @@ CWin32DirectSound::CWin32DirectSound() :
 {
 }
 
-bool CWin32DirectSound::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels* channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, bool bAudioPassthrough)
+bool CWin32DirectSound::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels* channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, EEncoded bAudioPassthrough)
 {
   m_uiDataChannels = iChannels;
 

--- a/xbmc/cores/AudioRenderers/Win32DirectSound.h
+++ b/xbmc/cores/AudioRenderers/Win32DirectSound.h
@@ -45,7 +45,7 @@ public:
   virtual float GetCacheTime();
   virtual float GetCacheTotal();
   CWin32DirectSound();
-  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels* channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, bool bPassthrough = false);
+  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels* channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, EEncoded encoded = IAudioRenderer::ENCODED_NONE);
   virtual ~CWin32DirectSound();
 
   virtual unsigned int AddPackets(const void* data, unsigned int len);

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
@@ -87,7 +87,7 @@ CWin32WASAPI::CWin32WASAPI() :
 {
 }
 
-bool CWin32WASAPI::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, bool bAudioPassthrough)
+bool CWin32WASAPI::Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic, EEncoded bAudioPassthrough)
 {
   CLog::Log(LOGDEBUG, __FUNCTION__": endpoint device %s", device.c_str());
 

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.h
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.h
@@ -47,7 +47,7 @@ public:
   virtual float GetDelay();
   virtual float GetCacheTime();
   virtual float GetCacheTotal();
-  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, bool bAudioPassthrough=false);
+  virtual bool Initialize(IAudioCallback* pCallback, const CStdString& device, int iChannels, enum PCMChannels *channelMap, unsigned int uiSamplesPerSec, unsigned int uiBitsPerSample, bool bResample, bool bIsMusic=false, EEncoded encoded = IAudioRenderer::ENCODED_NONE);
 
   virtual unsigned int AddPackets(const void* data, unsigned int len);
   virtual unsigned int GetSpace();

--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -78,7 +78,22 @@ bool CDVDAudio::Create(const DVDAudioFrame &audioframe, CodecID codec)
 
   // if passthrough isset do something else
   CSingleLock lock (m_critSection);
-  m_pAudioDecoder = CAudioRendererFactory::Create(m_pCallback, audioframe.channels, audioframe.channel_map, audioframe.sample_rate, audioframe.bits_per_sample, false, false, audioframe.passthrough);
+
+  IAudioRenderer::EEncoded encoded = IAudioRenderer::ENCODED_NONE;
+  if(audioframe.passthrough)
+  {
+    switch(codec) {
+      case CODEC_ID_AC3 : encoded = IAudioRenderer::ENCODED_IEC61937_AC3;     break;
+      case CODEC_ID_EAC3: encoded = IAudioRenderer::ENCODED_IEC61937_EAC3;    break;
+      case CODEC_ID_DTS : encoded = IAudioRenderer::ENCODED_IEC61937_DTS;     break;
+      case CODEC_ID_MP1 :
+      case CODEC_ID_MP2 :
+      case CODEC_ID_MP3 : encoded = IAudioRenderer::ENCODED_IEC61937_MPEG;    break;
+      default:            encoded = IAudioRenderer::ENCODED_IEC61937_UNKNOWN; break;
+    }
+  }
+
+  m_pAudioDecoder = CAudioRendererFactory::Create(m_pCallback, audioframe.channels, audioframe.channel_map, audioframe.sample_rate, audioframe.bits_per_sample, false, false, encoded);
 
   if (!m_pAudioDecoder) return false;
 

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -383,7 +383,7 @@ bool PAPlayer::CreateStream(int num, unsigned int channels, unsigned int sampler
       m_bitsPerSample[num], //uiBitsPerSample
       false               , //bResample
       true                , //bIsMusic
-      false                 //bPassthrough
+      IAudioRenderer::ENCODED_NONE //bPassthrough
     );
 
     if (!m_pAudioDecoder[num]) return false;


### PR DESCRIPTION
Should be backward compatible and not enable on systems with older pulseaudio.

If your pavucontrol mixer doesn't allow you to set supported output types, you may need to use something like:

```
pactl set-sink-formats 0 "pcm; ac3-iec61937; dts-iec61937"
```

To signal that your audio sink support ac3. 

It should after that show up as available devices in the passthrough audio selection box.
