### PR TITLE
[WIN] fix crash when ejecting an audio CD

### DIFF
--- a/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderCDDA.cpp
@@ -116,7 +116,7 @@ bool CMusicInfoTagLoaderCDDA::Load(const CStdString& strFileName, CMusicInfoTag&
       trackinfo ti = pCdInfo->GetTrackInformation(iTrack);
 
       // Fill the fileitems music tag with CD-Text information, if available
-      CStdString strTitle = ti.cdtext.field[CDTEXT_TITLE];
+      CStdString strTitle = ti.cdtext[CDTEXT_TITLE];
       if (strTitle.size() > 0)
       {
         // Tracknumber
@@ -126,23 +126,23 @@ bool CMusicInfoTagLoaderCDDA::Load(const CStdString& strFileName, CMusicInfoTag&
         tag.SetTitle(strTitle);
 
         // Get info for track zero, as we may have and need CD-Text Album info
-        cdtext_t discCDText = pCdInfo->GetDiscCDTextInformation();
+        xbmc_cdtext_t discCDText = pCdInfo->GetDiscCDTextInformation();
 
         // Artist: Use track artist or disc artist
-        CStdString strArtist = ti.cdtext.field[CDTEXT_PERFORMER];
+        CStdString strArtist = ti.cdtext[CDTEXT_PERFORMER];
         if (strArtist.IsEmpty())
-          strArtist = discCDText.field[CDTEXT_PERFORMER];
+          strArtist = discCDText[CDTEXT_PERFORMER];
         tag.SetArtist(strArtist);
 
         // Album
         CStdString strAlbum;
-        strAlbum = discCDText.field[CDTEXT_TITLE];
+        strAlbum = discCDText[CDTEXT_TITLE];
         tag.SetAlbum(strAlbum);
 
         // Genre: use track or disc genre
-        CStdString strGenre = ti.cdtext.field[CDTEXT_GENRE];
+        CStdString strGenre = ti.cdtext[CDTEXT_GENRE];
         if (strGenre.IsEmpty())
-          strGenre = discCDText.field[CDTEXT_GENRE];
+          strGenre = discCDText[CDTEXT_GENRE];
         tag.SetGenre( strGenre );
 
         tag.SetLoaded(true);

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -815,14 +815,14 @@ CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
       {
       case TRACK_FORMAT_AUDIO:
         {
-        trackinfo ti;
-        ti.nfsInfo = FS_NO_DATA;
-        m_nFs = FS_NO_DATA;
-        ti.ms_offset = 0;
-        ti.isofs_size = 0;
-        ti.nJolietLevel = 0;
-        ti.nFrames = ::cdio_get_track_lba(cdio, i);
-        info->SetTrackInformation( i + 1, ti );
+          trackinfo ti;
+          ti.nfsInfo = FS_NO_DATA;
+          m_nFs = FS_NO_DATA;
+          ti.ms_offset = 0;
+          ti.isofs_size = 0;
+          ti.nJolietLevel = 0;
+          ti.nFrames = ::cdio_get_track_lba(cdio, i);
+          info->SetTrackInformation( i + 1, ti );
         }
       case TRACK_FORMAT_ERROR:
         break;

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -643,23 +643,20 @@ int CCdIoSupport::GuessFilesystem(int start_session, track_t track_num)
   return ret;
 }
 
-void CCdIoSupport::GetCdTextInfo(trackinfo *pti, int trackNum)
+void CCdIoSupport::GetCdTextInfo(xbmc_cdtext_t &xcdt, int trackNum)
 {
   CSingleLock lock(*m_cdio);
 
   // Get the CD-Text , if any
   cdtext_t *pcdtext = (cdtext_t *)::cdio_get_cdtext(cdio, trackNum);
 
-  cdtext_init(&pti->cdtext);
-
   if (pcdtext == NULL)
     return ;
 
+  // same ids used in libcdio and for our structure + the ids are consecutive make this copy loop safe.
   for (int i = 0; i < MAX_CDTEXT_FIELDS; i++)
-  {
     if (pcdtext->field[i])
-      pti->cdtext.field[i] = strdup(pcdtext->field[i]);
-  }
+      xcdt[(cdtext_field_t)i] = pcdtext->field[(cdtext_field_t)i];
 }
 
 CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
@@ -720,7 +717,6 @@ CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
       ti.isofs_size = 0;
       ti.nJolietLevel = 0;
       ti.nFrames = 0;
-      cdtext_init(&ti.cdtext);
       info->SetTrackInformation( i, ti );
       CLog::Log(LOGDEBUG, "cdio_track_msf for track %i failed, I give up.", i);
       delete info;
@@ -728,9 +724,7 @@ CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
       return NULL;
     }
 
-    trackinfo ti_0, ti;
-    cdtext_init(&ti_0.cdtext);
-    cdtext_init(&ti.cdtext);
+    trackinfo ti;
     if (bIsCDRom && TRACK_FORMAT_AUDIO == ::cdio_get_track_format(cdio, i))
     {
       m_nNumAudio++;
@@ -749,12 +743,13 @@ CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
       // Make sure that we have the Disc related info available
       if (i == 1)
       {
-        GetCdTextInfo(&ti_0, 0);
-        info->SetDiscCDTextInformation( ti_0.cdtext );
+        xbmc_cdtext_t xcdt;
+        GetCdTextInfo(xcdt, 0);
+        info->SetDiscCDTextInformation( xcdt );
       }
 
       // Get this tracks info
-      GetCdTextInfo(&ti, i);
+      GetCdTextInfo(ti.cdtext, i);
     }
     else
     {
@@ -819,6 +814,7 @@ CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
       switch ( track_format )
       {
       case TRACK_FORMAT_AUDIO:
+        {
         trackinfo ti;
         ti.nfsInfo = FS_NO_DATA;
         m_nFs = FS_NO_DATA;
@@ -826,8 +822,8 @@ CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
         ti.isofs_size = 0;
         ti.nJolietLevel = 0;
         ti.nFrames = ::cdio_get_track_lba(cdio, i);
-        cdtext_init(&ti.cdtext);
         info->SetTrackInformation( i + 1, ti );
+        }
       case TRACK_FORMAT_ERROR:
         break;
       case TRACK_FORMAT_CDI:
@@ -849,7 +845,6 @@ CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
 
       m_nFs = GuessFilesystem(m_nStartTrack, i);
       trackinfo ti;
-      cdtext_init(&ti.cdtext);
       ti.nfsInfo = m_nFs;
       // valid UDF version for xbox
       if ((m_nFs & FS_MASK) == FS_UDF)

--- a/xbmc/storage/cdioSupport.h
+++ b/xbmc/storage/cdioSupport.h
@@ -124,7 +124,7 @@ public:
     m_nLength = m_nFirstTrack = m_nNumTrack = m_nNumAudio = m_nFirstAudio = m_nNumData = m_nFirstData = 0;
   }
 
-trackinfo GetTrackInformation( int nTrack ) { return m_ti[nTrack -1]; }
+  trackinfo GetTrackInformation( int nTrack ) { return m_ti[nTrack -1]; }
   xbmc_cdtext_t GetDiscCDTextInformation() { return m_cdtext; }
 
   bool HasDataTracks() { return (m_nNumData > 0); }
@@ -142,13 +142,13 @@ trackinfo GetTrackInformation( int nTrack ) { return m_ti[nTrack -1]; }
   // CD-ROM with ISO 9660 filesystem
   bool IsIso9660( int nTrack ) { return ((m_ti[nTrack - 1].nfsInfo & FS_MASK) == FS_ISO_9660); }
   // CD-ROM with joliet extension
-bool IsJoliet( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & JOLIET) ? false : true; }
+  bool IsJoliet( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & JOLIET) ? false : true; }
   // Joliet extension level
   int GetJolietLevel( int nTrack ) { return m_ti[nTrack - 1].nJolietLevel; }
   // ISO filesystem size
   int GetIsoSize( int nTrack ) { return m_ti[nTrack - 1].isofs_size; }
   // CD-ROM with rockridge extensions
-bool IsRockridge( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & ROCKRIDGE) ? false : true; }
+  bool IsRockridge( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & ROCKRIDGE) ? false : true; }
 
   // CD-ROM with CD-RTOS and ISO 9660 filesystem
   bool IsIso9660Interactive( int nTrack ) { return ((m_ti[nTrack - 1].nfsInfo & FS_MASK) == FS_ISO_9660_INTERACTIVE); }
