### PR TITLE
vdpau fixes

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -125,6 +125,7 @@ struct DVDVideoUserData
 
 #define DVP_FLAG_NOSKIP             0x00000010 // indicate this picture should never be dropped
 #define DVP_FLAG_DROPPED            0x00000020 // indicate that this picture has been dropped in decoder stage, will have no data
+#define DVP_FLAG_IGNORE_PTS         0x00000040 // indicate that pts of this pic shall be ignored by pullup correction
 
 // DVP_FLAG 0x00000100 - 0x00000f00 is in use by libmpeg2!
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -1562,6 +1562,7 @@ bool CVDPAU::GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* 
     {
       picture->dts = DVD_NOPTS_VALUE;
       picture->pts = DVD_NOPTS_VALUE;
+      picture->iFlags |= DVP_FLAG_IGNORE_PTS;
     }
   }
   return true;

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1094,12 +1094,15 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
   if(m_fFrameRate * abs(m_speed) / DVD_PLAYSPEED_NORMAL > maxfps*0.9)
     limited = true;
 
-  //correct any pattern in the timestamps
-  m_pullupCorrection.Add(pts);
-  pts += m_pullupCorrection.GetCorrection();
+  if (!(picture.iFlags & DVP_FLAG_IGNORE_PTS))
+  {
+    //correct any pattern in the timestamps
+    m_pullupCorrection.Add(pts);
+    pts += m_pullupCorrection.GetCorrection();
 
-  //try to calculate the framerate
-  CalcFrameRate();
+    //try to calculate the framerate
+    CalcFrameRate();
+  }
 
   // signal to clock what our framerate is, it may want to adjust it's
   // speed to better match with our video renderer's output speed


### PR DESCRIPTION
84b34622c8757046a8a25f8d82340e2f4c57c17c
vdpau de-interlacing creates an additional frame with a pts that ruins pattern detection. As a result some 29.97 interlaced movies play jerky.
For some reason the sample file I got played fine with Dharma just before ffmpeg was upgraded, though CalcFrameRate was not successful either.

3f10dc612a07253299482201b48e10791ad27556
After having changed size of video surfaces to coded_height users noticed a corrupted bottom line. The reason is that those extra lines of h.264 take part in vdpau de-interlacing and corrupt the bottom lines. 

Please review. If ok, I recommend to backport this to Eden because those problems did not show in Dharma.
