### PR TITLE
Fix the resume function on DVD discs after commit 1c6460362b92581f4c7147...

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3544,7 +3544,9 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
 #ifdef HAS_DVD_DRIVE
     // Display the Play Eject dialog
     if (CGUIDialogPlayEject::ShowAndGetInput(item))
-      return MEDIA_DETECT::CAutorun::PlayDiscAskResume(item.GetPath());
+      // PlayDiscAskResume takes path to disc. No parameter means default DVD drive.
+      // Can't do better as CGUIDialogPlayEject calls CMediaManager::IsDiscInDrive, which assumes default DVD drive anyway
+      return MEDIA_DETECT::CAutorun::PlayDiscAskResume(); 
 #endif
     return true;
   }
@@ -3640,9 +3642,9 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
         options.starttime = 0.0f;
         CBookmark bookmark;
         CStdString path = item.GetPath();
-        if (item.IsDVD()) 
+        if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_strFileNameAndPath.Find("removable://") == 0) 
           path = item.GetVideoInfoTag()->m_strFileNameAndPath;
-        if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
+        else if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
           path = item.GetProperty("original_listitem_url").asString();
         if(dbs.GetResumeBookMark(path, bookmark))
         {

--- a/xbmc/Autorun.h
+++ b/xbmc/Autorun.h
@@ -48,8 +48,8 @@ public:
   CAutorun();
   virtual ~CAutorun();
   static bool CanResumePlayDVD(const CStdString& path);
-  static bool PlayDisc(const CStdString& path, bool startFromBeginning);
-  static bool PlayDiscAskResume(const CStdString& path);
+  static bool PlayDisc(const CStdString& path="", bool bypassSettings = false, bool startFromBeginning = false);
+  static bool PlayDiscAskResume(const CStdString& path="");
   bool IsEnabled() const;
   void Enable();
   void Disable();
@@ -57,7 +57,6 @@ public:
   static void ExecuteAutorun(bool bypassSettings = false, bool ignoreplaying = false, bool startFromBeginning = false);
 protected:
   static bool RunCdda();
-  static void RunMedia(bool bypassSettings, bool startFromBeginning);
   static bool RunDisc(XFILE::IDirectory* pDir, const CStdString& strDrive, int& nAddedToPlaylist, bool bRoot, bool bypassSettings, bool startFromBeginning);
   bool m_bEnable;
 };

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -393,10 +393,10 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
 
 #ifdef HAS_DVD_DRIVE
   case CONTEXT_BUTTON_PLAY_DISC:
-    return MEDIA_DETECT::CAutorun::PlayDisc(item->GetPath(), true); // restart
+    return MEDIA_DETECT::CAutorun::PlayDisc(item->GetPath(), true, true); // restart
 
   case CONTEXT_BUTTON_RESUME_DISC:
-    return MEDIA_DETECT::CAutorun::PlayDisc(item->GetPath(), false);// resume
+    return MEDIA_DETECT::CAutorun::PlayDisc(item->GetPath(), true, false); // resume
 
   case CONTEXT_BUTTON_EJECT_DISC:
 #ifdef _WIN32

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -941,7 +941,7 @@ int CBuiltins::Execute(const CStdString& execString)
     bool restart = false;
     if (params.size() > 0 && params[0].CompareNoCase("restart") == 0)
       restart = true;
-    CAutorun::PlayDisc(g_mediaManager.GetDiscPath(), restart);
+    CAutorun::PlayDisc(g_mediaManager.GetDiscPath(), true, restart);
 #endif
   }
   else if (execute.Equals("ripcd"))

--- a/xbmc/utils/SaveFileStateJob.h
+++ b/xbmc/utils/SaveFileStateJob.h
@@ -24,12 +24,11 @@ public:
 bool CSaveFileStateJob::DoWork()
 {
   CStdString progressTrackingFile = m_item.GetPath();
-  if (m_item.HasProperty("original_listitem_url") && 
+  if (m_item.HasVideoInfoTag() && m_item.GetVideoInfoTag()->m_strFileNameAndPath.Find("removable://") == 0)
+    progressTrackingFile = m_item.GetVideoInfoTag()->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label+uniqueid or is empty if label not uniquely identified
+  else if (m_item.HasProperty("original_listitem_url") && 
       URIUtils::IsPlugin(m_item.GetProperty("original_listitem_url").asString()))
     progressTrackingFile = m_item.GetProperty("original_listitem_url").asString();
-
-  if (m_item.IsDVD()) 
-    progressTrackingFile = m_item.GetVideoInfoTag()->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label+uniqueid or is empty if label not uniquely identified
 
   if (progressTrackingFile != "")
   {


### PR DESCRIPTION
...f7be18c1ccbb59e961

Since commit 1c6460362b92581f4c7147f7be18c1ccbb59e961 the resume function on DVD discs didn't work anymore. 

3 use cases should be tested for resume of removable DVDs :
(a) insert a disc and play it using the "Play Disc" function from the home screen. Go far enough (> 3 mins) and stop playback. Use "Play Disc" again, the disc should resume where left off.
(b) insert a disc and play it using the Videos > Files menu. When a resume point exists, the context menu on the top-level disc item should show the menu item "Resume from xx:xx". This should resume the disc where left off.
(c) insert a disc and play it through a disc stub added in the library. Eg. "Toy Story.dvd.disc". There should be first a pop-up asking to insert a disc, and next a pop up asking whether you want to resume or start over. The disc should resume where left off.

For non-removable dvd's, the bookmarks are stored using the real, non-removable path, and are not affected by the issue.

In this PR, the following problems with the code were addressed:

1) when starting a disc through a stub, the code incorrectly tried to start the disc from the path of the stub, while it should start from the path where the DVD is actually inserted. It still only works with the default DVD drive (typically the first one) because of limitations with the MediaManager class. TO DO: With multiple drives and using another than the default, it is difficult to implement, as the MediaManager uses a function IsDiscInserted that tells you only when a disc is inserted in the "default" DVD drive. Because of this, an alternative flow in CAutoRun::PlayDisc was needed to allow playing a disc using the default DVD drive.

2) after the last refactoring in the abovementioned commit, the DVD playback generally started from the \VIDEO_TS\VIDEO_TS.IFO file. This however caused the Item.IsDVD() checks to fail when looking for a stored bookmark. Therefore, no bookmark was ever loaded for the disc, only for the VIDEO_TS.IFO file (which is incorrect for removeable media, and only works for files on non-removable storage). 
The existing code was however smart enough to attach the correct values in the VideoInfoTag, so that we can replace the IsDVD() check with checking the VideoInfoTag strFileNameAndPath whether it starts with "removable://".
The same correction was needed in SaveFileStateJob, in order to save the bookmark for the disc instead of the VIDEO_TS.IFO file.
