### PR TITLE
Fix name and id of inserted DVDs for computers with multiple drives

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -728,9 +728,9 @@ case TMSG_POWERDOWN:
     case TMSG_OPTICAL_MOUNT:
       {
         CMediaSource share;
+        share.strPath = pMsg->strParam;
         share.strStatus = g_mediaManager.GetDiskLabel(share.strPath);
         share.strDiskUniqueId = g_mediaManager.GetDiskUniqueId(share.strPath);
-        share.strPath = pMsg->strParam;
         if(g_mediaManager.IsAudio(share.strPath))
           share.strStatus = "Audio-CD";
         else if(share.strStatus == "")


### PR DESCRIPTION
Impact: resume points broken (they rely on the new DiskUniqueId stuff), and all DVDs appear as "E:\ (DVD)" instead of "E:\ (AMELIE)" for example.

Problem is that for a system with more than one drive, the strPath is not set when calling the label and id reading functions, and they use the first available drive on the system, not the one in which a disc was inserted.

Submitted as a PR because the fix is obviously correct on Windows as the path to the inserted media is passed in pMsg->strParam, but I don't know if that could cause problems for other platforms.
