### PR TITLE
Efile stubs: stub files for files stored on removable drives

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1279,7 +1279,10 @@ msgctxt "#294"
 msgid "Create bookmark"
 msgstr ""
 
-#empty string with id 295
+#: xbmc/dialogs/GUIDialogPlayEject.cpp
+msgctxt "#295"
+msgid "Please attach storage device"
+msgstr ""
 
 msgctxt "#296"
 msgid "Clear bookmarks"
@@ -2062,7 +2065,14 @@ msgctxt "#470"
 msgid "Credits"
 msgstr ""
 
-#empty strings from id 471 to 473
+#empty string with id 471
+
+#: xbmc/dialogs/GUIDialogPlayEject.cpp
+msgctxt "#472"
+msgid "Please insert the following hard drive:"
+msgstr ""
+
+#empty string with id 473
 
 msgctxt "#474"
 msgid "Off"
@@ -6545,7 +6555,12 @@ msgctxt "#13459"
 msgid "Use OMXPlayer for decoding of video files."
 msgstr ""
 
-#empty strings from id 13460 to 13504
+#: xbmc/dialogs/GUIDialogPlayEject.cpp
+msgctxt "#13460"
+msgid "Close"
+msgstr ""
+
+#empty strings from id 13461 to 13504
 
 #: system/settings/settings.xml
 msgctxt "#13505"

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1272,6 +1272,7 @@
     <ClCompile Include="..\..\xbmc\utils\StreamDetails.cpp" />
     <ClCompile Include="..\..\xbmc\utils\StreamUtils.cpp" />
     <ClCompile Include="..\..\xbmc\utils\StringUtils.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\StubUtil.cpp" />
     <ClCompile Include="..\..\xbmc\utils\SystemInfo.cpp" />
     <ClCompile Include="..\..\xbmc\utils\test\TestFileOperationJob.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -2122,6 +2123,7 @@
     <ClInclude Include="..\..\xbmc\utils\StreamDetails.h" />
     <ClInclude Include="..\..\xbmc\utils\StreamUtils.h" />
     <ClInclude Include="..\..\xbmc\utils\StringUtils.h" />
+    <ClInclude Include="..\..\xbmc\utils\StubUtil.h" />
     <ClInclude Include="..\..\xbmc\utils\SystemInfo.h" />
     <ClCompile Include="..\..\xbmc\utils\test\TestGlobalsHandlingPattern1.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2144,6 +2144,9 @@
     <ClCompile Include="..\..\xbmc\utils\POUtils.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\StubUtil.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\XbmcContext.cpp" />
     <ClCompile Include="..\..\xbmc\network\ZeroconfBrowser.cpp">
       <Filter>network</Filter>
@@ -5112,6 +5115,9 @@
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\POUtils.h">
+      <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\StubUtil.h">
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\ZeroconfBrowser.h">

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -68,6 +68,7 @@
 #ifdef HAS_FILESYSTEM_SAP
 #include "filesystem/SAPDirectory.h"
 #endif
+#include "utils/StubUtil.h"
 #include "utils/SystemInfo.h"
 #include "utils/TimeUtils.h"
 #include "GUILargeTextureManager.h"
@@ -2886,7 +2887,7 @@ PlayBackRet CApplication::PlayStack(const CFileItem& item, bool bRestart)
       else
       {
         int duration;
-        if (!CDVDFileInfo::GetFileDuration((*m_currentStack)[i]->GetPath(), duration))
+        if (!CDVDFileInfo::GetFileDuration((*m_currentStack)[i]->GetPlayablePath(), duration))
         {
           m_currentStack->Clear();
           return PLAYBACK_FAIL;
@@ -2991,6 +2992,27 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
     return PLAYBACK_OK;
   }
 
+  if (item.IsEfileStub())
+  {
+    if (!item.HasProperty("playable_path") || item.IsEfileStub(true))
+    {
+      CFileItem item_new(item);
+      item_new.SetPlayablePath(g_stubutil.GetXMLString(item.GetPath(), "efilestub", "path"));
+      return PlayFile(item_new, bRestart);
+    }
+    else
+    {
+      if(!CFile::Exists(item.GetPlayablePath()))
+      {
+        // Show PlayEject dialoge
+        if (CGUIDialogPlayEject::ShowAndGetInput(item))
+          return PlayFile(item, bRestart);
+
+		return PLAYBACK_OK;
+      }
+    }
+  }
+
   if (item.IsPlayList())
     return PLAYBACK_FAIL;
 
@@ -3011,7 +3033,7 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   }
 
 #ifdef HAS_UPNP
