### PR TITLE
minor cec fixes

### DIFF
--- a/language/Catalan/strings.xml
+++ b/language/Catalan/strings.xml
@@ -2382,7 +2382,6 @@
   <string id="36007">Power on the TV when starting XBMC</string>
   <string id="36008">Power off devices when stopping XBMC</string>
   <string id="36009">Put devices in standby mode when activating screensaver</string>
-  <string id="36010">Set as inactive source when stopping XBMC</string>
   <string id="36011">Could not detect the CEC port. Set it up manually.</string>
   <string id="36012">Could not detect the CEC adapter.</string>
   <string id="36013">Unsupported libcec interface version. %d is greater than the version XBMC supports (%d)</string>

--- a/language/Chinese (Simple)/strings.xml
+++ b/language/Chinese (Simple)/strings.xml
@@ -2376,7 +2376,6 @@
   <string id="36007">启动XBMC时开启电视</string>
   <string id="36008">退出XBMC时关闭设备</string>
   <string id="36009">激活屏幕保护程序时设备进入待机状态</string>
-  <string id="36010">退出XBMC时设为禁用资源</string>
   <string id="36011">未检测到 CEC 端口。需人工设置。</string>
   <string id="36012">未检测到 CEC 适配器。</string>
   <string id="36013">不支持的 libcec 界面版本。%d 高于 XBMC 支持的版本（%d）</string>

--- a/language/Czech/strings.xml
+++ b/language/Czech/strings.xml
@@ -2383,7 +2383,6 @@
   <string id="36007">Zapnout TV při spouštění XBMC</string>
   <string id="36008">Vypnout zařízení při ukončování XBMC</string>
   <string id="36009">Uvést zařízení do pohotovostního režimu při aktivování spořiče obrazovky</string>
-  <string id="36010">Nastavit jako neaktivní zdroj při ukončování XBMC</string>
   <string id="36011">Nepodařilo se najít CEC port. Nastavte jej ručně.</string>
   <string id="36012">Nepodařilo se najít CEC adaptér.</string>
   <string id="36013">Nepodporovaná verze libcec rozhraní. %d je vyšší než verze podporovaná XBMC (%d)</string>

--- a/language/Dutch/strings.xml
+++ b/language/Dutch/strings.xml
@@ -2345,7 +2345,6 @@
   <string id="36007">Schakel de TV in bij het opstarten van XBMC</string>
   <string id="36008">Schakel apparatuur uit bij het stoppen van XBMC</string>
   <string id="36009">Schakel app. uit zolang de schermbeveiliging actief is</string>
-  <string id="36010">Markeer als inactieve bron bij het stoppen van XBMC</string>
   <string id="36011">Kon de CEC poort niet detecteren. Stel het manueel in.</string>
   <string id="36012">Kon de CEC adapter niet detecteren.</string>
   <string id="36013">Versie %d van de libcec interface version wordt niet ondersteund door XBMC (> %d)</string>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2380,7 +2380,6 @@
   <string id="36007">Power on the TV when starting XBMC</string>
   <string id="36008">Power off devices when stopping XBMC</string>
   <string id="36009">Put devices in standby mode when activating screensaver</string>
-  <string id="36010">Set as inactive source when stopping XBMC</string>
   <string id="36011">Could not detect the CEC port. Set it up manually.</string>
   <string id="36012">Could not detect the CEC adapter.</string>
   <string id="36013">Unsupported libcec interface version. %d is greater than the version XBMC supports (%d)</string>

--- a/language/Finnish/strings.xml
+++ b/language/Finnish/strings.xml
@@ -2382,7 +2382,6 @@
   <string id="36007">Käynnistä laitteet kun XBMC käynnistetään</string>
   <string id="36008">Sammuta laitteet kun XBMC sammutetaan</string>
   <string id="36009">Aseta laitteet valmiustilaan näytönsäästäjän aktivoituessa</string>
-  <string id="36010">Aseta laite toimettomaksi lähteeksi kun XBMC sammutetaan</string>
   <string id="36011">CEC-porttia ei havaittu. Määritä se käsin.</string>
   <string id="36012">CEC-sovitinta ei havaittu.</string>
   <string id="36013">Ei tuettu libcec-rajapinnan versio. %d on suurempi kuin versio, jota XBMC tukee (%d)</string>

