### PR TITLE
Add event when moving windows, and fix D3D device creation

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -425,6 +425,9 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
         g_settings.Save();
       }
       break;
+    case XBMC_VIDEOMOVE:
+      g_Windowing.OnMove(newEvent.move.x, newEvent.move.y);
+      break;
     case XBMC_USEREVENT:
       g_application.getApplicationMessenger().UserEvent(newEvent.user.code);
       break;

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -195,6 +195,18 @@ bool CRenderSystemDX::ResetRenderSystem(int width, int height, bool fullScreen, 
   return true;
 }
 
+void CRenderSystemDX::OnMove()
+{
+  if (!m_bRenderCreated)
+    return;
+
+  HMONITOR currentMonitor = m_pD3D->GetAdapterMonitor(m_adapter);
+  HMONITOR newMonitor = MonitorFromWindow(m_hDeviceWnd, MONITOR_DEFAULTTONULL);
+  if (newMonitor != NULL && currentMonitor != newMonitor)
+    ResetRenderSystem(m_nBackBufferWidth, m_nBackBufferHeight, m_bFullScreenDevice, m_refreshRate);
+}
+
+
 bool CRenderSystemDX::IsSurfaceFormatOk(D3DFORMAT surfFormat, DWORD usage)
 {
   // Verify the compatibility

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -172,6 +172,10 @@ void CRenderSystemDX::SetMonitor(HMONITOR monitor)
 
 bool CRenderSystemDX::ResetRenderSystem(int width, int height, bool fullScreen, float refreshRate)
 {
+  HMONITOR hMonitor = MonitorFromWindow(m_hDeviceWnd, MONITOR_DEFAULTTONULL);
+  if (hMonitor)
+    SetMonitor(hMonitor);
+
   SetRenderParams(width, height, fullScreen, refreshRate);
 
   CRect rc;

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -121,6 +121,7 @@ protected:
   void BuildPresentParameters();
   virtual void UpdateMonitor() {};
   BOOL IsDepthFormatOk(D3DFORMAT DepthFormat, D3DFORMAT RenderTargetFormat);
+  void OnMove();
 
   LPDIRECT3D9                 m_pD3D;
 

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -79,6 +79,9 @@ public:
   virtual bool Hide() { return false; }
   virtual bool Show(bool raise = true) { return false; }
 
+  // notifications
+  virtual void OnMove(int x, int y) {}
+
   // OS System screensaver
   virtual void EnableSystemScreenSaver(bool bEnable) {};
   virtual bool IsSystemScreenSaverEnabled() {return false;}

--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -35,30 +35,30 @@
 
 /* Event enumerations */
 typedef enum {
-       XBMC_NOEVENT = 0,			/* Unused (do not remove) */
-       XBMC_ACTIVEEVENT,			/* Application loses/gains visibility */
-       XBMC_KEYDOWN,			/* Keys pressed */
-       XBMC_KEYUP,			/* Keys released */
-       XBMC_MOUSEMOTION,			/* Mouse moved */
-       XBMC_MOUSEBUTTONDOWN,		/* Mouse button pressed */
-       XBMC_MOUSEBUTTONUP,		/* Mouse button released */
-       XBMC_JOYAXISMOTION,		/* Joystick axis motion */
-       XBMC_JOYBALLMOTION,		/* Joystick trackball motion */
-       XBMC_JOYHATMOTION,		/* Joystick hat position change */
-       XBMC_JOYBUTTONDOWN,		/* Joystick button pressed */
-       XBMC_JOYBUTTONUP,			/* Joystick button released */
-       XBMC_QUIT,			/* User-requested quit */
-       XBMC_SYSWMEVENT,			/* System specific event */
-       XBMC_EVENT_RESERVEDA,		/* Reserved for future use.. */
-       XBMC_EVENT_RESERVEDB,		/* Reserved for future use.. */
-       XBMC_VIDEORESIZE,			/* User resized video mode */
-       XBMC_VIDEOMOVE,        /* User moved the window */
-       XBMC_VIDEOEXPOSE,			/* Screen needs to be redrawn */
-       XBMC_APPCOMMAND,            /* Media commands, such as WM_APPCOMMAND on Windows for media keys. */
-       XBMC_EVENT_RESERVED4,		/* Reserved for future use.. */
-       XBMC_EVENT_RESERVED5,		/* Reserved for future use.. */
-       XBMC_EVENT_RESERVED6,		/* Reserved for future use.. */
-       XBMC_EVENT_RESERVED7,		/* Reserved for future use.. */
+       XBMC_NOEVENT = 0,        /* Unused (do not remove) */
+       XBMC_ACTIVEEVENT,        /* Application loses/gains visibility */
+       XBMC_KEYDOWN,            /* Keys pressed */
+       XBMC_KEYUP,              /* Keys released */
+       XBMC_MOUSEMOTION,        /* Mouse moved */
+       XBMC_MOUSEBUTTONDOWN,    /* Mouse button pressed */
+       XBMC_MOUSEBUTTONUP,      /* Mouse button released */
+       XBMC_JOYAXISMOTION,      /* Joystick axis motion */
+       XBMC_JOYBALLMOTION,      /* Joystick trackball motion */
+       XBMC_JOYHATMOTION,       /* Joystick hat position change */
+       XBMC_JOYBUTTONDOWN,      /* Joystick button pressed */
+       XBMC_JOYBUTTONUP,        /* Joystick button released */
+       XBMC_QUIT,               /* User-requested quit */
+       XBMC_SYSWMEVENT,         /* System specific event */
+       XBMC_EVENT_RESERVEDA,    /* Reserved for future use.. */
+       XBMC_EVENT_RESERVEDB,    /* Reserved for future use.. */
+       XBMC_VIDEORESIZE,        /* User resized video mode */
+       XBMC_VIDEOMOVE,          /* User moved the window */
+       XBMC_VIDEOEXPOSE,        /* Screen needs to be redrawn */
+       XBMC_APPCOMMAND,         /* Media commands, such as WM_APPCOMMAND on Windows for media keys. */
+       XBMC_EVENT_RESERVED4,    /* Reserved for future use.. */
+       XBMC_EVENT_RESERVED5,    /* Reserved for future use.. */
+       XBMC_EVENT_RESERVED6,    /* Reserved for future use.. */
+       XBMC_EVENT_RESERVED7,    /* Reserved for future use.. */
        /* Events XBMC_USEREVENT through XBMC_MAXEVENTS-1 are for your use */
        XBMC_USEREVENT = 24,
        /* This last event is only for bounding internal arrays
@@ -70,32 +70,32 @@ typedef enum {
 /* Predefined event masks */
 #define XBMC_EVENTMASK(X)	(1<<(X))
 typedef enum {
-	XBMC_ACTIVEEVENTMASK	= XBMC_EVENTMASK(XBMC_ACTIVEEVENT),
-	XBMC_KEYDOWNMASK		= XBMC_EVENTMASK(XBMC_KEYDOWN),
-	XBMC_KEYUPMASK		= XBMC_EVENTMASK(XBMC_KEYUP),
-	XBMC_KEYEVENTMASK	= XBMC_EVENTMASK(XBMC_KEYDOWN)|
-	                          XBMC_EVENTMASK(XBMC_KEYUP),
-	XBMC_MOUSEMOTIONMASK	= XBMC_EVENTMASK(XBMC_MOUSEMOTION),
-	XBMC_MOUSEBUTTONDOWNMASK	= XBMC_EVENTMASK(XBMC_MOUSEBUTTONDOWN),
-	XBMC_MOUSEBUTTONUPMASK	= XBMC_EVENTMASK(XBMC_MOUSEBUTTONUP),
-	XBMC_MOUSEEVENTMASK	= XBMC_EVENTMASK(XBMC_MOUSEMOTION)|
-	                          XBMC_EVENTMASK(XBMC_MOUSEBUTTONDOWN)|
-	                          XBMC_EVENTMASK(XBMC_MOUSEBUTTONUP),
-	XBMC_JOYAXISMOTIONMASK	= XBMC_EVENTMASK(XBMC_JOYAXISMOTION),
-	XBMC_JOYBALLMOTIONMASK	= XBMC_EVENTMASK(XBMC_JOYBALLMOTION),
-	XBMC_JOYHATMOTIONMASK	= XBMC_EVENTMASK(XBMC_JOYHATMOTION),
-	XBMC_JOYBUTTONDOWNMASK	= XBMC_EVENTMASK(XBMC_JOYBUTTONDOWN),
-	XBMC_JOYBUTTONUPMASK	= XBMC_EVENTMASK(XBMC_JOYBUTTONUP),
-	XBMC_JOYEVENTMASK	= XBMC_EVENTMASK(XBMC_JOYAXISMOTION)|
-	                          XBMC_EVENTMASK(XBMC_JOYBALLMOTION)|
-	                          XBMC_EVENTMASK(XBMC_JOYHATMOTION)|
-	                          XBMC_EVENTMASK(XBMC_JOYBUTTONDOWN)|
-	                          XBMC_EVENTMASK(XBMC_JOYBUTTONUP),
-	XBMC_VIDEORESIZEMASK	= XBMC_EVENTMASK(XBMC_VIDEORESIZE),
-  XBMC_VIDEOMOVEMASK	= XBMC_EVENTMASK(XBMC_VIDEOMOVE),
-	XBMC_VIDEOEXPOSEMASK	= XBMC_EVENTMASK(XBMC_VIDEOEXPOSE),
-	XBMC_QUITMASK		= XBMC_EVENTMASK(XBMC_QUIT),
-	XBMC_SYSWMEVENTMASK	= XBMC_EVENTMASK(XBMC_SYSWMEVENT)
+  XBMC_ACTIVEEVENTMASK      = XBMC_EVENTMASK(XBMC_ACTIVEEVENT),
+  XBMC_KEYDOWNMASK          = XBMC_EVENTMASK(XBMC_KEYDOWN),
+  XBMC_KEYUPMASK            = XBMC_EVENTMASK(XBMC_KEYUP),
+  XBMC_KEYEVENTMASK         = XBMC_EVENTMASK(XBMC_KEYDOWN)|
+                              XBMC_EVENTMASK(XBMC_KEYUP),
+  XBMC_MOUSEMOTIONMASK      = XBMC_EVENTMASK(XBMC_MOUSEMOTION),
+  XBMC_MOUSEBUTTONDOWNMASK  = XBMC_EVENTMASK(XBMC_MOUSEBUTTONDOWN),
+  XBMC_MOUSEBUTTONUPMASK    = XBMC_EVENTMASK(XBMC_MOUSEBUTTONUP),
+  XBMC_MOUSEEVENTMASK       = XBMC_EVENTMASK(XBMC_MOUSEMOTION)|
+                              XBMC_EVENTMASK(XBMC_MOUSEBUTTONDOWN)|
+                              XBMC_EVENTMASK(XBMC_MOUSEBUTTONUP),
+  XBMC_JOYAXISMOTIONMASK    = XBMC_EVENTMASK(XBMC_JOYAXISMOTION),
+  XBMC_JOYBALLMOTIONMASK    = XBMC_EVENTMASK(XBMC_JOYBALLMOTION),
+  XBMC_JOYHATMOTIONMASK     = XBMC_EVENTMASK(XBMC_JOYHATMOTION),
+  XBMC_JOYBUTTONDOWNMASK    = XBMC_EVENTMASK(XBMC_JOYBUTTONDOWN),
+  XBMC_JOYBUTTONUPMASK      = XBMC_EVENTMASK(XBMC_JOYBUTTONUP),
+  XBMC_JOYEVENTMASK         = XBMC_EVENTMASK(XBMC_JOYAXISMOTION)|
+                              XBMC_EVENTMASK(XBMC_JOYBALLMOTION)|
+                              XBMC_EVENTMASK(XBMC_JOYHATMOTION)|
+                              XBMC_EVENTMASK(XBMC_JOYBUTTONDOWN)|
+                              XBMC_EVENTMASK(XBMC_JOYBUTTONUP),
+  XBMC_VIDEORESIZEMASK      = XBMC_EVENTMASK(XBMC_VIDEORESIZE),
+  XBMC_VIDEOMOVEMASK        = XBMC_EVENTMASK(XBMC_VIDEOMOVE),
+  XBMC_VIDEOEXPOSEMASK      = XBMC_EVENTMASK(XBMC_VIDEOEXPOSE),
+  XBMC_QUITMASK             = XBMC_EVENTMASK(XBMC_QUIT),
+  XBMC_SYSWMEVENTMASK      = XBMC_EVENTMASK(XBMC_SYSWMEVENT)
 } XBMC_EventMask ;
 #define XBMC_ALLEVENTS		0xFFFFFFFF
 
@@ -221,21 +221,21 @@ typedef struct XBMC_AppCommandEvent {
 
 /* General event structure */
 typedef union XBMC_Event {
-	unsigned char type;
-	XBMC_ActiveEvent active;
-	XBMC_KeyboardEvent key;
-	XBMC_MouseMotionEvent motion;
-	XBMC_MouseButtonEvent button;
-	XBMC_JoyAxisEvent jaxis;
-	XBMC_JoyBallEvent jball;
-	XBMC_JoyHatEvent jhat;
-	XBMC_JoyButtonEvent jbutton;
-	XBMC_ResizeEvent resize;
+  unsigned char type;
+  XBMC_ActiveEvent active;
+  XBMC_KeyboardEvent key;
+  XBMC_MouseMotionEvent motion;
+  XBMC_MouseButtonEvent button;
+  XBMC_JoyAxisEvent jaxis;
+  XBMC_JoyBallEvent jball;
+  XBMC_JoyHatEvent jhat;
+  XBMC_JoyButtonEvent jbutton;
+  XBMC_ResizeEvent resize;
   XBMC_MoveEvent move;
-	XBMC_ExposeEvent expose;
-	XBMC_QuitEvent quit;
-	XBMC_UserEvent user;
-	XBMC_SysWMEvent syswm;
+  XBMC_ExposeEvent expose;
+  XBMC_QuitEvent quit;
+  XBMC_UserEvent user;
+  XBMC_SysWMEvent syswm;
   XBMC_AppCommandEvent appcommand;
 } XBMC_Event;
 

--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -52,9 +52,9 @@ typedef enum {
        XBMC_EVENT_RESERVEDA,		/* Reserved for future use.. */
        XBMC_EVENT_RESERVEDB,		/* Reserved for future use.. */
        XBMC_VIDEORESIZE,			/* User resized video mode */
+       XBMC_VIDEOMOVE,        /* User moved the window */
        XBMC_VIDEOEXPOSE,			/* Screen needs to be redrawn */
        XBMC_APPCOMMAND,            /* Media commands, such as WM_APPCOMMAND on Windows for media keys. */
-       XBMC_EVENT_RESERVED3,		/* Reserved for future use.. */
        XBMC_EVENT_RESERVED4,		/* Reserved for future use.. */
        XBMC_EVENT_RESERVED5,		/* Reserved for future use.. */
        XBMC_EVENT_RESERVED6,		/* Reserved for future use.. */
@@ -92,6 +92,7 @@ typedef enum {
 	                          XBMC_EVENTMASK(XBMC_JOYBUTTONDOWN)|
 	                          XBMC_EVENTMASK(XBMC_JOYBUTTONUP),
 	XBMC_VIDEORESIZEMASK	= XBMC_EVENTMASK(XBMC_VIDEORESIZE),
+  XBMC_VIDEOMOVEMASK	= XBMC_EVENTMASK(XBMC_VIDEOMOVE),
 	XBMC_VIDEOEXPOSEMASK	= XBMC_EVENTMASK(XBMC_VIDEOEXPOSE),
 	XBMC_QUITMASK		= XBMC_EVENTMASK(XBMC_QUIT),
 	XBMC_SYSWMEVENTMASK	= XBMC_EVENTMASK(XBMC_SYSWMEVENT)
@@ -180,6 +181,12 @@ typedef struct XBMC_ResizeEvent {
 	int h;		/* New height */
 } XBMC_ResizeEvent;
 
+typedef struct XBMC_MoveEvent {
+	unsigned char type;	/* XBMC_VIDEOMOVE */
+	int x;		/* New x position */
+	int y;		/* New y position */
+} XBMC_MoveEvent;
+
 /* The "screen redraw" event */
 typedef struct XBMC_ExposeEvent {
 	unsigned char type;	/* XBMC_VIDEOEXPOSE */
@@ -224,6 +231,7 @@ typedef union XBMC_Event {
 	XBMC_JoyHatEvent jhat;
 	XBMC_JoyButtonEvent jbutton;
 	XBMC_ResizeEvent resize;
+  XBMC_MoveEvent move;
 	XBMC_ExposeEvent expose;
 	XBMC_QuitEvent quit;
 	XBMC_UserEvent user;

--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -49,55 +49,14 @@ typedef enum {
        XBMC_JOYBUTTONUP,        /* Joystick button released */
        XBMC_QUIT,               /* User-requested quit */
        XBMC_SYSWMEVENT,         /* System specific event */
-       XBMC_EVENT_RESERVEDA,    /* Reserved for future use.. */
-       XBMC_EVENT_RESERVEDB,    /* Reserved for future use.. */
        XBMC_VIDEORESIZE,        /* User resized video mode */
        XBMC_VIDEOMOVE,          /* User moved the window */
        XBMC_VIDEOEXPOSE,        /* Screen needs to be redrawn */
        XBMC_APPCOMMAND,         /* Media commands, such as WM_APPCOMMAND on Windows for media keys. */
-       XBMC_EVENT_RESERVED4,    /* Reserved for future use.. */
-       XBMC_EVENT_RESERVED5,    /* Reserved for future use.. */
-       XBMC_EVENT_RESERVED6,    /* Reserved for future use.. */
-       XBMC_EVENT_RESERVED7,    /* Reserved for future use.. */
-       /* Events XBMC_USEREVENT through XBMC_MAXEVENTS-1 are for your use */
-       XBMC_USEREVENT = 24,
-       /* This last event is only for bounding internal arrays
-	  It is the number of bits in the event mask datatype -- uint32_t
-        */
-       XBMC_NUMEVENTS = 32
-} XBMC_EventType;
+       XBMC_USEREVENT,
 
-/* Predefined event masks */
-#define XBMC_EVENTMASK(X)	(1<<(X))
-typedef enum {
-  XBMC_ACTIVEEVENTMASK      = XBMC_EVENTMASK(XBMC_ACTIVEEVENT),
-  XBMC_KEYDOWNMASK          = XBMC_EVENTMASK(XBMC_KEYDOWN),
-  XBMC_KEYUPMASK            = XBMC_EVENTMASK(XBMC_KEYUP),
-  XBMC_KEYEVENTMASK         = XBMC_EVENTMASK(XBMC_KEYDOWN)|
-                              XBMC_EVENTMASK(XBMC_KEYUP),
-  XBMC_MOUSEMOTIONMASK      = XBMC_EVENTMASK(XBMC_MOUSEMOTION),
-  XBMC_MOUSEBUTTONDOWNMASK  = XBMC_EVENTMASK(XBMC_MOUSEBUTTONDOWN),
-  XBMC_MOUSEBUTTONUPMASK    = XBMC_EVENTMASK(XBMC_MOUSEBUTTONUP),
-  XBMC_MOUSEEVENTMASK       = XBMC_EVENTMASK(XBMC_MOUSEMOTION)|
-                              XBMC_EVENTMASK(XBMC_MOUSEBUTTONDOWN)|
-                              XBMC_EVENTMASK(XBMC_MOUSEBUTTONUP),
-  XBMC_JOYAXISMOTIONMASK    = XBMC_EVENTMASK(XBMC_JOYAXISMOTION),
-  XBMC_JOYBALLMOTIONMASK    = XBMC_EVENTMASK(XBMC_JOYBALLMOTION),
-  XBMC_JOYHATMOTIONMASK     = XBMC_EVENTMASK(XBMC_JOYHATMOTION),
-  XBMC_JOYBUTTONDOWNMASK    = XBMC_EVENTMASK(XBMC_JOYBUTTONDOWN),
-  XBMC_JOYBUTTONUPMASK      = XBMC_EVENTMASK(XBMC_JOYBUTTONUP),
-  XBMC_JOYEVENTMASK         = XBMC_EVENTMASK(XBMC_JOYAXISMOTION)|
-                              XBMC_EVENTMASK(XBMC_JOYBALLMOTION)|
-                              XBMC_EVENTMASK(XBMC_JOYHATMOTION)|
-                              XBMC_EVENTMASK(XBMC_JOYBUTTONDOWN)|
-                              XBMC_EVENTMASK(XBMC_JOYBUTTONUP),
-  XBMC_VIDEORESIZEMASK      = XBMC_EVENTMASK(XBMC_VIDEORESIZE),
-  XBMC_VIDEOMOVEMASK        = XBMC_EVENTMASK(XBMC_VIDEOMOVE),
-  XBMC_VIDEOEXPOSEMASK      = XBMC_EVENTMASK(XBMC_VIDEOEXPOSE),
-  XBMC_QUITMASK             = XBMC_EVENTMASK(XBMC_QUIT),
-  XBMC_SYSWMEVENTMASK      = XBMC_EVENTMASK(XBMC_SYSWMEVENT)
-} XBMC_EventMask ;
-#define XBMC_ALLEVENTS		0xFFFFFFFF
+       XBMC_MAXEVENT = 256      /* XBMC_EventType is represented as uchar */
+} XBMC_EventType;
 
 /* Application visibility event structure */
 typedef struct XBMC_ActiveEvent {
@@ -199,7 +158,7 @@ typedef struct XBMC_QuitEvent {
 
 /* A user-defined event type */
 typedef struct XBMC_UserEvent {
-	unsigned char type;	/* XBMC_USEREVENT through XBMC_NUMEVENTS-1 */
+	unsigned char type;	/* XBMC_USEREVENT */
 	int code;	/* User defined event code */
 	void *data1;	/* User defined data pointer */
 	void *data2;	/* User defined data pointer */

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -599,11 +599,16 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       return(0);
     case WM_SIZE:
       newEvent.type = XBMC_VIDEORESIZE;
-      newEvent.resize.type = XBMC_VIDEORESIZE;
       newEvent.resize.w = GET_X_LPARAM(lParam);
       newEvent.resize.h = GET_Y_LPARAM(lParam);
       if (newEvent.resize.w * newEvent.resize.h)
         m_pEventFunc(newEvent);
+      return(0);
+    case WM_MOVE:
+      newEvent.type = XBMC_VIDEOMOVE;
+      newEvent.move.x = GET_X_LPARAM(lParam);
+      newEvent.move.y = GET_Y_LPARAM(lParam);
+      m_pEventFunc(newEvent);
       return(0);
     case WM_MEDIA_CHANGE:
       {

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -72,6 +72,11 @@ bool CWinSystemWin32DX::ResizeWindow(int newWidth, int newHeight, int newLeft, i
   return true;
 }
 
+void CWinSystemWin32DX::OnMove(int x, int y)
+{
+  CRenderSystemDX::OnMove();
+}
+
 bool CWinSystemWin32DX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   // When going DX fullscreen -> windowed, we must reset the D3D device first to

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -42,6 +42,7 @@ public:
 
   virtual bool CreateNewWindow(CStdString name, bool fullScreen, RESOLUTION_INFO& res, PHANDLE_EVENT_FUNC userFunction);
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop);
+  virtual void OnMove(int x, int y);
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual bool WindowedMode() { return CRenderSystemDX::m_useWindowedDX; }
 


### PR DESCRIPTION
This PR adds the plumbing for an event raised when the XBMC window is moved.
I'm looking for feedback on the way I added this.
I'm not sure if there is a binary compatibility to maintain on the event numbers, was it OK to add XBMC_VIDEOMOVE in the middle?

@davilla, you mentioned OSX already does something with the window position, if I can make this PR more generic so that OSX can piggyback, let me know.

The PR also contains an implementation for Windows. In a multiscreen configuration the Direct3D device must be created/recreated for the screen overlapped most by the window. This is not taken care of in the non-fullscreen windowed mode and can lead to the dwm disabling itself.
