### PR TITLE
Fix playback of dvd, dvd iso and video_ts

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2255,6 +2255,8 @@ bool CDVDPlayer::IsPaused() const
 
 bool CDVDPlayer::HasVideo() const
 {
+  if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD)) return true;
+
   return m_SelectionStreams.Count(STREAM_VIDEO) > 0 ? true : false;
 }
 


### PR DESCRIPTION
Playing a DVD, iso or video_ts displays a visualization instead of the dvd since commit 38fa2ee5403310b381a6ac35859af4bed0c3e567

This happens because m_SelectionStreams is empty when playing a DVD or iso image of a dvd, and doesn't contain video streams when playing a video_ts folder.

This commit restores part of the code from before the breaking commit.
