### PR TITLE
Bugfix: MySql reconnect (in query_with_reconnect)

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -269,8 +269,9 @@ int MysqlDatabase::query_with_reconnect(const char* query) {
   int attempts = 5;
   int result;
 
-  // try to reconnect if server is gone (up to 3 times)
-  while ( ((result = mysql_real_query(conn, query, strlen(query))) == CR_SERVER_GONE_ERROR) &&
+  // try to reconnect if server is gone
+  while ( ((result = mysql_real_query(conn, query, strlen(query))) != MYSQL_OK) &&
+          ((result = mysql_errno(conn)) == CR_SERVER_GONE_ERROR) && 
           (attempts-- > 0) )
   {
     CLog::Log(LOGINFO,"MYSQL server has gone. Will try %d more attempt(s) to reconnect.", attempts);
@@ -278,11 +279,6 @@ int MysqlDatabase::query_with_reconnect(const char* query) {
     connect(true);
   }
 
-  // grab the latest error if not ok
-  if (result != MYSQL_OK)
-    result = mysql_errno(conn);
-
-  // set the error return string and return
   return result;
 }
 


### PR DESCRIPTION
The MySql reconnect in query_with_reconnect is broken. Thus after a longer suspend/resume or server restart, the MySql connection fails with "ERROR: SQL: The MySQL server has gone away". 

Function mysql-real-query does not return the error code itself. Instead it only returns 0 (success) or a non zero value (always 1 in 5.5.19) on failiure. To get the actual error code, we have to call mysql_errno on the connection.

see http://dev.mysql.com/doc/refman/5.5/en/mysql-real-query.html and http://dev.mysql.com/doc/refman/5.5/en/mysql-errno.html
