### PR TITLE
upnp: fix additional slash at the end of container URIs

### DIFF
--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -383,7 +383,7 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
 
             CStdString id = (char*) (*entry)->m_ObjectID;
             CURL::Encode(id);
-            pItem->SetPath(CStdString((const char*) "upnp://" + uuid + "/" + id.c_str() + "/"));
+            pItem->SetPath(CStdString((const char*) "upnp://" + uuid + "/" + id.c_str()));
 
             // if it's a container, format a string as upnp://uuid/object_id
             if (pItem->m_bIsFolder) {

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -387,8 +387,6 @@ CUPnPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items)
 
             // if it's a container, format a string as upnp://uuid/object_id
             if (pItem->m_bIsFolder) {
-                CStdString id = (char*) (*entry)->m_ObjectID;
-                CURL::Encode(id);
                 pItem->SetPath(pItem->GetPath() + "/");
 
                 // look for metadata


### PR DESCRIPTION
When browsing UPnP shares in XBMC all URI's that point to a subdirectory of the share contain two slashes at the end. This results in odd behaviour when using the "Parent folder" item in the GUI to get back to the parent directory. The logic removes everything up to the second last slash. If I e.g. am in the directory with the URI "upnp://7d7ec181-2b56-37a2-832b-9503f1957eab/0%2e00000//" I end up in the directory with the URI "upnp://7d7ec181-2b56-37a2-832b-9503f1957eab/0%2e00000/" which is the exact same directory.

This fix first checks if there already is a slash at the end of the URI before adding another one.
