### PR TITLE
couple of updates/fixes for libcec

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1161,7 +1161,7 @@ if test "x$use_libcec" != "xno"; then
 
   # libcec is dyloaded, so we need to check for its headers and link any depends.
   if test "x$use_libcec" != "xno"; then
-    PKG_CHECK_MODULES([CEC],[libcec = 0.7.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
+    PKG_CHECK_MODULES([CEC],[libcec >= 1.0.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
 
     if test "x$use_libcec" != "xno"; then
       INCLUDES="$INCLUDES $CEC_CFLAGS"

--- a/language/Dutch/strings.xml
+++ b/language/Dutch/strings.xml
@@ -2353,4 +2353,5 @@
   <string id="36015">HDMI poort nummer</string>
   <string id="36016">XBMC verbonden</string>
   <string id="36017">Adapter gevonden, maar libcec is niet beschikbaar</string>
+  <string id="36018">Gebruik de taalinstelling van de TV</string>
 </strings>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2388,4 +2388,5 @@
   <string id="36015">HDMI port number</string>
   <string id="36016">XBMC connected</string>
   <string id="36017">Adapter found, but libcec is not available</string>
+  <string id="36018">Use the TV's language setting</string>
 </strings>

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        mirror                                      source of the file
 
-libcec7.zip                       http://xbmc.opdenkamp.eu/                   http://packages.pulse-eight.net/
+libcec1.0.zip                     http://xbmc.opdenkamp.eu/                   http://packages.pulse-eight.net/

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -26,5 +26,6 @@
     <setting key="cec_mark_inactive_shutdown" type="bool" value="0" label="36010" />
     <setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" />
     <setting key="cec_debug_logging" type="bool" value="0" label="20191" />
+	<setting key="use_tv_menu_language" type="bool" value="1" label="36018" />
   </peripheral>
 </peripherals>

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -238,6 +238,10 @@ void CPeripheralCecAdapter::Process(void)
   }
 
   CLog::Log(LOGDEBUG, "%s - connection to the CEC adapter opened", __FUNCTION__);
+
+  /* get the vendor id directly after connecting, because the TV might be using a non-standard CEC implementation */
+  m_cecAdapter->GetDeviceVendorId(CECDEVICE_TV);
+
   m_bIsReady = true;
   CAnnouncementManager::AddAnnouncer(this);
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -640,6 +640,7 @@ bool CPeripheralCecAdapter::GetNextKey(void)
   case CEC_USER_CONTROL_CODE_F5:
   case CEC_USER_CONTROL_CODE_DATA:
   case CEC_USER_CONTROL_CODE_UNKNOWN:
+  default:
     m_bHasButton = false;
     return false;
   }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -225,12 +225,6 @@ void CPeripheralCecAdapter::Process(void)
   if (strPort.empty())
     return;
 
-  // set correct physical address from peripheral settings
-  int iHdmiPort = GetSettingInt("cec_hdmi_port");
-  if (iHdmiPort <= 0 || iHdmiPort > 16)
-    iHdmiPort = 1;
-  m_cecAdapter->SetPhysicalAddress((uint16_t) (iHdmiPort << 12));
-
   // open the CEC adapter
   CLog::Log(LOGDEBUG, "%s - opening a connection to the CEC adapter: %s", __FUNCTION__, strPort.c_str());
 
@@ -246,6 +240,12 @@ void CPeripheralCecAdapter::Process(void)
   CLog::Log(LOGDEBUG, "%s - connection to the CEC adapter opened", __FUNCTION__);
   m_bIsReady = true;
   CAnnouncementManager::AddAnnouncer(this);
+
+  // set correct physical address from peripheral settings
+  int iHdmiPort = GetSettingInt("cec_hdmi_port");
+  if (iHdmiPort <= 0 || iHdmiPort > 16)
+    iHdmiPort = 1;
+  m_cecAdapter->SetPhysicalAddress((uint16_t) (iHdmiPort << 12));
 
   FlushLog();
 
@@ -276,7 +276,7 @@ void CPeripheralCecAdapter::Process(void)
     if (!m_bStop)
       ProcessNextCommand();
     if (!m_bStop)
-      Sleep(50);
+      Sleep(5);
   }
 
   m_cecAdapter->Close();

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -39,7 +39,7 @@ using namespace PERIPHERALS;
 using namespace ANNOUNCEMENT;
 using namespace CEC;
 
-#define CEC_LIB_SUPPORTED_VERSION 7
+#define CEC_LIB_SUPPORTED_VERSION 1
 
 /* time in seconds to ignore standby commands from devices */
 #define SCREENSAVER_TIMEOUT       10
@@ -70,7 +70,8 @@ CPeripheralCecAdapter::CPeripheralCecAdapter(const PeripheralType type, const Pe
   CThread("CEC Adapter"),
   m_bStarted(false),
   m_bHasButton(false),
-  m_bIsReady(false)
+  m_bIsReady(false),
+  m_strMenuLanguage("???")
 {
   m_button.iButton = 0;
   m_button.iDuration = 0;
@@ -81,13 +82,13 @@ CPeripheralCecAdapter::CPeripheralCecAdapter(const PeripheralType type, const Pe
   else
     m_cecAdapter = NULL;
 
-  if (!m_cecAdapter || m_cecAdapter->GetMinVersion() > CEC_LIB_SUPPORTED_VERSION)
+  if (!m_cecAdapter || m_cecAdapter->GetMinLibVersion() > CEC_LIB_SUPPORTED_VERSION)
   {
     /* unsupported libcec version */
-    CLog::Log(LOGERROR, g_localizeStrings.Get(36013).c_str(), CEC_LIB_SUPPORTED_VERSION, m_cecAdapter ? m_cecAdapter->GetMinVersion() : -1);
+    CLog::Log(LOGERROR, g_localizeStrings.Get(36013).c_str(), CEC_LIB_SUPPORTED_VERSION, m_cecAdapter ? m_cecAdapter->GetMinLibVersion() : -1);
 
     CStdString strMessage;
-    strMessage.Format(g_localizeStrings.Get(36013).c_str(), CEC_LIB_SUPPORTED_VERSION, m_cecAdapter ? m_cecAdapter->GetMinVersion() : -1);
+    strMessage.Format(g_localizeStrings.Get(36013).c_str(), CEC_LIB_SUPPORTED_VERSION, m_cecAdapter ? m_cecAdapter->GetMinLibVersion() : -1);
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(36000), strMessage);
     m_bError = true;
     if (m_cecAdapter)
@@ -96,6 +97,7 @@ CPeripheralCecAdapter::CPeripheralCecAdapter(const PeripheralType type, const Pe
   }
   else
   {
+    CLog::Log(LOGDEBUG, "%s - using libCEC v%d.%d", __FUNCTION__, m_cecAdapter->GetLibVersionMajor(), m_cecAdapter->GetLibVersionMinor());
     m_features.push_back(FEATURE_CEC);
   }
 }
@@ -149,18 +151,21 @@ void CPeripheralCecAdapter::Announce(EAnnouncementFlag flag, const char *sender,
     CLog::Log(LOGDEBUG, "%s - reconnecting to the CEC adapter after standby mode", __FUNCTION__);
     m_cecAdapter->Close();
 
-    CStdString strPort = GetSettingString("port");
-    if (!m_cecAdapter->Open(strPort.c_str(), 10000))
+    CStdString strPort = GetComPort();
+    if (!strPort.empty())
     {
-      CLog::Log(LOGERROR, "%s - failed to reconnect to the CEC adapter", __FUNCTION__);
-      FlushLog();
-      m_bStop = true;
-    }
-    else
-    {
-      if (GetSettingBool("cec_power_on_startup"))
-        PowerOnCecDevices();
-      m_cecAdapter->SetActiveView();
+      if (!m_cecAdapter->Open(strPort.c_str(), 10000))
+      {
+        CLog::Log(LOGERROR, "%s - failed to reconnect to the CEC adapter", __FUNCTION__);
+        FlushLog();
+        m_bStop = true;
+      }
+      else
+      {
+        if (GetSettingBool("cec_power_on_startup"))
+          PowerOnCecDevices(CECDEVICE_TV);
+        m_cecAdapter->SetActiveView();
+      }
     }
   }
 }
@@ -176,15 +181,8 @@ bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)
   return CPeripheral::InitialiseFeature(feature);
 }
 
