### PR TITLE
[fixed] Stutter with auto refresh change and Aero enabled

### DIFF
--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -26,6 +26,7 @@
 #include "settings/GUISettings.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
+#include "utils/SystemInfo.h"
 
 #ifdef _WIN32
 #include <tpcshrd.h>
@@ -155,6 +156,7 @@ bool CWinSystemWin32::CreateNewWindow(const CStdString& name, bool fullScreen, R
   m_bWindowCreated = true;
 
   CreateBlankWindows();
+  CreateDwmFixWindow();
 
   ResizeInternal(true);
 
@@ -162,6 +164,37 @@ bool CWinSystemWin32::CreateNewWindow(const CStdString& name, bool fullScreen, R
   ShowWindow( m_hWnd, SW_SHOWDEFAULT );
   UpdateWindow( m_hWnd );
 
+  return true;
+}
+
+LRESULT CALLBACK DwmFixWindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+  return (DefWindowProc(hWnd, msg, wParam, lParam));
+}
+
+bool CWinSystemWin32::CreateDwmFixWindow()
+{
+  m_hWndDwmFix = NULL;
+
+  // Register the windows class
+  WNDCLASSEX wc = {0};
+  wc.cbSize = sizeof(WNDCLASSEX);
+  wc.lpfnWndProc = (WNDPROC) DwmFixWindowProc;
+  wc.hInstance = m_hInstance;
+  wc.hbrBackground = HBRUSH(0);
+  wc.lpszClassName = TEXT("DwmFixClass");
+  if (!RegisterClassEx(&wc))
+    return false;
+
+  // Create and hide the window
+  HWND hWnd = CreateWindowEx(WS_EX_TRANSPARENT | WS_EX_COMPOSITED, TEXT("DwmFixClass"), TEXT(""), 
+                             WS_SYSMENU | WS_CAPTION, 1, m_nHeight + 50, 1, 1, 
+                             NULL, NULL, m_hInstance, NULL);
+  if (hWnd == NULL)
+    return false;
+
+  ShowWindow(hWnd, SW_HIDE);
+  m_hWndDwmFix = hWnd;
   return true;
 }
 
@@ -445,6 +478,14 @@ bool CWinSystemWin32::ChangeResolution(RESOLUTION_INFO res)
     }
     else
     {
+      // Hack around DWM not realizing the refresh change by showing/hiding an offscreen window
+      if (!(g_sysinfo.IsAeroDisabled()) && m_hWndDwmFix != NULL)
+      {
+        CLog::Log(LOGDEBUG, "Aero enabled and in windowed fullscreen mode, apply DWM composition rate fix workaround");
+        ShowWindow(m_hWndDwmFix, SW_SHOWNORMAL);
+        UpdateWindow(m_hWndDwmFix);
+        ShowWindow(m_hWndDwmFix, SW_HIDE);
+      }
       return true;
     }
   }

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -130,6 +130,7 @@ public:
   virtual bool InitWindowSystem();
   virtual bool DestroyWindowSystem();
   virtual bool CreateNewWindow(const CStdString& name, bool fullScreen, RESOLUTION_INFO& res, PHANDLE_EVENT_FUNC userFunction);
+  virtual bool CreateDwmFixWindow();
   virtual bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop);
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual void UpdateResolutions();
@@ -176,6 +177,7 @@ protected:
   void AddResolution(const RESOLUTION_INFO &res);
 
   HWND m_hWnd;
+  HWND m_hWndDwmFix;
   std::vector<HWND> m_hBlankWindows;
   HDC m_hDC;
   HINSTANCE m_hInstance;


### PR DESCRIPTION
This PR fixes the heavy video stutter caused by fake fullscreen mode with Aero and auto refresh rate enabled.

It seems the composition rate in DWM is not updated after ChangeDisplaySettingsEx(). The only known workaround I found is to show a window after the refresh rate change. This does some magic within Windows and makes DWM update the composition rate. Fortunately the window can be positioned offscreen so this will not disturb the user experience. I found a similar workaround in MediaPortal as well.

This is a known issue and it is not XBMC's fault (other players suffer as well), but if one must use fake fullscreen (this is also the default setting of the OOTB installation), disabling Aero (as suggested by the Wiki) is usually not an option because it results in massive tearing in most cases.
