### PR TITLE
Allow displaying text on splash screen

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -42,6 +42,7 @@
 #include "guilib/GUIDialog.h"
 #include "windowing/WindowingFactory.h"
 #include "GUIInfoManager.h"
+#include "utils/Splash.h"
 
 #include "powermanagement/PowerManager.h"
 
@@ -748,6 +749,11 @@ case TMSG_POWERDOWN:
         CAction action((int)pMsg->dwParam1);
         g_application.ShowVolumeBar(&action);
       }
+    case TMSG_SPLASH_MESSAGE:
+      {
+        if (g_application.m_splash)
+          g_application.m_splash->Show(pMsg->strParam);
+      }
   }
 }
 
@@ -1172,4 +1178,16 @@ void CApplicationMessenger::ShowVolumeBar(bool up)
   ThreadMessage tMsg = {TMSG_VOLUME_SHOW};
   tMsg.dwParam1 = up ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN;
   SendMessage(tMsg, false);
+}
+
+void CApplicationMessenger::SetSplashMessage(const CStdString& message)
+{
+  ThreadMessage tMsg = {TMSG_SPLASH_MESSAGE};
+  tMsg.strParam = message;
+  SendMessage(tMsg, true);
+}
+
+void CApplicationMessenger::SetSplashMessage(int stringID)
+{
+  SetSplashMessage(g_localizeStrings.Get(stringID));
 }

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -96,6 +96,7 @@ class CGUIWindow;
 #define TMSG_CALLBACK             800
 
 #define TMSG_VOLUME_SHOW          900
+#define TMSG_SPLASH_MESSAGE       901
 
 typedef struct
 {
@@ -198,6 +199,9 @@ public:
   void OpticalUnMount(CStdString device);
 
   void ShowVolumeBar(bool up);
+
+  void SetSplashMessage(const CStdString& message);
+  void SetSplashMessage(int stringID);
 
 private:
   void ProcessMessage(ThreadMessage *pMsg);

--- a/xbmc/utils/Splash.cpp
+++ b/xbmc/utils/Splash.cpp
@@ -22,6 +22,8 @@
 #include "system.h"
 #include "Splash.h"
 #include "guilib/GUIImage.h"
+#include "guilib/GUILabelControl.h"
+#include "guilib/GUIFontManager.h"
 #include "filesystem/File.h"
 #include "windowing/WindowingFactory.h"
 #include "rendering/RenderSystem.h"
@@ -33,12 +35,17 @@ CSplash::CSplash(const CStdString& imageName)
 {
   m_ImageName = imageName;
   fade = 0.5;
+  m_messageLayout = NULL;
+  m_image = NULL;
+  m_layoutWasLoading = false;
 }
 
 
 CSplash::~CSplash()
 {
   Stop();
+  delete m_image;
+  delete m_messageLayout;
 }
 
 void CSplash::OnStartup()
@@ -49,21 +56,54 @@ void CSplash::OnExit()
 
 void CSplash::Show()
 {
+  Show("");
+}
+
+void CSplash::Show(const CStdString& message)
+{
   g_graphicsContext.Lock();
   g_graphicsContext.Clear();
 
   RESOLUTION_INFO res(1280,720,0);
   g_graphicsContext.SetRenderingResolution(res, true);  
-  CGUIImage* image = new CGUIImage(0, 0, 0, 0, 1280, 720, m_ImageName);  
-  image->SetAspectRatio(CAspectRatio::AR_CENTER);  
+  if (!m_image)
+  {
+    m_image = new CGUIImage(0, 0, 0, 0, 1280, 720, m_ImageName);
+    m_image->SetAspectRatio(CAspectRatio::AR_CENTER);
+  }
 
   //render splash image
   g_Windowing.BeginRender();
 
-  image->AllocResources();
-  image->Render();
-  image->FreeResources();
-  delete image;
+  m_image->AllocResources();
+  m_image->Render();
+  m_image->FreeResources();
+
+  // render message
+  if (!message.IsEmpty())
+  {
+    if (!m_layoutWasLoading)
+    {
+      // load arial font, white body, no shadow, size: 20, no additional styling
+      CGUIFont *messageFont = g_fontManager.LoadTTF("__splash__", "arial.ttf", 0xFFFFFFFF, 0, 20, FONT_STYLE_NORMAL, false, 1.0f, 1.0f, &res);
+      if (messageFont)
+        m_messageLayout = new CGUITextLayout(messageFont, true, 0);
+      m_layoutWasLoading = true;
+    }
+    if (m_messageLayout)
+    {
+      m_messageLayout->Update(message, 1150, false, true);
+
+      float textWidth, textHeight;
+      m_messageLayout->GetTextExtent(textWidth, textHeight);
+      // ideally place text in center of empty area below splash image
+      float y = 540 + m_image->GetTextureHeight() / 4 - textHeight / 2;
+      if (y + textHeight > 720) // make sure entire text is visible
+        y = 720 - textHeight;
+
+      m_messageLayout->RenderOutline(640, y, 0, 0xFF000000, XBFONT_CENTER_X, 1280);
+    }
+  }
 
   //show it on screen
   g_Windowing.EndRender();

--- a/xbmc/utils/Splash.h
+++ b/xbmc/utils/Splash.h
@@ -24,6 +24,9 @@
 #include "StdString.h"
 #include "threads/Thread.h"
 
+class CGUITextLayout;
+class CGUIImage;
+
 class CSplash : public CThread
 {
 public:
@@ -36,6 +39,7 @@ public:
 
   // In case you don't want to use another thread
   void Show();
+  void Show(const CStdString& message);
   void Hide();
 
 private:
@@ -45,6 +49,10 @@ private:
 
   float fade;
   CStdString m_ImageName;
+
+  CGUITextLayout* m_messageLayout;
+  CGUIImage* m_image;
+  bool m_layoutWasLoading;
 #ifdef HAS_DX
   D3DGAMMARAMP newRamp;
   D3DGAMMARAMP oldRamp;


### PR DESCRIPTION
This PR adds possibility to display text message on splash screen. This can be used to notify user about whatever time-consuming tasks we may be doing on startup (like f.e. database update - what, I think, was reason I was asked to cook this up).

To show message we call

<pre>
// in case we build text string using string::format()
g_application.getApplicationMessenger().SetSplashMessage("some text"); 
// localized string
g_application.getApplicationMessenger().SetSplashMessage(12345);</pre>


And it looks like this:
http://dl.dropbox.com/u/28899396/splash_text.png (text is rendered centered in area below splash image)
