### PR TITLE
cec: control volume settings on a CEC capable amp (when one is found) + fix when XBMC is connected to something else than a TV

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1173,7 +1173,7 @@ if test "x$use_libcec" != "xno"; then
 
   # libcec is dyloaded, so we need to check for its headers and link any depends.
   if test "x$use_libcec" != "xno"; then
-    PKG_CHECK_MODULES([CEC],[libcec >= 1.1.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
+    PKG_CHECK_MODULES([CEC],[libcec >= 1.5.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
 
     if test "x$use_libcec" != "xno"; then
       INCLUDES="$INCLUDES $CEC_CFLAGS"

--- a/language/Dutch/strings.xml
+++ b/language/Dutch/strings.xml
@@ -2391,17 +2391,20 @@
   <string id="36004">Druk op "user" knop commando</string>
   <string id="36005">Schakel commando's in bij het wisselen van kant</string>
   <string id="36006">Kon de adapter niet openen</string>
-  <string id="36007">Schakel de TV in bij het opstarten van XBMC</string>
+  <string id="36007">Schakel apparatuur in bij het opstarten van XBMC</string>
   <string id="36008">Schakel apparatuur uit bij het stoppen van XBMC</string>
   <string id="36009">Schakel app. uit zolang de schermbeveiliging actief is</string>
   <string id="36010"></string>
-  <string id="36011">Kon de CEC poort niet detecteren. Stel het manueel in.</string>
-  <string id="36012">Kon de CEC adapter niet detecteren.</string>
-  <string id="36013">Versie %d van de libcec interface version wordt niet ondersteund door XBMC (> %d)</string>
+  <string id="36011">Kon de COM poort niet detecteren. Stel het manueel in.</string>
+  <string id="36012">Kon de CEC adapter niet initialiseren.</string>
+  <string id="36013">Versie %d van de libCEC interface version wordt niet ondersteund door XBMC (> %d)</string>
   <string id="36014">Zet XBMC in standby wanneer de TV uitgeschakeld wordt</string>
   <string id="36015">HDMI poort nummer</string>
   <string id="36016">Verbonden</string> <!-- max. 13 characters -->
-  <string id="36017">Adapter gevonden, maar libcec is niet beschikbaar</string>
+  <string id="36017">Adapter gevonden, maar libCEC is niet beschikbaar</string>
   <string id="36018">Gebruik de taalinstelling van de TV</string>
   <string id="36019">Verbonden met HDMI apparaat</string>
+  <string id="36020">Maak XBMC de actieve bron bij het opstarten</string>
+  <string id="36021">Physiek adres (overschrijft HDMI poort)</string>
+  <string id="36022">COM poort (laat leeg, tenzij noodzakelijk)</string>
 </strings>

--- a/language/Dutch/strings.xml
+++ b/language/Dutch/strings.xml
@@ -2407,4 +2407,7 @@
   <string id="36020">Maak XBMC de actieve bron bij het opstarten</string>
   <string id="36021">Physiek adres (overschrijft HDMI poort)</string>
   <string id="36022">COM poort (laat leeg, tenzij noodzakelijk)</string>
+  <string id="36023">Configuratie aangepast</string>
+  <string id="36024">Kon de nieuwe configuratie niet instellen. Controleer de instellingen.</string>
+  <string id="36025">Verstuur 'inactieve bron' commando bij het stoppen</string>
 </strings>

--- a/language/Dutch/strings.xml
+++ b/language/Dutch/strings.xml
@@ -2403,4 +2403,5 @@
   <string id="36016">Verbonden</string> <!-- max. 13 characters -->
   <string id="36017">Adapter gevonden, maar libcec is niet beschikbaar</string>
   <string id="36018">Gebruik de taalinstelling van de TV</string>
+  <string id="36019">Verbonden met HDMI apparaat</string>
 </strings>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2414,4 +2414,5 @@
   <string id="36022">COM port (leave empty unless needed)</string>
   <string id="36023">Configuration updated</string>
   <string id="36024">Failed to set the new configuration. Please check your settings.</string>
+  <string id="36025">Send 'inactive source' command when stopping XBMC</string>
 </strings>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2407,4 +2407,5 @@
   <string id="36016">Connected</string> <!-- max. 13 characters -->
   <string id="36017">Adapter found, but libcec is not available</string>
   <string id="36018">Use the TV's language setting</string>
+  <string id="36019">Connected to HDMI device</string>
 </strings>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2396,17 +2396,20 @@
   <string id="36004">Press "user" button command</string>
   <string id="36005">Enable switch side commands</string>
   <string id="36006">Could not open the adapter</string>
-  <string id="36007">Power on the TV when starting XBMC</string>
-  <string id="36008">Power off devices when stopping XBMC</string>
+  <string id="36007">Devices to power on the TV when starting XBMC</string>
+  <string id="36008">Devices to power off devices when stopping XBMC</string>
   <string id="36009">Put devices in standby mode when activating screensaver</string>
   <string id="36010"></string>
   <string id="36011">Could not detect the CEC port. Set it up manually.</string>
-  <string id="36012">Could not detect the CEC adapter.</string>
-  <string id="36013">Unsupported libcec interface version. %d is greater than the version XBMC supports (%d)</string>
+  <string id="36012">Could not initialise the CEC adapter. Check your settings.</string>
+  <string id="36013">Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)</string>
   <string id="36014">Put this PC in standby mode when the TV is switched off</string>
   <string id="36015">HDMI port number</string>
   <string id="36016">Connected</string> <!-- max. 13 characters -->
-  <string id="36017">Adapter found, but libcec is not available</string>
+  <string id="36017">Adapter found, but libCEC is not available</string>
   <string id="36018">Use the TV's language setting</string>
   <string id="36019">Connected to HDMI device</string>
+  <string id="36020">Make XBMC the active source when starting</string>
+  <string id="36021">Physical address (overrules HDMI port)</string>
+  <string id="36022">COM port (leave empty unless needed)</string>
 </strings>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2412,4 +2412,6 @@
   <string id="36020">Make XBMC the active source when starting</string>
   <string id="36021">Physical address (overrules HDMI port)</string>
   <string id="36022">COM port (leave empty unless needed)</string>
+  <string id="36023">Configuration updated</string>
+  <string id="36024">Failed to set the new configuration. Please check your settings.</string>
 </strings>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2381,6 +2381,7 @@
   <string id="35006">Device removed</string>
   <string id="35007">Keymap to use for this device</string>
   <string id="35008">Keymap enabled</string>
+  <string id="35009">Do not use the custom keymap for this device</string>
 
   <string id="35500">Location</string>
   <string id="35501">Class</string>

--- a/lib/libcec/Makefile
+++ b/lib/libcec/Makefile
@@ -7,17 +7,17 @@
 
 # lib name, version
 LIBNAME=libcec
-VERSION=1.5.1
+VERSION=latest
 SOURCE=$(LIBNAME)-$(VERSION)
 
 # download location and format
-BASE_URL=http://mirrors.xbmc.org/build-deps/darwin-libs
-ARCHIVE=$(SOURCE).tar.gz 
+BASE_URL=http://packages.pulse-eight.net/pulse/sources/libcec
+ARCHIVE=$(SOURCE).tar.bz2 
 TARBALLS_LOCATION=.
 RETRIEVE_TOOL=/usr/bin/curl
 RETRIEVE_TOOL_FLAGS=-Ls --create-dirs --output $(TARBALLS_LOCATION)/$(ARCHIVE)
 ARCHIVE_TOOL=tar
-ARCHIVE_TOOL_FLAGS=xf
+ARCHIVE_TOOL_FLAGS=jxf
 
 PREFIX ?= /usr/local
 LIBCEC_CONFIGOPTS ?= --prefix=$(PREFIX)
@@ -25,30 +25,30 @@ LIBCEC_CONFIGOPTS ?= --prefix=$(PREFIX)
 # configuration settings
 CONFIGURE=./configure CFLAGS=-D_FILE_OFFSET_BITS=64 $(LIBCEC_CONFIGOPTS)
 
-SO_NAME=$(SOURCE)/.libs/$(LIBNAME).so
+SO_NAME=$(LIBNAME)/.libs/$(LIBNAME).so
 
 all: $(SO_NAME)
 
 $(TARBALLS_LOCATION)/$(ARCHIVE):
 	$(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
 
-$(SOURCE): $(TARBALLS_LOCATION)/$(ARCHIVE)
-	rm -rf $(SOURCE)
+$(LIBNAME): $(TARBALLS_LOCATION)/$(ARCHIVE)
+	rm -rf $(LIBNAME)
 	$(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	echo $(SOURCE) > .gitignore
-	cd $(SOURCE); autoreconf -vif
-	cd $(SOURCE); $(CONFIGURE)
+	echo $(LIBNAME) > .gitignore
+	cd $(LIBNAME); autoreconf -vif
+	cd $(LIBNAME); $(CONFIGURE)
 
-$(SO_NAME): $(SOURCE)
-	make -j 1 -C $(SOURCE)
+$(SO_NAME): $(LIBNAME)
+	make -j 1 -C $(LIBNAME)
 
 install:
-	make -C $(SOURCE) install
+	make -C $(LIBNAME) install
 	ldconfig
 
 clean:
-	rm -rf $(SOURCE)
+	rm -rf $(LIBNAME)
 
 distclean::
-	rm -rf $(SOURCE)
+	rm -rf $(LIBNAME)
 

--- a/lib/libcec/Makefile
+++ b/lib/libcec/Makefile
@@ -7,7 +7,7 @@
 
 # lib name, version
 LIBNAME=libcec
-VERSION=1.2.0
+VERSION=1.5.0
 SOURCE=$(LIBNAME)-$(VERSION)
 
 # download location and format

--- a/lib/libcec/Makefile
+++ b/lib/libcec/Makefile
@@ -7,7 +7,7 @@
 
 # lib name, version
 LIBNAME=libcec
-VERSION=1.5.0
+VERSION=1.5.1
 SOURCE=$(LIBNAME)-$(VERSION)
 
 # download location and format

--- a/project/BuildDependencies/scripts/libcec_d.bat
+++ b/project/BuildDependencies/scripts/libcec_d.bat
@@ -7,7 +7,8 @@ CALL dlextract.bat libcec %FILES%
 
 cd %TMP_PATH%
 
-xcopy libcec\include\* "%CUR_PATH%\include" /E /Q /I /Y
+mkdir "%CUR_PATH%\include\libcec"
+xcopy libcec\include\* "%CUR_PATH%\include\libcec\." /E /Q /I /Y
 
 copy libcec\libcec.dll "%XBMC_PATH%\system\."
 copy libcec\pthreadVC2.dll "%XBMC_PATH%\system\."

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        source of the file
 
-libcec1.5.1.zip                   http://packages.pulse-eight.net/windows/
+libcec-latest.zip                 http://packages.pulse-eight.net/windows/

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        source of the file
 
-libcec1.2.zip                     http://packages.pulse-eight.net/windows/
+libcec1.5.0.zip                   http://packages.pulse-eight.net/windows/

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        source of the file
 
-libcec1.5.0.zip                   http://packages.pulse-eight.net/windows/
+libcec1.5.1.zip                   http://packages.pulse-eight.net/windows/

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -10,18 +10,19 @@
 
   <peripheral vendor_product="2548:1001" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">
     <setting key="enabled" type="bool" value="1" label="305" order="1" />
-	<setting key="activate_source" type="bool" value="1" label="36020" order="2" />
-	<setting key="wake_devices" type="string" value="0" label="36007" order="3" />
-	<setting key="standby_devices" type="string" value="0" label="36008" order="4" />
+    <setting key="activate_source" type="bool" value="1" label="36020" order="2" />
+    <setting key="wake_devices" type="string" value="0" label="36007" order="3" />
+    <setting key="standby_devices" type="string" value="0" label="36008" order="4" />
     <setting key="cec_standby_screensaver" type="bool" value="1" label="36009" order="5" />
-	<setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" order="6" />
-	<setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="7" />
-	<setting key="physical_address" type="string" label="36021" value="0" order="8" />
-    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="16" label="36015" order="9" />
-    <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" order="10" />
-    <setting key="port" type="string" value="" label="36022" order="11" />
+    <setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" order="6" />
+    <setting key="send_inactive_source" type="bool" value="1" label="36025" order="7" />
+    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="8" />
+    <setting key="physical_address" type="string" label="36021" value="0" order="9" />
+    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="16" label="36015" order="10" />
+    <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" order="11" />
+    <setting key="port" type="string" value="" label="36022" order="12" />
 
-	<setting key="tv_vendor" type="int" value="0" configurable="0" />
+    <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="XBMC" configurable="0" />
     <setting key="device_type" type="int" value="1" configurable="0" />
   </peripheral>

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -1,6 +1,6 @@
 <peripherals>
   <peripheral vendor_product="1915:003B,22B8:003B" bus="usb" name="Motorola Nyxboard Hybrid" mapTo="nyxboard">
-    <setting key="keymap_enabled" type="bool" value="1" label="35008" order="1" />
+    <setting key="do_not_use_custom_keymap" type="bool" value="0" label="35009" order="1" />
     <setting key="keymap" value="nyxboard" label="35007" configurable="0" />
     <setting key="enable_flip_commands" type="bool" value="1" label="36005" order="2" />
     <setting key="flip_keyboard" value="XBMC.VideoLibrary.Search" label="36002" order="3" />

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -1,22 +1,22 @@
 <peripherals>
   <peripheral vendor_product="1915:003B,22B8:003B" bus="usb" name="Motorola Nyxboard Hybrid" mapTo="nyxboard">
-    <setting key="keymap_enabled" type="bool" value="1" label="35008" />
+    <setting key="keymap_enabled" type="bool" value="1" label="35008" order="1" />
     <setting key="keymap" value="nyxboard" label="35007" configurable="0" />
-    <setting key="enable_flip_commands" type="bool" value="1" label="36005" />
-    <setting key="flip_keyboard" value="XBMC.VideoLibrary.Search" label="36002" />
-    <setting key="flip_remote" value="Dialog.Close(virtualkeyboard)" label="36003" />
-    <setting key="key_user" value="" label="36004" />
+    <setting key="enable_flip_commands" type="bool" value="1" label="36005" order="2" />
+    <setting key="flip_keyboard" value="XBMC.VideoLibrary.Search" label="36002" order="3" />
+    <setting key="flip_remote" value="Dialog.Close(virtualkeyboard)" label="36003" order="4" />
+    <setting key="key_user" value="" label="36004" order="5" />
   </peripheral>
 
   <peripheral vendor_product="2548:1001" bus="usb" name="Pulse-Eight CEC Adaptor" mapTo="cec">
-    <setting key="enabled" type="bool" value="1" label="305" />
-    <setting key="port" type="string" value="" label="792" />
-    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="16" label="36015" />
-    <setting key="cec_power_on_startup" type="bool" value="1" label="36007" />
-    <setting key="cec_power_off_shutdown" type="bool" value="1" label="36008" />
-    <setting key="cec_standby_screensaver" type="bool" value="1" label="36009" />
-    <setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" />
-    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" />
-    <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" />
+    <setting key="enabled" type="bool" value="1" label="305" order="1" />
+    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="16" label="36015" order="2" />
+    <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" order="3" />
+    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="4" />
+    <setting key="cec_power_on_startup" type="bool" value="1" label="36007" order="5" />
+    <setting key="cec_power_off_shutdown" type="bool" value="1" label="36008" order="6" />
+    <setting key="cec_standby_screensaver" type="bool" value="1" label="36009" order="7" />
+    <setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" order="8" />
+    <setting key="port" type="string" value="" label="792" order="9" />
   </peripheral>
 </peripherals>

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -16,7 +16,6 @@
     <setting key="cec_power_off_shutdown" type="bool" value="1" label="36008" />
     <setting key="cec_standby_screensaver" type="bool" value="1" label="36009" />
     <setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" />
-    <setting key="cec_debug_logging" type="bool" value="0" label="20191" />
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" />
     <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" />
   </peripheral>

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -8,15 +8,21 @@
     <setting key="key_user" value="" label="36004" order="5" />
   </peripheral>
 
-  <peripheral vendor_product="2548:1001" bus="usb" name="Pulse-Eight CEC Adaptor" mapTo="cec">
+  <peripheral vendor_product="2548:1001" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">
     <setting key="enabled" type="bool" value="1" label="305" order="1" />
-    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="16" label="36015" order="2" />
-    <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" order="3" />
-    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="4" />
-    <setting key="cec_power_on_startup" type="bool" value="1" label="36007" order="5" />
-    <setting key="cec_power_off_shutdown" type="bool" value="1" label="36008" order="6" />
-    <setting key="cec_standby_screensaver" type="bool" value="1" label="36009" order="7" />
-    <setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" order="8" />
-    <setting key="port" type="string" value="" label="792" order="9" />
+	<setting key="activate_source" type="bool" value="1" label="36020" order="2" />
+	<setting key="wake_devices" type="string" value="0" label="36007" order="3" />
+	<setting key="standby_devices" type="string" value="0" label="36008" order="4" />
+    <setting key="cec_standby_screensaver" type="bool" value="1" label="36009" order="5" />
+	<setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" order="6" />
+	<setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="7" />
+	<setting key="physical_address" type="string" label="36021" value="0" order="8" />
+    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="16" label="36015" order="9" />
+    <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" order="10" />
+    <setting key="port" type="string" value="" label="36022" order="11" />
+
+	<setting key="tv_vendor" type="int" value="0" configurable="0" />
+    <setting key="device_name" type="string" value="XBMC" configurable="0" />
+    <setting key="device_type" type="int" value="1" configurable="0" />
   </peripheral>
 </peripherals>

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -18,5 +18,6 @@
     <setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" />
     <setting key="cec_debug_logging" type="bool" value="0" label="20191" />
     <setting key="use_tv_menu_language" type="bool" value="1" label="36018" />
+    <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" />
   </peripheral>
 </peripherals>

--- a/tools/darwin/depends/libcec/Makefile
+++ b/tools/darwin/depends/libcec/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.include
 
 # lib name, version
 LIBNAME=libcec
-VERSION=1.5.0
+VERSION=1.5.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/tools/darwin/depends/libcec/Makefile
+++ b/tools/darwin/depends/libcec/Makefile
@@ -2,37 +2,37 @@ include ../Makefile.include
 
 # lib name, version
 LIBNAME=libcec
-VERSION=1.5.1
+VERSION=latest
 SOURCE=$(LIBNAME)-$(VERSION)
-ARCHIVE=$(SOURCE).tar.gz
+ARCHIVE=$(SOURCE).tar.bz2
 
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX)
 
-LIBDYLIB=$(SOURCE)/.libs/$(LIBNAME).dylib
+LIBDYLIB=$(LIBNAME)/.libs/$(LIBNAME).dylib
 
 all: $(LIBDYLIB) .installed
 
 $(TARBALLS_LOCATION)/$(ARCHIVE):
 	$(RETRIEVE_TOOL) $(RETRIEVE_TOOL_FLAGS) $(BASE_URL)/$(ARCHIVE)
 
-$(SOURCE): $(TARBALLS_LOCATION)/$(ARCHIVE)
-	rm -rf $(SOURCE)
+$(LIBNAME): $(TARBALLS_LOCATION)/$(ARCHIVE)
+	rm -rf $(LIBNAME)
 	$(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	echo $(SOURCE) > .gitignore
-	cd $(SOURCE); autoreconf -vif
-	cd $(SOURCE); $(CONFIGURE)
+	echo $(LIBNAME) > .gitignore
+	cd $(LIBNAME); autoreconf -vif
+	cd $(LIBNAME); $(CONFIGURE)
 
-$(LIBDYLIB): $(SOURCE)
-	make -j 1 -C $(SOURCE)
+$(LIBDYLIB): $(LIBNAME)
+	make -j 1 -C $(LIBNAME)
 
 .installed:
-	make -C $(SOURCE) install
+	make -C $(LIBNAME) install
 	touch $@
 
 clean:
-	rm -rf $(SOURCE) .installed
+	rm -rf $(LIBNAME) .installed
 
 distclean::
-	rm -rf $(SOURCE) .installed
+	rm -rf $(LIBNAME) .installed
 

--- a/tools/darwin/depends/libcec/Makefile
+++ b/tools/darwin/depends/libcec/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.include
 
 # lib name, version
 LIBNAME=libcec
-VERSION=1.2.0
+VERSION=1.5.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2583,6 +2583,26 @@ bool CApplication::OnAction(const CAction &action)
   // Check for global volume control
   if (action.GetAmount() && (action.GetID() == ACTION_VOLUME_UP || action.GetID() == ACTION_VOLUME_DOWN))
   {
+    /* try to set the volume on a connected amp */
+  #ifdef HAVE_LIBCEC
+    vector<CPeripheral *> peripherals;
+    if (g_peripherals.GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
+    {
+      for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < peripherals.size(); iPeripheralPtr++)
+      {
+        CPeripheralCecAdapter *cecDevice = (CPeripheralCecAdapter *) peripherals.at(iPeripheralPtr);
+        if (cecDevice && cecDevice->HasConnectedAudioSystem())
+        {
+          if (action.GetID() == ACTION_VOLUME_UP)
+            cecDevice->ScheduleVolumeUp();
+          else
+            cecDevice->ScheduleVolumeDown();
+          return true;
+        }
+      }
+    }
+  #endif
+
     if (!m_pPlayer || !m_pPlayer->IsPassthrough())
     {
       // increase or decrease the volume
@@ -5027,11 +5047,49 @@ void CApplication::ShowVolumeBar(const CAction *action)
 
 bool CApplication::IsMuted() const
 {
+  /* try to set the mute setting on a connected amp */
+#ifdef HAVE_LIBCEC
+  vector<CPeripheral *> peripherals;
+  if (g_peripherals.GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
+  {
+    for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < peripherals.size(); iPeripheralPtr++)
+    {
+      CPeripheralCecAdapter *cecDevice = (CPeripheralCecAdapter *) peripherals.at(iPeripheralPtr);
+      if (cecDevice && cecDevice->HasConnectedAudioSystem())
+        return false;
+    }
+  }
+#endif
   return g_settings.m_bMute;
+}
+
+bool CApplication::CecMute(void)
+{
+  /* try to set the mute setting on a connected amp */
+#ifdef HAVE_LIBCEC
+  vector<CPeripheral *> peripherals;
+  if (g_peripherals.GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
+  {
+    for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < peripherals.size(); iPeripheralPtr++)
+    {
+      CPeripheralCecAdapter *cecDevice = (CPeripheralCecAdapter *) peripherals.at(iPeripheralPtr);
+      if (cecDevice && cecDevice->HasConnectedAudioSystem())
+      {
+        cecDevice->ScheduleMute();
+        return true;
+      }
+    }
+  }
+#endif
+
+  return false;
 }
 
 void CApplication::ToggleMute(void)
 {
+  if (CecMute())
+    return;
+
   if (g_settings.m_bMute)
     UnMute();
   else
@@ -5040,6 +5098,9 @@ void CApplication::ToggleMute(void)
 
 void CApplication::Mute()
 {
+  if (CecMute())
+    return;
+
   g_settings.m_iPreMuteVolumeLevel = GetVolume();
   SetVolume(0);
   g_settings.m_bMute = true;
@@ -5047,6 +5108,9 @@ void CApplication::Mute()
 
 void CApplication::UnMute()
 {
+  if (CecMute())
+    return;
+
   SetVolume(g_settings.m_iPreMuteVolumeLevel);
   g_settings.m_iPreMuteVolumeLevel = 0;
   g_settings.m_bMute = false;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3308,7 +3308,8 @@ void CApplication::Stop(int exitCode)
 {
   try
   {
-    CAnnouncementManager::Announce(System, "xbmc", "OnQuit");
+    CVariant vExitCode(exitCode);
+    CAnnouncementManager::Announce(System, "xbmc", "OnQuit", vExitCode);
 
     // cancel any jobs from the jobmanager
     CJobManager::GetInstance().CancelJobs();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -167,7 +167,6 @@ public:
   void SetVolume(long iValue, bool isPercentage = true);
   bool IsMuted() const;
   void ToggleMute(void);
-  bool CecMute(void);
   void ShowVolumeBar(const CAction *action = NULL);
   int GetPlaySpeed() const;
   int GetSubtitleDelay() const;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -167,6 +167,7 @@ public:
   void SetVolume(long iValue, bool isPercentage = true);
   bool IsMuted() const;
   void ToggleMute(void);
+  bool CecMute(void);
   void ShowVolumeBar(const CAction *action = NULL);
   int GetPlaySpeed() const;
   int GetSubtitleDelay() const;

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -447,6 +447,8 @@ bool CPeripherals::LoadMappings(void)
 void CPeripherals::GetSettingsFromMappingsFile(TiXmlElement *xmlNode, map<CStdString, CSetting *> &m_settings)
 {
   TiXmlElement *currentNode = xmlNode->FirstChildElement("setting");
+  int iMaxOrder(0);
+
   while (currentNode)
   {
     CSetting *setting = NULL;
@@ -492,9 +494,31 @@ void CPeripherals::GetSettingsFromMappingsFile(TiXmlElement *xmlNode, map<CStdSt
     }
 
     //TODO add more types if needed
+
+    /* set the visibility */
     setting->SetVisible(bConfigurable);
+
+    /* set the order */
+    int iOrder(0);
+    currentNode->Attribute("order", &iOrder);
+    /* if the order attribute is invalid or 0, then the setting will be added at the end */
+    if (iOrder < 0)
+      iOrder = 0;
+    setting->SetOrder(iOrder);
+    if (iOrder > iMaxOrder)
+      iMaxOrder = iOrder;
+
+    /* and add this new setting */
     m_settings[strKey] = setting;
+
     currentNode = currentNode->NextSiblingElement("setting");
+  }
+
+  /* add the settings without an order attribute or an invalid order attribute set at the end */
+  for (map<CStdString, CSetting *>::iterator it = m_settings.begin(); it != m_settings.end(); it++)
+  {
+    if (it->second->GetOrder() == 0)
+      it->second->SetOrder(++iMaxOrder);
   }
 }
 

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -27,9 +27,7 @@
 #include "devices/PeripheralNIC.h"
 #include "devices/PeripheralNyxboard.h"
 #include "devices/PeripheralTuner.h"
-#if defined(HAVE_LIBCEC)
 #include "devices/PeripheralCecAdapter.h"
-#endif
 #include "bus/PeripheralBusUSB.h"
 #include "dialogs/GUIDialogPeripheralManager.h"
 
@@ -564,9 +562,8 @@ bool CPeripherals::OnAction(const CAction &action)
     return ToggleMute();
   }
 
-  if (action.GetAmount() && (action.GetID() == ACTION_VOLUME_UP || action.GetID() == ACTION_VOLUME_DOWN))
+  if (SupportsCEC() && action.GetAmount() && (action.GetID() == ACTION_VOLUME_UP || action.GetID() == ACTION_VOLUME_DOWN))
   {
-#ifdef HAVE_LIBCEC
     vector<CPeripheral *> peripherals;
     if (GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
     {
@@ -583,7 +580,6 @@ bool CPeripherals::OnAction(const CAction &action)
         }
       }
     }
-#endif
   }
 
   return false;
@@ -591,9 +587,8 @@ bool CPeripherals::OnAction(const CAction &action)
 
 bool CPeripherals::IsMuted(void)
 {
-#ifdef HAVE_LIBCEC
   vector<CPeripheral *> peripherals;
-  if (GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
+  if (SupportsCEC() && GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
   {
     for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < peripherals.size(); iPeripheralPtr++)
     {
@@ -602,16 +597,14 @@ bool CPeripherals::IsMuted(void)
         return true;
     }
   }
-#endif
 
   return false;
 }
 
 bool CPeripherals::ToggleMute(void)
 {
-#ifdef HAVE_LIBCEC
   vector<CPeripheral *> peripherals;
-  if (GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
+  if (SupportsCEC() && GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
   {
     for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < peripherals.size(); iPeripheralPtr++)
     {
@@ -623,16 +616,14 @@ bool CPeripherals::ToggleMute(void)
       }
     }
   }
-#endif
 
   return false;
 }
 
 bool CPeripherals::GetNextKeypress(float frameTime, CKey &key)
 {
-#ifdef HAVE_LIBCEC
   vector<CPeripheral *> peripherals;
-  if (GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
+  if (SupportsCEC() && GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
   {
     for (unsigned int iPeripheralPtr = 0; iPeripheralPtr < peripherals.size(); iPeripheralPtr++)
     {
@@ -646,7 +637,6 @@ bool CPeripherals::GetNextKeypress(float frameTime, CKey &key)
       }
     }
   }
-#endif
 
   return false;
 }

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -188,6 +188,15 @@ namespace PERIPHERALS
      */
     virtual bool GetNextKeypress(float frameTime, CKey &key);
 
+    bool SupportsCEC(void) const
+    {
+#if defined(HAVE_LIBCEC)
+      return true;
+#else
+      return false;
+#endif
+    }
+
   private:
     CPeripherals(void);
     bool LoadMappings(void);

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -29,6 +29,8 @@ class CFileItemList;
 class CSetting;
 class CSettingsCategory;
 class TiXmlElement;
+class CAction;
+class CKey;
 
 namespace PERIPHERALS
 {
@@ -146,6 +148,45 @@ namespace PERIPHERALS
      * @return The peripheral or NULL if it wasn't found.
      */
     virtual CPeripheral *GetByPath(const CStdString &strPath) const;
+
+    /*!
+     * @brief Try to let one of the peripherals handle an action.
+     * @param action The change to handle.
+     * @return True when this change was handled by a peripheral (and should not be handled by anything else), false otherwise.
+     */
+    virtual bool OnAction(const CAction &action);
+
+    /*!
+     * @brief Check whether there's a peripheral that reports to be muted.
+     * @return True when at least one peripheral reports to be muted, false otherwise.
+     */
+    virtual bool IsMuted(void);
+
+    /*!
+     * @brief Try to toggle the mute status via a peripheral.
+     * @return True when this change was handled by a peripheral (and should not be handled by anything else), false otherwise.
+     */
+    virtual bool ToggleMute(void);
+
+    /*!
+     * @brief Try to mute the audio via a peripheral.
+     * @return True when this change was handled by a peripheral (and should not be handled by anything else), false otherwise.
+     */
+    virtual bool Mute(void) { return ToggleMute(); } // TODO CEC only supports toggling the mute status at this time
+
+    /*!
+     * @brief Try to unmute the audio via a peripheral.
+     * @return True when this change was handled by a peripheral (and should not be handled by anything else), false otherwise.
+     */
+    virtual bool UnMute(void) { return ToggleMute(); } // TODO CEC only supports toggling the mute status at this time
+
+    /*!
+     * @brief Try to get a keypress from a peripheral.
+     * @param frameTime The current frametime.
+     * @param key The fetched key.
+     * @return True when a keypress was fetched, false otherwise.
+     */
+    virtual bool GetNextKeypress(float frameTime, CKey &key);
 
   private:
     CPeripherals(void);

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -340,7 +340,7 @@ void CPeripheral::SetSetting(const CStdString &strKey, bool bValue)
       bool bChanged(boolSetting->GetData() != bValue);
       boolSetting->SetData(bValue);
       if (bChanged && m_bInitialised)
-        m_changedSettings.push_back(strKey);
+        m_changedSettings.insert(strKey);
     }
   }
 }
@@ -356,7 +356,7 @@ void CPeripheral::SetSetting(const CStdString &strKey, int iValue)
       bool bChanged(intSetting->GetData() != iValue);
       intSetting->SetData(iValue);
       if (bChanged && m_bInitialised)
-        m_changedSettings.push_back(strKey);
+        m_changedSettings.insert(strKey);
     }
   }
 }
@@ -372,7 +372,7 @@ void CPeripheral::SetSetting(const CStdString &strKey, float fValue)
       bool bChanged(floatSetting->GetData() != fValue);
       floatSetting->SetData(fValue);
       if (bChanged && m_bInitialised)
-        m_changedSettings.push_back(strKey);
+        m_changedSettings.insert(strKey);
     }
   }
 }
@@ -405,7 +405,7 @@ void CPeripheral::SetSetting(const CStdString &strKey, const CStdString &strValu
         bool bChanged(!stringSetting->GetData().Equals(strValue));
         stringSetting->SetData(strValue);
         if (bChanged && m_bInitialised)
-          m_changedSettings.push_back(strKey);
+          m_changedSettings.insert(strKey);
       }
     }
     else if ((*it).second->GetType() == SETTINGS_TYPE_INT)
@@ -468,7 +468,7 @@ void CPeripheral::PersistSettings(bool bExiting /* = false */)
 
   if (!bExiting)
   {
-    for (vector<CStdString>::iterator it = m_changedSettings.begin(); it != m_changedSettings.end(); it++)
+    for (set<CStdString>::const_iterator it = m_changedSettings.begin(); it != m_changedSettings.end(); it++)
       OnSettingChanged(*it);
   }
   m_changedSettings.clear();
@@ -499,7 +499,7 @@ void CPeripheral::ResetDefaultSettings(void)
   map<CStdString, CSetting *>::iterator it = m_settings.begin();
   while (it != m_settings.end())
   {
-    m_changedSettings.push_back((*it).first);
+    m_changedSettings.insert((*it).first);
     ++it;
   }
 

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -30,6 +30,14 @@
 using namespace PERIPHERALS;
 using namespace std;
 
+struct SortBySettingsOrder
+{
+  bool operator()(const CSetting *left, const CSetting *right)
+  {
+    return left->GetOrder() < right->GetOrder();
+  }
+};
+
 CPeripheral::CPeripheral(const PeripheralType type, const PeripheralBusType busType, const CStdString &strLocation, const CStdString &strDeviceName, int iVendorId, int iProductId) :
   m_type(type),
   m_busType(busType),
@@ -168,6 +176,15 @@ bool CPeripheral::IsMultiFunctional(void) const
   return m_subDevices.size() > 0;
 }
 
+vector<CSetting *> CPeripheral::GetSettings(void) const
+{
+  vector<CSetting *> settings;
+  for (map<CStdString, CSetting *>::const_iterator it = m_settings.begin(); it != m_settings.end(); it++)
+    settings.push_back(it->second);
+  sort(settings.begin(), settings.end(), SortBySettingsOrder());
+  return settings;
+}
+
 void CPeripheral::AddSetting(const CStdString &strKey, const CSetting *setting)
 {
   if (!setting)
@@ -183,7 +200,7 @@ void CPeripheral::AddSetting(const CStdString &strKey, const CSetting *setting)
     case SETTINGS_TYPE_BOOL:
       {
         const CSettingBool *mappedSetting = (const CSettingBool *) setting;
-        CSettingBool *boolSetting = new CSettingBool(0, strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData(), mappedSetting->GetControlType());
+        CSettingBool *boolSetting = new CSettingBool(mappedSetting->GetOrder(), strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData(), mappedSetting->GetControlType());
         if (boolSetting)
         {
           boolSetting->SetVisible(mappedSetting->IsVisible());
@@ -194,7 +211,7 @@ void CPeripheral::AddSetting(const CStdString &strKey, const CSetting *setting)
     case SETTINGS_TYPE_INT:
       {
         const CSettingInt *mappedSetting = (const CSettingInt *) setting;
-        CSettingInt *intSetting = new CSettingInt(0, strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData(), mappedSetting->m_iMin, mappedSetting->m_iStep, mappedSetting->m_iMax, mappedSetting->GetControlType(), mappedSetting->m_strFormat);
+        CSettingInt *intSetting = new CSettingInt(mappedSetting->GetOrder(), strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData(), mappedSetting->m_iMin, mappedSetting->m_iStep, mappedSetting->m_iMax, mappedSetting->GetControlType(), mappedSetting->m_strFormat);
         if (intSetting)
         {
           intSetting->SetVisible(mappedSetting->IsVisible());
@@ -205,7 +222,7 @@ void CPeripheral::AddSetting(const CStdString &strKey, const CSetting *setting)
     case SETTINGS_TYPE_FLOAT:
       {
         const CSettingFloat *mappedSetting = (const CSettingFloat *) setting;
-        CSettingFloat *floatSetting = new CSettingFloat(0, strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData(), mappedSetting->m_fMin, mappedSetting->m_fStep, mappedSetting->m_fMax, mappedSetting->GetControlType());
+        CSettingFloat *floatSetting = new CSettingFloat(mappedSetting->GetOrder(), strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData(), mappedSetting->m_fMin, mappedSetting->m_fStep, mappedSetting->m_fMax, mappedSetting->GetControlType());
         if (floatSetting)
         {
           floatSetting->SetVisible(mappedSetting->IsVisible());
@@ -216,7 +233,7 @@ void CPeripheral::AddSetting(const CStdString &strKey, const CSetting *setting)
     case SETTINGS_TYPE_STRING:
       {
         const CSettingString *mappedSetting = (const CSettingString *) setting;
-        CSettingString *stringSetting = new CSettingString(0, strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData().c_str(), mappedSetting->GetControlType(), mappedSetting->m_bAllowEmpty, mappedSetting->m_iHeadingString);
+        CSettingString *stringSetting = new CSettingString(mappedSetting->GetOrder(), strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData().c_str(), mappedSetting->GetControlType(), mappedSetting->m_bAllowEmpty, mappedSetting->m_iHeadingString);
         if (stringSetting)
         {
           stringSetting->SetVisible(mappedSetting->IsVisible());

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -377,6 +377,21 @@ void CPeripheral::SetSetting(const CStdString &strKey, float fValue)
   }
 }
 
+void CPeripheral::SetSettingVisible(const CStdString &strKey, bool bSetTo)
+{
+  map<CStdString, CSetting *>::iterator it = m_settings.find(strKey);
+  if (it != m_settings.end())
+    (*it).second->SetVisible(bSetTo);
+}
+
+bool CPeripheral::IsSettingVisible(const CStdString &strKey) const
+{
+  map<CStdString, CSetting *>::const_iterator it = m_settings.find(strKey);
+  if (it != m_settings.end())
+    return (*it).second->IsVisible();
+  return false;
+}
+
 void CPeripheral::SetSetting(const CStdString &strKey, const CStdString &strValue)
 {
   map<CStdString, CSetting *>::iterator it = m_settings.find(strKey);

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -20,7 +20,7 @@
  *
  */
 
-#include <vector>
+#include <set>
 #include "utils/StdString.h"
 #include "peripherals/PeripheralTypes.h"
 
@@ -167,6 +167,6 @@ namespace PERIPHERALS
     std::vector<PeripheralFeature>   m_features;
     std::vector<CPeripheral *>       m_subDevices;
     std::map<CStdString, CSetting *> m_settings;
-    std::vector<CStdString>          m_changedSettings;
+    std::set<CStdString>             m_changedSettings;
   };
 }

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -142,6 +142,8 @@ namespace PERIPHERALS
     virtual void LoadPersistedSettings(void);
     virtual void ResetDefaultSettings(void);
 
+    virtual std::vector<CSetting *> GetSettings(void) const;
+
     virtual bool ErrorOccured(void) const { return m_bError; }
 
   protected:

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -128,6 +128,8 @@ namespace PERIPHERALS
      */
     virtual const CStdString GetSettingString(const CStdString &strKey) const;
     virtual void SetSetting(const CStdString &strKey, const CStdString &strValue);
+    virtual void SetSettingVisible(const CStdString &strKey, bool bSetTo);
+    virtual bool IsSettingVisible(const CStdString &strKey) const;
 
     virtual int GetSettingInt(const CStdString &strKey) const;
     virtual void SetSetting(const CStdString &strKey, int iValue);

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -79,7 +79,8 @@ CPeripheralCecAdapter::CPeripheralCecAdapter(const PeripheralType type, const Pe
   m_strMenuLanguage("???"),
   m_lastKeypress(0),
   m_lastChange(VOLUME_CHANGE_NONE),
-  m_iExitCode(0)
+  m_iExitCode(0),
+  m_bIsMuted(false) // TODO fetch the correct initial value when system audiostatus is implemented in libCEC
 {
   m_button.iButton = 0;
   m_button.iDuration = 0;
@@ -426,6 +427,10 @@ void CPeripheralCecAdapter::ProcessVolumeChange(void)
     break;
   case VOLUME_CHANGE_MUTE:
     m_cecAdapter->SendKeypress(CECDEVICE_AUDIOSYSTEM, CEC_USER_CONTROL_CODE_MUTE, false);
+    {
+      CSingleLock lock(m_critSection);
+      m_bIsMuted = !m_bIsMuted;
+    }
     break;
   case VOLUME_CHANGE_NONE:
     if (bSendRelease)
@@ -459,6 +464,16 @@ void CPeripheralCecAdapter::Mute(void)
     CSingleLock lock(m_critSection);
     m_volumeChangeQueue.push(VOLUME_CHANGE_MUTE);
   }
+}
+
+bool CPeripheralCecAdapter::IsMuted(void)
+{
+  if (HasConnectedAudioSystem())
+  {
+    CSingleLock lock(m_critSection);
+    return m_bIsMuted;
+  }
+  return false;
 }
 
 void CPeripheralCecAdapter::SetMenuLanguage(const char *strLanguage)

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -888,8 +888,7 @@ int CPeripheralCecAdapter::CecLogMessage(void *cbParam, const cec_log_message &m
     break;
   case CEC_LOG_TRAFFIC:
   case CEC_LOG_DEBUG:
-    if (adapter->GetSettingBool("cec_debug_logging"))
-      iLevel = LOGDEBUG;
+    iLevel = LOGDEBUG;
     break;
   default:
     break;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -160,7 +160,7 @@ void CPeripheralCecAdapter::Announce(AnnouncementFlag flag, const char *sender, 
 
 bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)
 {
-  if (feature == FEATURE_CEC && !m_bStarted)
+  if (feature == FEATURE_CEC && !m_bStarted && GetSettingBool("enabled"))
   {
     SetConfigurationFromSettings();
     m_callbacks.CBCecLogMessage           = &CecLogMessage;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -268,6 +268,7 @@ void CPeripheralCecAdapter::Process(void)
   if (GetSettingBool("cec_power_on_startup"))
   {
     PowerOnCecDevices(CECDEVICE_TV);
+    m_cecAdapter->SetActiveSource();
     FlushLog();
   }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -309,7 +309,7 @@ void CPeripheralCecAdapter::Process(void)
   {
     if (m_configuration.bPowerOffOnStandby == 1)
       m_cecAdapter->StandbyDevices();
-    else
+    else if (m_configuration.bSendInactiveSource == 1)
       m_cecAdapter->SetInactiveView();
   }
 
@@ -956,23 +956,27 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
   SetSetting("wake_devices", strPowerOffDevices.Trim());
 
   // set the boolean settings
-  m_configuration.bUseTVMenuLanguage = m_configuration.bUseTVMenuLanguage;
+  m_configuration.bUseTVMenuLanguage = config.bUseTVMenuLanguage;
   SetSetting("use_tv_menu_language", m_configuration.bUseTVMenuLanguage == 1);
 
-  m_configuration.bActivateSource = m_configuration.bActivateSource;
+  m_configuration.bActivateSource = config.bActivateSource;
   SetSetting("activate_source", m_configuration.bActivateSource == 1);
 
-  m_configuration.bPowerOffScreensaver = m_configuration.bPowerOffScreensaver;
+  m_configuration.bPowerOffScreensaver = config.bPowerOffScreensaver;
   SetSetting("cec_standby_screensaver", m_configuration.bPowerOffScreensaver == 1);
 
-  m_configuration.bPowerOffOnStandby = m_configuration.bPowerOffOnStandby;
+  m_configuration.bPowerOffOnStandby = config.bPowerOffOnStandby;
   SetSetting("standby_pc_on_tv_standby", m_configuration.bPowerOffOnStandby == 1);
+
+  if (config.serverVersion >= CEC_SERVER_VERSION_1_5_1)
+    m_configuration.bSendInactiveSource = config.bSendInactiveSource;
+  SetSetting("send_inactive_source", m_configuration.bSendInactiveSource == 1);
 }
 
 void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
 {
   // client version 1.5.0
-  m_configuration.clientVersion = CEC_CLIENT_VERSION_1_5_0;
+  m_configuration.clientVersion = CEC_CLIENT_VERSION_1_5_1;
 
   // device name 'XBMC'
   snprintf(m_configuration.strDeviceName, 13, "%s", GetSettingString("device_name").c_str());
@@ -1030,6 +1034,7 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
   m_configuration.bActivateSource      = GetSettingBool("activate_source") ? 1 : 0;
   m_configuration.bPowerOffScreensaver = GetSettingBool("cec_standby_screensaver") ? 1 : 0;
   m_configuration.bPowerOffOnStandby   = GetSettingBool("standby_pc_on_tv_standby") ? 1 : 0;
+  m_configuration.bSendInactiveSource  = GetSettingBool("send_inactive_source") ? 1 : 0;
 }
 
 void CPeripheralCecAdapter::ReadLogicalAddresses(const CStdString &strString, cec_logical_addresses &addresses)

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -107,16 +107,7 @@ void CPeripheralCecAdapter::Announce(AnnouncementFlag flag, const char *sender, 
 {
   if (flag == System && !strcmp(sender, "xbmc") && !strcmp(message, "OnQuit") && m_bIsReady)
   {
-    // only send power off and inactive source command when we're currently active
-    if (m_cecAdapter->IsLibCECActiveSource())
-    {
-      // if there are any devices to power off set, power them off
-      if (!m_configuration.powerOffDevices.IsEmpty())
-        m_cecAdapter->StandbyDevices(CECDEVICE_BROADCAST);
-      // send an inactive source command otherwise
-      else
-        m_cecAdapter->SetInactiveView();
-    }
+    StopThread(false);
   }
   else if (flag == GUI && !strcmp(sender, "xbmc") && !strcmp(message, "OnScreensaverDeactivated") && m_bIsReady)
   {

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -31,6 +31,7 @@
 #include "peripherals/Peripherals.h"
 #include "peripherals/bus/PeripheralBus.h"
 #include "settings/GUISettings.h"
+#include "settings/Settings.h"
 #include "utils/log.h"
 
 #include <cec.h>
@@ -43,6 +44,8 @@ using namespace CEC;
 
 /* time in seconds to ignore standby commands from devices after the screensaver has been activated */
 #define SCREENSAVER_TIMEOUT       10
+#define VOLUME_CHANGE_TIMEOUT     250
+#define VOLUME_REFRESH_TIMEOUT    100
 
 class DllLibCECInterface
 {
@@ -72,7 +75,8 @@ CPeripheralCecAdapter::CPeripheralCecAdapter(const PeripheralType type, const Pe
   m_bHasButton(false),
   m_bIsReady(false),
   m_strMenuLanguage("???"),
-  m_lastKeypress(0)
+  m_lastKeypress(0),
+  m_lastChange(VOLUME_CHANGE_NONE)
 {
   m_button.iButton = 0;
   m_button.iDuration = 0;
@@ -273,14 +277,32 @@ void CPeripheralCecAdapter::Process(void)
       SetMenuLanguage(language.language);
   }
 
+  CStdString strNotification;
+  cec_osd_name tvName = m_cecAdapter->GetDeviceOSDName(CECDEVICE_TV);
+  strNotification.Format("%s: %s", g_localizeStrings.Get(36016), tvName.name);
+
+  /* disable the mute setting when an amp is found, because the amp handles the mute setting and
+     set PCM output to 100% */
+  if (HasConnectedAudioSystem())
+  {
+    cec_osd_name ampName = m_cecAdapter->GetDeviceOSDName(CECDEVICE_AUDIOSYSTEM);
+    CLog::Log(LOGDEBUG, "%s - CEC capable amplifier found (%s). volume will be controlled on the amp", __FUNCTION__, ampName.name);
+    strNotification.AppendFormat(" - %s", ampName.name);
+
+    g_settings.m_bMute = false;
+    g_settings.m_nVolumeLevel = VOLUME_MAXIMUM;
+  }
+
   m_cecAdapter->SetOSDString(CECDEVICE_TV, CEC_DISPLAY_CONTROL_DISPLAY_FOR_DEFAULT_TIME, g_localizeStrings.Get(36016).c_str());
-  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36000), g_localizeStrings.Get(36016));
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36000), strNotification);
 
   while (!m_bStop)
   {
     FlushLog();
     if (!m_bStop)
       ProcessNextCommand();
+    if (!m_bStop)
+      ProcessVolumeChange();
     if (!m_bStop)
       Sleep(5);
   }
@@ -341,6 +363,125 @@ bool CPeripheralCecAdapter::SetHdmiPort(int iHdmiPort)
   }
 
   return bReturn;
+}
+
+bool CPeripheralCecAdapter::HasConnectedAudioSystem(void)
+{
+  return m_cecAdapter && m_cecAdapter->IsActiveDeviceType(CEC_DEVICE_TYPE_AUDIO_SYSTEM);
+}
+
+void CPeripheralCecAdapter::ScheduleVolumeUp(void)
+{
+  {
+    CSingleLock lock(m_critSection);
+    m_volumeChangeQueue.push(VOLUME_CHANGE_UP);
+  }
+  Sleep(5);
+}
+
+void CPeripheralCecAdapter::ScheduleVolumeDown(void)
+{
+  {
+    CSingleLock lock(m_critSection);
+    m_volumeChangeQueue.push(VOLUME_CHANGE_DOWN);
+  }
+  Sleep(5);
+}
+
+void CPeripheralCecAdapter::ScheduleMute(void)
+{
+  {
+    CSingleLock lock(m_critSection);
+    m_volumeChangeQueue.push(VOLUME_CHANGE_MUTE);
+  }
+  Sleep(5);
+}
+
+void CPeripheralCecAdapter::ProcessVolumeChange(void)
+{
+  bool bSendRelease(false);
+  CecVolumeChange pendingVolumeChange = VOLUME_CHANGE_NONE;
+  {
+    CSingleLock lock(m_critSection);
+    if (m_volumeChangeQueue.size() > 0)
+    {
+      /* get the first change from the queue */
+      pendingVolumeChange = m_volumeChangeQueue.front();
+      m_volumeChangeQueue.pop();
+
+      /* remove all dupe entries */
+      while (m_volumeChangeQueue.size() > 0 && m_volumeChangeQueue.front() == pendingVolumeChange)
+        m_volumeChangeQueue.pop();
+
+      /* send another keypress after VOLUME_REFRESH_TIMEOUT ms */
+      bool bRefresh(m_lastKeypress + VOLUME_REFRESH_TIMEOUT < XbmcThreads::SystemClockMillis());
+
+      /* only send the keypress when it hasn't been sent yet */
+      if (pendingVolumeChange != m_lastChange)
+      {
+        m_lastKeypress = XbmcThreads::SystemClockMillis();
+        m_lastChange = pendingVolumeChange;
+      }
+      else if (bRefresh)
+      {
+        m_lastKeypress = XbmcThreads::SystemClockMillis();
+        pendingVolumeChange = m_lastChange;
+      }
+      else
+        pendingVolumeChange = VOLUME_CHANGE_NONE;
+    }
+    else if (m_lastKeypress > 0 && m_lastKeypress + VOLUME_CHANGE_TIMEOUT < XbmcThreads::SystemClockMillis())
+    {
+      /* send a key release */
+      m_lastKeypress = 0;
+      bSendRelease = true;
+      m_lastChange = VOLUME_CHANGE_NONE;
+    }
+  }
+
+  switch (pendingVolumeChange)
+  {
+  case VOLUME_CHANGE_UP:
+    m_cecAdapter->SendKeypress(CECDEVICE_AUDIOSYSTEM, CEC_USER_CONTROL_CODE_VOLUME_UP, false);
+    break;
+  case VOLUME_CHANGE_DOWN:
+    m_cecAdapter->SendKeypress(CECDEVICE_AUDIOSYSTEM, CEC_USER_CONTROL_CODE_VOLUME_DOWN, false);
+    break;
+  case VOLUME_CHANGE_MUTE:
+    m_cecAdapter->SendKeypress(CECDEVICE_AUDIOSYSTEM, CEC_USER_CONTROL_CODE_MUTE, false);
+    break;
+  case VOLUME_CHANGE_NONE:
+    if (bSendRelease)
+      m_cecAdapter->SendKeyRelease(CECDEVICE_AUDIOSYSTEM, false);
+    break;
+  }
+}
+
+void CPeripheralCecAdapter::VolumeUp(void)
+{
+  if (HasConnectedAudioSystem())
+  {
+    CSingleLock lock(m_critSection);
+    m_volumeChangeQueue.push(VOLUME_CHANGE_UP);
+  }
+}
+
+void CPeripheralCecAdapter::VolumeDown(void)
+{
+  if (HasConnectedAudioSystem())
+  {
+    CSingleLock lock(m_critSection);
+    m_volumeChangeQueue.push(VOLUME_CHANGE_DOWN);
+  }
+}
+
+void CPeripheralCecAdapter::Mute(void)
+{
+  if (HasConnectedAudioSystem())
+  {
+    CSingleLock lock(m_critSection);
+    m_volumeChangeQueue.push(VOLUME_CHANGE_MUTE);
+  }
 }
 
 void CPeripheralCecAdapter::SetMenuLanguage(const char *strLanguage)

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -239,8 +239,9 @@ void CPeripheralCecAdapter::Process(void)
     return;
 
   // set correct physical address from peripheral settings
+  int iDevice = GetSettingInt("connected_device");
   int iHdmiPort = GetSettingInt("cec_hdmi_port");
-  SetHdmiPort(iHdmiPort);
+  m_cecAdapter->SetHDMIPort((cec_logical_address)iDevice, iHdmiPort);
   FlushLog();
 
   // open the CEC adapter
@@ -351,15 +352,15 @@ bool CPeripheralCecAdapter::SendPing(void)
   return bReturn;
 }
 
-bool CPeripheralCecAdapter::SetHdmiPort(int iHdmiPort)
+bool CPeripheralCecAdapter::SetHdmiPort(int iDevice, int iHdmiPort)
 {
   bool bReturn(false);
   if (m_cecAdapter && m_bIsReady)
   {
     if (iHdmiPort <= 0 || iHdmiPort > 16)
       iHdmiPort = 1;
-    CLog::Log(LOGDEBUG, "%s - changing active HDMI port to %d", __FUNCTION__, iHdmiPort);
-    bReturn = m_cecAdapter->SetPhysicalAddress(iHdmiPort << 12);
+    CLog::Log(LOGDEBUG, "%s - changing active HDMI port to %d on device %d", __FUNCTION__, iHdmiPort, iDevice);
+    bReturn = m_cecAdapter->SetHDMIPort((cec_logical_address)iDevice, iHdmiPort);
   }
 
   return bReturn;
@@ -867,9 +868,9 @@ void CPeripheralCecAdapter::OnSettingChanged(const CStdString &strChangedSetting
     else if (bEnabled && !m_cecAdapter && m_bStarted)
       InitialiseFeature(FEATURE_CEC);
   }
-  else if (strChangedSetting.Equals("cec_hdmi_port"))
+  else if (strChangedSetting.Equals("connected_device") || strChangedSetting.Equals("cec_hdmi_port"))
   {
-    SetHdmiPort(GetSettingInt("cec_hdmi_port"));
+    SetHdmiPort(GetSettingInt("connected_device"), GetSettingInt("cec_hdmi_port"));
   }
 }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -132,9 +132,10 @@ void CPeripheralCecAdapter::Announce(AnnouncementFlag flag, const char *sender, 
 {
   if (flag == System && !strcmp(sender, "xbmc") && !strcmp(message, "OnQuit") && m_bIsReady)
   {
-    m_cecAdapter->SetInactiveView();
     if (GetSettingBool("cec_power_off_shutdown"))
       m_cecAdapter->StandbyDevices();
+    else
+      m_cecAdapter->SetInactiveView();
   }
   else if (flag == GUI && !strcmp(sender, "xbmc") && !strcmp(message, "OnScreensaverDeactivated") && GetSettingBool("cec_standby_screensaver") && m_bIsReady)
   {

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1197,6 +1197,8 @@ void CPeripheralCecAdapterUpdateThread::Process(void)
     // update received
     if (m_event.WaitMSec(500) || bUpdate)
     {
+      if (m_bStop)
+        return;
       // set the new configuration
       bool bConfigSet(m_adapter->m_cecAdapter->SetConfiguration(&m_configuration));
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36000), g_localizeStrings.Get(bConfigSet ? 36023 : 36024));

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -76,6 +76,7 @@ namespace PERIPHERALS
     virtual void VolumeDown(void);
     virtual void ScheduleMute(void);
     virtual void Mute(void);
+    virtual bool IsMuted(void);
 
     virtual void OnSettingChanged(const CStdString &strChangedSetting);
 
@@ -117,6 +118,7 @@ namespace PERIPHERALS
     unsigned int                      m_lastKeypress;
     CecVolumeChange                   m_lastChange;
     int                               m_iExitCode;
+    bool                              m_bIsMuted;
     CPeripheralCecAdapterUpdateThread*m_queryThread;
     CEC::ICECCallbacks                m_callbacks;
     CCriticalSection                  m_critSection;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -116,6 +116,7 @@ namespace PERIPHERALS
     std::queue<CecVolumeChange>       m_volumeChangeQueue;
     unsigned int                      m_lastKeypress;
     CecVolumeChange                   m_lastChange;
+    int                               m_iExitCode;
     CPeripheralCecAdapterUpdateThread*m_queryThread;
     CEC::ICECCallbacks                m_callbacks;
     CCriticalSection                  m_critSection;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -32,7 +32,7 @@
 #ifdef isset
 #undef isset
 #endif
-#include <cectypes.h>
+#include <libcec/cectypes.h>
 
 class DllLibCEC;
 
@@ -68,8 +68,6 @@ namespace PERIPHERALS
     virtual ~CPeripheralCecAdapter(void);
 
     virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
-    virtual bool PowerOnCecDevices(CEC::cec_logical_address iLogicalAddress);
-    virtual bool StandbyCecDevices(CEC::cec_logical_address iLogicalAddress);
     virtual bool HasConnectedAudioSystem(void);
     virtual void SetAudioSystemConnected(bool bSetTo);
     virtual void ScheduleVolumeUp(void);
@@ -79,9 +77,6 @@ namespace PERIPHERALS
     virtual void ScheduleMute(void);
     virtual void Mute(void);
 
-    virtual bool SendPing(void);
-    virtual bool SetHdmiPort(int iDevice, int iHdmiPort);
-
     virtual void OnSettingChanged(const CStdString &strChangedSetting);
 
     virtual WORD GetButton(void);
@@ -90,10 +85,14 @@ namespace PERIPHERALS
     virtual CStdString GetComPort(void);
 
   protected:
-    virtual void EnableCallbacks(void);
+    virtual bool OpenConnection(void);
+    virtual void SetConfigurationFromSettings(void);
+    virtual void SetConfigurationFromLibCEC(const CEC::libcec_configuration &config);
+    static void ReadLogicalAddresses(const CStdString &strString, CEC::cec_logical_addresses &addresses);
     static int CecKeyPress(void *cbParam, const CEC::cec_keypress &key);
     static int CecLogMessage(void *cbParam, const CEC::cec_log_message &message);
     static int CecCommand(void *cbParam, const CEC::cec_command &command);
+    static int CecConfiguration(void *cbParam, const CEC::libcec_configuration &config);
 
     virtual bool GetNextKey(void);
     virtual bool GetNextCecKey(CEC::cec_keypress &key);
@@ -120,12 +119,13 @@ namespace PERIPHERALS
     CPeripheralCecAdapterQueryThread *m_queryThread;
     CEC::ICECCallbacks                m_callbacks;
     CCriticalSection                  m_critSection;
+    CEC::libcec_configuration         m_configuration;
   };
 
   class CPeripheralCecAdapterQueryThread : public CThread
   {
   public:
-    CPeripheralCecAdapterQueryThread(CPeripheralCecAdapter *adapter);
+    CPeripheralCecAdapterQueryThread(CPeripheralCecAdapter *adapter, bool bGetMenuLanguage);
     virtual ~CPeripheralCecAdapterQueryThread(void);
 
     virtual void Signal(void);
@@ -135,6 +135,7 @@ namespace PERIPHERALS
 
     CPeripheralCecAdapter *m_adapter;
     CEvent                 m_event;
+    bool                   m_bGetMenuLanguage;
   };
 }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -20,7 +20,28 @@
  *
  */
 
-#if defined(HAVE_LIBCEC)
+#if !defined(HAVE_LIBCEC)
+#include "Peripheral.h"
+
+// an empty implementation, so CPeripherals can be compiled without a bunch of #ifdef's when libCEC is not available
+namespace PERIPHERALS
+{
+  class CPeripheralCecAdapter : public CPeripheral
+  {
+  public:
+    bool HasConnectedAudioSystem(void) { return false; }
+    void ScheduleVolumeUp(void) {}
+    void ScheduleVolumeDown(void) {}
+    bool IsMuted(void) { return false; }
+    void ScheduleMute(void) {}
+
+    WORD GetButton(void) { return 0; }
+    unsigned int GetHoldTime(void) { return 0; }
+    void ResetButton(void) {}
+  };
+}
+
+#else
 
 #include "PeripheralHID.h"
 #include "interfaces/AnnouncementManager.h"

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -43,6 +43,8 @@ namespace CEC
 
 namespace PERIPHERALS
 {
+  class CPeripheralCecAdapterQueryThread;
+
   typedef struct
   {
     WORD         iButton;
@@ -59,6 +61,8 @@ namespace PERIPHERALS
 
   class CPeripheralCecAdapter : public CPeripheralHID, public ANNOUNCEMENT::IAnnouncer, private CThread
   {
+    friend class CPeripheralCecAdapterQueryThread;
+
   public:
     CPeripheralCecAdapter(const PeripheralType type, const PeripheralBusType busType, const CStdString &strLocation, const CStdString &strDeviceName, int iVendorId, int iProductId);
     virtual ~CPeripheralCecAdapter(void);
@@ -96,19 +100,35 @@ namespace PERIPHERALS
     static bool FindConfigLocation(CStdString &strString);
     static bool TranslateComPort(CStdString &strPort);
 
-    DllLibCEC*                    m_dll;
-    CEC::ICECAdapter*             m_cecAdapter;
-    bool                          m_bStarted;
-    bool                          m_bHasButton;
-    bool                          m_bIsReady;
-    CStdString                    m_strMenuLanguage;
-    CDateTime                     m_screensaverLastActivated;
-    CecButtonPress                m_button;
-    std::queue<CEC::cec_keypress> m_buttonQueue;
-    std::queue<CecVolumeChange>   m_volumeChangeQueue;
-    unsigned int                  m_lastKeypress;
-    CecVolumeChange               m_lastChange;
-    CCriticalSection              m_critSection;
+    DllLibCEC*                        m_dll;
+    CEC::ICECAdapter*                 m_cecAdapter;
+    bool                              m_bStarted;
+    bool                              m_bHasButton;
+    bool                              m_bIsReady;
+    CStdString                        m_strMenuLanguage;
+    CDateTime                         m_screensaverLastActivated;
+    CecButtonPress                    m_button;
+    std::queue<CEC::cec_keypress>     m_buttonQueue;
+    std::queue<CecVolumeChange>       m_volumeChangeQueue;
+    unsigned int                      m_lastKeypress;
+    CecVolumeChange                   m_lastChange;
+    CPeripheralCecAdapterQueryThread *m_queryThread;
+    CCriticalSection                  m_critSection;
+  };
+
+  class CPeripheralCecAdapterQueryThread : public CThread
+  {
+  public:
+    CPeripheralCecAdapterQueryThread(CPeripheralCecAdapter *adapter);
+    virtual ~CPeripheralCecAdapterQueryThread(void);
+
+    virtual void Signal(void);
+
+  protected:
+    virtual void Process(void);
+
+    CPeripheralCecAdapter *m_adapter;
+    CEvent                 m_event;
   };
 }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -89,12 +89,15 @@ namespace PERIPHERALS
     virtual CStdString GetComPort(void);
 
   protected:
-    virtual void FlushLog(void);
-    virtual bool GetNextCecKey(CEC::cec_keypress &key);
+    virtual void EnableCallbacks(void);
+    static int CecKeyPress(void *cbParam, const CEC::cec_keypress &key);
+    static int CecLogMessage(void *cbParam, const CEC::cec_log_message &message);
+    static int CecCommand(void *cbParam, const CEC::cec_command &command);
+
     virtual bool GetNextKey(void);
+    virtual bool GetNextCecKey(CEC::cec_keypress &key);
     virtual bool InitialiseFeature(const PeripheralFeature feature);
     virtual void Process(void);
-    virtual void ProcessNextCommand(void);
     virtual void ProcessVolumeChange(void);
     virtual void SetMenuLanguage(const char *strLanguage);
     static bool FindConfigLocation(CStdString &strString);
@@ -113,6 +116,7 @@ namespace PERIPHERALS
     unsigned int                      m_lastKeypress;
     CecVolumeChange                   m_lastChange;
     CPeripheralCecAdapterQueryThread *m_queryThread;
+    CEC::ICECCallbacks                m_callbacks;
     CCriticalSection                  m_critSection;
   };
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -71,6 +71,7 @@ namespace PERIPHERALS
     virtual bool PowerOnCecDevices(CEC::cec_logical_address iLogicalAddress);
     virtual bool StandbyCecDevices(CEC::cec_logical_address iLogicalAddress);
     virtual bool HasConnectedAudioSystem(void);
+    virtual void SetAudioSystemConnected(bool bSetTo);
     virtual void ScheduleVolumeUp(void);
     virtual void VolumeUp(void);
     virtual void ScheduleVolumeDown(void);
@@ -108,6 +109,7 @@ namespace PERIPHERALS
     bool                              m_bStarted;
     bool                              m_bHasButton;
     bool                              m_bIsReady;
+    bool                              m_bHasConnectedAudioSystem;
     CStdString                        m_strMenuLanguage;
     CDateTime                         m_screensaverLastActivated;
     CecButtonPress                    m_button;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -75,7 +75,7 @@ namespace PERIPHERALS
     virtual void Mute(void);
 
     virtual bool SendPing(void);
-    virtual bool SetHdmiPort(int iHdmiPort);
+    virtual bool SetHdmiPort(int iDevice, int iHdmiPort);
 
     virtual void OnSettingChanged(const CStdString &strChangedSetting);
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -49,6 +49,13 @@ namespace PERIPHERALS
     unsigned int iDuration;
   } CecButtonPress;
 
+  typedef enum
+  {
+    VOLUME_CHANGE_NONE,
+    VOLUME_CHANGE_UP,
+    VOLUME_CHANGE_DOWN,
+    VOLUME_CHANGE_MUTE
+  } CecVolumeChange;
 
   class CPeripheralCecAdapter : public CPeripheralHID, public ANNOUNCEMENT::IAnnouncer, private CThread
   {
@@ -59,6 +66,13 @@ namespace PERIPHERALS
     virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
     virtual bool PowerOnCecDevices(CEC::cec_logical_address iLogicalAddress);
     virtual bool StandbyCecDevices(CEC::cec_logical_address iLogicalAddress);
+    virtual bool HasConnectedAudioSystem(void);
+    virtual void ScheduleVolumeUp(void);
+    virtual void VolumeUp(void);
+    virtual void ScheduleVolumeDown(void);
+    virtual void VolumeDown(void);
+    virtual void ScheduleMute(void);
+    virtual void Mute(void);
 
     virtual bool SendPing(void);
     virtual bool SetHdmiPort(int iHdmiPort);
@@ -77,6 +91,7 @@ namespace PERIPHERALS
     virtual bool InitialiseFeature(const PeripheralFeature feature);
     virtual void Process(void);
     virtual void ProcessNextCommand(void);
+    virtual void ProcessVolumeChange(void);
     virtual void SetMenuLanguage(const char *strLanguage);
     static bool FindConfigLocation(CStdString &strString);
     static bool TranslateComPort(CStdString &strPort);
@@ -90,7 +105,9 @@ namespace PERIPHERALS
     CDateTime                     m_screensaverLastActivated;
     CecButtonPress                m_button;
     std::queue<CEC::cec_keypress> m_buttonQueue;
+    std::queue<CecVolumeChange>   m_volumeChangeQueue;
     unsigned int                  m_lastKeypress;
+    CecVolumeChange               m_lastChange;
     CCriticalSection              m_critSection;
   };
 }

--- a/xbmc/peripherals/devices/PeripheralHID.cpp
+++ b/xbmc/peripherals/devices/PeripheralHID.cpp
@@ -37,7 +37,7 @@ CPeripheralHID::CPeripheralHID(const PeripheralType type, const PeripheralBusTyp
 
 CPeripheralHID::~CPeripheralHID(void)
 {
-  if (!m_strKeymap.IsEmpty() && GetSettingBool("keymap_enabled"))
+  if (!m_strKeymap.IsEmpty() && !GetSettingBool("do_not_use_custom_keymap"))
   {
     CLog::Log(LOGDEBUG, "%s - switching active keymapping to: default", __FUNCTION__);
     CButtonTranslator::GetInstance().RemoveDevice(m_strKeymap);
@@ -59,9 +59,12 @@ bool CPeripheralHID::InitialiseFeature(const PeripheralFeature feature)
       SetSetting("keymap", m_strKeymap);
     }
 
+    if (!IsSettingVisible("keymap"))
+      SetSettingVisible("do_not_use_custom_keymap", false);
+
     if (!m_strKeymap.IsEmpty())
     {
-      bool bKeymapEnabled(GetSettingBool("keymap_enabled"));
+      bool bKeymapEnabled(!GetSettingBool("do_not_use_custom_keymap"));
       if (bKeymapEnabled)
       {
         CLog::Log(LOGDEBUG, "%s - adding keymapping for: %s", __FUNCTION__, m_strKeymap.c_str());
@@ -82,7 +85,7 @@ bool CPeripheralHID::InitialiseFeature(const PeripheralFeature feature)
 
 void CPeripheralHID::OnSettingChanged(const CStdString &strChangedSetting)
 {
-  if (m_bInitialised && ((strChangedSetting.Equals("keymap") && GetSettingBool("keymap_enabled")) || strChangedSetting.Equals("keymap_enabled")))
+  if (m_bInitialised && ((strChangedSetting.Equals("keymap") && !GetSettingBool("do_not_use_custom_keymap")) || strChangedSetting.Equals("keymap_enabled")))
   {
     m_bInitialised = false;
     InitialiseFeature(FEATURE_HID);

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -66,17 +66,15 @@ void CGUIDialogPeripheralSettings::CreateSettings()
 
   if (m_item)
   {
-    int iIndex = 1;
     CPeripheral *peripheral = g_peripherals.GetByPath(m_item->GetPath());
     if (peripheral)
     {
-      map<CStdString, CSetting *>::iterator it = peripheral->m_settings.begin();
-      while (it != peripheral->m_settings.end())
+      vector<CSetting *> settings = peripheral->GetSettings();
+      for (size_t iPtr = 0; iPtr < settings.size(); iPtr++)
       {
-        CSetting *setting = (*it).second;
+        CSetting *setting = settings[iPtr];
         if (!setting->IsVisible())
         {
-          ++it;
           CLog::Log(LOGDEBUG, "%s - invisible", __FUNCTION__);
           continue;
         }
@@ -89,7 +87,7 @@ void CGUIDialogPeripheralSettings::CreateSettings()
             if (boolSetting)
             {
               m_boolSettings.insert(make_pair(CStdString(boolSetting->GetSetting()), boolSetting->GetData()));
-              AddBool(iIndex++, boolSetting->GetLabel(), &m_boolSettings[boolSetting->GetSetting()], true);
+              AddBool(boolSetting->GetOrder(), boolSetting->GetLabel(), &m_boolSettings[boolSetting->GetSetting()], true);
             }
           }
           break;
@@ -99,7 +97,7 @@ void CGUIDialogPeripheralSettings::CreateSettings()
             if (intSetting)
             {
               m_intSettings.insert(make_pair(CStdString(intSetting->GetSetting()), (float) intSetting->GetData()));
-              AddSlider(iIndex++, intSetting->GetLabel(), &m_intSettings[intSetting->GetSetting()], (float)intSetting->m_iMin, (float)intSetting->m_iStep, (float)intSetting->m_iMax, CGUIDialogVideoSettings::FormatInteger, false);
+              AddSlider(intSetting->GetOrder(), intSetting->GetLabel(), &m_intSettings[intSetting->GetSetting()], (float)intSetting->m_iMin, (float)intSetting->m_iStep, (float)intSetting->m_iMax, CGUIDialogVideoSettings::FormatInteger, false);
             }
           }
           break;
@@ -109,7 +107,7 @@ void CGUIDialogPeripheralSettings::CreateSettings()
             if (floatSetting)
             {
               m_floatSettings.insert(make_pair(CStdString(floatSetting->GetSetting()), floatSetting->GetData()));
-              AddSlider(iIndex++, floatSetting->GetLabel(), &m_floatSettings[floatSetting->GetSetting()], floatSetting->m_fMin, floatSetting->m_fStep, floatSetting->m_fMax, CGUIDialogVideoSettings::FormatFloat, false);
+              AddSlider(floatSetting->GetOrder(), floatSetting->GetLabel(), &m_floatSettings[floatSetting->GetSetting()], floatSetting->m_fMin, floatSetting->m_fStep, floatSetting->m_fMax, CGUIDialogVideoSettings::FormatFloat, false);
             }
           }
           break;
@@ -119,7 +117,7 @@ void CGUIDialogPeripheralSettings::CreateSettings()
             if (stringSetting)
             {
               m_stringSettings.insert(make_pair(CStdString(stringSetting->GetSetting()), stringSetting->GetData()));
-              AddString(iIndex, stringSetting->GetLabel(), &m_stringSettings[stringSetting->GetSetting()]);
+              AddString(stringSetting->GetOrder(), stringSetting->GetLabel(), &m_stringSettings[stringSetting->GetSetting()]);
             }
           }
           break;
@@ -128,7 +126,6 @@ void CGUIDialogPeripheralSettings::CreateSettings()
           CLog::Log(LOGDEBUG, "%s - unknown type", __FUNCTION__);
           break;
         }
-        ++it;
       }
     }
     else


### PR DESCRIPTION
This PR adds the following:
- check whether a CEC capable amp is avaiable on the bus. when one is found, the PCM volume is set to 100%, and all volume related changes (vol up, down, mute) are sent to the amp.
- added some settings for the adapter, to configure it's behaviour. since the CEC adapter does not support physical address detection (yet), we need to know to which device and on which HDMI port XBMC is connected, so we can determine the correct address. if the wrong physical address is used, CEC capable devices will use the wrong device as active source. so people who have an amp and have XBMC connected to that amp (which is a standard setup), will not get any sound out of their amp without this change (or without pressing a button on the amp's remote ofc)
- added settings to configure whether or not you want to send the TV (or other devices) to standby when shutting down, and what devices to wake up when starting
- no longer puts the TV in standby when rebooting
- added an optional order to peripheral settings, so they no longer have a semi-random order
- some more fixes/changes. details can be found in the commit messages