-  if (URIUtils::IsUPnP(item.GetPath()))
+  if (URIUtils::IsUPnP(item.GetPlayablePath()))
   {
     CFileItem item_new(item);
     if (XFILE::CUPnPDirectory::GetResource(item.GetURL(), item_new))
@@ -3024,7 +3046,21 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
   // "seamless" seeking and total time of the movie etc.
   // will recall with restart set to true
   if (item.IsStack())
-    return PlayStack(item, bRestart);
+  {
+    std::string strPathFirstElement = CStackDirectory::GetFirstStackedFile(item.GetPath());
+    if (g_stubutil.IsEfileStub(strPathFirstElement) && !CFile::Exists(g_stubutil.GetXMLString(strPathFirstElement, "efilestub", "path"), false))
+    {
+      CFileItem item_new(item);
+      item_new.SetPath(strPathFirstElement);
+      item_new.SetPlayablePath(g_stubutil.GetXMLString(strPathFirstElement, "efilestub", "path"));
+      if (CGUIDialogPlayEject::ShowAndGetInput(item_new))
+        return PlayFile(item, bRestart);
+
+	  return PLAYBACK_OK;
+    }
+    else
+      return PlayStack(item, bRestart);
+  }
 
   CPlayerOptions options;
 
@@ -3069,8 +3105,6 @@ PlayBackRet CApplication::PlayFile(const CFileItem& item, bool bRestart)
         std::string path = item.GetPath();
         if (item.HasVideoInfoTag() && StringUtils::StartsWith(item.GetVideoInfoTag()->m_strFileNameAndPath, "removable://"))
           path = item.GetVideoInfoTag()->m_strFileNameAndPath;
-        else if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
-          path = item.GetProperty("original_listitem_url").asString();
         if(dbs.GetResumeBookMark(path, bookmark))
         {
           options.starttime = bookmark.timeInSeconds;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -58,6 +58,7 @@
 #include "utils/Variant.h"
 #include "music/karaoke/karaokelyricsfactory.h"
 #include "utils/Mime.h"
+#include "utils/StubUtil.h"
 
 #include <assert.h>
 #include <algorithm>
@@ -732,6 +733,17 @@ bool CFileItem::IsPVRTimer() const
   return HasPVRTimerInfoTag();
 }
 
+bool CFileItem::IsStub(bool checkPlayablePath) const
+{
+  std::string path;
+  if (checkPlayablePath)
+    path = GetPlayablePath();
+  else
+    path = GetPath();
+
+  return URIUtils::HasExtension(path, g_advancedSettings.m_discStubExtensions);
+}
+
 bool CFileItem::IsDiscStub() const
 {
   if (IsVideoDb() && HasVideoInfoTag())
@@ -740,7 +752,25 @@ bool CFileItem::IsDiscStub() const
     return dbItem.IsDiscStub();
   }
 
-  return URIUtils::HasExtension(m_strPath, g_advancedSettings.m_discStubExtensions);
+  if (IsStub())
+    return g_stubutil.CheckRootElement(m_strPath, "discstub");
+
+  return false;
+}
+
+bool CFileItem::IsEfileStub(bool checkPlayablePath) const
+{
+  if (checkPlayablePath)
+  {
+    if (IsStub(true))
+      return g_stubutil.CheckRootElement(GetPlayablePath(), "efilestub");
+  }
+  else
+  {
+    if (IsStub())
+      return g_stubutil.CheckRootElement(GetPath(), "efilestub");
+  }
+  return false;
 }
 
 bool CFileItem::IsAudio() const
@@ -976,7 +1006,7 @@ bool CFileItem::IsStack() const
 
 bool CFileItem::IsPlugin() const
 {
-  return URIUtils::IsPlugin(m_strPath);
+  return URIUtils::IsPlugin(GetPlayablePath());
 }
 
 bool CFileItem::IsScript() const
@@ -3272,4 +3302,17 @@ double CFileItem::GetCurrentResumeTime() const
   }
   // Resume from start when resume points are invalid or the PVR server returns an error
   return 0;
