### PR TITLE
fixed, hook adjust display refresh to WinSystemOSX/CoreAudioRenderer

### DIFF
--- a/xbmc/cores/AudioRenderers/CoreAudioRenderer.h
+++ b/xbmc/cores/AudioRenderers/CoreAudioRenderer.h
@@ -26,6 +26,7 @@
 #include "IAudioRenderer.h"
 #include "threads/Event.h"
 #include "threads/LockFree.h"
+#include "guilib/DispResource.h"
 
 struct audio_slice
 {
@@ -118,7 +119,7 @@ private:
   bool m_isValid;
 };
 
-class CCoreAudioRenderer : public IAudioRenderer, public ICoreAudioSource
+class CCoreAudioRenderer : public IAudioRenderer, public ICoreAudioSource, public IDispResource 
 {
 public:
   CCoreAudioRenderer();
@@ -153,6 +154,8 @@ public:
   // AudioUnit Rendering Connection Point (called by down-stream sinks)
   virtual OSStatus Render(AudioUnitRenderActionFlags* actionFlags, const AudioTimeStamp* pTimeStamp, UInt32 busNumber, UInt32 frameCount, AudioBufferList* pBufList);
   
+  virtual void OnLostDevice();
+  virtual void OnResetDevice();
 private:
   OSStatus OnRender(AudioUnitRenderActionFlags *ioActionFlags, const AudioTimeStamp *inTimeStamp, UInt32 inBusNumber, UInt32 inNumberFrames, AudioBufferList *ioData);
   static OSStatus DirectRenderCallback(AudioDeviceID inDevice, const AudioTimeStamp* inNow, const AudioBufferList* inInputData, const AudioTimeStamp* inInputTime, AudioBufferList* outOutputData, const AudioTimeStamp* inOutputTime, void* inClientData);
@@ -195,6 +198,7 @@ private:
   // Thread synchronization
   CEvent m_RunoutEvent;
   long m_DoRunout;
+  bool m_silence;
 };
 
 #endif

--- a/xbmc/guilib/DispResource.h
+++ b/xbmc/guilib/DispResource.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#ifdef HAS_GLX
+#if defined(HAS_GLX) || defined(TARGET_DARWIN_OSX)
 class IDispResource
 {
 public:

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -24,7 +24,13 @@
 #define WINDOW_SYSTEM_OSX_H
 
 #include "windowing/WinSystem.h"
+#include "threads/CriticalSection.h"
 #include <SDL/SDL_video.h>
+
+typedef struct _CGDirectDisplayID *CGDirectDisplayID;
+typedef u_int32_t CGDisplayChangeSummaryFlags;
+
+class IDispResource;
 
 class CWinEventsOSX;
 class CWinSystemOSX : public CWinSystemBase
@@ -48,6 +54,9 @@ public:
   virtual bool Hide();
   virtual bool Show(bool raise = true);
 
+  virtual void Register(IDispResource *resource);
+  virtual void Unregister(IDispResource *resource);
+
   virtual void EnableSystemScreenSaver(bool bEnable);
   virtual bool IsSystemScreenSaverEnabled();
   
@@ -63,10 +72,18 @@ protected:
   void  FillInVideoModes();
   bool  FlushBuffer(void);
 
+  void  CheckDisplayChanging(u_int32_t flags);
+  static void DisplayReconfigured(CGDirectDisplayID display, 
+    CGDisplayChangeSummaryFlags flags, void *userData);
+  
   void* m_glContext;
   static void* m_lastOwnedContext;
   SDL_Surface* m_SDLSurface;
   CWinEventsOSX *m_osx_events;
+  bool                         m_can_display_switch;
+
+  CCriticalSection             m_resourceSection;
+  std::vector<IDispResource*>  m_resources;
 };
 
 #endif // WINDOW_SYSTEM_H


### PR DESCRIPTION
   Output silence during pre-change to post-change.
   This fixes hdmi audio getting wonky on osx.
