### PR TITLE
libcmyth fix for negative program length on occasion

### DIFF
--- a/lib/cmyth/libcmyth/socket.c
+++ b/lib/cmyth/libcmyth/socket.c
@@ -998,7 +998,7 @@ cmyth_rcv_int64(cmyth_conn_t conn, int *err, long long *buf, int count)
 	/*
 	 * Got a result, return it.
 	 */
-	*buf = (long)(sign * val);
+	*buf = (long long)(sign * val);
 
 	return consumed;
 }


### PR DESCRIPTION
Using a pull request from my old libcmyth branch because I don't have time to update to master and push in from there. This should be a fast-forward so perhaps I still could have pushed to master.
