### PR TITLE
Fixes for Video cleaning

### DIFF
--- a/xbmc/filesystem/FileCurl.cpp
+++ b/xbmc/filesystem/FileCurl.cpp
@@ -1135,8 +1135,8 @@ int CFileCurl::Stat(const CURL& url, struct __stat64* buffer)
 
   if(buffer)
   {
-    char content[255];
-    if (CURLE_OK != g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_CONTENT_TYPE, content))
+    char *content;
+    if (CURLE_OK != g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_CONTENT_TYPE, &content))
     {
       g_curlInterface.easy_release(&m_state->m_easyHandle, NULL);
       errno = ENOENT;
@@ -1146,7 +1146,7 @@ int CFileCurl::Stat(const CURL& url, struct __stat64* buffer)
     {
       memset(buffer, 0, sizeof(struct __stat64));
       buffer->st_size = (int64_t)length;
-      if(strstr(content, "text/html")) //consider html files directories
+      if(content && strstr(content, "text/html")) //consider html files directories
         buffer->st_mode = _S_IFDIR;
       else
         buffer->st_mode = _S_IFREG;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6645,8 +6645,8 @@ void CVideoDatabase::CleanDatabase(IVideoInfoScannerObserver* pObserver, const v
       m_pDS->exec(sql.c_str());
     }
 
-    CLog::Log(LOGDEBUG, "%s: Cleaning paths that don't exist and don't have content set...", __FUNCTION__);
-    sql = "select * from path where strContent not like ''";
+    CLog::Log(LOGDEBUG, "%s: Cleaning paths that don't exist and have content set...", __FUNCTION__);
+    sql = "select * from path where strContent != ''";
     m_pDS->query(sql.c_str());
     CStdString strIds;
     while (!m_pDS->eof())


### PR DESCRIPTION
Hi,

Here are 2 fixes for bugs I encountered when cleaning videos:

1) g_curlInterface.easy_getinfo with CURLINFO_CONTENT_TYPE requires a pointer to char pointer, not a char pointer. See http://curl.haxx.se/libcurl/c/getinfo.html for an example.
The issue here is that the mime-type is not correctly, returned, so HTTP directories cannot be detected and the Video cleaning delete the http paths

2) In VideoDatabase.cpp, a logging says "Cleaning paths that don't exist and don't have content set...", while the sql actually selects for deletion the paths which HAVE content set. I assume this is a bug.
