### PR TITLE
Add subtitle option to override the ASS/SSA subtitles font - work around ass fonts problems

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1922,7 +1922,8 @@
   <string id="21365">Remove media share</string>
   <string id="21366">Subtitle folder</string>
   <string id="21367">Movie &amp; alternate subtitle directory</string>
-
+  <string id="21368">Override ASS/SSA subtitles fonts</string>
+  
   <string id="21369">Enable mouse and Touch Screen support</string>
   <string id="21370">Play navigation sounds during media playback</string>
   <string id="21371">Thumbnail</string>

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -78,13 +78,14 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
   //Setting default font to the Arial in \media\fonts (used if FontConfig fails)
   strPath = "special://xbmc/media/Fonts/";
   strPath += g_guiSettings.GetString("subtitles.font");
+  int fc = !g_guiSettings.GetBool("subtitles.overrideassfonts");
 
   m_dll.ass_set_margins(m_renderer, 0, 0, 0, 0);
   m_dll.ass_set_use_margins(m_renderer, 0);
   m_dll.ass_set_font_scale(m_renderer, 1);
   // libass uses fontconfig (system lib) which is not wrapped
   //  so translate the path before calling into libass
-  m_dll.ass_set_fonts(m_renderer, _P(strPath).c_str(), "", 1, NULL, 0);
+  m_dll.ass_set_fonts(m_renderer, _P(strPath).c_str(), "", fc, NULL, 0);
 }
 
 

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -690,6 +690,7 @@ void CGUISettings::Initialize()
   AddInt(sub, "subtitles.style", 736, FONT_STYLE_BOLD, fontStyles, SPIN_CONTROL_TEXT);
   AddInt(sub, "subtitles.color", 737, SUBTITLE_COLOR_START + 1, SUBTITLE_COLOR_START, 1, SUBTITLE_COLOR_END, SPIN_CONTROL_TEXT);
   AddString(sub, "subtitles.charset", 735, "DEFAULT", SPIN_CONTROL_TEXT);
+  AddBool(sub,"subtitles.overrideassfonts", 21368, false);
   AddSeparator(sub, "subtitles.sep1");
   AddPath(sub, "subtitles.custompath", 21366, "", BUTTON_CONTROL_PATH_INPUT, false, 657);
 


### PR DESCRIPTION
Add an option to make libass use the font specified for srt subs with the ass/ssa subtitles rendering, instead of using the services of fontconfig and the fonts embedded in mkv files. That typically means using arial.ttf

This is both a bug work around and a new feature:
- bug fix, as it allows users to work around any weirdness that happens with the font selection issues noticed in ticket 12023 and described in team forum thread. This option also provides a way out in case the upcoming fix for fontconfig cache issues has unexpected side-effects. I checked that this PR works for all samples that otherwise fail.
- new feature, as it allows overriding the sometimes hard-to-read fonts specified and embedded in some mkv. It's possible to expand this feature later and also use the srt size/style/color values (with libass style overrides)

Works by preventing libass from using fontconfig and specifying the default font.
When disabling fontconfig, it's 100% correct to call ass_set_fonts with update=0.

This is low risk for Eden. What do you guys think, in or out?
