### PR TITLE
add websocket support for JSON-RPC

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -61,6 +61,7 @@ DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
                    xbmc/music/tags/musictags.a \
                    xbmc/music/windows/musicwindows.a \
                    xbmc/network/libscrobbler/scrobbler.a \
+                   xbmc/network/websocket/websocket.a \
                    xbmc/network/network.a \
                    xbmc/peripherals/bus/peripheral-bus.a \
                    xbmc/peripherals/devices/peripheral-devices.a \

--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -36,6 +36,12 @@
 		DF4485341400651B0069344B /* FilePipe.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4485301400651B0069344B /* FilePipe.cpp */; };
 		DF4485351400651B0069344B /* PipesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4485321400651B0069344B /* PipesManager.cpp */; };
 		DF4485381400654A0069344B /* AirTunesServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4485361400654A0069344B /* AirTunesServer.cpp */; };
+		DF527780151BAFD600B5B63B /* WebSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527777151BAFD600B5B63B /* WebSocket.cpp */; };
+		DF527781151BAFD600B5B63B /* WebSocketManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527779151BAFD600B5B63B /* WebSocketManager.cpp */; };
+		DF527782151BAFD600B5B63B /* WebSocketV13.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52777B151BAFD600B5B63B /* WebSocketV13.cpp */; };
+		DF527783151BAFD600B5B63B /* WebSocketV8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52777D151BAFD600B5B63B /* WebSocketV8.cpp */; };
+		DF527788151BAFEE00B5B63B /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527784151BAFEE00B5B63B /* Base64.cpp */; };
+		DF527789151BAFEE00B5B63B /* HttpResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527786151BAFEE00B5B63B /* HttpResponse.cpp */; };
 		DF673A251443769300A5A509 /* FileUPnP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF673A231443769300A5A509 /* FileUPnP.cpp */; };
 		DF98D9A81434F4B400A6EBE1 /* SkinVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF98D9A61434F4B400A6EBE1 /* SkinVariable.cpp */; };
 		DFA6BE8713FED2A10048CC11 /* AirPlayServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFA6BE8513FED2A10048CC11 /* AirPlayServer.cpp */; };
@@ -1008,6 +1014,18 @@
 		DF4485331400651B0069344B /* PipesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PipesManager.h; sourceTree = "<group>"; };
 		DF4485361400654A0069344B /* AirTunesServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AirTunesServer.cpp; sourceTree = "<group>"; };
 		DF4485371400654A0069344B /* AirTunesServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AirTunesServer.h; sourceTree = "<group>"; };
+		DF527777151BAFD600B5B63B /* WebSocket.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocket.cpp; sourceTree = "<group>"; };
+		DF527778151BAFD600B5B63B /* WebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocket.h; sourceTree = "<group>"; };
+		DF527779151BAFD600B5B63B /* WebSocketManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocketManager.cpp; sourceTree = "<group>"; };
+		DF52777A151BAFD600B5B63B /* WebSocketManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketManager.h; sourceTree = "<group>"; };
+		DF52777B151BAFD600B5B63B /* WebSocketV13.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocketV13.cpp; sourceTree = "<group>"; };
+		DF52777C151BAFD600B5B63B /* WebSocketV13.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketV13.h; sourceTree = "<group>"; };
+		DF52777D151BAFD600B5B63B /* WebSocketV8.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocketV8.cpp; sourceTree = "<group>"; };
+		DF52777E151BAFD600B5B63B /* WebSocketV8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketV8.h; sourceTree = "<group>"; };
+		DF527784151BAFEE00B5B63B /* Base64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Base64.cpp; sourceTree = "<group>"; };
+		DF527785151BAFEE00B5B63B /* Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Base64.h; sourceTree = "<group>"; };
+		DF527786151BAFEE00B5B63B /* HttpResponse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HttpResponse.cpp; sourceTree = "<group>"; };
+		DF527787151BAFEE00B5B63B /* HttpResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HttpResponse.h; sourceTree = "<group>"; };
 		DF673A231443769300A5A509 /* FileUPnP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileUPnP.cpp; sourceTree = "<group>"; };
 		DF673A241443769300A5A509 /* FileUPnP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileUPnP.h; sourceTree = "<group>"; };
 		DF98D9A61434F4B400A6EBE1 /* SkinVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SkinVariable.cpp; sourceTree = "<group>"; };
@@ -3017,6 +3035,21 @@
 			name = Documentation;
 			sourceTree = "<group>";
 		};
+		DF527775151BAFD600B5B63B /* websocket */ = {
+			isa = PBXGroup;
+			children = (
+				DF527777151BAFD600B5B63B /* WebSocket.cpp */,
+				DF527778151BAFD600B5B63B /* WebSocket.h */,
+				DF527779151BAFD600B5B63B /* WebSocketManager.cpp */,
+				DF52777A151BAFD600B5B63B /* WebSocketManager.h */,
+				DF52777B151BAFD600B5B63B /* WebSocketV13.cpp */,
+				DF52777C151BAFD600B5B63B /* WebSocketV13.h */,
+				DF52777D151BAFD600B5B63B /* WebSocketV8.cpp */,
+				DF52777E151BAFD600B5B63B /* WebSocketV8.h */,
+			);
+			path = websocket;
+			sourceTree = "<group>";
+		};
 		DFD4D20C13D7286E00A47C47 /* platform */ = {
 			isa = PBXGroup;
 			children = (
@@ -4847,6 +4880,7 @@
 				F56C7648131EC153000AD0F6 /* libscrobbler */,
 				F56C7650131EC153000AD0F6 /* linux */,
 				F56C7653131EC153000AD0F6 /* osx */,
+				DF527775151BAFD600B5B63B /* websocket */,
 				DFA6BE8513FED2A10048CC11 /* AirPlayServer.cpp */,
 				DFA6BE8613FED2A10048CC11 /* AirPlayServer.h */,
 				DF4485361400654A0069344B /* AirTunesServer.cpp */,
@@ -5144,6 +5178,8 @@
 				F56C7724131EC154000AD0F6 /* AsyncFileCopy.h */,
 				F56C7725131EC154000AD0F6 /* AutoPtrHandle.cpp */,
 				F56C7726131EC154000AD0F6 /* AutoPtrHandle.h */,
+				DF527784151BAFEE00B5B63B /* Base64.cpp */,
+				DF527785151BAFEE00B5B63B /* Base64.h */,
 				F56C7727131EC154000AD0F6 /* BitstreamStats.cpp */,
 				F56C7728131EC154000AD0F6 /* BitstreamStats.h */,
 				F56C7729131EC154000AD0F6 /* CharsetConverter.cpp */,
@@ -5182,6 +5218,8 @@
 				F56C7740131EC154000AD0F6 /* HttpHeader.h */,
 				DFA6BE8813FED2B40048CC11 /* HttpParser.cpp */,
 				DFA6BE8913FED2B40048CC11 /* HttpParser.h */,
+				DF527786151BAFEE00B5B63B /* HttpResponse.cpp */,
+				DF527787151BAFEE00B5B63B /* HttpResponse.h */,
 				F56C7741131EC154000AD0F6 /* InfoLoader.cpp */,
 				F56C7742131EC154000AD0F6 /* InfoLoader.h */,
 				F56C7747131EC154000AD0F6 /* Job.h */,
@@ -6940,6 +6978,12 @@
 				DF673A251443769300A5A509 /* FileUPnP.cpp in Sources */,
 				F5BD033A148D4923001B5583 /* CryptThreading.cpp in Sources */,
 				7CCFD9AA1514952700211D82 /* PCMCodec.cpp in Sources */,
+				DF527780151BAFD600B5B63B /* WebSocket.cpp in Sources */,
+				DF527781151BAFD600B5B63B /* WebSocketManager.cpp in Sources */,
+				DF527782151BAFD600B5B63B /* WebSocketV13.cpp in Sources */,
+				DF527783151BAFD600B5B63B /* WebSocketV8.cpp in Sources */,
+				DF527788151BAFEE00B5B63B /* Base64.cpp in Sources */,
+				DF527789151BAFEE00B5B63B /* HttpResponse.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -37,6 +37,12 @@
 		DF448571140065E10069344B /* FilePipe.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF44856D140065E10069344B /* FilePipe.cpp */; };
 		DF448572140065E10069344B /* PipesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF44856F140065E10069344B /* PipesManager.cpp */; };
 		DF4485751400662D0069344B /* AirTunesServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4485731400662D0069344B /* AirTunesServer.cpp */; };
+		DF527757151BAF8200B5B63B /* WebSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52774E151BAF8200B5B63B /* WebSocket.cpp */; };
+		DF527758151BAF8200B5B63B /* WebSocketManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527750151BAF8200B5B63B /* WebSocketManager.cpp */; };
+		DF527759151BAF8200B5B63B /* WebSocketV13.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527752151BAF8200B5B63B /* WebSocketV13.cpp */; };
+		DF52775A151BAF8200B5B63B /* WebSocketV8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527754151BAF8200B5B63B /* WebSocketV8.cpp */; };
+		DF527760151BAFA000B5B63B /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52775C151BAFA000B5B63B /* Base64.cpp */; };
+		DF527761151BAFA000B5B63B /* HttpResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52775E151BAFA000B5B63B /* HttpResponse.cpp */; };
 		DF6739E21443765F00A5A509 /* FileUPnP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF6739E01443765F00A5A509 /* FileUPnP.cpp */; };
 		DF98D9991434F49500A6EBE1 /* SkinVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF98D9971434F49500A6EBE1 /* SkinVariable.cpp */; };
 		DFA6BE4313FECA010048CC11 /* AirPlayServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFA6BE4113FECA010048CC11 /* AirPlayServer.cpp */; };
@@ -1008,6 +1014,18 @@
 		DF448570140065E10069344B /* PipesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PipesManager.h; sourceTree = "<group>"; };
 		DF4485731400662D0069344B /* AirTunesServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AirTunesServer.cpp; sourceTree = "<group>"; };
 		DF4485741400662D0069344B /* AirTunesServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AirTunesServer.h; sourceTree = "<group>"; };
+		DF52774E151BAF8200B5B63B /* WebSocket.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocket.cpp; sourceTree = "<group>"; };
+		DF52774F151BAF8200B5B63B /* WebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocket.h; sourceTree = "<group>"; };
+		DF527750151BAF8200B5B63B /* WebSocketManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocketManager.cpp; sourceTree = "<group>"; };
+		DF527751151BAF8200B5B63B /* WebSocketManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketManager.h; sourceTree = "<group>"; };
+		DF527752151BAF8200B5B63B /* WebSocketV13.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocketV13.cpp; sourceTree = "<group>"; };
+		DF527753151BAF8200B5B63B /* WebSocketV13.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketV13.h; sourceTree = "<group>"; };
+		DF527754151BAF8200B5B63B /* WebSocketV8.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocketV8.cpp; sourceTree = "<group>"; };
+		DF527755151BAF8200B5B63B /* WebSocketV8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketV8.h; sourceTree = "<group>"; };
+		DF52775C151BAFA000B5B63B /* Base64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Base64.cpp; sourceTree = "<group>"; };
+		DF52775D151BAFA000B5B63B /* Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Base64.h; sourceTree = "<group>"; };
+		DF52775E151BAFA000B5B63B /* HttpResponse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HttpResponse.cpp; sourceTree = "<group>"; };
+		DF52775F151BAFA000B5B63B /* HttpResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HttpResponse.h; sourceTree = "<group>"; };
 		DF6739E01443765F00A5A509 /* FileUPnP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileUPnP.cpp; sourceTree = "<group>"; };
 		DF6739E11443765F00A5A509 /* FileUPnP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileUPnP.h; sourceTree = "<group>"; };
 		DF98D9971434F49500A6EBE1 /* SkinVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SkinVariable.cpp; sourceTree = "<group>"; };
@@ -3015,6 +3033,21 @@
 				83D619BB13C0D25300418A0F /* README.ios */,
 			);
 			name = Documentation;
