### PR TITLE
Fix compiling with external ffmpeg libraries

### DIFF
--- a/xbmc/xbmc.cpp
+++ b/xbmc/xbmc.cpp
@@ -101,6 +101,7 @@ int main(int argc, char* argv[])
   return status;
 }
 
+#ifndef USE_EXTERNAL_FFMPEG
 extern "C"
 {
   void mp_msg( int x, int lev, const char *format, ... )
@@ -119,3 +120,4 @@ extern "C"
     OutputDebugString(tmp);
   }
 }
+#endif


### PR DESCRIPTION
Fix multiply defined mp_msg when compiling with external ffmpeg libraries.
