### PR TITLE
fixed: Play CDDA's when choosing "Play Disc" from the context menu

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -315,6 +315,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
     }
     if(nAddedToPlaylist > 0)
     {
+      bPlaying = true;
       g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_MUSIC);
       g_playlistPlayer.Play(0);
     }

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -313,6 +313,11 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
         g_playlistPlayer.Add(PLAYLIST_MUSIC, pItem);
       }
     }
+    if(nAddedToPlaylist > 0)
+    {
+      g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_MUSIC);
+      g_playlistPlayer.Play(0);
+    }
   }
   /* Probably want this if/when we add some automedia action dialog...
   // and finally pictures


### PR DESCRIPTION
just issued as a pull request as I don't know if the playlist has to be cleaned before and if I can use nAddedToPlaylist in that case.
Any better idea to fix it?