+			sourceTree = "<group>";
+		};
+		DF52774C151BAF8200B5B63B /* websocket */ = {
+			isa = PBXGroup;
+			children = (
+				DF52774E151BAF8200B5B63B /* WebSocket.cpp */,
+				DF52774F151BAF8200B5B63B /* WebSocket.h */,
+				DF527750151BAF8200B5B63B /* WebSocketManager.cpp */,
+				DF527751151BAF8200B5B63B /* WebSocketManager.h */,
+				DF527752151BAF8200B5B63B /* WebSocketV13.cpp */,
+				DF527753151BAF8200B5B63B /* WebSocketV13.h */,
+				DF527754151BAF8200B5B63B /* WebSocketV8.cpp */,
+				DF527755151BAF8200B5B63B /* WebSocketV8.h */,
+			);
+			path = websocket;
 			sourceTree = "<group>";
 		};
 		DFD4D1D013D725ED00A47C47 /* platform */ = {
@@ -5206,6 +5239,7 @@
 				F56C862B131F42EA000AD0F6 /* libscrobbler */,
 				F56C8633131F42EA000AD0F6 /* linux */,
 				F56C8636131F42EA000AD0F6 /* osx */,
+				DF52774C151BAF8200B5B63B /* websocket */,
 				DFA6BE4113FECA010048CC11 /* AirPlayServer.cpp */,
 				DFA6BE4213FECA010048CC11 /* AirPlayServer.h */,
 				DF4485731400662D0069344B /* AirTunesServer.cpp */,
@@ -5512,6 +5546,8 @@
 				F56C8713131F42EC000AD0F6 /* AsyncFileCopy.h */,
 				F56C8714131F42EC000AD0F6 /* AutoPtrHandle.cpp */,
 				F56C8715131F42EC000AD0F6 /* AutoPtrHandle.h */,
+				DF52775C151BAFA000B5B63B /* Base64.cpp */,
+				DF52775D151BAFA000B5B63B /* Base64.h */,
 				F56C8716131F42EC000AD0F6 /* BitstreamStats.cpp */,
 				F56C8717131F42EC000AD0F6 /* BitstreamStats.h */,
 				F56C8718131F42EC000AD0F6 /* CharsetConverter.cpp */,
@@ -5550,6 +5586,8 @@
 				F56C872F131F42EC000AD0F6 /* HttpHeader.h */,
 				DFA6BE7513FED09C0048CC11 /* HttpParser.cpp */,
 				DFA6BE7613FED09C0048CC11 /* HttpParser.h */,
+				DF52775E151BAFA000B5B63B /* HttpResponse.cpp */,
+				DF52775F151BAFA000B5B63B /* HttpResponse.h */,
 				F56C8730131F42EC000AD0F6 /* InfoLoader.cpp */,
 				F56C8731131F42EC000AD0F6 /* InfoLoader.h */,
 				F56C8736131F42EC000AD0F6 /* Job.h */,
@@ -6955,6 +6993,12 @@
 				DF6739E21443765F00A5A509 /* FileUPnP.cpp in Sources */,
 				F5BD034F148D496A001B5583 /* CryptThreading.cpp in Sources */,
 				7CCFD9991514950700211D82 /* PCMCodec.cpp in Sources */,
+				DF527757151BAF8200B5B63B /* WebSocket.cpp in Sources */,
+				DF527758151BAF8200B5B63B /* WebSocketManager.cpp in Sources */,
+				DF527759151BAF8200B5B63B /* WebSocketV13.cpp in Sources */,
+				DF52775A151BAF8200B5B63B /* WebSocketV8.cpp in Sources */,
+				DF527760151BAFA000B5B63B /* Base64.cpp in Sources */,
+				DF527761151BAFA000B5B63B /* HttpResponse.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -637,6 +637,18 @@
 		DF448460140048C80069344B /* PipesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF44845B140048C80069344B /* PipesManager.cpp */; };
 		DF4484EE140054530069344B /* BXAcodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4484EC140054530069344B /* BXAcodec.cpp */; };
 		DF4484EF140054530069344B /* BXAcodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4484EC140054530069344B /* BXAcodec.cpp */; };
+		DF5276E1151BAEDA00B5B63B /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52769A151BAEDA00B5B63B /* Base64.cpp */; };
+		DF5276E2151BAEDA00B5B63B /* HttpResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52769C151BAEDA00B5B63B /* HttpResponse.cpp */; };
+		DF527726151BAEDA00B5B63B /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52769A151BAEDA00B5B63B /* Base64.cpp */; };
+		DF527727151BAEDA00B5B63B /* HttpResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52769C151BAEDA00B5B63B /* HttpResponse.cpp */; };
+		DF527734151BAF4C00B5B63B /* WebSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772B151BAF4C00B5B63B /* WebSocket.cpp */; };
+		DF527735151BAF4C00B5B63B /* WebSocketManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772D151BAF4C00B5B63B /* WebSocketManager.cpp */; };
+		DF527736151BAF4C00B5B63B /* WebSocketV13.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772F151BAF4C00B5B63B /* WebSocketV13.cpp */; };
+		DF527737151BAF4C00B5B63B /* WebSocketV8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527731151BAF4C00B5B63B /* WebSocketV8.cpp */; };
+		DF527739151BAF4C00B5B63B /* WebSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772B151BAF4C00B5B63B /* WebSocket.cpp */; };
+		DF52773A151BAF4C00B5B63B /* WebSocketManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772D151BAF4C00B5B63B /* WebSocketManager.cpp */; };
+		DF52773B151BAF4C00B5B63B /* WebSocketV13.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772F151BAF4C00B5B63B /* WebSocketV13.cpp */; };
+		DF52773C151BAF4C00B5B63B /* WebSocketV8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527731151BAF4C00B5B63B /* WebSocketV8.cpp */; };
 		DF673AA51443819600A5A509 /* AddonManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FF41152BFA5001AF8A6 /* AddonManager.cpp */; };
 		DF85BAB51443669A000686BE /* FileUPnP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF85BAB41443669A000686BE /* FileUPnP.cpp */; };
 		DF85BAB61443669A000686BE /* FileUPnP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF85BAB41443669A000686BE /* FileUPnP.cpp */; };
@@ -2613,6 +2625,18 @@
 		DF44845C140048C80069344B /* PipesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PipesManager.h; sourceTree = "<group>"; };
 		DF4484EC140054530069344B /* BXAcodec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BXAcodec.cpp; sourceTree = "<group>"; };
 		DF4484ED140054530069344B /* BXAcodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BXAcodec.h; sourceTree = "<group>"; };
+		DF52769A151BAEDA00B5B63B /* Base64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Base64.cpp; sourceTree = "<group>"; };
+		DF52769B151BAEDA00B5B63B /* Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Base64.h; sourceTree = "<group>"; };
+		DF52769C151BAEDA00B5B63B /* HttpResponse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HttpResponse.cpp; sourceTree = "<group>"; };
+		DF52769D151BAEDA00B5B63B /* HttpResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HttpResponse.h; sourceTree = "<group>"; };
+		DF52772B151BAF4C00B5B63B /* WebSocket.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocket.cpp; sourceTree = "<group>"; };
+		DF52772C151BAF4C00B5B63B /* WebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocket.h; sourceTree = "<group>"; };
+		DF52772D151BAF4C00B5B63B /* WebSocketManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocketManager.cpp; sourceTree = "<group>"; };
+		DF52772E151BAF4C00B5B63B /* WebSocketManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketManager.h; sourceTree = "<group>"; };
+		DF52772F151BAF4C00B5B63B /* WebSocketV13.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocketV13.cpp; sourceTree = "<group>"; };
+		DF527730151BAF4C00B5B63B /* WebSocketV13.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketV13.h; sourceTree = "<group>"; };
+		DF527731151BAF4C00B5B63B /* WebSocketV8.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSocketV8.cpp; sourceTree = "<group>"; };
+		DF527732151BAF4C00B5B63B /* WebSocketV8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebSocketV8.h; sourceTree = "<group>"; };
 		DF85BAB31443669A000686BE /* FileUPnP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileUPnP.h; sourceTree = "<group>"; };
 		DF85BAB41443669A000686BE /* FileUPnP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileUPnP.cpp; sourceTree = "<group>"; };
 		DF98D98A1434F47D00A6EBE1 /* SkinVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SkinVariable.cpp; sourceTree = "<group>"; };
@@ -4708,6 +4732,7 @@
 				4313772B12D6474F00680C15 /* libscrobbler */,
 				432D7CE112D86D4900CE4C49 /* linux */,
 				4313772312D646E300680C15 /* osx */,
+				DF527729151BAF4C00B5B63B /* websocket */,
 				DF34892813FD9C780026A711 /* AirPlayServer.cpp */,
 				DF34892913FD9C780026A711 /* AirPlayServer.h */,
 				DF448455140048A60069344B /* AirTunesServer.cpp */,
@@ -5049,6 +5074,21 @@
 				880DBE360DC2077000E26B71 /* README.osx */,
 			);
 			name = Documentation;