@@ -184,33 +184,33 @@ bool IsRockridge( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & ROCKRIDGE) ?
   bool IsMixedMode( int nTrack ) { return (m_nFirstData == 1 && m_nNumAudio > 0); }
 
   // CD-ROM with XA sectors
-bool IsXA( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & XA) ? false : true; }
+  bool IsXA( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & XA) ? false : true; }
 
   // Multisession CD-ROM
-bool IsMultiSession( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & MULTISESSION) ? false : true; }
+  bool IsMultiSession( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & MULTISESSION) ? false : true; }
   // Gets multisession offset
   int GetMultisessionOffset( int nTrack ) { return m_ti[nTrack - 1].ms_offset; }
 
   // Hidden Track on Audio CD
-bool IsHiddenTrack( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & HIDDEN_TRACK) ? false : true; }
+  bool IsHiddenTrack( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & HIDDEN_TRACK) ? false : true; }
 
   // Photo CD, with audiotracks > 0 Portfolio Photo CD
-bool IsPhotoCd( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & PHOTO_CD) ? false : true; }
+  bool IsPhotoCd( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & PHOTO_CD) ? false : true; }
 
   // CD-ROM with Commodore CDTV
-bool IsCdTv( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & CDTV) ? false : true; }
+  bool IsCdTv( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & CDTV) ? false : true; }
 
   // CD-Plus/Extra
   bool IsCDExtra( int nTrack ) { return (m_nFirstData > 1); }
 
   // Bootable CD
