### PR TITLE
vdpau: fix race condition

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -368,12 +368,10 @@ void CVDPAU::OnLostDevice()
 {
   CLog::Log(LOGNOTICE,"CVDPAU::OnLostDevice event");
 
-  { CExclusiveLock lock(m_DecoderSection);
-    FiniVDPAUOutput();
-    FiniVDPAUProcs();
-  }
+  CExclusiveLock lock(m_DecoderSection);
+  FiniVDPAUOutput();
+  FiniVDPAUProcs();
 
-  CExclusiveLock lock(m_DisplaySection);
   m_DisplayState = VDPAU_LOST;
   m_DisplayEvent.Reset();
 }


### PR DESCRIPTION
m_DisplayState is already protected by the exclusive lock m_DecoderSection.
