### PR TITLE
Fix crypted dvd playback

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -73,8 +73,13 @@ bool CDVDInputStreamNavigator::Open(const char* strFile, const std::string& cont
   // load the dvd language codes
   // g_LangCodeExpander.LoadStandardCodes();
 
-  // since libdvdnav automaticly play's the dvd if the directory contains VIDEO_TS.IFO
-  // we strip it here.
+  // libdvdcss fails if the file path contains VIDEO_TS.IFO or VIDEO_TS/VIDEO_TS.IFO
+  // libdvdnav is still able to play without, so strip them.
+
+  // stripping only works 100% correctly for absolute paths.
+  // relative paths are not expected here and wouldn't make sense, so it's safe to assume we'll have
+  // at least one path separator character.
+
   strDVDFile = strdup(strFile);
   int len = strlen(strDVDFile);
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -80,6 +80,9 @@ bool CDVDInputStreamNavigator::Open(const char* strFile, const std::string& cont
   {
     strDVDFile[strlen(strDVDFile) - 13] = '\0';
   }
+  if (strncasecmp(strDVDFile + strlen(strDVDFile) - 8, "VIDEO_TS", 8) == 0)
+    strDVDFile[strlen(strDVDFile) - 9] = '\0';
+
 #if defined(__APPLE__) && !defined(__arm__)
   // if physical DVDs, libdvdnav wants "/dev/rdiskN" device name for OSX,
   // strDVDFile will get realloc'ed and replaced IF this is a physical DVD.

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -76,11 +76,16 @@ bool CDVDInputStreamNavigator::Open(const char* strFile, const std::string& cont
   // since libdvdnav automaticly play's the dvd if the directory contains VIDEO_TS.IFO
   // we strip it here.
   strDVDFile = strdup(strFile);
-  if (strncasecmp(strDVDFile + strlen(strDVDFile) - 12, "VIDEO_TS.IFO", 12) == 0)
-    strDVDFile[strlen(strDVDFile) - 13] = '\0';
+  int len = strlen(strDVDFile);
 
-  if (strncasecmp(strDVDFile + strlen(strDVDFile) - 8, "VIDEO_TS", 8) == 0)
-    strDVDFile[strlen(strDVDFile) - 9] = '\0';
+  if(len >= 13  // +1 on purpose, to include a separator char before the searched string
+  && strncasecmp(strDVDFile + len - 12, "VIDEO_TS.IFO", 12) == 0)
+    strDVDFile[len - 13] = '\0';
+
+  len = strlen(strDVDFile);
+  if(len >= 9  // +1 on purpose, to include a separator char before the searched string
+  && strncasecmp(strDVDFile + len - 8, "VIDEO_TS", 8) == 0)
+    strDVDFile[len - 9] = '\0';
 
 #if defined(__APPLE__) && !defined(__arm__)
   // if physical DVDs, libdvdnav wants "/dev/rdiskN" device name for OSX,

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -77,9 +77,8 @@ bool CDVDInputStreamNavigator::Open(const char* strFile, const std::string& cont
   // we strip it here.
   strDVDFile = strdup(strFile);
   if (strncasecmp(strDVDFile + strlen(strDVDFile) - 12, "VIDEO_TS.IFO", 12) == 0)
-  {
     strDVDFile[strlen(strDVDFile) - 13] = '\0';
-  }
+
   if (strncasecmp(strDVDFile + strlen(strDVDFile) - 8, "VIDEO_TS", 8) == 0)
     strDVDFile[strlen(strDVDFile) - 9] = '\0';
 


### PR DESCRIPTION
Playing encrypted dvds from home page or context menu->Play Disc doesn't work.
That happens at least in Windows, for master and Eden beta.
I'd appreciate to know if this also happens on linux and OSX and whether the PR helps or if it's not necessary.

This happens because libdvdnav (and in turn libdvdcss) receive a more complete file path since recent changes in the playdisc functions.
It used to receive something like H:, which worked, but now receives H:\VIDEO_TS and lidvdcss fails.

I see three solutions:
- change the play discs function to pass the drive path again
- extend the truncation done in CDVDInputStreamNavigator::Open().
- patch libdvdnav or libdvdcss.

This PR implements the least intrusive change: a more thorough truncation of the file path.
It might be better to truncate video_ts\video_ts.ifo in one step instead of truncating video_ts.ifo, then video_ts, I'm not sure.
This works correctly for dvds, iso and ripped video_ts folders.
