### PR TITLE
fix more vdpau crashes, see ticket 12243

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -412,7 +412,6 @@ int CVDPAU::Check(AVCodecContext* avctx)
   {
     CLog::Log(LOGNOTICE,"Attempting recovery");
 
-    CSingleLock gLock(g_graphicsContext);
     CExclusiveLock lock(m_DecoderSection);
 
     FiniVDPAUOutput();
@@ -441,6 +440,8 @@ void CVDPAU::CheckFeatures()
 {
   if (videoMixer == VDP_INVALID_HANDLE)
   {
+    X11Lock xlock(g_Windowing);
+
     CLog::Log(LOGNOTICE, " (VDPAU) Creating the video mixer");
     // Creation of VideoMixer.
     VdpVideoMixerParameter parameters[] = {
@@ -673,6 +674,8 @@ void CVDPAU::SetDeinterlacing()
 
 void CVDPAU::InitVDPAUProcs()
 {
+  X11Lock xlock(g_Windowing);
+
   char* error;
 
   (void)dlerror();
@@ -690,7 +693,6 @@ void CVDPAU::InitVDPAUProcs()
 
   if (dl_vdp_device_create_x11)
   {
-    CSingleLock lock(g_graphicsContext);
     m_Display = g_Windowing.GetDisplay();
   }
 
@@ -779,6 +781,8 @@ void CVDPAU::InitVDPAUProcs()
 
 void CVDPAU::FiniVDPAUProcs()
 {
+  X11Lock xlock(g_Windowing);
+
   while (!m_videoSurfaces.empty())
   {
     vdpau_render_state *render = m_videoSurfaces.back();
@@ -931,6 +935,8 @@ bool CVDPAU::ConfigOutputMethod(AVCodecContext *avctx, AVFrame *pFrame)
 
   FiniOutputMethod();
 
+  X11Lock xlock(g_Windowing);
+
   MakePixmap(avctx->width,avctx->height);
 
   vdp_st = vdp_presentation_queue_target_create_x11(vdp_device,
@@ -979,6 +985,8 @@ bool CVDPAU::ConfigOutputMethod(AVCodecContext *avctx, AVFrame *pFrame)
 
 bool CVDPAU::FiniOutputMethod()
 {
+  X11Lock xlock(g_Windowing);
+
   VdpStatus vdp_st;
 
   if (vdp_flip_queue != VDP_INVALID_HANDLE)

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -504,21 +504,21 @@ void CVideoReferenceClock::RunGLX()
         return;
 
       //because of a bug in the nvidia driver, glXWaitVideoSyncSGI breaks when the vblank counter resets
-      CLog::Log(LOGDEBUG, "CVideoReferenceClock: Detaching glX context");
-      ReturnV = glXMakeCurrent(m_Dpy, None, NULL);
-      if (ReturnV != True)
-      {
-        CLog::Log(LOGDEBUG, "CVideoReferenceClock: glXMakeCurrent returned %i", ReturnV);
-        return;
-      }
-
-      CLog::Log(LOGDEBUG, "CVideoReferenceClock: Attaching glX context");
-      ReturnV = glXMakeCurrent(m_Dpy, m_Window, m_Context);
-      if (ReturnV != True)
-      {
-        CLog::Log(LOGDEBUG, "CVideoReferenceClock: glXMakeCurrent returned %i", ReturnV);
-        return;
-      }
+//      CLog::Log(LOGDEBUG, "CVideoReferenceClock: Detaching glX context");
+//      ReturnV = glXMakeCurrent(m_Dpy, None, NULL);
+//      if (ReturnV != True)
+//      {
+//        CLog::Log(LOGDEBUG, "CVideoReferenceClock: glXMakeCurrent returned %i", ReturnV);
+//        return;
+//      }
+//
+//      CLog::Log(LOGDEBUG, "CVideoReferenceClock: Attaching glX context");
+//      ReturnV = glXMakeCurrent(m_Dpy, m_Window, m_Context);
+//      if (ReturnV != True)
+//      {
+//        CLog::Log(LOGDEBUG, "CVideoReferenceClock: glXMakeCurrent returned %i", ReturnV);
+//        return;
+//      }
 
       m_glXGetVideoSyncSGI(&VblankCount);
 

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -216,8 +216,16 @@ bool CWinEventsSDL::MessagePump()
   SDL_Event event;
   bool ret = false;
 
-  while (SDL_PollEvent(&event))
+  while (1)
   {
+    {
+#if defined(HAS_GLX)
+      X11Lock xlock(g_Windowing);
+#endif
+      if (!SDL_PollEvent(&event))
+        break;
+    }
+
     switch(event.type)
     {
       case SDL_QUIT:
@@ -330,7 +338,14 @@ bool CWinEventsSDL::MessagePump()
 
       case SDL_MOUSEMOTION:
       {
-        if (0 == (SDL_GetAppState() & SDL_APPMOUSEFOCUS))
+        Uint8 state;
+        {
+#if defined(HAS_GLX)
+          X11Lock xlock(g_Windowing);
+#endif
+          state = SDL_GetAppState() & SDL_APPMOUSEFOCUS;
+        }
+        if (0 == state)
         {
           g_Mouse.SetActive(false);
 #if defined(__APPLE__)

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -333,8 +333,8 @@ bool CWinSystemX11::RefreshGlxContext()
   if(m_glWindow == info.info.x11.window && m_glContext)
   {
     CLog::Log(LOGERROR, "GLX: Same window as before, refreshing context");
-    glXMakeCurrent(m_dpy, None, NULL);
-    glXMakeCurrent(m_dpy, m_glWindow, m_glContext);
+//    glXMakeCurrent(m_dpy, None, NULL);
+//    glXMakeCurrent(m_dpy, m_glWindow, m_glContext);
     return true;
   }
 

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -83,5 +83,14 @@ private:
   CStopWatch m_screensaverReset;
 };
 
+class X11Lock
+{
+public:
+  X11Lock(CWinSystemX11 &winX11) { dpy = winX11.GetDisplay(); if (dpy) XLockDisplay(dpy); };
+  virtual ~X11Lock() { if (dpy) XUnlockDisplay(dpy); };
+private:
+  Display *dpy;
+};
+
 #endif // WINDOW_SYSTEM_H
 

--- a/xbmc/windowing/X11/WinSystemX11GL.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GL.cpp
@@ -43,6 +43,8 @@ CWinSystemX11GL::~CWinSystemX11GL()
 
 bool CWinSystemX11GL::PresentRenderImpl(const CDirtyRegionList& dirty)
 {
+  X11Lock xlock(*this);
+
   CheckDisplayEvents();
 
   if(m_iVSyncMode == 3)
@@ -124,6 +126,8 @@ bool CWinSystemX11GL::PresentRenderImpl(const CDirtyRegionList& dirty)
 
 void CWinSystemX11GL::SetVSyncImpl(bool enable)
 {
+  X11Lock xlock(*this);
+
   /* turn of current setting first */
   if(m_glXSwapIntervalSGI)
     m_glXSwapIntervalSGI(0);
@@ -200,6 +204,8 @@ bool CWinSystemX11GL::IsExtSupported(const char* extension)
 
 bool CWinSystemX11GL::CreateNewWindow(const CStdString& name, bool fullScreen, RESOLUTION_INFO& res, PHANDLE_EVENT_FUNC userFunction)
 {
+  X11Lock xlock(*this);
+
   if(!CWinSystemX11::CreateNewWindow(name, fullScreen, res, userFunction))
     return false;
 
@@ -246,6 +252,8 @@ bool CWinSystemX11GL::CreateNewWindow(const CStdString& name, bool fullScreen, R
 
 bool CWinSystemX11GL::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
+  X11Lock xlock(*this);
+
   CWinSystemX11::ResizeWindow(newWidth, newHeight, newLeft, newTop);
   CRenderSystemGL::ResetRenderSystem(newWidth, newHeight, false, 0);
 
@@ -254,6 +262,8 @@ bool CWinSystemX11GL::ResizeWindow(int newWidth, int newHeight, int newLeft, int
 
 bool CWinSystemX11GL::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
+  X11Lock xlock(*this);
+
   CWinSystemX11::SetFullScreen(fullScreen, res, blankOtherDisplays);
   CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
 


### PR DESCRIPTION
vdpau needs to share a display connection with the main thread because it shares resources. This requires locks around X11 communication.