+}
+
+std::string CFileItem::GetPlayablePath() const
+{
+  if (HasProperty("playable_path"))
+    return GetProperty("playable_path").asString();
+  else
+    return GetPath();
+}
+
+void CFileItem::SetPlayablePath(const std::string &path)
+{
+  SetProperty("playable_path", path);
 }

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -123,6 +123,9 @@ public:
   void SetPath(const std::string &path) { m_strPath = path; };
   bool IsPath(const std::string& path) const;
 
+  std::string GetPlayablePath() const;
+  void SetPlayablePath(const std::string &path);
+
   /*! \brief reset class to it's default values as per construction.
    Free's all allocated memory.
    \sa Initialize
@@ -151,8 +154,9 @@ public:
    \return true if item is video, false otherwise. 
    */
   bool IsVideo() const;
-
+  bool IsStub(bool checkPlayablePath = false) const;
   bool IsDiscStub() const;
+  bool IsEfileStub(bool checkPlayablePath = false) const;
 
   /*!
    \brief Check whether an item is a picture item. Note that this returns true for
@@ -169,7 +173,6 @@ public:
    \return true if item is audio, false otherwise. 
    */
   bool IsAudio() const;
-
   bool IsKaraoke() const;
   bool IsCUESheet() const;
   bool IsInternetStream(const bool bStrictCheck = false) const;

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -101,7 +101,7 @@ bool CExternalPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &opti
     m_bIsPlaying = true;
     m_time = 0;
     m_playbackStartTime = XbmcThreads::SystemClockMillis();
-    m_launchFilename = file.GetPath();
+    m_launchFilename = file.GetPlayablePath();
     CLog::Log(LOGNOTICE, "%s: %s", __FUNCTION__, m_launchFilename.c_str());
     Create();
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -635,7 +635,7 @@ bool CDVDPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
     m_PlayerOptions = options;
     m_item     = file;
     m_mimetype  = file.GetMimeType();
