### PR TITLE
Fix VAAPI VC1 decoding with Intel Sandy Bridge Gpus

### DIFF
--- a/lib/ffmpeg/libavcodec/vaapi_vc1.c
+++ b/lib/ffmpeg/libavcodec/vaapi_vc1.c
@@ -116,6 +116,18 @@ static inline VAMvModeVC1 vc1_get_MVMODE2(VC1Context *v)
     return 0;
 }
 
+/** Reconstruct bitstream TTFRM (7.1.1.41, Table-53) */
+static inline int vc1_get_TTFRM(VC1Context *v)
+{
+    switch (v->ttfrm) {
+    case TT_8X8: return 0;
+    case TT_8X4: return 1;
+    case TT_4X8: return 2;
+    case TT_4X4: return 3;
+    }
+    return 0;
+}
+
 /** Pack FFmpeg bitplanes into a VABitPlaneBuffer element */
 static inline void vc1_pack_bitplanes(uint8_t *bitplane, int n, const uint8_t *ff_bp[3], int x, int y, int stride)
 {
@@ -160,6 +172,9 @@ static int vaapi_vc1_start_frame(AVCodecContext *avctx, av_unused const uint8_t 
     pic_param->sequence_fields.bits.syncmarker                      = s->resync_marker;
     pic_param->sequence_fields.bits.rangered                        = v->rangered;
     pic_param->sequence_fields.bits.max_b_frames                    = s->avctx->max_b_frames;
+#if VA_CHECK_VERSION(0,32,0)
+    pic_param->sequence_fields.bits.profile                         = v->profile;
+#endif
     pic_param->coded_width                                          = s->avctx->coded_width;
     pic_param->coded_height                                         = s->avctx->coded_height;
     pic_param->entrypoint_fields.value                              = 0; /* reset all bits */
@@ -236,7 +251,7 @@ static int vaapi_vc1_start_frame(AVCodecContext *avctx, av_unused const uint8_t 
     pic_param->transform_fields.value                               = 0; /* reset all bits */
     pic_param->transform_fields.bits.variable_sized_transform_flag  = v->vstransform;
     pic_param->transform_fields.bits.mb_level_transform_type_flag   = v->ttmbf;
-    pic_param->transform_fields.bits.frame_level_transform_type     = v->ttfrm;
+    pic_param->transform_fields.bits.frame_level_transform_type     = vc1_get_TTFRM(v);
     pic_param->transform_fields.bits.transform_ac_codingset_idx1    = v->c_ac_table_index;
     pic_param->transform_fields.bits.transform_ac_codingset_idx2    = v->y_ac_table_index;
     pic_param->transform_fields.bits.intra_transform_dc_table       = v->s.dc_table_index;

--- a/lib/ffmpeg/patches/0061-fix-vc1-vaapi-intel-sandy-bridge.patch
+++ b/lib/ffmpeg/patches/0061-fix-vc1-vaapi-intel-sandy-bridge.patch
@@ -1,0 +1,48 @@
+This patch backports 53efb758c045900f512c947074900c0dbc988685 and a18e7b4fb77d3799cf21110b5e6dda4691a295b3
+
+Written by Gwenole Beauchesne <gwenole.beauchesne@intel.com>
+and fixes vc1 decoding with vaapi on Intel Sandy Bridge GPUs.
+
+
+diff --git a/lib/ffmpeg/libavcodec/vaapi_vc1.c b/lib/ffmpeg/libavcodec/vaapi_vc1.c
+index c61a5bd..a9bcd7b 100644
+--- a/lib/ffmpeg/libavcodec/vaapi_vc1.c
++++ b/lib/ffmpeg/libavcodec/vaapi_vc1.c
+@@ -116,6 +116,18 @@ static inline VAMvModeVC1 vc1_get_MVMODE2(VC1Context *v)
+     return 0;
+ }
+ 
++/** Reconstruct bitstream TTFRM (7.1.1.41, Table-53) */
++static inline int vc1_get_TTFRM(VC1Context *v)
++{
++    switch (v->ttfrm) {
++    case TT_8X8: return 0;
++    case TT_8X4: return 1;
++    case TT_4X8: return 2;
++    case TT_4X4: return 3;
++    }
++    return 0;
++}
++
+ /** Pack FFmpeg bitplanes into a VABitPlaneBuffer element */
+ static inline void vc1_pack_bitplanes(uint8_t *bitplane, int n, const uint8_t *ff_bp[3], int x, int y, int stride)
+ {
+@@ -160,6 +172,9 @@ static int vaapi_vc1_start_frame(AVCodecContext *avctx, av_unused const uint8_t
+     pic_param->sequence_fields.bits.syncmarker                      = s->resync_marker;
+     pic_param->sequence_fields.bits.rangered                        = v->rangered;
+     pic_param->sequence_fields.bits.max_b_frames                    = s->avctx->max_b_frames;
++#if VA_CHECK_VERSION(0,32,0)
++    pic_param->sequence_fields.bits.profile                         = v->profile;
++#endif
+     pic_param->coded_width                                          = s->avctx->coded_width;
+     pic_param->coded_height                                         = s->avctx->coded_height;
+     pic_param->entrypoint_fields.value                              = 0; /* reset all bits */
+@@ -236,7 +251,7 @@ static int vaapi_vc1_start_frame(AVCodecContext *avctx, av_unused const uint8_t
+     pic_param->transform_fields.value                               = 0; /* reset all bits */
+     pic_param->transform_fields.bits.variable_sized_transform_flag  = v->vstransform;
+     pic_param->transform_fields.bits.mb_level_transform_type_flag   = v->ttmbf;
+-    pic_param->transform_fields.bits.frame_level_transform_type     = v->ttfrm;
++    pic_param->transform_fields.bits.frame_level_transform_type     = vc1_get_TTFRM(v);
+     pic_param->transform_fields.bits.transform_ac_codingset_idx1    = v->c_ac_table_index;
+     pic_param->transform_fields.bits.transform_ac_codingset_idx2    = v->y_ac_table_index;
+     pic_param->transform_fields.bits.intra_transform_dc_table       = v->s.dc_table_index;


### PR DESCRIPTION
It is a small backport of two Gwenole Beauchesne's important ffmpeg upstream commits. Seem to fix playback for all users who reported.
