### PR TITLE
Allow multiple ids per USB device

### DIFF
--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -1,13 +1,5 @@
 <peripherals>
-  <peripheral vendor="1915" product="003B" bus="usb" name="Motorola Nyxboard Hybrid" mapTo="nyxboard">
-    <setting key="keymap_enabled" type="bool" value="1" label="35008" />
-    <setting key="keymap" value="nyxboard" label="35007" configurable="0" />
-    <setting key="enable_flip_commands" type="bool" value="1" label="36005" />
-    <setting key="flip_keyboard" value="XBMC.VideoLibrary.Search" label="36002" />
-    <setting key="flip_remote" value="Dialog.Close(virtualkeyboard)" label="36003" />
-    <setting key="key_user" value="" label="36004" />
-  </peripheral>
-  <peripheral vendor="22B8" product="003B" bus="usb" name="Motorola Nyxboard Hybrid" mapTo="nyxboard">
+  <peripheral vendor_product="1915:003B,22B8:003B" bus="usb" name="Motorola Nyxboard Hybrid" mapTo="nyxboard">
     <setting key="keymap_enabled" type="bool" value="1" label="35008" />
     <setting key="keymap" value="nyxboard" label="35007" configurable="0" />
     <setting key="enable_flip_commands" type="bool" value="1" label="36005" />
@@ -16,7 +8,7 @@
     <setting key="key_user" value="" label="36004" />
   </peripheral>
 
-  <peripheral vendor="2548" product="1001" bus="usb" name="Pulse-Eight CEC Adaptor" mapTo="cec">
+  <peripheral vendor_product="2548:1001" bus="usb" name="Pulse-Eight CEC Adaptor" mapTo="cec">
     <setting key="enabled" type="bool" value="1" label="305" />
     <setting key="port" type="string" value="" label="792" />
     <setting key="cec_hdmi_port" type="int" value="1" min="1" max="16" label="36015" />

--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -62,10 +62,15 @@ namespace PERIPHERALS
     PERIPHERAL_TUNER
   };
 