-    m_filename = file.GetPath();
+    m_filename = file.GetPlayablePath();
 
     m_ready.Reset();
 

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -31,6 +31,7 @@
 #include "PlayerCoreConfig.h"
 #include "PlayerSelectionRule.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/StubUtil.h"
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 
@@ -162,9 +163,13 @@ void CPlayerCoreFactory::GetPlayers( VECPLAYERCORES &vecCores, const bool audio,
 
 void CPlayerCoreFactory::GetPlayers( const CFileItem& item, VECPLAYERCORES &vecCores) const
 {
-  CURL url(item.GetPath());
+  std::string path = item.GetPath();
+  if (item.IsEfileStub())
+    g_stubutil.GetXMLString(item.GetPath(), "efilestub", "path", path);
 
-  CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers(%s)", CURL::GetRedacted(item.GetPath()).c_str());
+  CURL url(path);
+
+  CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers(%s)", CURL::GetRedacted(path).c_str());
 
   // Process rules
   for(unsigned int i = 0; i < m_vecCoreSelectionRules.size(); i++)

--- a/xbmc/dialogs/GUIDialogPlayEject.cpp
+++ b/xbmc/dialogs/GUIDialogPlayEject.cpp
@@ -18,14 +18,20 @@
  *
  */
 
+#include "FileItem.h"
 #include "GUIDialogPlayEject.h"
 #include "guilib/GUIWindowManager.h"
 #include "storage/MediaManager.h"
+#include "filesystem/File.h"
+
 #include "utils/log.h"
+#include "utils/StubUtil.h"
 #include "utils/XMLUtils.h"
 
 #define ID_BUTTON_PLAY      11
 #define ID_BUTTON_EJECT     10
+
+CFileItem currentItem;
 
 CGUIDialogPlayEject::CGUIDialogPlayEject()
     : CGUIDialogYesNo(WINDOW_DIALOG_PLAY_EJECT)
@@ -43,7 +49,7 @@ bool CGUIDialogPlayEject::OnMessage(CGUIMessage& message)
     int iControl = message.GetSenderId();
     if (iControl == ID_BUTTON_PLAY)
     {
-      if (g_mediaManager.IsDiscInDrive())
+      if ((currentItem.IsEfileStub() && XFILE::CFile::Exists(currentItem.GetPlayablePath(), false)) || g_mediaManager.IsDiscInDrive())
       {
         m_bConfirmed = true;
         Close();
@@ -53,17 +59,23 @@ bool CGUIDialogPlayEject::OnMessage(CGUIMessage& message)
     }
     if (iControl == ID_BUTTON_EJECT)
     {
-      g_mediaManager.ToggleTray();
-      return true;
+      if (currentItem.IsEfileStub())
+        Close();
+      else
+        g_mediaManager.ToggleTray();
+
+	  return true;
     }
   }
-
   return CGUIDialogYesNo::OnMessage(message);
 }
 
 void CGUIDialogPlayEject::FrameMove()
 {
-  CONTROL_ENABLE_ON_CONDITION(ID_BUTTON_PLAY, g_mediaManager.IsDiscInDrive());
+  if (currentItem.IsEfileStub())
+    CONTROL_ENABLE_ON_CONDITION(ID_BUTTON_PLAY, XFILE::CFile::Exists(currentItem.GetPlayablePath(), false));
+  else
+    CONTROL_ENABLE_ON_CONDITION(ID_BUTTON_PLAY, g_mediaManager.IsDiscInDrive());
 
   CGUIDialogYesNo::FrameMove();
 }
@@ -87,8 +99,31 @@ bool CGUIDialogPlayEject::ShowAndGetInput(const CFileItem & item,
   unsigned int uiAutoCloseTime /* = 0 */)
 {
   // Make sure we're actually dealing with a Disc Stub
-  if (!item.IsDiscStub())
+  if (!item.IsStub())
     return false;
+
+  currentItem = item;
+
+  int headingStr;
+  int line0Str;
+  int ejectButtonStr;
+
+  std::string strRootElement;
+
+  if (item.IsDiscStub())
+  {
+    headingStr = 219;
+    line0Str = 429;
+    ejectButtonStr = 13391;
+    strRootElement = "discstub";
+  }
+  else if (item.IsEfileStub())
+  {
+    headingStr = 295;
+    line0Str = 472;
+    ejectButtonStr = 13460;
+    strRootElement = "efilestub";
+  }
 
   // Create the dialog
   CGUIDialogPlayEject * pDialog = (CGUIDialogPlayEject *)g_windowManager.
@@ -98,30 +133,21 @@ bool CGUIDialogPlayEject::ShowAndGetInput(const CFileItem & item,
 
   // Figure out Lines 1 and 2 of the dialog
   std::string strLine1, strLine2;
-  CXBMCTinyXML discStubXML;
-  if (discStubXML.LoadFile(item.GetPath()))
-  {
-    TiXmlElement * pRootElement = discStubXML.RootElement();
-    if (!pRootElement || strcmpi(pRootElement->Value(), "discstub") != 0)
-      CLog::Log(LOGERROR, "Error loading %s, no <discstub> node", item.GetPath().c_str());
-    else
-    {
-      XMLUtils::GetString(pRootElement, "title", strLine1);
-      XMLUtils::GetString(pRootElement, "message", strLine2);
-    }
-  }
+  g_stubutil.GetXMLString(item.GetPath(), strRootElement, "title", strLine1);
+  g_stubutil.GetXMLString(item.GetPath(), strRootElement, "message", strLine2);
+  
 
   // Use the label for Line 1 if not defined
   if (strLine1.empty())
     strLine1 = item.GetLabel();
 
   // Setup dialog parameters
-  pDialog->SetHeading(219);
-  pDialog->SetLine(0, 429);
+  pDialog->SetHeading(headingStr);
+  pDialog->SetLine(0, line0Str);
   pDialog->SetLine(1, strLine1);
   pDialog->SetLine(2, strLine2);
   pDialog->SetChoice(ID_BUTTON_PLAY - 10, 208);
-  pDialog->SetChoice(ID_BUTTON_EJECT - 10, 13391);
+  pDialog->SetChoice(ID_BUTTON_EJECT - 10, ejectButtonStr);
   if (uiAutoCloseTime)
     pDialog->SetAutoClose(uiAutoCloseTime);
 

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -153,9 +153,7 @@ bool CPluginDirectory::GetPluginResult(const std::string& strPath, CFileItem &re
 
   if (success)
   { // update the play path and metadata, saving the old one as needed
-    if (!resultItem.HasProperty("original_listitem_url"))
-      resultItem.SetProperty("original_listitem_url", resultItem.GetPath());
-    resultItem.SetPath(newDir->m_fileResult->GetPath());
+    resultItem.SetPlayablePath(newDir->m_fileResult->GetPath());
     resultItem.SetMimeType(newDir->m_fileResult->GetMimeType());
     resultItem.UpdateInfo(*newDir->m_fileResult);
     if (newDir->m_fileResult->HasVideoInfoTag() && newDir->m_fileResult->GetVideoInfoTag()->m_resumePoint.IsSet())

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -26,6 +26,7 @@
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "URL.h"
+#include "utils/StubUtil.h"
 
 using namespace std;
 namespace XFILE
@@ -50,6 +51,8 @@ namespace XFILE
     {
       CFileItemPtr item(new CFileItem(*i));
       item->SetPath(*i);
+      if (item->IsEfileStub())
+        item->SetPlayablePath(g_stubutil.GetXMLString(item->GetPath(), "efilestub", "path"));
       item->m_bIsFolder = false;
       items.Add(item);
     }

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1046,8 +1046,6 @@ bool GetResource(const PLT_MediaObject* entry, CFileItem& item)
 {
   PLT_MediaItemResource resource;
 
-  // store original path so we remember it
-  item.SetProperty("original_listitem_url",  item.GetPath());
   item.SetProperty("original_listitem_mime", item.GetMimeType());
 
   // get a sorted list based on our preference

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -374,7 +374,7 @@ void CAdvancedSettings::Initialize()
   m_musicExtensions = ".nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.rar|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf";
   m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.rar|.001|.wpl|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.webm|.bdmv|.wtv";
   m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|.ass|.idx|.ifo|.rar|.zip";
-  m_discStubExtensions = ".disc";
+  m_discStubExtensions = ".disc|.efile";
   // internal music extensions
   m_musicExtensions += "|.cdda";
   // internal video extensions

--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -63,6 +63,7 @@ SRCS += StreamDetails.cpp
 SRCS += StreamUtils.cpp
 SRCS += StringUtils.cpp
 SRCS += StringValidation.cpp
+SRCS += StubUtil.cpp
 SRCS += SystemInfo.cpp
 SRCS += Temperature.cpp
 SRCS += TextSearch.cpp

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -41,13 +41,6 @@ bool CSaveFileStateJob::DoWork()
 
   if (m_item.HasVideoInfoTag() && StringUtils::StartsWith(m_item.GetVideoInfoTag()->m_strFileNameAndPath, "removable://"))
     progressTrackingFile = m_item.GetVideoInfoTag()->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label+uniqueid or is empty if label not uniquely identified
-  else if (m_item.HasProperty("original_listitem_url"))
-  {
-    // only use original_listitem_url for Python, UPnP and Bluray sources
-    std::string original = m_item.GetProperty("original_listitem_url").asString();
-    if (URIUtils::IsPlugin(original) || URIUtils::IsUPnP(original) || URIUtils::IsBluray(m_item.GetPath()))
-      progressTrackingFile = original;
-  }
 
   if (progressTrackingFile != "")
   {

--- a/xbmc/utils/StubUtil.cpp
+++ b/xbmc/utils/StubUtil.cpp
@@ -1,0 +1,74 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "StubUtil.h"
+#include "FileItem.h"
+#include "utils/XMLUtils.h"
+#include "utils/log.h"
+#include "utils/Variant.h"
+#include "filesystem/File.h"
+
+CStubUtil g_stubutil;
+
+CStubUtil::CStubUtil(void)
+{
+}
+CStubUtil::~CStubUtil(void)
+{
+}
+
+bool CStubUtil::IsEfileStub(const std::string strPath)
+{
+  CFileItem item = CFileItem(strPath, false);
+  return item.IsEfileStub();
+}
+
+bool CStubUtil::CheckRootElement(const std::string strFilename, std::string strRootElement)
+{
+  CXBMCTinyXML stubXML;
+  if (stubXML.LoadFile(strFilename))
+  {
+    TiXmlElement * pRootElement = stubXML.RootElement();
+    if (pRootElement && strcmpi(pRootElement->Value(), strRootElement.c_str()) == 0)
+      return true;
+  }
+  return false;
+}
+
+void CStubUtil::GetXMLString(const std::string strFilename, std::string strRootElement, std::string strXMLTag, std::string& strValue)
+{
+  CXBMCTinyXML stubXML;
+  if (stubXML.LoadFile(strFilename))
+  {
+    TiXmlElement * pRootElement = stubXML.RootElement();
+    if (!pRootElement || strcmpi(pRootElement->Value(), strRootElement.c_str()) != 0)
+
+		CLog::Log(LOGERROR, "Error loading %s, no <%s> node", strFilename.c_str(), strRootElement.c_str());
+    else
+      XMLUtils::GetString(pRootElement, strXMLTag.c_str(), strValue);
+  }
+}
+
+std::string CStubUtil::GetXMLString(const std::string strFilename, std::string strRootElement, std::string strXMLTag)
+{
+  std::string strValue;
+  GetXMLString(strFilename, strRootElement, strXMLTag, strValue);
+  return strValue;
+}

--- a/xbmc/utils/StubUtil.h
+++ b/xbmc/utils/StubUtil.h
@@ -1,0 +1,36 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "FileItem.h"
+
+class CStubUtil
+{
+  public:
+
+    CStubUtil(void);
+    virtual ~CStubUtil(void);
+
+    bool IsEfileStub(const std::string strPath);
+    bool CheckRootElement(const std::string strFilename, std::string strRootElement);
+    void GetXMLString(const std::string strFilename, std::string strRootElement, std::string strXMLTag, std::string& strValue);
+    std::string GetXMLString(const std::string strFilename, std::string strRootElement, std::string strXMLTag);
+};
+
+extern CStubUtil g_stubutil;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4749,16 +4749,7 @@ void CVideoDatabase::UpdateFanart(const CFileItem &item, VIDEODB_CONTENT_TYPE ty
 
 void CVideoDatabase::SetPlayCount(const CFileItem &item, int count, const CDateTime &date)
 {
-  int id;
-  if (item.HasProperty("original_listitem_url") &&
-      URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
-  {
-    CFileItem item2(item);
-    item2.SetPath(item.GetProperty("original_listitem_url").asString());
-    id = AddFile(item2);
-  }
-  else
-    id = AddFile(item);
+  int id = AddFile(item);
   if (id < 0)
     return;
 

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -243,9 +243,6 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
   
   // open the d/b and retrieve the bookmarks for the current movie
   m_filePath = g_application.CurrentFile();
-  if (g_application.CurrentFileItem().HasProperty("original_listitem_url") && 
-     !URIUtils::IsVideoDb(g_application.CurrentFileItem().GetProperty("original_listitem_url").asString()))
-     m_filePath = g_application.CurrentFileItem().GetProperty("original_listitem_url").asString();
 
   CVideoDatabase videoDatabase;
   videoDatabase.Open();
@@ -396,9 +393,6 @@ void CGUIDialogVideoBookmarks::ClearBookmarks()
   CVideoDatabase videoDatabase;
   videoDatabase.Open();
   std::string path = g_application.CurrentFile();
-  if (g_application.CurrentFileItem().HasProperty("original_listitem_url") && 
-     !URIUtils::IsVideoDb(g_application.CurrentFileItem().GetProperty("original_listitem_url").asString()))
-    path = g_application.CurrentFileItem().GetProperty("original_listitem_url").asString();
   videoDatabase.ClearBookMarksOfFile(path, CBookmark::STANDARD);
   videoDatabase.ClearBookMarksOfFile(path, CBookmark::RESUME);
   videoDatabase.ClearBookMarksOfFile(path, CBookmark::EPISODE);
@@ -471,9 +465,6 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
   else
   {
     std::string path = g_application.CurrentFile();
-    if (g_application.CurrentFileItem().HasProperty("original_listitem_url") && 
-       !URIUtils::IsVideoDb(g_application.CurrentFileItem().GetProperty("original_listitem_url").asString()))
-      path = g_application.CurrentFileItem().GetProperty("original_listitem_url").asString();
     videoDatabase.AddBookMarkToFile(path, bookmark, CBookmark::STANDARD);
   }
   videoDatabase.Close();


### PR DESCRIPTION
This will implement a new type of stub files for video files on removable drives (usb, esata, nas...).
The extension of the stub files is .efile. An example of an efile stub file and futher information can be found here: http://trac.xbmc.org/ticket/12172

It's tested on win and linux.

I know Eden is feature freezed but maybe this is something for Frodo.
