### PR TITLE
 [JSONRPC] Returns a mimetype from Files.GetDirectory in place of a filetype

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1101,7 +1101,35 @@ const CStdString& CFileItem::GetMimeType(bool lookup /*= true*/) const
       if(i>=0)
         m_ref.Delete(i,m_ref.length()-i);
       m_ref.Trim();
-    }
+    } else {
+		CStdString ext = m_strPath.Right(3);
+		if( ext.Equals("avi") )
+	      m_ref = "video/x-msvideo";
+		else if( ext.Equals("wmv") )
+	      m_ref = "video/x-ms-wmv";
+		else if( ext.Equals("mp4") )
+	      m_ref = "video/mp4";
+		else if( ext.Equals("mkv") )
+	      m_ref = "video/x-matroska";
+		else if( ext.Equals("flv") )
+	      m_ref = "video/x-flv";
+		else if( ext.Equals("mp3") )
+	      m_ref = "audio/mpeg";
+		else if( ext.Equals("wma") )
+	      m_ref = "audio/x-ms-wma";
+		else if( ext.Equals("ogg") )
+	      m_ref = "audio/ogg";
+		else if( m_strPath.Right(4).Equals("flac") )
+	      m_ref = "audio/flac";
+		else if( ext.Equals("jpg") )
+	      m_ref = "image/jpeg";
+		else if( ext.Equals("jpeg") )
+	      m_ref = "image/jpeg";
+		else if( ext.Equals("png") )
+	      m_ref = "image/png";
+		else if( ext.Equals("gif") )
+	      m_ref = "image/gif";
+	}
 
     // if it's still empty set to an unknown type
     if( m_ref.IsEmpty() )

--- a/xbmc/filesystem/FileCurl.cpp
+++ b/xbmc/filesystem/FileCurl.cpp
@@ -1376,9 +1376,13 @@ bool CFileCurl::GetMimeType(const CURL &url, CStdString &content, CStdString use
    if (!useragent.IsEmpty())
      file.SetUserAgent(useragent);
 
-   if( file.Stat(url, NULL) == 0 )
+   struct __stat64 buffer;
+   if( file.Stat(url, &buffer) == 0 )
    {
-     content = file.GetMimeType();
+      if (buffer.st_mode == _S_IFDIR)
+         content = "x-directory/normal";
+      else
+         content = file.GetMimeType();
      CLog::Log(LOGDEBUG, "CFileCurl::GetMimeType - %s -> %s", url.Get().c_str(), content.c_str());
      return true;
    }

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -117,6 +117,7 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
 {
   CVariant object;
   bool hasFileField = false;
+  bool hasMimeField = false;
   bool hasThumbnailField = false;
 
   if (item.get())
@@ -127,6 +128,8 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
 
       if (field == "file")
         hasFileField = true;
+      if (field == "mimetype")
+        hasMimeField = true;
       if (field == "thumbnail")
         hasThumbnailField = true;
     }
@@ -141,6 +144,11 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
       if (!object.isMember("file"))
         object["file"] = item->GetPath().c_str();
     }
+
+    if (allowFile && hasMimeField)
+    {
+		object["mimetype"] = item->GetMimeType().c_str();
+	}
 
     if (ID)
     {

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -142,30 +142,28 @@ JSON_STATUS CFileOperations::GetDirectory(const CStdString &method, ITransportLa
       param["properties"] = CVariant(CVariant::VariantTypeArray);
 
     bool hasFileField = false;
+    bool hasMimeField = false;
     for (CVariant::const_iterator_array itr = param["properties"].begin_array(); itr != param["properties"].end_array(); itr++)
     {
       if (*itr == CVariant("file"))
       {
         hasFileField = true;
-        break;
+      }
+      if (*itr == CVariant("mimetype"))
+      {
+        hasMimeField = true;
       }
     }
 
     if (!hasFileField)
       param["properties"].append("file");
+    if (!hasMimeField)
+      param["properties"].append("mimetype");
 
     HandleFileItemList("id", true, "files", filteredDirectories, param, result);
-    for (unsigned int index = 0; index < result["files"].size(); index++)
-    {
-      result["files"][index]["filetype"] = "directory";
-    }
     int count = (int)result["limits"]["total"].asInteger();
 
     HandleFileItemList("id", true, "files", filteredFiles, param, result);
-    for (unsigned int index = count; index < result["files"].size(); index++)
-    {
-      result["files"][index]["filetype"] = "file";
-    }
     count += (int)result["limits"]["total"].asInteger();
 
     result["limits"]["end"] = count;

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -700,7 +700,7 @@
     "extends": "List.Item.All",
     "properties": {
 			"file": { "type": "string", "required": true },
-			"filetype": { "type": "string", "enum": [ "file", "directory" ], "required": true }
+			"mimetype": { "type": "string", "required": true }
 		}
   },
   "List.Items.Sources": {


### PR DESCRIPTION
- Add basic mime types for local files

This is a patch proposal following up forum discussion (http://forum.xbmc.org/showthread.php?p=929235) and trac ticket (http://trac.xbmc.org/ticket/12203)