+			sourceTree = "<group>";
+		};
+		DF527729151BAF4C00B5B63B /* websocket */ = {
+			isa = PBXGroup;
+			children = (
+				DF52772B151BAF4C00B5B63B /* WebSocket.cpp */,
+				DF52772C151BAF4C00B5B63B /* WebSocket.h */,
+				DF52772D151BAF4C00B5B63B /* WebSocketManager.cpp */,
+				DF52772E151BAF4C00B5B63B /* WebSocketManager.h */,
+				DF52772F151BAF4C00B5B63B /* WebSocketV13.cpp */,
+				DF527730151BAF4C00B5B63B /* WebSocketV13.h */,
+				DF527731151BAF4C00B5B63B /* WebSocketV8.cpp */,
+				DF527732151BAF4C00B5B63B /* WebSocketV8.h */,
+			);
+			path = websocket;
 			sourceTree = "<group>";
 		};
 		E37D5CB40D3023BB0081D327 /* osx */ = {
@@ -6584,6 +6624,8 @@
 				F5FDF51B0E7218950005B0A6 /* AsyncFileCopy.h */,
 				F5BDB81F120203C200F0B710 /* AutoPtrHandle.cpp */,
 				F5BDB81E120203C200F0B710 /* AutoPtrHandle.h */,
+				DF52769A151BAEDA00B5B63B /* Base64.cpp */,
+				DF52769B151BAEDA00B5B63B /* Base64.h */,
 				E38E1E270D25F9FD00618676 /* BitstreamStats.cpp */,
 				E38E1E280D25F9FD00618676 /* BitstreamStats.h */,
 				E38E1E290D25F9FD00618676 /* CharsetConverter.cpp */,
@@ -6622,6 +6664,8 @@
 				E38E1E470D25F9FD00618676 /* HttpHeader.h */,
 				DF34898113FDAAF60026A711 /* HttpParser.cpp */,
 				DF34897A13FDAA270026A711 /* HttpParser.h */,
+				DF52769C151BAEDA00B5B63B /* HttpResponse.cpp */,
+				DF52769D151BAEDA00B5B63B /* HttpResponse.h */,
 				E38E1E4C0D25F9FD00618676 /* InfoLoader.cpp */,
 				E38E1E4D0D25F9FD00618676 /* InfoLoader.h */,
 				7CAA205B107AFC280096DE39 /* Job.h */,
@@ -8050,6 +8094,12 @@
 				DF673AA51443819600A5A509 /* AddonManager.cpp in Sources */,
 				F5BD02F6148D3A7E001B5583 /* CryptThreading.cpp in Sources */,
 				7CCFD98D151494E100211D82 /* PCMCodec.cpp in Sources */,
+				DF5276E1151BAEDA00B5B63B /* Base64.cpp in Sources */,
+				DF5276E2151BAEDA00B5B63B /* HttpResponse.cpp in Sources */,
+				DF527734151BAF4C00B5B63B /* WebSocket.cpp in Sources */,
+				DF527735151BAF4C00B5B63B /* WebSocketManager.cpp in Sources */,
+				DF527736151BAF4C00B5B63B /* WebSocketV13.cpp in Sources */,
+				DF527737151BAF4C00B5B63B /* WebSocketV8.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8971,6 +9021,12 @@
 				DF85BAB61443669A000686BE /* FileUPnP.cpp in Sources */,
 				F5BD02F7148D3A7E001B5583 /* CryptThreading.cpp in Sources */,
 				7CCFD98C151494E100211D82 /* PCMCodec.cpp in Sources */,
+				DF527726151BAEDA00B5B63B /* Base64.cpp in Sources */,
+				DF527727151BAEDA00B5B63B /* HttpResponse.cpp in Sources */,
+				DF527739151BAF4C00B5B63B /* WebSocket.cpp in Sources */,
+				DF52773A151BAF4C00B5B63B /* WebSocketManager.cpp in Sources */,
+				DF52773B151BAF4C00B5B63B /* WebSocketV13.cpp in Sources */,
+				DF52773C151BAF4C00B5B63B /* WebSocketV8.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/BuildDependencies/scripts/boost_d.txt
+++ b/project/BuildDependencies/scripts/boost_d.txt
@@ -1,5 +1,5 @@
 ; filename                          mirror of the file
-boost-1_46_1-xbmc-win32.7z			http://mirrors.xbmc.org/build-deps/win32/
+boost-1_46_1-xbmc-win32-1.7z			http://mirrors.xbmc.org/build-deps/win32/
 ;boost_1_46_1-headers-win32.7z      http://mirrors.xbmc.org/build-deps/win32/
 ;boost_1_46_1-libs-win32.7z         http://mirrors.xbmc.org/build-deps/win32/
 ;boost_1_46_1-debug-libs-win32.7z   http://mirrors.xbmc.org/build-deps/win32/

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -673,6 +673,9 @@
     <ClCompile Include="..\..\xbmc\network\UdpClient.cpp" />
     <ClCompile Include="..\..\xbmc\network\UPnP.cpp" />
     <ClCompile Include="..\..\xbmc\network\WebServer.cpp" />
+    <ClCompile Include="..\..\xbmc\network\websocket\WebSocket.cpp" />
+    <ClCompile Include="..\..\xbmc\network\websocket\WebSocketManager.cpp" />
+    <ClCompile Include="..\..\xbmc\network\websocket\WebSocketV8.cpp" />
     <ClCompile Include="..\..\xbmc\network\windows\NetworkWin32.cpp" />
     <ClCompile Include="..\..\xbmc\network\windows\ZeroconfWIN.cpp" />
     <ClCompile Include="..\..\xbmc\network\Zeroconf.cpp" />
@@ -759,6 +762,9 @@
     <ClInclude Include="..\..\xbmc\cores\paplayer\PCMCodec.h" />
     <ClInclude Include="..\..\xbmc\filesystem\FileUPnP.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pythreadstate.h" />
+    <ClInclude Include="..\..\xbmc\network\websocket\WebSocket.h" />
+    <ClInclude Include="..\..\xbmc\network\websocket\WebSocketManager.h" />
+    <ClInclude Include="..\..\xbmc\network\websocket\WebSocketV8.h" />
     <ClInclude Include="..\..\xbmc\threads\platform\win\Implementation.cpp" />
     <ClCompile Include="..\..\xbmc\threads\SystemClock.cpp" />
     <ClCompile Include="..\..\xbmc\threads\Thread.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -771,6 +771,7 @@
     <ClCompile Include="..\..\xbmc\utils\Archive.cpp" />
     <ClCompile Include="..\..\xbmc\utils\AsyncFileCopy.cpp" />
     <ClCompile Include="..\..\xbmc\utils\AutoPtrHandle.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\Base64.cpp" />
     <ClCompile Include="..\..\xbmc\utils\BitstreamStats.cpp" />
     <ClCompile Include="..\..\xbmc\utils\CharsetConverter.cpp" />
     <ClCompile Include="..\..\xbmc\utils\CPUInfo.cpp" />
@@ -1644,6 +1645,7 @@
     <ClInclude Include="..\..\xbmc\utils\Archive.h" />
     <ClInclude Include="..\..\xbmc\utils\AsyncFileCopy.h" />
     <ClInclude Include="..\..\xbmc\utils\AutoPtrHandle.h" />
+    <ClInclude Include="..\..\xbmc\utils\Base64.h" />
     <ClInclude Include="..\..\xbmc\utils\BitstreamStats.h" />
     <ClInclude Include="..\..\xbmc\utils\CharsetConverter.h" />
     <ClInclude Include="..\..\xbmc\utils\CPUInfo.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -794,6 +794,7 @@
     <ClCompile Include="..\..\xbmc\utils\HTMLUtil.cpp" />
     <ClCompile Include="..\..\xbmc\utils\HttpHeader.cpp" />
     <ClCompile Include="..\..\xbmc\utils\HttpParser.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\HttpResponse.cpp" />
     <ClCompile Include="..\..\xbmc\utils\InfoLoader.cpp" />
     <ClCompile Include="..\..\xbmc\utils\JobManager.cpp" />
     <ClCompile Include="..\..\xbmc\utils\JSONVariantParser.cpp" />
@@ -1664,6 +1665,7 @@
     <ClInclude Include="..\..\xbmc\utils\HTMLUtil.h" />
     <ClInclude Include="..\..\xbmc\utils\HttpHeader.h" />
     <ClInclude Include="..\..\xbmc\utils\HttpParser.h" />
+    <ClInclude Include="..\..\xbmc\utils\HttpResponse.h" />
     <ClInclude Include="..\..\xbmc\utils\InfoLoader.h" />
     <ClInclude Include="..\..\xbmc\utils\ISerializable.h" />
     <ClInclude Include="..\..\xbmc\utils\Job.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -675,6 +675,7 @@
     <ClCompile Include="..\..\xbmc\network\WebServer.cpp" />
     <ClCompile Include="..\..\xbmc\network\websocket\WebSocket.cpp" />
     <ClCompile Include="..\..\xbmc\network\websocket\WebSocketManager.cpp" />
+    <ClCompile Include="..\..\xbmc\network\websocket\WebSocketV13.cpp" />
     <ClCompile Include="..\..\xbmc\network\websocket\WebSocketV8.cpp" />
     <ClCompile Include="..\..\xbmc\network\windows\NetworkWin32.cpp" />
     <ClCompile Include="..\..\xbmc\network\windows\ZeroconfWIN.cpp" />
@@ -764,6 +765,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pythreadstate.h" />
     <ClInclude Include="..\..\xbmc\network\websocket\WebSocket.h" />
     <ClInclude Include="..\..\xbmc\network\websocket\WebSocketManager.h" />
+    <ClInclude Include="..\..\xbmc\network\websocket\WebSocketV13.h" />
     <ClInclude Include="..\..\xbmc\network\websocket\WebSocketV8.h" />
     <ClInclude Include="..\..\xbmc\threads\platform\win\Implementation.cpp" />
     <ClCompile Include="..\..\xbmc\threads\SystemClock.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2568,6 +2568,9 @@
     <ClCompile Include="..\..\xbmc\cores\paplayer\PCMCodec.cpp">
       <Filter>cores\paplayer</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\Base64.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5159,6 +5162,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\paplayer\PCMCodec.h">
       <Filter>cores\paplayer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\Base64.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -250,6 +250,9 @@
     <Filter Include="peripherals\dialogs">
       <UniqueIdentifier>{9571e2bc-891d-4496-bcba-2ec3eed45704}</UniqueIdentifier>
     </Filter>
+    <Filter Include="network\websocket">
+      <UniqueIdentifier>{88e84682-dede-4bdf-9e33-a8023dd5ac78}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\xbmc\win32\pch.cpp">
@@ -2573,6 +2576,15 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\utils\HttpResponse.cpp">
       <Filter>utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\websocket\WebSocket.cpp">
+      <Filter>network\websocket</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\websocket\WebSocketV8.cpp">
+      <Filter>network\websocket</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\websocket\WebSocketManager.cpp">
+      <Filter>network\websocket</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -5171,6 +5183,15 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\HttpResponse.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\websocket\WebSocket.h">
+      <Filter>network\websocket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\websocket\WebSocketV8.h">
+      <Filter>network\websocket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\websocket\WebSocketManager.h">
+      <Filter>network\websocket</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2586,6 +2586,9 @@
     <ClCompile Include="..\..\xbmc\network\websocket\WebSocketManager.cpp">
       <Filter>network\websocket</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\websocket\WebSocketV13.cpp">
+      <Filter>network\websocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5191,6 +5194,9 @@
       <Filter>network\websocket</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\websocket\WebSocketManager.h">
+      <Filter>network\websocket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\websocket\WebSocketV13.h">
       <Filter>network\websocket</Filter>
     </ClInclude>
   </ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2571,6 +2571,9 @@
     <ClCompile Include="..\..\xbmc\utils\Base64.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\HttpResponse.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5164,6 +5167,9 @@
       <Filter>cores\paplayer</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\Base64.h">
+      <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\HttpResponse.h">
       <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -29,6 +29,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "utils/Base64.h"
 #include "threads/SingleLock.h"
 #include "XBDateTime.h"
 #include "addons/AddonManager.h"
@@ -479,44 +480,12 @@ bool CWebServer::IsStarted()
   return m_running;
 }
 
-void CWebServer::StringToBase64(const char *input, CStdString &output)
-{
-  const char *lookup = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-  unsigned long l;
-  size_t length = strlen (input);
-  output = "";
-
-  for (unsigned int i = 0; i < length; i += 3)
-  {
-    l = (((unsigned long) input[i]) << 16)
-      | (((i + 1) < length) ? (((unsigned long) input[i + 1]) << 8) : 0)
-      | (((i + 2) < length) ? ((unsigned long) input[i + 2]) : 0);
-
-
-    output.push_back(lookup[(l >> 18) & 0x3F]);
-    output.push_back(lookup[(l >> 12) & 0x3F]);
-
-    if (i + 1 < length)
-      output.push_back(lookup[(l >> 6) & 0x3F]);
-    if (i + 2 < length)
-      output.push_back(lookup[l & 0x3F]);
-  }
-
-  int left = 3 - (length % 3);
-
-  if (length % 3)
-  {
-    for (int i = 0; i < left; i++)
-      output.push_back('=');
-  }
-}
-
 void CWebServer::SetCredentials(const CStdString &username, const CStdString &password)
 {
   CSingleLock lock (m_critSection);
   CStdString str = username + ":" + password;
 
-  StringToBase64(str.c_str(), m_Credentials64Encoded);
+  Base64::Encode(str.c_str(), m_Credentials64Encoded);
   m_needcredentials = !password.IsEmpty();
 }
 

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -94,7 +94,6 @@ private:
   static int CreateAddonsListResponse(struct MHD_Connection *connection);
 
   static int FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
-  static void StringToBase64(const char *input, CStdString &output);
 
   static const char *CreateMimeTypeFromExtension(const char *ext);
 

--- a/xbmc/network/websocket/Makefile
+++ b/xbmc/network/websocket/Makefile
@@ -1,6 +1,7 @@
 SRCS=WebSocket.cpp \
      WebSocketManager.cpp \
      WebSocketV8.cpp \
+     WebSocketV13.cpp \
 
 LIB=websocket.a
 

--- a/xbmc/network/websocket/Makefile
+++ b/xbmc/network/websocket/Makefile
@@ -1,0 +1,8 @@
+SRCS=WebSocket.cpp \
+     WebSocketManager.cpp \
+     WebSocketV8.cpp \
+
+LIB=websocket.a
+
+include ../../../Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/network/websocket/WebSocket.cpp
+++ b/xbmc/network/websocket/WebSocket.cpp
@@ -1,0 +1,432 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+#include <sstream>
+
+#include "WebSocket.h"
+#include "utils/EndianSwap.h"
+#include "utils/log.h"
+#include "utils/HttpParser.h"
+#include "utils/Base64.h"
+#include "utils/StdString.h"
+#include "utils/StringUtils.h"
+#include "utils/HttpResponse.h"
+
+#define MASK_FIN      0x80
+#define MASK_RSV1     0x40
+#define MASK_RSV2     0x20
+#define MASK_RSV3     0x10
+#define MASK_RSV      (MASK_RSV1 | MASK_RSV2 | MASK_RSV3)
+#define MASK_OPCODE   0x0F
+#define MASK_MASK     0x80
+#define MASK_LENGTH   0x7F
+
+#define CONTROL_FRAME 0x08
+
+#define LENGTH_MIN    0x2
+
+using namespace std;
+
+CWebSocketFrame::CWebSocketFrame(const char* data, uint64_t length)
+{
+  reset();
+
+  if (data == NULL || length < LENGTH_MIN)
+    return;
+
+  m_free = false;
+  m_data = data;
+  m_lengthFrame = length;
+
+  // Get the FIN flag
+  m_final = ((m_data[0] & MASK_FIN) == MASK_FIN);
+  // Get the RSV1 - RSV3 flags
+  m_extension |= m_data[0] & MASK_RSV1;
+  m_extension |= (m_data[0] & MASK_RSV2) << 1;
+  m_extension |= (m_data[0] & MASK_RSV3) << 2;
+  // Get the opcode
+  m_opcode = (WebSocketFrameOpcode)(m_data[0] & MASK_OPCODE);
+  if (m_opcode >= WebSocketUnknownFrame)
+  {
+    CLog::Log(LOGINFO, "WebSocket: Frame with invalid opcode %2X received", m_opcode);
+    reset();
+    return;
+  }
+  if ((m_opcode & CONTROL_FRAME) == CONTROL_FRAME && !m_final)
+  {
+    CLog::Log(LOGINFO, "WebSocket: Fragmented control frame (opcode %2X) received", m_opcode);
+    reset();
+    return;
+  }
+
+  // Get the MASK flag
+  m_masked = ((m_data[1] & MASK_MASK) == MASK_MASK);
+
+  // Get the playload length
+  m_length = (uint64_t)(m_data[1] & MASK_LENGTH);
+  if ((m_length <= 125 && length  < m_length + LENGTH_MIN) ||
+      (m_length == 126 && length < LENGTH_MIN + 2) ||
+      (m_length == 127 && length < LENGTH_MIN + 8))
+  {
+    CLog::Log(LOGINFO, "WebSocket: Frame with invalid length received");
+    reset();
+    return;
+  }
+
+  if (IsControlFrame() && (m_length > 125 || !m_final))
+  {
+    CLog::Log(LOGWARNING, "WebSocket: Invalid control frame received");
+    reset();
+    return;
+  }
+
+  int offset = 0;
+  if (m_length == 126)
+  {
+    m_length = (uint64_t)Endian_SwapBE16(*(uint16_t *)(m_data + 2));
+    offset = 2;
+  }
+  else if (m_length == 127)
+  {
+    m_length = Endian_SwapBE64(*(uint64_t *)(m_data + 2));
+    offset = 8;
+  }
+
+  if (length < LENGTH_MIN + offset + m_length)
+  {
+    CLog::Log(LOGINFO, "WebSocket: Frame with invalid length received");
+    reset();
+    return;
+  }
+
+  // Get the mask
+  if (m_masked)
+  {
+    m_mask = *(uint32_t *)(m_data + LENGTH_MIN + offset);
+    offset += 4;
+  }
+
+  if (length != LENGTH_MIN + offset + m_length)
+  {
+    CLog::Log(LOGINFO, "WebSocket: Frame with invalid length received");
+    reset();
+    return;
+  }
+
+  // Get application data
+  if (m_length > 0)
+    m_applicationData = (char *)(m_data + LENGTH_MIN + offset);
+  else
+    m_applicationData = NULL;
+
+  // Unmask the application data if necessary
+  if (m_masked)
+  {
+    for (uint64_t index = 0; index < m_length; index++)
+      m_applicationData[index] = m_applicationData[index] ^ ((char *)(&m_mask))[index % 4];
+  }
+
+  m_valid = true;
+}
+
+CWebSocketFrame::CWebSocketFrame(WebSocketFrameOpcode opcode, const char* data /* = NULL */, uint32_t length /* = 0 */,
+                                 bool final /* = true */, bool masked /* = false */, int32_t mask /* = 0 */, int8_t extension /* = 0 */)
+{
+  reset();
+
+  if (opcode >= WebSocketUnknownFrame)
+    return;
+
+  m_free = true;
+  m_opcode = opcode;
+
+  if (length >= 0)
+    m_length = length;
+
+  m_masked = masked;
+  m_mask = mask;
+  m_final = final;
+  m_extension = extension;
+
+  string buffer;
+  char dataByte = 0;
+
+  // Set the FIN flag
+  if (m_final)
+    dataByte |= MASK_FIN;
+
+  // Set RSV1 - RSV3 flags
+  if (m_extension != 0)
+    dataByte |= (m_extension << 4) & MASK_RSV;
+
+  // Set opcode flag
+  dataByte |= opcode & MASK_OPCODE;
+
+  buffer.push_back(dataByte);
+  dataByte = 0;
+
+  // Set MASK flag
+  if (m_masked)
+    dataByte |= MASK_MASK;
+
+  // Set payload length
+  if (m_length < 126)
+  {
+    dataByte |= m_length & MASK_LENGTH;
+    buffer.push_back(dataByte);
+  }
+  else if (m_length <= 65535)
+  {
+    dataByte |= 126 & MASK_LENGTH;
+    buffer.push_back(dataByte);
+
+    uint16_t dataLength = Endian_SwapBE16((uint16_t)m_length);
+    buffer.append((const char*)&dataLength, 2);
+  }
+  else
+  {
+    dataByte |= 127 & MASK_LENGTH;
+    buffer.push_back(dataByte);
+    
+    uint64_t dataLength = Endian_SwapBE64(m_length);
+    buffer.append((const char*)&dataLength, 8);
+  }
+
+  uint64_t applicationDataOffset = 0;
+  if (data)
+  {
+    // Set masking key
+    if (m_masked)
+    {
+      buffer.append((char *)&m_mask, sizeof(m_mask));
+      applicationDataOffset = buffer.size();
+
+      for (uint64_t index = 0; index < m_length; index++)
+        buffer.push_back(data[index] ^ ((char *)(&m_mask))[index % 4]);
+    }
+    else
+    {
+      applicationDataOffset = buffer.size();
+      buffer.append(data, (unsigned int)length);
+    }
+  }
+
+  // Get the whole data
+  m_lengthFrame = buffer.size();
+  m_data = new char[(uint32_t)m_lengthFrame];
+  strncpy((char *)m_data, buffer.c_str(), (uint32_t)m_lengthFrame);
+
+  if (data)
+  {
+    m_applicationData = (char *)m_data;
+    m_applicationData += applicationDataOffset;
+  }
+
+  m_valid = true;
+}
+
+CWebSocketFrame::~CWebSocketFrame()
+{
+  if (!m_valid)
+    return;
+
+  if (m_free && m_data != NULL)
+  {
+    delete m_data;
+    m_data = NULL;
+  }
+}
+
+void CWebSocketFrame::reset()
+{
+  m_free = false;
+  m_data = NULL;
+  m_lengthFrame = 0;
+  m_length = 0;
+  m_valid = false;
+  m_final = false;
+  m_extension = 0;
+  m_opcode = WebSocketUnknownFrame;
+  m_masked = false;
+  m_mask = 0;
+  m_applicationData = NULL;
+}
+
+CWebSocketMessage::CWebSocketMessage()
+{
+  Clear();
+}
+
+CWebSocketMessage::~CWebSocketMessage()
+{
+  for (unsigned int index = 0; index < m_frames.size(); index++)
+    delete m_frames[index];
+
+  m_frames.clear();
+}
+
+bool CWebSocketMessage::AddFrame(const CWebSocketFrame *frame)
+{
+  if (!frame->IsValid() || m_complete)
+    return false;
+
+  if (frame->IsFinal())
+    m_complete = true;
+  else
+    m_fragmented = true;
+
+  m_frames.push_back(frame);
+
+  return true;
+}
+
+void CWebSocketMessage::Clear()
+{
+  m_fragmented = false;
+  m_complete = false;
+
+  m_frames.clear();
+}
+
+const CWebSocketMessage* CWebSocket::Handle(const char *buffer, size_t length, bool &send)
+{
+  send = false;
+
+  switch (m_state)
+  {
+    case WebSocketStateConnected:
+    {
+      CWebSocketFrame *frame = GetFrame(buffer, length);
+      if (!frame->IsValid())
+      {
+        CLog::Log(LOGINFO, "WebSocket: Invalid frame received");
+        delete frame;
+        return NULL;
+      }
+
+      if (frame->IsControlFrame())
+      {
+        if (!frame->IsFinal())
+        {
+          delete frame;
+          return NULL;
+        }
+
+        CWebSocketMessage *msg = NULL;
+        switch (frame->GetOpcode())
+        {
+          case WebSocketPing:
+            msg = GetMessage();
+            if (msg != NULL)
+              msg->AddFrame(Pong(frame->GetApplicationData()));
+            break;
+            
+          case WebSocketConnectionClose:
+            CLog::Log(LOGINFO, "WebSocket: connection closed by client");
+
+            msg = GetMessage();
+            if (msg != NULL)
+              msg->AddFrame(Close());
+
+            m_state = WebSocketStateClosed;
+            break;
+
+          case WebSocketContinuationFrame:
+          case WebSocketTextFrame:
+          case WebSocketBinaryFrame:
+          case WebSocketPong:
+          case WebSocketUnknownFrame:
+          default:
+            break;
+        }
+
+        delete frame;
+
+        if (msg != NULL)
+          send = true;
+
+        return msg;
+      }
+
+      if (m_message == NULL && (m_message = GetMessage()) == NULL)
+      {
+        CLog::Log(LOGINFO, "WebSocket: Could not allocate a new websocket message");
+        delete frame;
+        return NULL;
+      }
+
+      m_message->AddFrame(frame);
+      if (!m_message->IsComplete())
+        return NULL;
+
+      CWebSocketMessage *msg = m_message;
+      m_message = NULL;
+      return msg;
+    }
+
+    case WebSocketStateClosing:
+    {
+      CWebSocketFrame *frame = GetFrame(buffer, length);
+      if (!frame->IsValid() || frame->GetOpcode() == WebSocketConnectionClose)
+      {
+        CLog::Log(LOGINFO, "WebSocket: Invalid or unexpected frame received (only closing handshake expected)");
+        delete frame;
+        return NULL;
+      }
+
+      m_state = WebSocketStateClosed;
+      return NULL;
+    }
+
+    case WebSocketStateNotConnected:
+    case WebSocketStateClosed:
+    case WebSocketStateHandshaking:
+    default:
+      CLog::Log(LOGINFO, "WebSocket: No frame expected in the current state");
+      return NULL;
+  }
+
+  return NULL;
+}
+
+const CWebSocketMessage* CWebSocket::Send(WebSocketFrameOpcode opcode, const char* data /* = NULL */, uint32_t length /* = 0 */)
+{
+  CWebSocketFrame *frame = GetFrame(opcode, data, length);
+  if (frame == NULL || !frame->IsValid())
+  {
+    CLog::Log(LOGINFO, "WebSocket: Trying to send an invalid frame");
+    return NULL;
+  }
+
+  CWebSocketMessage *msg = GetMessage();
+  if (msg == NULL)
+  {
+    CLog::Log(LOGINFO, "WebSocket: Could not allocate a message");
+    return NULL;
+  }
+
+  msg->AddFrame(frame);
+  if (msg->IsComplete())
+    return msg;
+
+  return NULL;
+}