-bool IsBootable( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & BOOTABLE) ? false : true; }
+  bool IsBootable( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & BOOTABLE) ? false : true; }
 
   // Video CD
   bool IsVideoCd( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & VIDEOCDI && m_nNumAudio == 0); }
 
   // Chaoji Video CD
-bool IsChaojiVideoCD( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & CVD) ? false : true; }
+  bool IsChaojiVideoCD( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & CVD) ? false : true; }
 
   // Audio Track
   bool IsAudio( int nTrack ) { return ((m_ti[nTrack - 1].nfsInfo & FS_MASK) == FS_NO_DATA); }
@@ -228,7 +228,7 @@ bool IsChaojiVideoCD( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & CVD) ? f
   void SetDataTrackCount( int nCount ) { m_nNumData = nCount; }
   void SetAudioTrackCount( int nCount ) { m_nNumAudio = nCount; }
   void SetTrackInformation( int nTrack, trackinfo nInfo ) { if ( nTrack > 0 && nTrack <= 99 ) m_ti[nTrack - 1] = nInfo; }
-void SetDiscCDTextInformation( xbmc_cdtext_t cdtext ) { m_cdtext = cdtext; }
+  void SetDiscCDTextInformation( xbmc_cdtext_t cdtext ) { m_cdtext = cdtext; }
 
   void SetCddbDiscId( ULONG ulCddbDiscId ) { m_ulCddbDiscId = ulCddbDiscId; }
   void SetDiscLength( int nLength ) { m_nLength = nLength; }

--- a/xbmc/storage/cdioSupport.h
+++ b/xbmc/storage/cdioSupport.h
@@ -99,6 +99,8 @@ typedef struct signature
 }
 signature_t;
 
