### PR TITLE
Make changed settings visible to python addons without restart of XBMC (approach 1/2)

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -368,9 +368,9 @@ bool CAddon::HasSettings()
   return LoadSettings();
 }
 
-bool CAddon::LoadSettings()
+bool CAddon::LoadSettings(bool bForce /* = false*/)
 {
-  if (m_settingsLoaded)
+  if (m_settingsLoaded && !bForce)
     return true;
   if (!m_hasSettings)
     return false;
@@ -405,6 +405,11 @@ bool CAddon::HasUserSettings()
   return m_userSettingsLoaded;
 }
 
+bool CAddon::ReloadSettings()
+{
+  return LoadSettings(true);
+}
+
 bool CAddon::LoadUserSettings()
 {
   m_userSettingsLoaded = false;
@@ -436,6 +441,8 @@ void CAddon::SaveSettings(void)
   TiXmlDocument doc;
   SettingsToXML(doc);
   doc.SaveFile(m_userSettingsPath);
+  
+  CAddonMgr::Get().ReloadSettings(ID());//push the settings changes to the running addon instance
 }
 
 CStdString CAddon::GetSetting(const CStdString& key)

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -168,6 +168,7 @@ public:
    \return true if  min_version <= version <= current_version, false otherwise.
    */
   bool MeetsVersion(const AddonVersion &version) const;
+  virtual bool ReloadSettings();
 
 protected:
   CAddon(const CAddon&); // protected as all copying is handled by Clone()
@@ -176,10 +177,11 @@ protected:
   virtual void BuildLibName(const cp_extension_t *ext = NULL);
 
   /*! \brief Load the default settings and override these with any previously configured user settings
+   \param bForce force the load of settings even if they are already loaded (reload)
    \return true if settings exist, false otherwise
    \sa LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, GetSetting, UpdateSetting
    */
-  virtual bool LoadSettings();
+  virtual bool LoadSettings(bool bForce = false);
 
   /*! \brief Load the user settings
    \return true if user settings exist, false otherwise

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -92,6 +92,9 @@ namespace ADDON
     bool HasAddons(const TYPE &type, bool enabled = true);
     bool GetAddons(const TYPE &type, VECADDONS &addons, bool enabled = true);
     bool GetAllAddons(VECADDONS &addons, bool enabled = true, bool allowRepos = false);
+    void AddToUpdateableAddons(AddonPtr &pAddon);
+    void RemoveFromUpdateableAddons(AddonPtr &pAddon);    
+    bool ReloadSettings(const CStdString &id);
     /*! \brief Get all addons with available updates
      \param addons List to fill with all outdated addons
      \param enabled Whether to get only enabled or disabled addons
@@ -172,6 +175,7 @@ namespace ADDON
     const cp_cfg_element_t *GetExtElement(cp_cfg_element_t *base, const char *path);
     cp_context_t *m_cp_context;
     DllLibCPluff *m_cpluff;
+    VECADDONS    m_updateableAddons;
 
     /*! \brief Fetch a (single) addon from a plugin descriptor.
      Assumes that there is a single (non-trivial) extension point per addon.

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -111,10 +111,11 @@ namespace ADDON
     virtual CStdString GetString(uint32_t id) =0;
     virtual const ADDONDEPS &GetDeps() const =0;
     virtual bool MeetsVersion(const AddonVersion &version) const =0;
+    virtual bool ReloadSettings() =0;
 
   protected:
     virtual const AddonPtr Parent() const =0;
-    virtual bool LoadSettings() =0;
+    virtual bool LoadSettings(bool bForce = false) =0;
 
   private:
     friend class CAddonMgr;

--- a/xbmc/interfaces/python/xbmcmodule/PythonAddon.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/PythonAddon.cpp
@@ -143,11 +143,13 @@ namespace PYXBMC
       }
     }
 
+    CAddonMgr::Get().AddToUpdateableAddons(self->pAddon);
     return (PyObject*)self;
   }
 
   void Addon_Dealloc(Addon* self)
   {
+    CAddonMgr::Get().RemoveFromUpdateableAddons(self->pAddon);  
     self->ob_type->tp_free((PyObject*)self);
   }
 


### PR DESCRIPTION
This is one of too possible solutions for getting running python addons aware of changed settings without restarting XBMC.

CptSpiff  - because i wasn't sure if i understood you correct i've done to approaches here. Of course only one of these Pull Requests is supposed to be merged (or none of them if i totally screwed up ;).

This approach registers the running python instances into a vector in addonmanager. When Savesettings is called from gui - the settings are reloaded in that registered instances - matched on the addon id.

Benefit is - settings are only refreshed when needed.