--- a/xbmc/network/websocket/WebSocket.h
+++ b/xbmc/network/websocket/WebSocket.h
@@ -1,0 +1,141 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+ 
+#include <stdint.h>
+#include <vector>
+
+enum WebSocketFrameOpcode
+{
+  WebSocketContinuationFrame  = 0x00,
+  WebSocketTextFrame          = 0x01,
+  WebSocketBinaryFrame        = 0x02,
+  //0x3 - 0x7 are reserved for non-control frames
+  WebSocketConnectionClose    = 0x08,
+  WebSocketPing               = 0x09,
+  WebSocketPong               = 0x0A,
+  //0xB - 0xF are reserved for control frames
+  WebSocketUnknownFrame       = 0x10
+};
+
+enum WebSocketState
+{
+  WebSocketStateNotConnected    = 0,
+  WebSocketStateHandshaking     = 1,
+  WebSocketStateConnected       = 2,
+  WebSocketStateClosing         = 3,
+  WebSocketStateClosed          = 4
+};
+
+enum WebSocketCloseReason
+{
+  WebSocketCloseNormal          = 1000,
+  WebSocketCloseLeaving         = 1001,
+  WebSocketCloseProtocolError   = 1002,
+  WebSocketCloseInvalidData     = 1003,
+  WebSocketCloseFrameTooLarge   = 1004,
+  // Reserved status code       = 1005,
+  // Reserved status code       = 1006,
+  WebSocketCloseInvalidUtf8     = 1007
+};
+
+class CWebSocketFrame
+{
+public:
+  CWebSocketFrame(const char* data, uint64_t length);
+  CWebSocketFrame(WebSocketFrameOpcode opcode, const char* data = NULL, uint32_t length = 0, bool final = true, bool masked = false, int32_t mask = 0, int8_t extension = 0);
+  virtual ~CWebSocketFrame();
+
+  virtual bool IsValid() const { return m_valid; }
+  virtual uint64_t GetFrameLength() const { return m_lengthFrame; }
+  virtual bool IsFinal() const { return m_final; }
+  virtual int8_t GetExtension() const { return m_extension; }
+  virtual WebSocketFrameOpcode GetOpcode() const { return m_opcode; }
+  virtual bool IsControlFrame() const { return (m_valid && (m_opcode & 0x8) == 0x8); }
+  virtual bool IsMasekd() const { return m_masked; }
+  virtual uint64_t GetLength() const { return m_length; }
+  virtual int32_t GetMask() const { return m_mask; }
+  virtual const char* GetFrameData() const { return m_data; }
+  virtual const char* GetApplicationData() const { return m_applicationData; }
+
+protected:
+  bool m_free;
+  const char *m_data;
+  uint64_t m_lengthFrame;
+  uint64_t m_length;
+  bool m_valid;
+  bool m_final;
+  int8_t m_extension;
+  WebSocketFrameOpcode m_opcode;
+  bool m_masked;
+  int32_t m_mask;
+  char *m_applicationData;
+
+private:
+  void reset();
+};
+
+class CWebSocketMessage
+{
+public:
+  CWebSocketMessage();
+  virtual ~CWebSocketMessage();
+
+  virtual bool IsFragmented() const { return m_fragmented; }
+  virtual bool IsComplete() const { return m_complete; }
+
+  virtual bool AddFrame(const CWebSocketFrame* frame);
+  virtual const std::vector<const CWebSocketFrame *>& GetFrames() const { return m_frames; }
+
+  virtual void Clear();
+
+protected:
+  std::vector<const CWebSocketFrame *> m_frames;
+  bool m_fragmented;
+  bool m_complete;
+};
+
+class CWebSocket
+{
+public:
+  CWebSocket() { m_state = WebSocketStateNotConnected; m_message = NULL; }
+  virtual ~CWebSocket() { if (m_message) delete m_message; };
+
+  int GetVersion() { return m_version; }
+  WebSocketState GetState() { return m_state; }
+
+  virtual bool Handshake(const char* data, size_t length, std::string &response) = 0;
+  virtual const CWebSocketMessage* Handle(const char *buffer, size_t length, bool &send); // TODO
+  virtual const CWebSocketMessage* Send(WebSocketFrameOpcode opcode, const char* data = NULL, uint32_t length = 0);
+  virtual const CWebSocketFrame* Ping(const char* data = NULL) const = 0;
+  virtual const CWebSocketFrame* Pong(const char* data = NULL) const = 0;
+  virtual const CWebSocketFrame* Close(WebSocketCloseReason reason = WebSocketCloseNormal, const std::string &message = "") = 0;
+  virtual void Fail() = 0;
+
+protected:
+  int m_version;
+  WebSocketState m_state;
+  CWebSocketMessage *m_message;
+
+  virtual CWebSocketFrame* GetFrame(const char* data, uint64_t length) = 0;
+  virtual CWebSocketFrame* GetFrame(WebSocketFrameOpcode opcode, const char* data = NULL, uint32_t length = 0, bool final = true, bool masked = false, int32_t mask = 0, int8_t extension = 0) = 0;
+  virtual CWebSocketMessage* GetMessage() = 0;
+};

