### PR TITLE
guilib: execute actions when going through navigation path

### DIFF
--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -38,7 +38,7 @@ CGUIAction::CGUIAction(int controlID)
   SetNavigation(controlID);
 }
 
-bool CGUIAction::Execute(int controlID, int parentID, int direction /*= 0*/) const
+bool CGUIAction::ExecuteActions(int controlID, int parentID) const
 {
   if (m_actions.size() == 0) return false;
   bool retval = false;
@@ -47,21 +47,7 @@ bool CGUIAction::Execute(int controlID, int parentID, int direction /*= 0*/) con
   {
     if (it->condition.IsEmpty() || g_infoManager.EvaluateBool(it->condition))
     {
-      if (StringUtils::IsInteger(it->action))
-      {
-        CGUIMessage msg(GUI_MSG_MOVE, parentID, controlID, direction);
-        if (parentID)
-        {
-          CGUIWindow *pWindow = g_windowManager.GetWindow(parentID);
-          if (pWindow)
-          {
-            retval |= pWindow->OnMessage(msg);
-            continue;
-          }
-        }
-        retval |= g_windowManager.SendMessage(msg);
-      }
-      else
+      if (!StringUtils::IsInteger(it->action))
       {
         CGUIMessage msg(GUI_MSG_EXECUTE, controlID, parentID);
         msg.SetStringParam(it->action);

--- a/xbmc/guilib/GUIAction.h
+++ b/xbmc/guilib/GUIAction.h
@@ -35,9 +35,9 @@ public:
   CGUIAction(int controlID);
 
   /**
-   * Execute actions, if action is paired with condition - evaluate condition first
+   * Execute actions (no navigation paths), if action is paired with condition - evaluate condition first
    */
-  bool Execute(int controlID, int parentID, int direction = 0) const;
+  bool ExecuteActions(int controlID, int parentID) const;
   /**
    * Check if there is any action that meet its condition
    */

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -700,7 +700,7 @@ bool CGUIBaseContainer::OnClick(int actionID)
       if (selected >= 0 && selected < (int)m_items.size())
       {
         CGUIStaticItemPtr item = boost::static_pointer_cast<CGUIStaticItem>(m_items[selected]);
-        item->GetClickActions().Execute(GetID(), GetParentID());
+        item->GetClickActions().ExecuteActions(GetID(), GetParentID());
       }
       return true;
     }

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -307,17 +307,17 @@ void CGUIButtonControl::OnClick()
   CGUIMessage msg(GUI_MSG_CLICKED, controlID, parentID, 0);
   SendWindowMessage(msg);
 
-  clickActions.Execute(controlID, parentID);
+  clickActions.ExecuteActions(controlID, parentID);
 }
 
 void CGUIButtonControl::OnFocus()
 {
-  m_focusActions.Execute(GetID(), GetParentID());
+  m_focusActions.ExecuteActions(GetID(), GetParentID());
 }
 
 void CGUIButtonControl::OnUnFocus()
 {
-  m_unfocusActions.Execute(GetID(), GetParentID());
+  m_unfocusActions.ExecuteActions(GetID(), GetParentID());
 }
 
 void CGUIButtonControl::SetSelected(bool bSelected)

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -224,46 +224,50 @@ bool CGUIControl::OnAction(const CAction &action)
   return false;
 }
 
+bool CGUIControl::Navigate(int direction)
+{
+  if (HasFocus())
+  {
+    CGUIMessage msg(GUI_MSG_MOVE, GetParentID(), GetID(), direction);
+    return SendWindowMessage(msg);
+  }
+  return false;
+}
+
 // Movement controls (derived classes can override)
 void CGUIControl::OnUp()
 {
-  if (HasFocus())
-    m_actionUp.Execute(GetID(), GetParentID(), ACTION_MOVE_UP);
+  Navigate(ACTION_MOVE_UP);
 }
 
 void CGUIControl::OnDown()
 {
-  if (HasFocus())
-    m_actionDown.Execute(GetID(), GetParentID(), ACTION_MOVE_DOWN);
+  Navigate(ACTION_MOVE_DOWN);
 }
 
 void CGUIControl::OnLeft()
 {
-  if (HasFocus())
-    m_actionLeft.Execute(GetID(), GetParentID(), ACTION_MOVE_LEFT);
+  Navigate(ACTION_MOVE_LEFT);
 }
 
 void CGUIControl::OnRight()
 {
-  if (HasFocus())
-    m_actionRight.Execute(GetID(), GetParentID(), ACTION_MOVE_RIGHT);
+  Navigate(ACTION_MOVE_RIGHT);
 }
 
 bool CGUIControl::OnBack()
 {
-  return HasFocus() ? m_actionBack.Execute(GetID(), GetParentID(), ACTION_NAV_BACK) : false;
+  return Navigate(ACTION_NAV_BACK);
 }
 
 void CGUIControl::OnNextControl()
 {
-  if (HasFocus())
-    m_actionNext.Execute(GetID(), GetParentID(), ACTION_NEXT_CONTROL);
+  Navigate(ACTION_NEXT_CONTROL);
 }
 
 void CGUIControl::OnPrevControl()
 {
-  if (HasFocus())
-    m_actionPrev.Execute(GetID(), GetParentID(), ACTION_PREV_CONTROL);
+  Navigate(ACTION_PREV_CONTROL);
 }
 
 bool CGUIControl::SendWindowMessage(CGUIMessage &message)

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -890,22 +890,27 @@ bool CGUIControl::IsAnimating(ANIMATION_TYPE animType)
   return false;
 }
 
