### PR TITLE
Fix video corruption for hardware decoding of H264 streams with cropping parameters

### DIFF
--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -90,6 +90,7 @@ public:
   virtual const AVCRC* av_crc_get_table(AVCRCId crc_id)=0;
   virtual uint32_t av_crc(const AVCRC *ctx, uint32_t crc, const uint8_t *buffer, size_t length)=0;
   virtual int av_set_string3(void *obj, const char *name, const char *val, int alloc, const AVOption **o_out)=0;
+  virtual int64_t av_get_int(void *obj, const char *name, const AVOption **o_out)=0;
   virtual AVFifoBuffer *av_fifo_alloc(unsigned int size) = 0;
   virtual void av_fifo_free(AVFifoBuffer *f) = 0;
   virtual void av_fifo_reset(AVFifoBuffer *f) = 0;
@@ -123,6 +124,7 @@ public:
 #else
    virtual int av_set_string3(void *obj, const char *name, const char *val, int alloc, const AVOption **o_out) { return AVERROR(ENOENT); }
 #endif
+  virtual int64_t av_get_int(void *obj, const char *name, const AVOption **o_out) { return ::av_get_int(obj, name, o_out); }
   virtual AVFifoBuffer *av_fifo_alloc(unsigned int size) {return ::av_fifo_alloc(size); }
   virtual void av_fifo_free(AVFifoBuffer *f) { ::av_fifo_free(f); }
   virtual void av_fifo_reset(AVFifoBuffer *f) { ::av_fifo_reset(f); }
@@ -161,6 +163,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
   DEFINE_METHOD1(const AVCRC*, av_crc_get_table, (AVCRCId p1))
   DEFINE_METHOD4(uint32_t, av_crc, (const AVCRC *p1, uint32_t p2, const uint8_t *p3, size_t p4));
   DEFINE_METHOD5(int, av_set_string3, (void *p1, const char *p2, const char *p3, int p4, const AVOption **p5));
+  DEFINE_METHOD3(int64_t, av_get_int, (void *p1, const char *p2, const AVOption **p3));
   DEFINE_METHOD1(AVFifoBuffer*, av_fifo_alloc, (unsigned int p1))
   DEFINE_METHOD1(void, av_fifo_free, (AVFifoBuffer *p1))
   DEFINE_METHOD1(void, av_fifo_reset, (AVFifoBuffer *p1))
@@ -182,6 +185,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
     RESOLVE_METHOD(av_crc_get_table)
     RESOLVE_METHOD(av_crc)
     RESOLVE_METHOD(av_set_string3)
+    RESOLVE_METHOD(av_get_int)
     RESOLVE_METHOD(av_fifo_alloc)
     RESOLVE_METHOD(av_fifo_free)
     RESOLVE_METHOD(av_fifo_reset)

