### PR TITLE
[DXVA] Fix "blocky" artifacts after skip with nVidia cards

### DIFF
--- a/lib/ffmpeg/libavcodec/dxva2.c
+++ b/lib/ffmpeg/libavcodec/dxva2.c
@@ -21,6 +21,9 @@
  */
 
 #include "dxva2_internal.h"
+#include <unistd.h>
+
+#define MAX_RETRY_ON_PENDING		50
 
 void *ff_dxva2_get_surface(const Picture *picture)
 {
@@ -88,10 +91,17 @@ int ff_dxva2_common_end_frame(AVCodecContext *avctx, MpegEncContext *s,
     DXVA2_DecodeBufferDesc buffer[4];
     DXVA2_DecodeExecuteParams exec;
     int      result;
+    HRESULT  hr;
+    int      tries = 0;
 
-    if (FAILED(IDirectXVideoDecoder_BeginFrame(ctx->decoder,
+    while ((hr=IDirectXVideoDecoder_BeginFrame(ctx->decoder,
                                                ff_dxva2_get_surface(s->current_picture_ptr),
-                                               NULL))) {
+                                               NULL)) == E_PENDING
+           && tries < MAX_RETRY_ON_PENDING) {
+        usleep(1000);
+        tries++;
+    }
+    if (FAILED(hr)) {
         av_log(avctx, AV_LOG_ERROR, "Failed to begin frame\n");
         return -1;
     }


### PR DESCRIPTION
The nVidia cards sometimes need time before they can start decoding a new frame and return E_PENDING when not ready.

This frequently happens after skipping or when the computer is busy and results in "blocking" artifacts/"pixellation" as frames that failed to decode are used as refs for later frames.

Helps things a lot with my G210, no more "Failed to begin frame" logged by ffmpeg for no good reason.
Once I found the issue, I took inspiration from MPC-HC and ffdshow for a fix. They wait up to a full second though, I'm not sure we want to do that.
