### PR TITLE
[hack] force curl to not unload, this hack fixes ssl from slipping out when python unloads

### DIFF
--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -39,7 +39,7 @@ bool DllLibCurlGlobal::Load()
   CSingleLock lock(m_critSection);
   if(g_curlReferences > 0)
   {
-    g_curlReferences++;
+    //g_curlReferences++;
     return true;
   }
 
@@ -56,13 +56,16 @@ bool DllLibCurlGlobal::Load()
   }
 
   /* check idle will clean up the last one */
-  g_curlReferences = 2;
+  //g_curlReferences = 2;
+  g_curlReferences = 1;
 
   return true;
 }
 
 void DllLibCurlGlobal::Unload()
 {
+  return;
+  /*
   CSingleLock lock(m_critSection);
   if (--g_curlReferences == 0)
   {
@@ -75,19 +78,22 @@ void DllLibCurlGlobal::Unload()
     DllDynamic::Unload();
   }
 
-  /* CheckIdle will clear this one up */
+  // CheckIdle will clear this one up
   if(g_curlReferences == 1)
     g_curlTimeout = XbmcThreads::SystemClockMillis();
+  */ 
 }
 
 void DllLibCurlGlobal::CheckIdle()
 {
   /* avoid locking section here, to avoid stalling gfx thread on loads*/
+  return;
+  /*
   if(g_curlReferences == 0)
     return;
 
   CSingleLock lock(m_critSection);
-  /* 20 seconds idle time before closing handle */
+  // 20 seconds idle time before closing handle
   const unsigned int idletime = 30000;
 
   VEC_CURLSESSIONS::iterator it = m_sessions.begin();
@@ -112,9 +118,10 @@ void DllLibCurlGlobal::CheckIdle()
     it++;
   }
 
-  /* check if we should unload the dll */
+  // check if we should unload the dll
   if(g_curlReferences == 1 && XbmcThreads::SystemClockMillis() - g_curlTimeout > idletime)
     Unload();
+  */ 
 }
 
 void DllLibCurlGlobal::easy_aquire(const char *protocol, const char *hostname, CURL_HANDLE** easy_handle, CURLM** multi_handle)


### PR DESCRIPTION
hacked for eden, keeping commented code so we remember to fix this right after eden release. libcurl is a major depends, we use it all over xbmc. We should hardlink and never load/unload it. Tested by amet and it does fix the issue where unloading python will cause ssl to unload and slip out from under curl.