+  struct PeripheralID
+  {
+    int m_iVendorId;
+    int m_iProductId;
+  };
+
   struct PeripheralDeviceMapping
   {
-    int                              m_iVendorId;
-    int                              m_iProductId;
+    std::vector<PeripheralID>        m_PeripheralID;
     PeripheralBusType                m_busType;
     PeripheralType                   m_class;
     CStdString                       m_strDeviceName;

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -324,12 +324,16 @@ int CPeripherals::GetMappingForDevice(const CPeripheralBus &bus, const Periphera
   for (unsigned int iMappingPtr = 0; iMappingPtr < m_mappings.size(); iMappingPtr++)
   {
     PeripheralDeviceMapping mapping = m_mappings.at(iMappingPtr);
+
+    bool bProductMatch = false;
+    for (unsigned int i = 0; i < mapping.m_PeripheralID.size(); i++)
+      if (mapping.m_PeripheralID[i].m_iVendorId == iVendorId && mapping.m_PeripheralID[i].m_iProductId == iProductId)
+        bProductMatch = true;
+
     bool bBusMatch = (mapping.m_busType == PERIPHERAL_BUS_UNKNOWN || mapping.m_busType == bus.Type());
-    bool bVendorMatch = (mapping.m_iVendorId == 0 || mapping.m_iVendorId == iVendorId);
-    bool bProductMatch = (mapping.m_iProductId == 0 || mapping.m_iProductId == iProductId);
     bool bClassMatch = (mapping.m_class == PERIPHERAL_UNKNOWN || mapping.m_class == classType);
 
-    if (bBusMatch && bVendorMatch && bProductMatch && bClassMatch)
+    if (bProductMatch && bBusMatch && bClassMatch)
     {
       CStdString strVendorId, strProductId;
       PeripheralTypeTranslator::FormatHexString(iVendorId, strVendorId);
@@ -348,12 +352,16 @@ void CPeripherals::GetSettingsFromMapping(CPeripheral &peripheral) const
   for (unsigned int iMappingPtr = 0; iMappingPtr < m_mappings.size(); iMappingPtr++)
   {
     const PeripheralDeviceMapping *mapping = &m_mappings.at(iMappingPtr);
+
+    bool bProductMatch = false;
+    for (unsigned int i = 0; i < mapping->m_PeripheralID.size(); i++)
+      if (mapping->m_PeripheralID[i].m_iVendorId == peripheral.VendorId() && mapping->m_PeripheralID[i].m_iProductId == peripheral.ProductId())
+        bProductMatch = true;
+
     bool bBusMatch = (mapping->m_busType == PERIPHERAL_BUS_UNKNOWN || mapping->m_busType == peripheral.GetBusType());
-    bool bVendorMatch = (mapping->m_iVendorId == 0 || mapping->m_iVendorId == peripheral.VendorId());
-    bool bProductMatch = (mapping->m_iProductId == 0 || mapping->m_iProductId == peripheral.ProductId());
     bool bClassMatch = (mapping->m_class == PERIPHERAL_UNKNOWN || mapping->m_class == peripheral.Type());
 
-    if (bBusMatch && bVendorMatch && bProductMatch && bClassMatch)
+    if (bBusMatch && bProductMatch && bClassMatch)
     {
       for (map<CStdString, CSetting *>::const_iterator itr = mapping->m_settings.begin(); itr != mapping->m_settings.end(); itr++)
         peripheral.AddSetting((*itr).first, (*itr).second);
@@ -380,10 +388,29 @@ bool CPeripherals::LoadMappings(void)
   TiXmlElement *currentNode = pRootElement->FirstChildElement("peripheral");
   while (currentNode)
   {
+    CStdStringArray vpArray, idArray;
+    PeripheralID id;
     PeripheralDeviceMapping mapping;
 
-    mapping.m_iVendorId     = currentNode->Attribute("vendor") ? PeripheralTypeTranslator::HexStringToInt(currentNode->Attribute("vendor")) : 0;
-    mapping.m_iProductId    = currentNode->Attribute("product") ? PeripheralTypeTranslator::HexStringToInt(currentNode->Attribute("product")) : 0;
+    // If there is no vendor_product attribute ignore this entry
+    if (!currentNode->Attribute("vendor_product"))
+      continue;
+
+    // The vendor_product attribute is a list of comma separated vendor:product pairs
+    StringUtils::SplitString(currentNode->Attribute("vendor_product"), ",", vpArray);
+    for (unsigned int i = 0; i < vpArray.size(); i++)
+    {
+      StringUtils::SplitString(vpArray[i], ":", idArray);
+      if (idArray.size() != 2)
+        continue;
+
+      id.m_iVendorId = PeripheralTypeTranslator::HexStringToInt(idArray[0]);
+      id.m_iProductId = PeripheralTypeTranslator::HexStringToInt(idArray[1]);
+      mapping.m_PeripheralID.push_back(id);
+    }
+    if (mapping.m_PeripheralID.size() == 0)
+      continue;
+
     mapping.m_busType       = PeripheralTypeTranslator::GetBusTypeFromString(currentNode->Attribute("bus"));
     mapping.m_class         = PeripheralTypeTranslator::GetTypeFromString(currentNode->Attribute("class"));
     mapping.m_strDeviceName = currentNode->Attribute("name") ? CStdString(currentNode->Attribute("name")) : StringUtils::EmptyString;
@@ -432,10 +459,10 @@ void CPeripherals::GetSettingsFromMappingsFile(TiXmlElement *xmlNode, map<CStdSt
     }
     else if (strSettingsType.Equals("float"))
     {
-      float fValue = currentNode->Attribute("value") ? atof(currentNode->Attribute("value")) : 0;
-      float fMin   = currentNode->Attribute("min") ? atof(currentNode->Attribute("min")) : 0;
-      float fStep  = currentNode->Attribute("step") ? atof(currentNode->Attribute("step")) : 0;
-      float fMax   = currentNode->Attribute("max") ? atof(currentNode->Attribute("max")) : 0;
+      float fValue = currentNode->Attribute("value") ? (float) atof(currentNode->Attribute("value")) : 0;
+      float fMin   = currentNode->Attribute("min") ? (float) atof(currentNode->Attribute("min")) : 0;
+      float fStep  = currentNode->Attribute("step") ? (float) atof(currentNode->Attribute("step")) : 0;
+      float fMax   = currentNode->Attribute("max") ? (float) atof(currentNode->Attribute("max")) : 0;
       setting = new CSettingFloat(0, strKey, iLabelId, fValue, fMin, fStep, fMax, SPIN_CONTROL_FLOAT);
     }
     else


### PR DESCRIPTION
This is really a tidying up exercise. It changes the format of peripherals.xml so that multiple vendor and product ids can be specified per device. At the moment, because the Nyxboard exists with two different vendor/product ids the Nyxboard <peripheral ...> tag has to be entered twice and you get two identical copies of all the settings tags.
