### PR TITLE
Added missing German string 13412

### DIFF
--- a/language/German/strings.xml
+++ b/language/German/strings.xml
@@ -1243,7 +1243,7 @@
   <string id="13409">Top 250</string>
   <string id="13410">Last.fm einschalten</string>
   <string id="13411">Minimale Lüftergeschwindigkeit</string>
-
+  <string id="13412">Ab hier abspielen</string>
   <string id="13413">Herunterladen</string>
   <string id="13414">Interpreten anzeigen die nur in Zusammenstellungen vorkommen</string>
   <string id="13415">Render-Methode</string>


### PR DESCRIPTION
The translation for string "Play from here" was not present in the German translation.