-void CPeripheralCecAdapter::Process(void)
+CStdString CPeripheralCecAdapter::GetComPort(void)
 {
-  if (!GetSettingBool("enabled"))
-  {
-    CLog::Log(LOGDEBUG, "%s - CEC adapter is disabled in peripheral settings", __FUNCTION__);
-    m_bStarted = false;
-    return;
-  }
-  
   CStdString strPort = GetSettingString("port");
   if (strPort.IsEmpty())
   {
@@ -197,8 +195,7 @@ void CPeripheralCecAdapter::Process(void)
     {
       CLog::Log(LOGWARNING, "%s - no CEC adapters found on %s", __FUNCTION__, strPort.c_str());
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(36000), g_localizeStrings.Get(36011));
-      m_bStarted = false;
-      return;
+      strPort = "";
     }
     else
     {
@@ -212,11 +209,27 @@ void CPeripheralCecAdapter::Process(void)
     }
   }
 
+  return strPort;
+}
+
+void CPeripheralCecAdapter::Process(void)
+{
+  if (!GetSettingBool("enabled"))
+  {
+    CLog::Log(LOGDEBUG, "%s - CEC adapter is disabled in peripheral settings", __FUNCTION__);
+    m_bStarted = false;
+    return;
+  }
+  
+  CStdString strPort = GetComPort();
+  if (strPort.empty())
+    return;
+
   // set the correct physical address
   int iHdmiPort = GetSettingInt("cec_hdmi_port");
   if (iHdmiPort <= 0 || iHdmiPort > 16)
     iHdmiPort = 1;
-  m_cecAdapter->SetPhysicalAddress(iHdmiPort << 12);
+  m_cecAdapter->SetPhysicalAddress((uint16_t) (iHdmiPort << 12));
 
   // open the CEC adapter
   CLog::Log(LOGDEBUG, "%s - opening a connection to the CEC adapter: %s", __FUNCTION__, strPort.c_str());
@@ -234,12 +247,25 @@ void CPeripheralCecAdapter::Process(void)
   m_bIsReady = true;
   CAnnouncementManager::AddAnnouncer(this);
 
+  FlushLog();
+
   if (GetSettingBool("cec_power_on_startup"))
-    PowerOnCecDevices();
+  {
+    cec_power_status status = m_cecAdapter->GetDevicePowerStatus(CECDEVICE_TV);
+    if (status == CEC_POWER_STATUS_STANDBY ||
+        status == CEC_POWER_STATUS_IN_TRANSITION_ON_TO_STANDBY)
+      PowerOnCecDevices(CECDEVICE_TV);
+    FlushLog();
+  }
+
   m_cecAdapter->SetActiveView();
   FlushLog();
 
   m_cecAdapter->SetOSDString(CECDEVICE_TV, CEC_DISPLAY_CONTROL_DISPLAY_FOR_DEFAULT_TIME, g_localizeStrings.Get(36016).c_str());
+
+  cec_menu_language language;
+  if (m_cecAdapter->GetDeviceMenuLanguage(CECDEVICE_TV, &language))
+    SetMenuLanguage(language.language);
 
   while (!m_bStop)
   {
@@ -256,27 +282,27 @@ void CPeripheralCecAdapter::Process(void)
   m_bStarted = false;
 }
 
-bool CPeripheralCecAdapter::PowerOnCecDevices(void)
+bool CPeripheralCecAdapter::PowerOnCecDevices(cec_logical_address iLogicalAddress)
 {
   bool bReturn(false);
 
   if (m_cecAdapter && m_bIsReady)
   {
-    CLog::Log(LOGDEBUG, "%s - powering on CEC capable devices", __FUNCTION__);
-    bReturn = m_cecAdapter->PowerOnDevices();
+    CLog::Log(LOGDEBUG, "%s - powering on CEC capable devices with address %1x", __FUNCTION__, iLogicalAddress);
+    bReturn = m_cecAdapter->PowerOnDevices(iLogicalAddress);
   }
 
   return bReturn;
 }
 
-bool CPeripheralCecAdapter::StandbyCecDevices(void)
+bool CPeripheralCecAdapter::StandbyCecDevices(cec_logical_address iLogicalAddress)
 {
   bool bReturn(false);
 
   if (m_cecAdapter && m_bIsReady)
   {
-    CLog::Log(LOGDEBUG, "%s - putting CEC capable devices in standby mode", __FUNCTION__);
-    bReturn = m_cecAdapter->StandbyDevices();
+    CLog::Log(LOGDEBUG, "%s - putting CEC capable devices with address %1x in standby mode", __FUNCTION__, iLogicalAddress);
+    bReturn = m_cecAdapter->StandbyDevices(iLogicalAddress);
   }
 
   return bReturn;
@@ -322,6 +348,9 @@ bool CPeripheralCecAdapter::SetHdmiPort(int iHdmiPort)
 
 void CPeripheralCecAdapter::SetMenuLanguage(const char *strLanguage)
 {
+  if (m_strMenuLanguage.Equals(strLanguage))
+    return;
+
   CStdString strGuiLanguage;
 
   if (!strcmp(strLanguage, "bul"))
@@ -383,13 +412,13 @@ void CPeripheralCecAdapter::ProcessNextCommand(void)
   cec_command command;
   if (m_cecAdapter && m_bIsReady && m_cecAdapter->GetNextCommand(&command))
   {
-    CLog::Log(LOGDEBUG, "%s - processing command: initiator=%d destination=%d opcode=%d", __FUNCTION__, command.initiator, command.destination, command.opcode);
+    CLog::Log(LOGDEBUG, "%s - processing command: initiator=%1x destination=%1x opcode=%02x", __FUNCTION__, command.initiator, command.destination, command.opcode);
 
     switch (command.opcode)
     {
     case CEC_OPCODE_STANDBY:
       /* a device was put in standby mode */
-      CLog::Log(LOGDEBUG, "%s - device %d was put in standby mode", __FUNCTION__, command.initiator);
+      CLog::Log(LOGDEBUG, "%s - device %1x was put in standby mode", __FUNCTION__, command.initiator);
       if (command.initiator == CECDEVICE_TV && GetSettingBool("standby_pc_on_tv_standby") &&
           (!m_screensaverLastActivated.IsValid() || CDateTime::GetCurrentDateTime() - m_screensaverLastActivated > CDateTimeSpan(0, 0, 0, SCREENSAVER_TIMEOUT)))
       {
@@ -440,7 +469,7 @@ bool CPeripheralCecAdapter::GetNextKey(void)
   if (!m_bIsReady || !m_cecAdapter->GetNextKeypress(&key))
     return false;
 
-  CLog::Log(LOGDEBUG, "%s - received key %d", __FUNCTION__, key.keycode);
+  CLog::Log(LOGDEBUG, "%s - received key %2x", __FUNCTION__, key.keycode);
   DWORD iButton = 0;
 
   switch (key.keycode)
@@ -683,9 +712,12 @@ void CPeripheralCecAdapter::FlushLog(void)
     case CEC_LOG_NOTICE:
       iLevel = LOGDEBUG;
       break;
+    case CEC_LOG_TRAFFIC:
     case CEC_LOG_DEBUG:
       if (GetSettingBool("cec_debug_logging"))
         iLevel = LOGDEBUG;
+      break;
+    default:
       break;
     }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -20,11 +20,15 @@
  *
  */
 
+#if defined(HAVE_LIBCEC)
+
 #include "PeripheralHID.h"
 #include "interfaces/AnnouncementManager.h"
 #include "threads/Thread.h"
 #include "threads/CriticalSection.h"
 #include <queue>
+
+#include <cectypes.h>
 
 class DllLibCEC;
 
@@ -49,8 +53,8 @@ namespace PERIPHERALS
     virtual ~CPeripheralCecAdapter(void);
 
     virtual void Announce(ANNOUNCEMENT::EAnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
-    virtual bool PowerOnCecDevices(void);
-    virtual bool StandbyCecDevices(void);
+    virtual bool PowerOnCecDevices(CEC::cec_logical_address iLogicalAddress);
+    virtual bool StandbyCecDevices(CEC::cec_logical_address iLogicalAddress);
 
     virtual bool SendPing(void);
     virtual bool StartBootloader(void);
@@ -61,6 +65,7 @@ namespace PERIPHERALS
     virtual WORD GetButton(void);
     virtual unsigned int GetHoldTime(void);
     virtual void ResetButton(void);
+    virtual CStdString GetComPort(void);
 
   protected:
     virtual void FlushLog(void);
@@ -77,8 +82,12 @@ namespace PERIPHERALS
     bool              m_bStarted;
     bool              m_bHasButton;
     bool              m_bIsReady;
+    CStdString        m_strMenuLanguage;
     CDateTime         m_screensaverLastActivated;
     CecButtonPress    m_button;
     CCriticalSection  m_critSection;
   };
 }
+
+#endif
+


### PR DESCRIPTION
- use libcec v1.0. this adds a new log level (CEC_LOG_TRAFFIC) and the ability to query some properties of connected devices.
- fixed reconnect when XBMC comes out of standby
- only send a "power on" command to the tv when it's not on already or powering on
- made using the TV's language optional, because some people didn't like it auto changing. configurable via peripheral settings. this adds one more gui string and because of the timing, I could remove this commit from the PR if needed.
- fixed - set the hdmi port after connecting, not before