--- a/xbmc/network/websocket/WebSocketManager.cpp
+++ b/xbmc/network/websocket/WebSocketManager.cpp
@@ -1,0 +1,95 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+
+#include "WebSocketManager.h"
+#include "WebSocket.h"
+#include "WebSocketV8.h"
+#include "WebSocketV13.h"
+#include "utils/HttpParser.h"
+#include "utils/HttpResponse.h"
+#include "utils/log.h"
+
+#define WS_HTTP_METHOD          "GET"
+#define WS_HTTP_TAG             "HTTP/"
+#define WS_SUPPORTED_VERSIONS   "8, 13"
+
+#define WS_HEADER_VERSION       "Sec-WebSocket-Version"
+#define WS_HEADER_VERSION_LC    "sec-websocket-version"     // "Sec-WebSocket-Version"
+
+using namespace std;
+
+CWebSocket* CWebSocketManager::Handle(const char* data, unsigned int length, string &response)
+{
+  if (data == NULL || length <= 0)
+    return NULL;
+
+  HttpParser header;
+  HttpParser::status_t status = header.addBytes(data, length);
+  switch (status)
+  {
+    case HttpParser::Error:
+    case HttpParser::Incomplete:
+      response.clear();
+      return NULL;
+
+    case HttpParser::Done:
+    default:
+      break;
+  }
+
+  // There must be a "Sec-WebSocket-Version" header
+  const char* value = header.getValue(WS_HEADER_VERSION_LC);
+  if (value == NULL)
+  {
+    CLog::Log(LOGINFO, "WebSocket: missing Sec-WebSocket-Version");
+    CHttpResponse httpResponse(HTTP::Get, HTTP::BadRequest, HTTP::Version1_1);
+    char *responseBuffer;
+    int responseLength = httpResponse.Create(responseBuffer);
+    response = std::string(responseBuffer, responseLength);
+
+    return NULL;
+  }
+  
+  CWebSocket *websocket = NULL;
+  if (strncmp(value, "8", 1) == 0)
+    websocket = new CWebSocketV8();
+  else if (strncmp(value, "13", 2) == 0)
+    websocket = new CWebSocketV13();
+
+  if (websocket == NULL)
+  {
+    CLog::Log(LOGINFO, "WebSocket: Unsupported Sec-WebSocket-Version %s", value);
+    CHttpResponse httpResponse(HTTP::Get, HTTP::UpgradeRequired, HTTP::Version1_1);
+    httpResponse.AddHeader(WS_HEADER_VERSION, WS_SUPPORTED_VERSIONS);
+    char *responseBuffer;
+    int responseLength = httpResponse.Create(responseBuffer);
+    response = std::string(responseBuffer, responseLength);
+
+    return NULL;
+  }
+
+  if (websocket->Handshake(data, length, response))
+    return websocket;
+
+  return NULL;
+}

