### PR TITLE
Make changed settings visible to python addons without restart of XBMC (approach 2/2)

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -368,9 +368,9 @@ bool CAddon::HasSettings()
   return LoadSettings();
 }
 
-bool CAddon::LoadSettings()
+bool CAddon::LoadSettings(bool bForce /* = false*/)
 {
-  if (m_settingsLoaded)
+  if (m_settingsLoaded && !bForce)
     return true;
   if (!m_hasSettings)
     return false;
@@ -403,6 +403,11 @@ bool CAddon::HasUserSettings()
     return false;
 
   return m_userSettingsLoaded;
+}
+
+bool CAddon::ReloadSettings()
+{
+  return LoadSettings(true);
 }
 
 bool CAddon::LoadUserSettings()

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -168,6 +168,7 @@ public:
    \return true if  min_version <= version <= current_version, false otherwise.
    */
   bool MeetsVersion(const AddonVersion &version) const;
+  virtual bool ReloadSettings();
 
 protected:
   CAddon(const CAddon&); // protected as all copying is handled by Clone()
@@ -176,10 +177,11 @@ protected:
   virtual void BuildLibName(const cp_extension_t *ext = NULL);
 
   /*! \brief Load the default settings and override these with any previously configured user settings
+   \param bForce force the load of settings even if they are already loaded (reload)
    \return true if settings exist, false otherwise
    \sa LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, GetSetting, UpdateSetting
    */
-  virtual bool LoadSettings();
+  virtual bool LoadSettings(bool bForce = false);
 
   /*! \brief Load the user settings
    \return true if user settings exist, false otherwise

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -111,10 +111,11 @@ namespace ADDON
     virtual CStdString GetString(uint32_t id) =0;
     virtual const ADDONDEPS &GetDeps() const =0;
     virtual bool MeetsVersion(const AddonVersion &version) const =0;
+    virtual bool ReloadSettings() =0;
 
   protected:
     virtual const AddonPtr Parent() const =0;
-    virtual bool LoadSettings() =0;
+    virtual bool LoadSettings(bool bForce = false) =0;
 
   private:
     friend class CAddonMgr;

--- a/xbmc/interfaces/python/xbmcmodule/PythonAddon.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/PythonAddon.cpp
@@ -205,6 +205,8 @@ namespace PYXBMC
     {
       return NULL;
     };
+    
+    self->pAddon->ReloadSettings();
 
     return Py_BuildValue((char*)"s", self->pAddon->GetSetting(id).c_str());
   }


### PR DESCRIPTION
This is the less intrusive version of that bugfix.

It has the obvious downside, that settings are reloaded whenever a addon calls its GetSetting function.
