### PR TITLE
Updated metadata parsing for pictures

### DIFF
--- a/lib/libexif/ExifParse.cpp
+++ b/lib/libexif/ExifParse.cpp
@@ -416,7 +416,7 @@ void CExifParse::ProcessDir(const unsigned char* const DirStart,
       case TAG_DESCRIPTION:
       {
         int length = max(ByteCount, 0);
-        length = min(length, 2000);
+        length = min(length, MAX_COMMENT);
         strncpy(m_ExifInfo->Description, (char *)ValuePtr, length);
         break;
       }
@@ -452,7 +452,7 @@ void CExifParse::ProcessDir(const unsigned char* const DirStart,
       {
         const int EXIF_COMMENT_HDR_LENGTH = 8;        // All comment tags have 8 bytes of header info
         int length = max(ByteCount - EXIF_COMMENT_HDR_LENGTH, 0);
-        length = min(length, 2000);
+        length = min(length, MAX_COMMENT);
         strncpy(m_ExifInfo->Comments, (char *)ValuePtr+EXIF_COMMENT_HDR_LENGTH, length);
 //        FixComment(comment);                          // Ensure comment is printable
       }

--- a/lib/libexif/ExifParse.cpp
+++ b/lib/libexif/ExifParse.cpp
@@ -413,7 +413,13 @@ void CExifParse::ProcessDir(const unsigned char* const DirStart,
     // Extract useful components of tag
     switch(Tag)
     {
-//      case TAG_DESCRIPTION:       strncpy(m_ExifInfo->Description, ValuePtr, 5);    break;
+      case TAG_DESCRIPTION:
+      {
+        int length = max(ByteCount, 0);
+        length = min(length, 2000);
+        strncpy(m_ExifInfo->Description, (char *)ValuePtr, length);
+        break;
+      }
       case TAG_MAKE:              strncpy(m_ExifInfo->CameraMake, (char *)ValuePtr, 32);    break;
       case TAG_MODEL:             strncpy(m_ExifInfo->CameraModel, (char *)ValuePtr, 40);    break;
 //      case TAG_SOFTWARE:          strncpy(m_ExifInfo->Software, ValuePtr, 5);    break;

--- a/lib/libexif/IptcParse.cpp
+++ b/lib/libexif/IptcParse.cpp
@@ -133,9 +133,6 @@ bool CIptcParse::Process (const unsigned char* const Data, const unsigned short 
 
   if (pos + 4 >= maxpos) return false;
 
-  // Get length (Motorola format)
-  //unsigned long length = CExifParse::Get32(pos);
-
   pos += 4;                                   // move data pointer to the next field
 
   // Now read IPTC data
@@ -145,13 +142,13 @@ bool CIptcParse::Process (const unsigned char* const Data, const unsigned short 
 
     short signature = (*pos << 8) + (*(pos+1));
 
-    pos += sizeof(short);
+    pos += 2;
     if (signature != 0x1C01 && signature != 0x1C02)
       break;
 
     unsigned char  type = *pos++;
     unsigned short length  = (*pos << 8) + (*(pos+1));
-    pos += sizeof(short);                   // Skip tag length
+    pos += 2;                   // Skip tag length
 
     if (pos + length > maxpos) return false;
 

--- a/lib/libexif/libexif.h
+++ b/lib/libexif/libexif.h
@@ -98,6 +98,7 @@ typedef struct {
     int   ISOequivalent;
     int   LightSource;
     char  Comments[MAX_COMMENT];
+    char  Description[MAX_COMMENT];
 
     unsigned ThumbnailOffset;          // Exif offset to thumbnail
     unsigned ThumbnailSize;            // Size of thumbnail.

--- a/lib/libexif/libexif.h
+++ b/lib/libexif/libexif.h
@@ -48,6 +48,7 @@ extern "C" {
 #define MAX_IPTC_STRING 256
 
 typedef struct {
+  char RecordVersion[MAX_IPTC_STRING];
   char SupplementalCategories[MAX_IPTC_STRING];
   char Keywords[MAX_IPTC_STRING];
   char Caption[MAX_IPTC_STRING];
@@ -69,6 +70,9 @@ typedef struct {
   char Copyright[MAX_IPTC_STRING];
   char ReferenceService[MAX_IPTC_STRING];
   char CountryCode[MAX_IPTC_STRING];
+  char TimeCreated[MAX_IPTC_STRING];
+  char SubLocation[MAX_IPTC_STRING];
+  char ImageType[MAX_IPTC_STRING];
 } IPTCInfo_t;
 
 #define MAX_COMMENT 2000

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -66,6 +66,7 @@ void CPictureInfoTag::Archive(CArchive& ar)
     ar << CStdString(m_exifInfo.CameraModel);
     ar << m_exifInfo.CCDWidth;
     ar << CStdString(m_exifInfo.Comments);
+    ar << CStdString(m_exifInfo.Description);
     ar << CStdString(m_exifInfo.DateTime);
     for (int i = 0; i < 10; i++)
       ar << m_exifInfo.DateTimeOffsets[i];
@@ -128,6 +129,7 @@ void CPictureInfoTag::Archive(CArchive& ar)
     GetStringFromArchive(ar, m_exifInfo.CameraModel, sizeof(m_exifInfo.CameraModel));
     ar >> m_exifInfo.CCDWidth;
     GetStringFromArchive(ar, m_exifInfo.Comments, sizeof(m_exifInfo.Comments));
+    GetStringFromArchive(ar, m_exifInfo.Description, sizeof(m_exifInfo.Description));
     GetStringFromArchive(ar, m_exifInfo.DateTime, sizeof(m_exifInfo.DateTime));
     for (int i = 0; i < 10; i++)
       ar >> m_exifInfo.DateTimeOffsets[i];
@@ -191,6 +193,7 @@ void CPictureInfoTag::Serialize(CVariant& value)
   value["cameramodel"] = CStdString(m_exifInfo.CameraModel);
   value["ccdwidth"] = m_exifInfo.CCDWidth;
   value["comments"] = CStdString(m_exifInfo.Comments);
+  value["description"] = CStdString(m_exifInfo.Description);
   value["datetime"] = CStdString(m_exifInfo.DateTime);
   for (int i = 0; i < 10; i++)
     value["datetimeoffsets"][i] = m_exifInfo.DateTimeOffsets[i];
@@ -311,9 +314,9 @@ const CStdString CPictureInfoTag::GetInfo(int info) const
       value = date.GetAsLocalizedDateTime();
     }
     break;
-//  case SLIDE_EXIF_DESCRIPTION:
-//    value = m_exifInfo.Description;
-//    break;
+  case SLIDE_EXIF_DESCRIPTION:
+    value = m_exifInfo.Description;
+    break;
   case SLIDE_EXIF_CAMERA_MAKE:
     value = m_exifInfo.CameraMake;
     break;


### PR DESCRIPTION
IptcParser: Updated the iptc parser code (from the public domain software jhead). IPTC data that commercial tools (like Adobe PS and Lightroom) produce were not readable by xbmc. This improved parser now supports recent IPTC versions.

ExifParser: Added support for the exif tag ImageDescription. The code that presents the info to the ui was already there; only a few lines in the parser were missing.
