### PR TITLE
Fix font issues for ass subtitles

### DIFF
--- a/system/players/dvdplayer/etc/fonts/fonts.conf
+++ b/system/players/dvdplayer/etc/fonts/fonts.conf
@@ -23,8 +23,13 @@
 
 <!-- Font directory list -->
 
-	<dir>WINDOWSFONTDIR</dir>
-	
+<!--
+  Uncomment this directory if we need libass and fontconfig to access all system fonts.
+  The drawback is the long initial indexing time by fontconfig, and mkv files usually
+  include their fonts.
+  <dir>WINDOWSFONTDIR</dir>
+-->
+  <dir>../../media/Fonts</dir>
 	<dir>~/.fonts</dir>
 
 <!-- Font cache directory list -->

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -739,6 +739,19 @@ void CUtil::ClearSubtitles()
   }
 }
 
+void CUtil::ClearTempFonts()
+{
+  CFileItemList items;
+  CDirectory::GetDirectory("special://temp/fonts/", items, "", false, false, XFILE::DIR_CACHE_NEVER);
+
+  for (int i=0; i<items.Size(); ++i)
+  {
+    if (items[i]->m_bIsFolder)
+      continue;
+    CFile::Delete(items[i]->GetPath());
+  }
+}
+
 static const char * sub_exts[] = { ".utf", ".utf8", ".utf-8", ".sub", ".srt", ".smi", ".rt", ".txt", ".ssa", ".aqt", ".jss", ".ass", ".idx", NULL};
 
 int64_t CUtil::ToInt64(uint32_t high, uint32_t low)

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -79,6 +79,7 @@ public:
   static bool GetDirectoryName(const CStdString& strFileName, CStdString& strDescription);
   static void GetDVDDriveIcon( const CStdString& strPath, CStdString& strIcon );
   static void RemoveTempFiles();
+  static void ClearTempFonts();
 
   static void ClearSubtitles();
   static void ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CStdString>& vecSubtitles );

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -433,6 +433,9 @@ void CDVDPlayer::OnStartup()
   m_messenger.Init();
 
   g_dvdPerformanceCounter.EnableMainPerformance(ThreadHandle());
+#ifdef TARGET_WINDOWS
+  CUtil::ClearTempFonts();
+#endif
 }
 
 bool CDVDPlayer::OpenInputStream()

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -433,9 +433,8 @@ void CDVDPlayer::OnStartup()
   m_messenger.Init();
 
   g_dvdPerformanceCounter.EnableMainPerformance(ThreadHandle());
-#ifdef TARGET_WINDOWS
+
   CUtil::ClearTempFonts();
-#endif
 }
 
 bool CDVDPlayer::OpenInputStream()

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -95,7 +95,7 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
 
   // libass uses fontconfig (system lib) which is not wrapped
   //  so translate the path before calling into libass
-  m_dll.ass_set_fonts(m_renderer, _P(strPath).c_str(), "", fc, NULL, update);
+  m_dll.ass_set_fonts(m_renderer, _P(strPath).c_str(), "Arial", fc, NULL, update);
 }
 
 

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -79,15 +79,6 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
   strPath = "special://xbmc/media/Fonts/";
   strPath += g_guiSettings.GetString("subtitles.font");
   int fc = !g_guiSettings.GetBool("subtitles.overrideassfonts");
-  // Calling ass_set_fonts with update = 1 is the correct usage. However font problems were only
-  // reported on Windows and not tested properly on all platforms, so restrict the change to Windows
-  // at this time.
-  int update;
-#ifdef TARGET_WINDOWS
-  update = 1;
-#else
-  update = 0;
-#endif
 
   m_dll.ass_set_margins(m_renderer, 0, 0, 0, 0);
   m_dll.ass_set_use_margins(m_renderer, 0);
@@ -95,7 +86,7 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
 
   // libass uses fontconfig (system lib) which is not wrapped
   //  so translate the path before calling into libass
-  m_dll.ass_set_fonts(m_renderer, _P(strPath).c_str(), "Arial", fc, NULL, update);
+  m_dll.ass_set_fonts(m_renderer, _P(strPath).c_str(), "Arial", fc, NULL, 1);
 }
 
 

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -79,13 +79,23 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
   strPath = "special://xbmc/media/Fonts/";
   strPath += g_guiSettings.GetString("subtitles.font");
   int fc = !g_guiSettings.GetBool("subtitles.overrideassfonts");
+  // Calling ass_set_fonts with update = 1 is the correct usage. However font problems were only
+  // reported on Windows and not tested properly on all platforms, so restrict the change to Windows
+  // at this time.
+  int update;
+#ifdef TARGET_WINDOWS
+  update = 1;
+#else
+  update = 0;
+#endif
 
   m_dll.ass_set_margins(m_renderer, 0, 0, 0, 0);
   m_dll.ass_set_use_margins(m_renderer, 0);
   m_dll.ass_set_font_scale(m_renderer, 1);
+
   // libass uses fontconfig (system lib) which is not wrapped
   //  so translate the path before calling into libass
-  m_dll.ass_set_fonts(m_renderer, _P(strPath).c_str(), "", fc, NULL, 0);
+  m_dll.ass_set_fonts(m_renderer, _P(strPath).c_str(), "", fc, NULL, update);
 }
 
 


### PR DESCRIPTION
Fixes issues with the samples of ticket 12023, where incorrect fonts were chosen.
- call ass_set_fonts with update = 1 as required in API
- clean temp fonts directory to avoid slow downs and conflicts
- make Arial font (the fallback) always available without taking the performance hit of adding all system fonts.

At this time, this is only activated for Windows as it's all I can test.
Should be safe for Linux, since fontconfig is a well-integrated system library. Test results welcome.
The unknown is OSX, test results welcome.

edit: added samples made from the ticket videos, on team ftp, samples/12023
sample1 is the beginning of the ticket video 1. Same as ticket screenshot.
sample2-orig has altered timing of orig. video 2. Shows the fonts of the screenshot at 00:05. Then a slightly different font is used.
sample2-alt is same as sample2-orig except it uses a font that's not provided by xbmc or the sample. May be provided by the system.
sample2-alt2 is same as sample2-orig except it uses a font that's not provided by xbmc or the sample. Definitely not provided by the system. Should fall back on standard Arial.
sample 3 is a smaller piece of the original.  See ticket screenshot for expected result.