--- a/xbmc/network/websocket/WebSocketManager.h
+++ b/xbmc/network/websocket/WebSocketManager.h
@@ -1,0 +1,29 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+class CWebSocket;
+
+class CWebSocketManager
+{
+public:
+  static CWebSocket* Handle(const char* data, unsigned int length, std::string &response);
+};

--- a/xbmc/network/websocket/WebSocketV13.cpp
+++ b/xbmc/network/websocket/WebSocketV13.cpp
@@ -1,0 +1,166 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+#include <sstream>
+#include <boost/uuid/sha1.hpp>
+
+#include "WebSocketV13.h"
+#include "WebSocket.h"
+#include "utils/Base64.h"
+#include "utils/CharsetConverter.h"
+#include "utils/HttpParser.h"
+#include "utils/HttpResponse.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+#define WS_HTTP_METHOD          "GET"
+#define WS_HTTP_TAG             "HTTP/"
+
+#define WS_HEADER_UPGRADE       "Upgrade"
+#define WS_HEADER_UPGRADE_LC    "upgrade"
+#define WS_HEADER_CONNECTION    "Connection"
+#define WS_HEADER_CONNECTION_LC "connection"
+
+#define WS_HEADER_KEY_LC        "sec-websocket-key"         // "Sec-WebSocket-Key"
+#define WS_HEADER_ACCEPT        "Sec-WebSocket-Accept"
+#define WS_HEADER_PROTOCOL      "Sec-WebSocket-Protocol"
+#define WS_HEADER_PROTOCOL_LC   "sec-websocket-protocol"    // "Sec-WebSocket-Protocol"
+
+#define WS_PROTOCOL_JSONRPC     "jsonrpc.xbmc.org"
+#define WS_HEADER_UPGRADE_VALUE "websocket"
+
+using namespace std;
+
+bool CWebSocketV13::Handshake(const char* data, size_t length, std::string &response)
+{
+  string strHeader(data, length);
+  const char *value;
+  HttpParser header;
+  if (header.addBytes(data, length) != HttpParser::Done)
+  {
+    CLog::Log(LOGINFO, "WebSocket [RFC6455]: incomplete handshake received");
+    return false;
+  }
+
+  // The request must be GET
+  value = header.getMethod();
+  if (value == NULL || strnicmp(value, WS_HTTP_METHOD, strlen(WS_HTTP_METHOD)) != 0)
+  {
+    CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid HTTP method received (GET expected)");
+    return false;
+  }
+
+  // The request must be HTTP/1.1 or higher
+  int pos;
+  if ((pos = strHeader.find(WS_HTTP_TAG)) == string::npos)
+  {
+    CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid handshake received");
+    return false;
+  }
+
+  pos += strlen(WS_HTTP_TAG);
+  istringstream converter(strHeader.substr(pos, strHeader.find_first_of(" \r\n\t", pos) - pos));
+  float fVersion;
+  converter >> fVersion;
+
+  if (fVersion < 1.1f)
+  {
+    CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid HTTP version %f (1.1 or higher expected)", fVersion);
+    return false;
+  }
+
+  string websocketKey, websocketProtocol;
+  // There must be a "Host" header
+  value = header.getValue("host");
+  if (value == NULL || strlen(value) == 0)
+  {
+    CLog::Log(LOGINFO, "WebSocket [RFC6455]: \"Host\" header missing");
+    return true;
+  }
+
+  // There must be a "Upgrade" header with the value "websocket"
+  value = header.getValue(WS_HEADER_UPGRADE_LC);
+  if (value == NULL || strcmp(value, WS_HEADER_UPGRADE_VALUE) != 0)
+  {
+    CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid \"%s\" received", WS_HEADER_UPGRADE);
+    return true;
+  }
+
+  // There must be a "Connection" header with the value "Upgrade"
+  value = header.getValue(WS_HEADER_CONNECTION_LC);
+  if (value == NULL || strcmp(value, WS_HEADER_UPGRADE) != 0)
+  {
+    CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid \"%s\" received", WS_HEADER_CONNECTION_LC);
+    return true;
+  }
+
+  // There must be a base64 encoded 16 byte (=> 24 byte as base62) "Sec-WebSocket-Key" header
+  value = header.getValue(WS_HEADER_KEY_LC);
+  if (value == NULL || (websocketKey = value).size() != 24)
+  {
+    CLog::Log(LOGINFO, "WebSocket [RFC6455]: invalid \"Sec-WebSocket-Key\" received");
+    return true;
+  }
+
+  // There might be a "Sec-WebSocket-Protocol" header
+  value = header.getValue(WS_HEADER_PROTOCOL_LC);
+  if (value && strlen(value) > 0)
+  {
+    CStdStringArray protocols;
+    StringUtils::SplitString(value, ",", protocols);
+    for (unsigned int index = 0; index < protocols.size(); index++)
+    {
+      if (protocols.at(index).Trim().Equals(WS_PROTOCOL_JSONRPC))
+      {
+        websocketProtocol = WS_PROTOCOL_JSONRPC;
+        break;
+      }
+    }
+  }
+
+  CHttpResponse httpResponse(HTTP::Get, HTTP::SwitchingProtocols, HTTP::Version1_1);
+  httpResponse.AddHeader(WS_HEADER_UPGRADE, WS_HEADER_UPGRADE_VALUE);
+  httpResponse.AddHeader(WS_HEADER_CONNECTION, WS_HEADER_UPGRADE);
+  std::string responseKey = calculateKey(websocketKey);
+  httpResponse.AddHeader(WS_HEADER_ACCEPT, responseKey);
+  if (!websocketProtocol.empty())
+    httpResponse.AddHeader(WS_HEADER_PROTOCOL, websocketProtocol);
+
+  char *responseBuffer;
+  int responseLength = httpResponse.Create(responseBuffer);
+  response = std::string(responseBuffer, responseLength);
+  
+  m_state = WebSocketStateConnected;
+
+  return true;
+}
+
+const CWebSocketFrame* CWebSocketV13::Close(WebSocketCloseReason reason /* = WebSocketCloseNormal */, const std::string &message /* = "" */)
+{
+  if (m_state == WebSocketStateNotConnected || m_state == WebSocketStateHandshaking || m_state == WebSocketStateClosed)
+  {
+    CLog::Log(LOGINFO, "WebSocket [RFC6455]: Cannot send a closing handshake if no connection has been established");
+    return NULL;
+  }
+
+  return close(reason, message);
+}

--- a/xbmc/network/websocket/WebSocketV13.h
+++ b/xbmc/network/websocket/WebSocketV13.h
@@ -1,0 +1,32 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "WebSocketV8.h"
+
+class CWebSocketV13 : public CWebSocketV8
+{
+public:
+  CWebSocketV13() { m_version = 13; }
+
+  virtual bool Handshake(const char* data, size_t length, std::string &response);
+  virtual const CWebSocketFrame* Close(WebSocketCloseReason reason = WebSocketCloseNormal, const std::string &message = "");
+};