--- a/lib/ffmpeg/libavcodec/h264.c
+++ b/lib/ffmpeg/libavcodec/h264.c
@@ -3408,6 +3408,8 @@ static const AVProfile profiles[] = {
 static const AVOption h264_options[] = {
     {"is_avc", "is avc", offsetof(H264Context, is_avc), FF_OPT_TYPE_INT, 0, 0, 1, 0},
     {"nal_length_size", "nal_length_size", offsetof(H264Context, nal_length_size), FF_OPT_TYPE_INT, 0, 0, 4, 0},
+    {"mb_width", "mb_width", offsetof(H264Context, s.mb_width), FF_OPT_TYPE_INT, 0, 0, 0, 0},
+    {"mb_height", "mb_height", offsetof(H264Context, s.mb_height), FF_OPT_TYPE_INT, 0, 0, 0, 0},
     {NULL}
 };
 

--- a/lib/ffmpeg/libavcodec/h264.c
+++ b/lib/ffmpeg/libavcodec/h264.c
@@ -26,6 +26,7 @@
  */
 
 #include "libavcore/imgutils.h"
+#include "libavutil/opt.h"
 #include "internal.h"
 #include "dsputil.h"
 #include "avcodec.h"
@@ -3404,6 +3405,26 @@ static const AVProfile profiles[] = {
     { FF_PROFILE_UNKNOWN },
 };
 
+static const AVOption h264_options[] = {
+    {"is_avc", "is avc", offsetof(H264Context, is_avc), FF_OPT_TYPE_INT, 0, 0, 1, 0},
+    {"nal_length_size", "nal_length_size", offsetof(H264Context, nal_length_size), FF_OPT_TYPE_INT, 0, 0, 4, 0},
+    {NULL}
+};
+
+static const AVClass h264_class = {
+    "H264 Decoder",
+    av_default_item_name,
+    h264_options,
+    LIBAVUTIL_VERSION_INT,
+};
+
+static const AVClass h264_vdpau_class = {
+    "H264 VDPAU Decoder",
+    av_default_item_name,
+    h264_options,
+    LIBAVUTIL_VERSION_INT,
+};
+
 AVCodec ff_h264_decoder = {
     "h264",
     AVMEDIA_TYPE_VIDEO,
@@ -3417,6 +3438,7 @@ AVCodec ff_h264_decoder = {
     .flush= flush_dpb,
     .long_name = NULL_IF_CONFIG_SMALL("H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10"),
     .profiles = NULL_IF_CONFIG_SMALL(profiles),
+    .priv_class     = &h264_class,
 };
 
 #if CONFIG_H264_VDPAU_DECODER
@@ -3434,5 +3456,6 @@ AVCodec ff_h264_vdpau_decoder = {
     .long_name = NULL_IF_CONFIG_SMALL("H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (VDPAU acceleration)"),
     .pix_fmts = (const enum PixelFormat[]){PIX_FMT_VDPAU_H264, PIX_FMT_NONE},
     .profiles = NULL_IF_CONFIG_SMALL(profiles),
+    .priv_class     = &h264_vdpau_class,
 };
 #endif

--- a/lib/ffmpeg/libavcodec/mpegvideo.h
+++ b/lib/ffmpeg/libavcodec/mpegvideo.h
@@ -195,6 +195,7 @@ typedef struct MotionEstContext{
  * MpegEncContext.
  */
 typedef struct MpegEncContext {
+    AVClass *class;
     struct AVCodecContext *avctx;
     /* the following parameters must be initialized before encoding */
     int width, height;///< picture size. must be a multiple of 16

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -30,6 +30,7 @@
 #include <vector>
 #include "settings/VideoSettings.h"
 #include "guilib/Geometry.h"
+#include "DllAvUtil.h"
 
 namespace DXVA {
 
@@ -80,6 +81,8 @@ protected:
   virtual void OnLostDevice()    { CSingleLock lock(m_section); m_state = DXVA_LOST;  m_event.Reset(); }
   virtual void OnResetDevice()   { CSingleLock lock(m_section); m_state = DXVA_RESET; m_event.Set();   }
 
+  virtual void UpdateDecoderSurfaceSize(AVCodecContext *avctx);
+
   struct SVideoBuffer
   {
     SVideoBuffer();
@@ -110,6 +113,7 @@ protected:
 
   CCriticalSection             m_section;
   CEvent                       m_event;
+  DllAvUtil                    m_dllAvUtil;
 };
 
 class CProcessor


### PR DESCRIPTION
See the issue in ticket #11499 - video corruption for BBC H264 streams.

The clips are encoded with extra lines and cropping parameters. The surfaces allocated for hardware decoding do not take the extra lines into account, which results in artefacts. The solution is to recover the proper size and use it to allocate the surfaces. The vdpau/Ion combination requires the exact size and not simply a bumped size aligned to 16 or 32.

This PR make a few members of ffmpeg's H264Context accessible in a safe manner. To avoid calculating in XBMC the size from the raw H264 fields, two new members are added to H264Context to contain the calculation result.
The DXVA patch uses the information exported by ffmpeg for the initial surface allocation and monitors any size change in the stream.

I'm not sure the optimization in the last commit is safe: is it possible that avctx->codec is not allocated when we Open() or is it possible that avctx->codec changes while we're playing a stream?

I'll be happy to take a vdpau and vaapi patch so that all platforms are merged at the same time.

The cropping for display will be the subject of another PR.
