### PR TITLE
cec: don't send playstate updates, but always keep the default playstate...

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -173,21 +173,6 @@ void CPeripheralCecAdapter::Announce(EAnnouncementFlag flag, const char *sender,
       }
     }
   }
-  else if (flag == Player && !strcmp(sender, "xbmc") && !strcmp(message, "OnStop"))
-  {
-    m_cecAdapter->SetDeckControlMode(CEC_DECK_CONTROL_MODE_STOP, false);
-    m_cecAdapter->SetDeckInfo(CEC_DECK_INFO_STOP);
-  }
-  else if (flag == Player && !strcmp(sender, "xbmc") && !strcmp(message, "OnPause"))
-  {
-    m_cecAdapter->SetDeckControlMode(CEC_DECK_CONTROL_MODE_SKIP_FORWARD_WIND, false);
-    m_cecAdapter->SetDeckInfo(CEC_DECK_INFO_STILL);
-  }
-  else if (flag == Player && !strcmp(sender, "xbmc") && !strcmp(message, "OnPlay"))
-  {
-    m_cecAdapter->SetDeckControlMode(CEC_DECK_CONTROL_MODE_SKIP_FORWARD_WIND, false);
-    m_cecAdapter->SetDeckInfo(CEC_DECK_INFO_PLAY);
-  }
 }
 
 bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)


### PR DESCRIPTION
.... fixes buttons becoming deactivated on some TVs when playback is started. most annoying ones that were reported are the up/down/left/right buttons.

it also wasn't very fast, which resulted in delays when starting/stopping playback