--- a/xbmc/network/websocket/WebSocketV8.cpp
+++ b/xbmc/network/websocket/WebSocketV8.cpp
@@ -1,0 +1,206 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+#include <sstream>
+#include <boost/uuid/sha1.hpp>
+
+#include "WebSocketV8.h"
+#include "WebSocket.h"
+#include "utils/Base64.h"
+#include "utils/CharsetConverter.h"
+#include "utils/EndianSwap.h"
+#include "utils/HttpParser.h"
+#include "utils/HttpResponse.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+#define WS_HTTP_METHOD          "GET"
+#define WS_HTTP_TAG             "HTTP/"
+
+#define WS_HEADER_UPGRADE       "Upgrade"
+#define WS_HEADER_CONNECTION    "Connection"
+
+#define WS_HEADER_KEY_LC        "sec-websocket-key"         // "Sec-WebSocket-Key"
+#define WS_HEADER_ACCEPT        "Sec-WebSocket-Accept"
+#define WS_HEADER_PROTOCOL      "Sec-WebSocket-Protocol"
+#define WS_HEADER_PROTOCOL_LC   "sec-websocket-protocol"    // "Sec-WebSocket-Protocol"
+
+#define WS_PROTOCOL_JSONRPC     "jsonrpc.xbmc.org"
+#define WS_HEADER_UPGRADE_VALUE "websocket"
+#define WS_KEY_MAGICSTRING      "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+using namespace std;
+
+bool CWebSocketV8::Handshake(const char* data, size_t length, std::string &response)
+{
+  string strHeader(data, length);
+  const char *value;
+  HttpParser header;
+  if (header.addBytes(data, length) != HttpParser::Done)
+  {
+    CLog::Log(LOGINFO, "WebSocket [hybi-10]: incomplete handshake received");
+    return false;
+  }
+
+  // The request must be GET
+  value = header.getMethod();
+  if (value == NULL || strnicmp(value, WS_HTTP_METHOD, strlen(WS_HTTP_METHOD)) != 0)
+  {
+    CLog::Log(LOGINFO, "WebSocket [hybi-10]: invalid HTTP method received (GET expected)");
+    return false;
+  }
+
+  // The request must be HTTP/1.1 or higher
+  int pos;
+  if ((pos = strHeader.find(WS_HTTP_TAG)) == string::npos)
+  {
+    CLog::Log(LOGINFO, "WebSocket [hybi-10]: invalid handshake received");
+    return false;
+  }
+
+  pos += strlen(WS_HTTP_TAG);
+  istringstream converter(strHeader.substr(pos, strHeader.find_first_of(" \r\n\t", pos) - pos));
+  float fVersion;
+  converter >> fVersion;
+
+  if (fVersion < 1.1f)
+  {
+    CLog::Log(LOGINFO, "WebSocket [hybi-10]: invalid HTTP version %f (1.1 or higher expected)", fVersion);
+    return false;
+  }
+
+  string websocketKey, websocketProtocol;
+  // There must be a "Host" header
+  value = header.getValue("host");
+  if (value == NULL || strlen(value) == 0)
+  {
+    CLog::Log(LOGINFO, "WebSocket [hybi-10]: \"Host\" header missing");
+    return true;
+  }
+
+  // There must be a base64 encoded 16 byte (=> 24 byte as base64) "Sec-WebSocket-Key" header
+  value = header.getValue(WS_HEADER_KEY_LC);
+  if (value == NULL || (websocketKey = value).size() != 24)
+  {
+    CLog::Log(LOGINFO, "WebSocket [hybi-10]: invalid \"Sec-WebSocket-Key\" received");
+    return true;
+  }
+
+  // There might be a "Sec-WebSocket-Protocol" header
+  value = header.getValue(WS_HEADER_PROTOCOL_LC);
+  if (value && strlen(value) > 0)
+  {
+    CStdStringArray protocols;
+    StringUtils::SplitString(value, ",", protocols);
+    for (unsigned int index = 0; index < protocols.size(); index++)
+    {
+      if (protocols.at(index).Trim().Equals(WS_PROTOCOL_JSONRPC))
+      {
+        websocketProtocol = WS_PROTOCOL_JSONRPC;
+        break;
+      }
+    }
+  }
+
+  CHttpResponse httpResponse(HTTP::Get, HTTP::SwitchingProtocols, HTTP::Version1_1);
+  httpResponse.AddHeader(WS_HEADER_UPGRADE, WS_HEADER_UPGRADE_VALUE);
+  httpResponse.AddHeader(WS_HEADER_CONNECTION, WS_HEADER_UPGRADE);
+  httpResponse.AddHeader(WS_HEADER_ACCEPT, calculateKey(websocketKey));
+  if (!websocketProtocol.empty())
+    httpResponse.AddHeader(WS_HEADER_PROTOCOL, websocketProtocol);
+
+  char *responseBuffer;
+  int responseLength = httpResponse.Create(responseBuffer);
+  response = std::string(responseBuffer, responseLength);
+  
+  m_state = WebSocketStateConnected;
+
+  return true;
+}
+
+const CWebSocketFrame* CWebSocketV8::Close(WebSocketCloseReason reason /* = WebSocketCloseNormal */, const std::string &message /* = "" */)
+{
+  if (m_state == WebSocketStateNotConnected || m_state == WebSocketStateHandshaking || m_state == WebSocketStateClosed)
+  {
+    CLog::Log(LOGINFO, "WebSocket [hybi-10]: Cannot send a closing handshake if no connection has been established");
+    return NULL;
+  }
+
+  return close(reason, message);
+}
+
+void CWebSocketV8::Fail()
+{
+  m_state = WebSocketStateClosed;
+}
+
+CWebSocketFrame* CWebSocketV8::GetFrame(const char* data, uint64_t length)
+{
+  return new CWebSocketFrame(data, length);
+}
+
+CWebSocketFrame* CWebSocketV8::GetFrame(WebSocketFrameOpcode opcode, const char* data /* = NULL */, uint32_t length /* = 0 */,
+                                        bool final /* = true */, bool masked /* = false */, int32_t mask /* = 0 */, int8_t extension /* = 0 */)
+{
+  return new CWebSocketFrame(opcode, data, length, final, masked, mask, extension);
+}
+
+CWebSocketMessage* CWebSocketV8::GetMessage()
+{
+  return new CWebSocketMessage();
+}
+
+const CWebSocketFrame* CWebSocketV8::close(WebSocketCloseReason reason /* = WebSocketCloseNormal */, const std::string &message /* = "" */)
+{
+  size_t length = 2 + message.size();
+
+  char* data = new char[length + 1];
+  memset(data, 0, sizeof(data));
+  unsigned short iReason = Endian_SwapBE16((uint16_t)reason);
+  data[0] = ((char *)&iReason)[0];
+  data[1] = ((char *)&iReason)[1];
+  message.copy(data + 2, message.size());
+
+  if (m_state == WebSocketStateConnected)
+    m_state = WebSocketStateClosing;
+  else
+    m_state = WebSocketStateClosed;
+
+  return new CWebSocketFrame(WebSocketConnectionClose, data, length);
+}
+
+std::string CWebSocketV8::calculateKey(const std::string &key)
+{
+  string acceptKey = key;
+  acceptKey.append(WS_KEY_MAGICSTRING);
+
+  boost::uuids::detail::sha1 hash;
+  hash.process_bytes(acceptKey.c_str(), acceptKey.size());
+
+  unsigned int digest[5];
+  hash.get_digest(digest);
+
+  for (unsigned int index = 0; index < 5; index++)
+    digest[index] = Endian_SwapBE32(digest[index]);
+
+  return Base64::Encode((const char*)digest, sizeof(digest));
+}

--- a/xbmc/network/websocket/WebSocketV8.h
+++ b/xbmc/network/websocket/WebSocketV8.h
@@ -1,0 +1,43 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "WebSocket.h"
+
+class CWebSocketV8 : public CWebSocket
+{
+public:
+  CWebSocketV8() { m_version = 8; }
+
+  virtual bool Handshake(const char* data, size_t length, std::string &response);
+  virtual const CWebSocketFrame* Ping(const char* data = NULL) const { return new CWebSocketFrame(WebSocketPing, data); }
+  virtual const CWebSocketFrame* Pong(const char* data = NULL) const { return new CWebSocketFrame(WebSocketPong, data); }
+  virtual const CWebSocketFrame* Close(WebSocketCloseReason reason = WebSocketCloseNormal, const std::string &message = "");
+  virtual void Fail();
+
+protected:
+  virtual CWebSocketFrame* GetFrame(const char* data, uint64_t length);
+  virtual CWebSocketFrame* GetFrame(WebSocketFrameOpcode opcode, const char* data = NULL, uint32_t length = 0, bool final = true, bool masked = false, int32_t mask = 0, int8_t extension = 0);
+  virtual CWebSocketMessage* GetMessage();
+  virtual const CWebSocketFrame* close(WebSocketCloseReason reason = WebSocketCloseNormal, const std::string &message = "");
+
+  std::string calculateKey(const std::string &key);
+};

--- a/xbmc/utils/Base64.cpp
+++ b/xbmc/utils/Base64.cpp
@@ -1,0 +1,140 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "Base64.h"
+
+#define PADDING '='
+
+using namespace std;
+
+const std::string Base64::m_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                         "abcdefghijklmnopqrstuvwxyz"
+                                         "0123456789+/";
+
+void Base64::Encode(const char* input, unsigned int length, std::string &output)
+{
+  if (input == NULL || length == 0)
+    return;
+
+  long l;
+  output.clear();
+
+  for (unsigned int i = 0; i < length; i += 3)
+  {
+    l  = ((((unsigned long) input[i]) << 16) & 0xFFFFFF) |
+         ((((i + 1) < length) ? (((unsigned long) input[i + 1]) << 8) : 0) & 0xFFFF) |
+         ((((i + 2) < length) ? (((unsigned long) input[i + 2]) << 0) : 0) & 0x00FF);
+
+    output.push_back(m_characters[(l >> 18) & 0x3F]);
+    output.push_back(m_characters[(l >> 12) & 0x3F]);
+
+    if (i + 1 < length)
+      output.push_back(m_characters[(l >> 6) & 0x3F]);
+    if (i + 2 < length)
+      output.push_back(m_characters[(l >> 0) & 0x3F]);
+  }
+
+  int left = 3 - (length % 3);
+
+  if (length % 3)
+  {
+    for (int i = 0; i < left; i++)
+      output.push_back(PADDING);
+  }
+}
+
+std::string Base64::Encode(const char* input, unsigned int length)
+{
+  std::string output;
+  Encode(input, length, output);
+
+  return output;
+}
+
+void Base64::Encode(const std::string &input, std::string &output)
+{
+  Encode(input.c_str(), input.size(), output);
+}
+
+std::string Base64::Encode(const std::string &input)
+{
+  std::string output;
+  Encode(input, output);
+
+  return output;
+}
+
+void Base64::Decode(const char* input, unsigned int length, std::string &output)
+{
+  if (input == NULL || length == 0)
+    return;
+
+  long l;
+  output.clear();
+
+  for (unsigned int index = 0; index < length; index++)
+  {
+    if (input[index] == '=')
+    {
+      length = index;
+      break;
+    }
+  }
+
+  for (unsigned int i = 0; i < length; i += 4)
+  {
+    l = ((((unsigned long) m_characters.find(input[i])) & 0x3F) << 18);
+    l |= (((i + 1) < length) ? ((((unsigned long) m_characters.find(input[i + 1])) & 0x3F) << 12) : 0);
+    l |= (((i + 2) < length) ? ((((unsigned long) m_characters.find(input[i + 2])) & 0x3F) <<  6) : 0);
+    l |= (((i + 3) < length) ? ((((unsigned long) m_characters.find(input[i + 3])) & 0x3F) <<  0) : 0);
+
+    output.push_back((char)((l >> 16) & 0xFF));
+    if (i + 2 < length)
+      output.push_back((char)((l >> 8) & 0xFF));
+    if (i + 3 < length)
+      output.push_back((char)((l >> 0) & 0xFF));
+  }
+}
+
+std::string Base64::Decode(const char* input, unsigned int length)
+{
+  std::string output;
+  Decode(input, length, output);
+
+  return output;
+}
+
+void Base64::Decode(const std::string &input, std::string &output)
+{
+  size_t length = input.find_first_of(PADDING);
+  if (length == string::npos)
+    length = input.size();
+
+  Decode(input.c_str(), length, output);
+}
+
+std::string Base64::Decode(const std::string &input)
+{
+  std::string output;
+  Decode(input, output);
+
+  return output;
+}

--- a/xbmc/utils/Base64.h
+++ b/xbmc/utils/Base64.h
@@ -1,0 +1,39 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+
+class Base64
+{
+public:
+  static void Encode(const char* input, unsigned int length, std::string &output);
+  static std::string Encode(const char* input, unsigned int length);
+  static void Encode(const std::string &input, std::string &output);
+  static std::string Encode(const std::string &input);
+  static void Decode(const char* input, unsigned int length, std::string &output);
+  static std::string Decode(const char* input, unsigned int length);
+  static void Decode(const std::string &input, std::string &output);
+  static std::string Decode(const std::string &input);
+
+private:
+  static const std::string m_characters;
+};

