### PR TITLE
Fix: Get URIUtils::IsDVD to return true when playing DVD

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -506,6 +506,11 @@ bool URIUtils::IsHD(const CStdString& strFileName)
 
 bool URIUtils::IsDVD(const CStdString& strFile)
 {
+  CStdString strFileLow = strFile;
+  strFileLow.MakeLower();
+  if (strFileLow.Find("video_ts.ifo") != -1 && IsOnDVD(strFile))
+	return true;
+
 #if defined(_WIN32)
   if (strFile.Left(6).Equals("dvd://"))
     return true;
@@ -517,8 +522,6 @@ bool URIUtils::IsDVD(const CStdString& strFile)
   if(GetDriveType(strFile.c_str()) == DRIVE_CDROM)
     return true;
 #else
-  CStdString strFileLow = strFile;
-  strFileLow.MakeLower();
   if (strFileLow == "d:/"  || strFileLow == "d:\\"  || strFileLow == "d:" || strFileLow == "iso9660://" || strFileLow == "udf://" || strFileLow == "dvd://1" )
     return true;
 #endif


### PR DESCRIPTION
Because AutoRun::RunDisc now uses the full path, IsDVD always returns false when you start playing a DVD.  This has the minor knock-on effect that the dvd="true" test in playercorefactory.xml will never match (if you notice in your debug logs DVDs currently match against the dvdfile rule rather than dvd rule).  That doesn't affect much (since it's the same default player), but hypothetically someone might want to use dvd="true" to launch an external player, and currently they can't.

This should work on all platforms, since it uses IsOnDVD which already handles the different cases, but I've only tested it on Windows.