+typedef std::map<cdtext_field_t, CStdString> xbmc_cdtext_t;
+
 typedef struct TRACKINFO
 {
   int nfsInfo;  // Information of the Tracks Filesystem
@@ -108,7 +110,7 @@ typedef struct TRACKINFO
   int nFrames;  // Can be used for cddb query
   int nMins;   // minutes playtime part of Track
   int nSecs;   // seconds playtime part of Track
-  cdtext_t cdtext; //  CD-Text for this track
+  xbmc_cdtext_t cdtext; //  CD-Text for this track
 }
 trackinfo;
 
@@ -119,21 +121,11 @@ public:
   CCdInfo()
   {
     m_bHasCDDBInfo = true;
-    cdtext_init(&m_cdtext);
-    for (int i = 0; i < 100; i++)
-      cdtext_init(&m_ti[i].cdtext);
-
     m_nLength = m_nFirstTrack = m_nNumTrack = m_nNumAudio = m_nFirstAudio = m_nNumData = m_nFirstData = 0;
-  }
-  virtual ~CCdInfo()
-  {
-    cdtext_destroy(&m_cdtext);
-    for (int i = 0; i < 100; i++)
-      cdtext_destroy(&m_ti[i].cdtext);
   }
 
 trackinfo GetTrackInformation( int nTrack ) { return m_ti[nTrack -1]; }
-  cdtext_t GetDiscCDTextInformation() { return m_cdtext; }
+  xbmc_cdtext_t GetDiscCDTextInformation() { return m_cdtext; }
 
   bool HasDataTracks() { return (m_nNumData > 0); }
   bool HasAudioTracks() { return (m_nNumAudio > 0); }
@@ -236,7 +228,7 @@ bool IsChaojiVideoCD( int nTrack ) { return (m_ti[nTrack - 1].nfsInfo & CVD) ? f
   void SetDataTrackCount( int nCount ) { m_nNumData = nCount; }
   void SetAudioTrackCount( int nCount ) { m_nNumAudio = nCount; }
   void SetTrackInformation( int nTrack, trackinfo nInfo ) { if ( nTrack > 0 && nTrack <= 99 ) m_ti[nTrack - 1] = nInfo; }
-void SetDiscCDTextInformation( cdtext_t cdtext ) { m_cdtext = cdtext; }
+void SetDiscCDTextInformation( xbmc_cdtext_t cdtext ) { m_cdtext = cdtext; }
 
   void SetCddbDiscId( ULONG ulCddbDiscId ) { m_ulCddbDiscId = ulCddbDiscId; }
   void SetDiscLength( int nLength ) { m_nLength = nLength; }
@@ -257,7 +249,7 @@ private:
   int m_nLength;   // Disclength can be used for cddb query, also see trackinfo.nFrames
   bool m_bHasCDDBInfo;
   CStdString m_strDiscLabel;
-  cdtext_t m_cdtext;  //  CD-Text for this disc
+  xbmc_cdtext_t m_cdtext;  //  CD-Text for this disc
 };
 
 class CLibcdio : public CCriticalSection
@@ -309,7 +301,7 @@ public:
   void PrintAnalysis(int fs, int num_audio);
 
   CCdInfo* GetCdInfo(char* cDeviceFileName=NULL);
-  void GetCdTextInfo(trackinfo *pti, int trackNum);
+  void GetCdTextInfo(xbmc_cdtext_t &xcdt, int trackNum);
 
 protected:
   int ReadBlock(int superblock, uint32_t offset, uint8_t bufnum, track_t track_num);


### PR DESCRIPTION
Probably happening since libcdio is not in-tree anymore, and compiled as a mingw dll.
The strings in the cdtext structures returned by libcdio are duplicated in XBMC with strdup() but freed with libcdio, which has a different memory allocator, causing a memory exception.

This PR replaces the cdtext_init/cdtext_destroy functions with new xbmc_ functions to make it clear that allocation/destruction belongs to XBMC.

The smaller fix (but less clear I think) would be to only replace the cdtext_destroy calls with free() loops.