--- a/xbmc/utils/HttpResponse.cpp
+++ b/xbmc/utils/HttpResponse.cpp
@@ -1,0 +1,180 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+ 
+#include <stdio.h>
+
+#include "HttpResponse.h"
+
+#define SPACE     " "
+#define SEPARATOR ": "
+#define LINEBREAK "\r\n"
+
+#define HEADER_CONTENT_LENGTH "Content-Length"
+
+std::map<HTTP::StatusCode, std::string> CHttpResponse::m_statusCodeText = CHttpResponse::createStatusCodes();
+
+CHttpResponse::CHttpResponse(HTTP::Method method, HTTP::StatusCode status, HTTP::Version version /* = HTTPVersion1_1 */)
+{
+  m_method = method;
+  m_status = status;
+  m_version = version;
+
+  m_content = NULL;
+  m_contentLength = 0;
+}
+
+void CHttpResponse::AddHeader(const std::string &field, const std::string &value)
+{
+  if (field.empty())
+    return;
+
+  m_headers.push_back(std::pair<std::string, std::string>(field, value));
+}
+
+void CHttpResponse::SetContent(const char* data, unsigned int length)
+{
+  m_content = data;
+
+  if (m_content == NULL)
+    m_contentLength = 0;
+  else
+    m_contentLength = length;
+}
+
+unsigned int CHttpResponse::Create(char *&response)
+{
+  m_buffer.clear();
+
+  m_buffer.append("HTTP/");
+  switch (m_version)
+  {
+    case HTTP::Version1_0:
+      m_buffer.append("1.0");
+      break;
+
+    case HTTP::Version1_1:
+      m_buffer.append("1.1");
+      break;
+
+    default:
+      return 0;
+  }
+
+  char statusBuffer[4];
+  sprintf(statusBuffer, "%d", (int)m_status);
+  m_buffer.append(SPACE);
+  m_buffer.append(statusBuffer);
+
+  m_buffer.append(SPACE);
+  m_buffer.append(m_statusCodeText.find(m_status)->second);
+  m_buffer.append(LINEBREAK);
+
+  bool hasContentLengthHeader = false;
+  for (unsigned int index = 0; index < m_headers.size(); index++)
+  {
+    m_buffer.append(m_headers[index].first);
+    m_buffer.append(SEPARATOR);
+    m_buffer.append(m_headers[index].second);
+    m_buffer.append(LINEBREAK);
+
+    if (m_headers[index].first.compare(HEADER_CONTENT_LENGTH) == 0)
+      hasContentLengthHeader = true;
+  }
+
+  if (!hasContentLengthHeader && m_content != NULL && m_contentLength > 0)
+  {
+    m_buffer.append(HEADER_CONTENT_LENGTH);
+    m_buffer.append(SEPARATOR);
+    char lengthBuffer[11];
+    sprintf(lengthBuffer, "%d", m_contentLength);
+    m_buffer.append(lengthBuffer);
+    m_buffer.append(LINEBREAK);
+  }
+
+  m_buffer.append(LINEBREAK);
+  if (m_content != NULL && m_contentLength > 0)
+    m_buffer.append(m_content, m_contentLength);
+
+  response = (char *)m_buffer.c_str();
+  return m_buffer.size();
+}
+
+std::map<HTTP::StatusCode, std::string> CHttpResponse::createStatusCodes()
+{
+  std::map<HTTP::StatusCode, std::string> map;
+  map[HTTP::Continue]                      = "Continue";
+  map[HTTP::SwitchingProtocols]            = "Switching Protocols";
+  map[HTTP::Processing]                    = "Processing";
+  map[HTTP::ConnectionTimedOut]            = "Connection timed out";
+  map[HTTP::OK]                            = "OK";
+  map[HTTP::Created]                       = "Created";
+  map[HTTP::Accepted]                      = "Accepted";
+  map[HTTP::NonAuthoritativeInformation]   = "Non-Authoritative Information";
+  map[HTTP::NoContent]                     = "No Content";
+  map[HTTP::ResetContent]                  = "Reset Content";
+  map[HTTP::PartialContent]                = "Partial Content";
+  map[HTTP::MultiStatus]                   = "Multi-Status";
+  map[HTTP::MultipleChoices]               = "Multiple Choices";
+  map[HTTP::MovedPermanently]              = "Moved Permanently";
+  map[HTTP::Found]                         = "Found";
+  map[HTTP::SeeOther]                      = "See Other";
+  map[HTTP::NotModified]                   = "Not Modified";
+  map[HTTP::UseProxy]                      = "Use Proxy";
+  //map[HTTP::SwitchProxy]                 = "Switch Proxy";
+  map[HTTP::TemporaryRedirect]             = "Temporary Redirect";
+  map[HTTP::BadRequest]                    = "Bad Request";
+  map[HTTP::Unauthorized]                  = "Unauthorized";
+  map[HTTP::PaymentRequired]               = "Payment Required";
+  map[HTTP::Forbidden]                     = "Forbidden";
+  map[HTTP::NotFound]                      = "Not Found";
+  map[HTTP::MethodNotAllowed]              = "Method Not Allowed";
+  map[HTTP::NotAcceptable]                 = "Not Acceptable";
+  map[HTTP::ProxyAuthenticationRequired]   = "Proxy Authentication Required";
+  map[HTTP::RequestTimeout]                = "Request Time-out";
+  map[HTTP::Conflict]                      = "Conflict";
+  map[HTTP::Gone]                          = "Gone";
+  map[HTTP::LengthRequired]                = "Length Required";
+  map[HTTP::PreconditionFailed]            = "Precondition Failed";
+  map[HTTP::RequestEntityTooLarge]         = "Request Entity Too Large";
+  map[HTTP::RequestURITooLong]             = "Request-URI Too Long";
+  map[HTTP::UnsupportedMediaType]          = "Unsupported Media Type";
+  map[HTTP::RequestedRangeNotSatisfiable]  = "Requested range not satisfiable";
+  map[HTTP::ExpectationFailed]             = "Expectation Failed";
+  map[HTTP::ImATeapot]                     = "I'm a Teapot";
+  map[HTTP::TooManyConnections]            = "There are too many connections from your internet address";
+  map[HTTP::UnprocessableEntity]           = "Unprocessable Entity";
+  map[HTTP::Locked]                        = "Locked";
+  map[HTTP::FailedDependency]              = "Failed Dependency";
+  map[HTTP::UnorderedCollection]           = "UnorderedCollection";
+  map[HTTP::UpgradeRequired]               = "Upgrade Required";
+  map[HTTP::InternalServerError]           = "Internal Server Error";
+  map[HTTP::NotImplemented]                = "Not Implemented";
+  map[HTTP::BadGateway]                    = "Bad Gateway";
+  map[HTTP::ServiceUnavailable]            = "Service Unavailable";
+  map[HTTP::GatewayTimeout]                = "Gateway Time-out";
+  map[HTTP::HTTPVersionNotSupported]       = "HTTP Version not supported";
+  map[HTTP::VariantAlsoNegotiates]         = "Variant Also Negotiates";
+  map[HTTP::InsufficientStorage]           = "Insufficient Storage";
+  map[HTTP::BandwidthLimitExceeded]        = "Bandwidth Limit Exceeded";
+  map[HTTP::NotExtended]                   = "Not Extended";
+
+  return map;
+}

--- a/xbmc/utils/HttpResponse.h
+++ b/xbmc/utils/HttpResponse.h
@@ -1,0 +1,136 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+#include <vector>
+#include <map>
+
+namespace HTTP
+{
+  enum Version
+  {
+    Version1_0,
+    Version1_1
+  };
+
+  enum Method
+  {
+    Get,
+    Head,
+    POST,
+    PUT,
+    Delete,
+    Trace,
+    Connect
+  };
+
+  enum StatusCode
+  {
+    // Information 1xx
+    Continue                      = 100,
+    SwitchingProtocols            = 101,
+    Processing                    = 102,
+    ConnectionTimedOut            = 103,
+
+    // Success 2xx
+    OK                            = 200,
+    Created                       = 201,
+    Accepted                      = 202,
+    NonAuthoritativeInformation   = 203,
+    NoContent                     = 204,
+    ResetContent                  = 205,
+    PartialContent                = 206,
+    MultiStatus                   = 207,
+
+    // Redirects 3xx
+    MultipleChoices               = 300,
+    MovedPermanently              = 301,
+    Found                         = 302,
+    SeeOther                      = 303,
+    NotModified                   = 304,
+    UseProxy                      = 305,
+    //SwitchProxy                 = 306,
+    TemporaryRedirect             = 307,
+
+    // Client errors 4xx
+    BadRequest                    = 400,
+    Unauthorized                  = 401,
+    PaymentRequired               = 402,
+    Forbidden                     = 403,
+    NotFound                      = 404,
+    MethodNotAllowed              = 405,
+    NotAcceptable                 = 406,
+    ProxyAuthenticationRequired   = 407,
+    RequestTimeout                = 408,
+    Conflict                      = 409,
+    Gone                          = 410,
+    LengthRequired                = 411,
+    PreconditionFailed            = 412,
+    RequestEntityTooLarge         = 413,
+    RequestURITooLong             = 414,
+    UnsupportedMediaType          = 415,
+    RequestedRangeNotSatisfiable  = 416,
+    ExpectationFailed             = 417,
+    ImATeapot                     = 418,
+    TooManyConnections            = 421,
+    UnprocessableEntity           = 422,
+    Locked                        = 423,
+    FailedDependency              = 424,
+    UnorderedCollection           = 425,
+    UpgradeRequired               = 426,
+
+    // Server errors 5xx
+    InternalServerError           = 500,
+    NotImplemented                = 501,
+    BadGateway                    = 502,
+    ServiceUnavailable            = 503,
+    GatewayTimeout                = 504,
+    HTTPVersionNotSupported       = 505,
+    VariantAlsoNegotiates         = 506,
+    InsufficientStorage           = 507,
+    BandwidthLimitExceeded        = 509,
+    NotExtended                   = 510
+  };
+}
+
+class CHttpResponse
+{
+public:
+  CHttpResponse(HTTP::Method method, HTTP::StatusCode status, HTTP::Version version = HTTP::Version1_1);
+
+  void AddHeader(const std::string &field, const std::string &value);
+  void SetContent(const char* data, unsigned int length);
+
+  unsigned int Create(char *&response);
+
+private:
+  HTTP::Method m_method;
+  HTTP::StatusCode m_status;
+  HTTP::Version m_version;
+  std::vector< std::pair<std::string, std::string> > m_headers;
+  const char* m_content;
+  unsigned int m_contentLength;
+  std::string m_buffer;
+
+  static std::map<HTTP::StatusCode, std::string> m_statusCodeText;
+  static std::map<HTTP::StatusCode, std::string> createStatusCodes();
+};

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -23,6 +23,7 @@ SRCS=AlarmClock.cpp \
      HTMLUtil.cpp \
      HttpHeader.cpp \
      HttpParser.cpp \
+		 HttpResponse.cpp \
      InfoLoader.cpp \
      JobManager.cpp \
      JSONVariantParser.cpp \

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -3,6 +3,7 @@ SRCS=AlarmClock.cpp \
      Archive.cpp \
      AsyncFileCopy.cpp \
      AutoPtrHandle.cpp \
+		 Base64.cpp \
      BitstreamStats.cpp \
      CharsetConverter.cpp \
      CPUInfo.cpp \


### PR DESCRIPTION
These commits add support for websockets (http://en.wikipedia.org/wiki/WebSocket) to CTCPServer so that web-based JSON-RPC clients can also benefit from the advantages of JSON-RPC over TCP like notifications sent by XBMC.

This PR only adds support for the IETF draft hybi-10 (http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-10) which handles websocket requests with version 8 but I have written the WebSocketManager in a way so that it can be extended with additional versions. The reason I chose the IETF draft hybi-10 is because it is the first draft that does not have a serious security issue all the earlier drafts suffered from and it is currently supported by Firefox 7, Chrome 14 and the developer version of IE 10.

EDIT (December 13): Yesterday the IETF released http://tools.ietf.org/html/rfc6455 which standardizes Websocket version 13 so I finally took the time to also add support for version 13 (there's no version between 8 and 13 in case someone wonders). Hopefully this also means that websocket support will be finally added to all modern browsers.

As usual I mainly tested this on win32 and with Chrome 14 but I also tested it once on linux and updated the makefiles. No testing on osx yet and the osx project files haven't been updated either.

PS: This PR also includes two new utility classes Base64 and CHttpResponse. Both could probably be used in other code parts as well (IIRC the airtunes/airplay server contains some code that manually puts together a HTTP response).
