### PR TITLE
[WIN] speed up detection of a missing/stopped Bonjour service

### DIFF
--- a/xbmc/network/windows/ZeroconfWIN.h
+++ b/xbmc/network/windows/ZeroconfWIN.h
@@ -26,6 +26,13 @@
 #include "threads/CriticalSection.h"
 #include <dns_sd.h>
 
+typedef enum
+{
+  DNSServiceStatus_Unknown,
+  DNSServiceStatus_Down,
+  DNSServiceStatus_Up
+} DNSServiceStatus;
+
 class CZeroconfWIN : public CZeroconf
 {
 public:
@@ -46,7 +53,7 @@ protected:
 private:
 
   static void DNSSD_API registerCallback(DNSServiceRef sdref, const DNSServiceFlags flags, DNSServiceErrorType errorCode, const char *name, const char *regtype, const char *domain, void *context);
-
+  static DNSServiceStatus IsmDNSResponderUp();
 
   //lock + data (accessed from runloop(main thread) + the rest)
   CCriticalSection m_data_guard;


### PR DESCRIPTION
Current code takes about 10 seconds to fail, because the dnssd library tries many times to connect to the service.
This takes 1-2 seconds, much nicer when toggling the Zeroconf setting in the GUI, because there is no feedback that something is happening. Also delays startup much less if service is not running.

The tcp port is a well-known port used on OSX as well.

I think I didn't change the current code behavior, but ignoring the return value of DNSServiceProcessResult seems strange.