-int CGUIControl::GetNextControl(int direction) const
+bool CGUIControl::GetNavigationAction(int direction, CGUIAction& action) const
 {
   switch (direction)
   {
   case ACTION_MOVE_UP:
-    return m_actionUp.GetNavigation();
+    action = m_actionUp;
+    return true;
   case ACTION_MOVE_DOWN:
-    return m_actionDown.GetNavigation();
+    action = m_actionDown;
+    return true;
   case ACTION_MOVE_LEFT:
-    return m_actionLeft.GetNavigation();
+    action = m_actionLeft;
+    return true;
   case ACTION_MOVE_RIGHT:
-    return m_actionRight.GetNavigation();
+    action = m_actionRight;
+    return true;
   case ACTION_NAV_BACK:
-    return m_actionBack.GetNavigation();
+    action = m_actionBack;
+    return true;
   default:
-    return -1;
+    return false;
   }
 }
 

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -200,6 +200,9 @@ public:
   int GetControlIdRight() const { return m_actionRight.GetNavigation(); };
   int GetControlIdBack() const { return m_actionBack.GetNavigation(); };
   bool GetNavigationAction(int direction, CGUIAction& action) const;
+  /*! \brief  Start navigating in given direction.
+   */
+  bool Navigate(int direction);
   virtual void SetFocus(bool focus);
   virtual void SetWidth(float width);
   virtual void SetHeight(float height);

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -199,7 +199,7 @@ public:
   int GetControlIdLeft() const { return m_actionLeft.GetNavigation(); };
   int GetControlIdRight() const { return m_actionRight.GetNavigation(); };
   int GetControlIdBack() const { return m_actionBack.GetNavigation(); };
-  virtual int GetNextControl(int direction) const;
+  bool GetNavigationAction(int direction, CGUIAction& action) const;
   virtual void SetFocus(bool focus);
   virtual void SetWidth(float width);
   virtual void SetHeight(float height);

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -306,7 +306,7 @@ void CGUIEditControl::UpdateText(bool sendUpdate)
   {
     SEND_CLICK_MESSAGE(GetID(), GetParentID(), 0);
 
-    m_textChangeActions.Execute(GetID(), GetParentID());
+    m_textChangeActions.ExecuteActions(GetID(), GetParentID());
   }
   SetInvalid();
 }

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -833,7 +833,10 @@ bool CGUIWindow::OnMove(int fromControl, int moveAction)
   while (control)
   { // grab the next control direction
     moveHistory.push_back(nextControl);
-    nextControl = control->GetNextControl(moveAction);
+    CGUIAction action;
+    if (!control->GetNavigationAction(moveAction, action))
+      return false;
+    nextControl = action.GetNavigation();
     // check our history - if the nextControl is in it, we can't focus it
     for (unsigned int i = 0; i < moveHistory.size(); i++)
     {

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -837,6 +837,8 @@ bool CGUIWindow::OnMove(int fromControl, int moveAction)
     if (!control->GetNavigationAction(moveAction, action))
       return false;
     nextControl = action.GetNavigation();
+    if (!nextControl) // 0 isn't valid control id
+      return false;
     // check our history - if the nextControl is in it, we can't focus it
     for (unsigned int i = 0; i < moveHistory.size(); i++)
     {

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -836,6 +836,7 @@ bool CGUIWindow::OnMove(int fromControl, int moveAction)
     CGUIAction action;
     if (!control->GetNavigationAction(moveAction, action))
       return false;
+    action.ExecuteActions(nextControl, GetParentID());
     nextControl = action.GetNavigation();
     if (!nextControl) // 0 isn't valid control id
       return false;
@@ -956,12 +957,12 @@ void CGUIWindow::SetRunActionsManually()
 
 void CGUIWindow::RunLoadActions()
 {
-  m_loadActions.Execute(GetID(), GetParentID());
+  m_loadActions.ExecuteActions(GetID(), GetParentID());
 }
 
 void CGUIWindow::RunUnloadActions()
 {
-  m_unloadActions.Execute(GetID(), GetParentID());
+  m_unloadActions.ExecuteActions(GetID(), GetParentID());
 }
 
 void CGUIWindow::ClearBackground()


### PR DESCRIPTION
Hitcher described potential issue in http://forum.xbmc.org/showthread.php?t=112767. It looks like bug for me but it might be this way by design. Simplified problematic scenario:

We have controls:
 id=1: currently focused, &lt;onright&gt;2&lt;/onright&gt;
 id=2: hidden, &lt;onright&gt;3&lt;/onright&gt;
 id=3: hidden, &lt;onright&gt;ExecuteSomeBuiltinFunction&lt;/onright&gt;

We have control id==1 focused, press right and currently it works like this:
We're going from control 1 to control 2, control 2 isn't focusable so we're checking where should we go from there. We're going from control 2 to control 3, control 3 still isn't focusable, we don't have navigation path so we simply stop there and in the end nothing is happening. Should we execute builtin from control id==3 or not?

If we should - this PR changes/fixes current behaviour. If not - with some cosmetic changes this can clean &lt;onfoo&gt; handling a little bit, I think.
