### PR TITLE
cec: no longer use a fixed logical addres and send deck state updates (play/pause/stop) over cec when the play state changes

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1161,7 +1161,7 @@ if test "x$use_libcec" != "xno"; then
 
   # libcec is dyloaded, so we need to check for its headers and link any depends.
   if test "x$use_libcec" != "xno"; then
-    PKG_CHECK_MODULES([CEC],[libcec >= 1.0.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
+    PKG_CHECK_MODULES([CEC],[libcec >= 1.1.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
 
     if test "x$use_libcec" != "xno"; then
       INCLUDES="$INCLUDES $CEC_CFLAGS"

--- a/language/Dutch/strings.xml
+++ b/language/Dutch/strings.xml
@@ -2351,7 +2351,7 @@
   <string id="36013">Versie %d van de libcec interface version wordt niet ondersteund door XBMC (> %d)</string>
   <string id="36014">Zet XBMC in standby wanneer de TV uitgeschakeld wordt</string>
   <string id="36015">HDMI poort nummer</string>
-  <string id="36016">XBMC verbonden</string>
+  <string id="36016">Verbonden</string> <!- max. 13 characters -->
   <string id="36017">Adapter gevonden, maar libcec is niet beschikbaar</string>
   <string id="36018">Gebruik de taalinstelling van de TV</string>
 </strings>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2386,7 +2386,7 @@
   <string id="36013">Unsupported libcec interface version. %d is greater than the version XBMC supports (%d)</string>
   <string id="36014">Put this PC in standby mode when the TV is switched off</string>
   <string id="36015">HDMI port number</string>
-  <string id="36016">XBMC connected</string>
+  <string id="36016">Connected</string> <!- max. 13 characters -->
   <string id="36017">Adapter found, but libcec is not available</string>
   <string id="36018">Use the TV's language setting</string>
 </strings>

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        mirror                                      source of the file
 
-libcec1.0.zip                     http://xbmc.opdenkamp.eu/                   http://packages.pulse-eight.net/
+libcec1.1.zip                     http://xbmc.opdenkamp.eu/                   http://packages.pulse-eight.net/

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -173,6 +173,21 @@ void CPeripheralCecAdapter::Announce(EAnnouncementFlag flag, const char *sender,
       }
     }
   }
+  else if (flag == Player && !strcmp(sender, "xbmc") && !strcmp(message, "OnStop"))
+  {
+    m_cecAdapter->SetDeckControlMode(CEC_DECK_CONTROL_MODE_STOP, false);
+    m_cecAdapter->SetDeckInfo(CEC_DECK_INFO_STOP);
+  }
+  else if (flag == Player && !strcmp(sender, "xbmc") && !strcmp(message, "OnPause"))
+  {
+    m_cecAdapter->SetDeckControlMode(CEC_DECK_CONTROL_MODE_SKIP_FORWARD_WIND, false);
+    m_cecAdapter->SetDeckInfo(CEC_DECK_INFO_STILL);
+  }
+  else if (flag == Player && !strcmp(sender, "xbmc") && !strcmp(message, "OnPlay"))
+  {
+    m_cecAdapter->SetDeckControlMode(CEC_DECK_CONTROL_MODE_SKIP_FORWARD_WIND, false);
+    m_cecAdapter->SetDeckInfo(CEC_DECK_INFO_PLAY);
+  }
 }
 
 bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -48,7 +48,7 @@ class DllLibCECInterface
 {
 public:
   virtual ~DllLibCECInterface() {}
-  virtual ICECAdapter* CECCreate(const char *interfaceName, uint8_t logicalAddress, uint16_t physicalAddress)=0;
+  virtual ICECAdapter* CECInit(const char *interfaceName, cec_device_type_list types)=0;
   virtual void* CECDestroy(ICECAdapter *adapter)=0;
 };
 
@@ -56,11 +56,11 @@ class DllLibCEC : public DllDynamic, DllLibCECInterface
 {
   DECLARE_DLL_WRAPPER(DllLibCEC, DLL_PATH_LIBCEC)
 
-  DEFINE_METHOD3(ICECAdapter*, CECCreate,   (const char *p1, uint8_t p2, uint16_t p3))
+  DEFINE_METHOD2(ICECAdapter*, CECInit,   (const char *p1, cec_device_type_list p2))
   DEFINE_METHOD1(void*       , CECDestroy,  (ICECAdapter *p1))
 
   BEGIN_METHOD_RESOLVE()
-    RESOLVE_METHOD_RENAME(CECCreate,  CECCreate)
+    RESOLVE_METHOD_RENAME(CECInit,  CECInit)
     RESOLVE_METHOD_RENAME(CECDestroy, CECDestroy)
   END_METHOD_RESOLVE()
 };
@@ -78,7 +78,12 @@ CPeripheralCecAdapter::CPeripheralCecAdapter(const PeripheralType type, const Pe
   m_screensaverLastActivated.SetValid(false);
   m_dll = new DllLibCEC;
   if (m_dll->Load() && m_dll->IsLoaded())
-    m_cecAdapter = m_dll->CECCreate("XBMC", CECDEVICE_PLAYBACKDEVICE1, CEC_DEFAULT_PHYSICAL_ADDRESS);
+  {
+    cec_device_type_list typeList;
+    typeList.clear();
+    typeList.add(CEC_DEVICE_TYPE_PLAYBACK_DEVICE);
+    m_cecAdapter = m_dll->CECInit("XBMC", typeList);
+  }
   else
     m_cecAdapter = NULL;
 
@@ -327,18 +332,6 @@ bool CPeripheralCecAdapter::SendPing(void)
   return bReturn;
 }
 
-bool CPeripheralCecAdapter::StartBootloader(void)
-{
-  bool bReturn(false);
-  if (m_cecAdapter && m_bIsReady)
-  {
-    CLog::Log(LOGDEBUG, "%s - starting the bootloader", __FUNCTION__);
-    bReturn = m_cecAdapter->StartBootloader();
-  }
-
-  return bReturn;
-}
-
 bool CPeripheralCecAdapter::SetHdmiPort(int iHdmiPort)
 {
   bool bReturn(false);
@@ -446,7 +439,7 @@ void CPeripheralCecAdapter::ProcessNextCommand(void)
     case CEC_OPCODE_DECK_CONTROL:
       if (command.initiator == CECDEVICE_TV &&
           command.parameters.size == 1 &&
-          command.parameters[0] == CEC_DESK_CONTROL_MODE_STOP)
+          command.parameters[0] == CEC_DECK_CONTROL_MODE_STOP)
       {
         CSingleLock lock(m_critSection);
         cec_keypress key;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -56,7 +56,6 @@ namespace PERIPHERALS
     virtual bool StandbyCecDevices(CEC::cec_logical_address iLogicalAddress);
 
     virtual bool SendPing(void);
-    virtual bool StartBootloader(void);
     virtual bool SetHdmiPort(int iHdmiPort);
 
     virtual void OnSettingChanged(const CStdString &strChangedSetting);


### PR DESCRIPTION
- no longer using a fixed logical address. this fixes the issue that cec doesn't work when there are multiple cec playback devices on the bus and one of them picked "playback 1" first.
- removed the StartBootLoader() method. we're not going to start the cec adapter's bootloader from within xbmc
- now sends out play state updates over cec
- made the string "XBMC connected" a bit shorter, cause the spec defines 13 chars max.
