### PR TITLE
[Windows] Fix remaining dvd resume issue and soft eject problem

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -97,7 +97,7 @@ bool CAutorun::PlayDisc(const CStdString& path, bool bypassSettings, bool startF
     mediaPath = path;
 
 #ifdef _WIN32
-  if (mediaPath.IsEmpty())
+  if (mediaPath.IsEmpty() || mediaPath.CompareNoCase("iso9660://") == 0)
     mediaPath = g_mediaManager.TranslateDevicePath("");
 #endif
 


### PR DESCRIPTION
two problems remained after commit ee8b61c8687ad6a2c0c58c476b69d1b58364d43c
**on Windows ONLY** because of the iso9660:// prefix 
- the dvd volume label could not to be determined anymore, causing resume point to be broken
- the ISO directory reader does something to Windows that breaks the soft disc eject function