--- a/language/German/strings.xml
+++ b/language/German/strings.xml
@@ -2378,7 +2378,6 @@
   <string id="36007">Geräte anschalten wenn XBMC startet</string>
   <string id="36008">Geräte ausschalten wenn XBMC beendet wird</string>
   <string id="36009">Geräte in den Standby versetzen wenn der Bilschirmschoner aktiviert wird</string>
-  <string id="36010">Als inaktiv markieren wenn XBMC beendet wird</string>
   <string id="36011">Der CEC Port konnte nicht gefunden werden. Manuell einstellen.</string>
   <string id="36012">Der CEC Adapter konnte nicht gefunden werden.</string>
   <string id="36013">Nicht unterstützte libcec Version. %d ist größer als die von XBMC unterstützte Version (%d)</string>

--- a/language/Korean/strings.xml
+++ b/language/Korean/strings.xml
@@ -2379,7 +2379,6 @@
   <string id="36007">Power on devices when starting XBMC</string>
   <string id="36008">Power off devices when stopping XBMC</string>
   <string id="36009">Put devices in standby mode when activating screensaver</string>
-  <string id="36010">Set as inactive source when stopping XBMC</string>
   <string id="36011">Could not detect the CEC port. Set it up manually.</string>
   <string id="36012">Could not detect the CEC adapter.</string>
   <string id="36013">Unsupported libcec interface version. %d is greater than the version XBMC supports (%d)</string>

--- a/language/Slovenian/strings.xml
+++ b/language/Slovenian/strings.xml
@@ -2383,7 +2383,6 @@
   <string id="36007">Vključi naprave ob zagonu XBMC</string>
   <string id="36008">Izključi naprave ob izhodu iz XBMC</string>
   <string id="36009">Postavi naprave v stanje pripravljenosti ob ohranjevalniku zaslona</string>
-  <string id="36010">Nastavi kot neaktiven vir ob izhodu iz XBMC</string>
   <string id="36011">Ni mogoče zaznati vrat CEC. Nastavite jih ročno.</string>
   <string id="36012">Ni mogoče zaznati adapterja CEC.</string>
   <string id="36013">Nepodprta različica libcec. %d je višja, kot jo podpira XBMC (%d)</string>

--- a/language/Turkish/strings.xml
+++ b/language/Turkish/strings.xml
@@ -2389,7 +2389,6 @@
   <string id="36007">XBMC başlatılınca Televizyonu aç</string>
   <string id="36008">XBMC durdurulunca aygıtı kapat</string>
   <string id="36009">Ekran koruyucu devreye girince aygıtı bekleme moduna geçir</string>
-  <string id="36010">XBMC durdurulunca etkin olmayan kaynak olarak ayarla</string>
   <string id="36011">CEC portu algılanamadı. El ile ayarla.</string>
   <string id="36012">CEC bağdaştırıcısı algılanamadı.</string>
   <string id="36013">Desteklenmeyen libcec arabirim sürümü. %d is greater than the version XBMC supports (%d)</string>

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -15,9 +15,8 @@
     <setting key="cec_power_on_startup" type="bool" value="1" label="36007" />
     <setting key="cec_power_off_shutdown" type="bool" value="1" label="36008" />
     <setting key="cec_standby_screensaver" type="bool" value="1" label="36009" />
-    <setting key="cec_mark_inactive_shutdown" type="bool" value="0" label="36010" />
     <setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" />
     <setting key="cec_debug_logging" type="bool" value="0" label="20191" />
-	<setting key="use_tv_menu_language" type="bool" value="1" label="36018" />
+    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" />
   </peripheral>
 </peripherals>

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -90,6 +90,7 @@ namespace PERIPHERALS
     CDateTime                     m_screensaverLastActivated;
     CecButtonPress                m_button;
     std::queue<CEC::cec_keypress> m_buttonQueue;
+    unsigned int                  m_lastKeypress;
     CCriticalSection              m_critSection;
   };
 }


### PR DESCRIPTION
these are not essential, but nice to have fixes, that can be pulled whenever is appropriate:
- pose as a recording device instead of a playback device on the cec bus, so the tuner related buttons on the tv's remote work too (chanup, chandown, etc.)
- removed the option to mark xbmc as inactive view when stopping, but always send the command instead, as is required by the cec spec.
- corrections in repeated keypress handling.

this does not need an updated libcec.
