### PR TITLE
added IsZCdaemonRunning() to zeroconf to test availability of the daemon

### DIFF
--- a/xbmc/network/Zeroconf.cpp
+++ b/xbmc/network/Zeroconf.cpp
@@ -21,6 +21,7 @@
 #include "system.h" //HAS_ZEROCONF define
 #include "Zeroconf.h"
 #include "settings/Settings.h"
+#include "settings/GUISettings.h"
 
 #ifdef _LINUX
 #ifndef __APPLE__
@@ -101,6 +102,13 @@ bool CZeroconf::HasService(const std::string& fcr_identifier) const
 void CZeroconf::Start()
 {
   CSingleLock lock(*mp_crit_sec);
+  if(!IsZCdaemonRunning())
+  {
+    g_guiSettings.SetBool("services.zeroconf", false);
+    if (g_guiSettings.GetBool("services.airplay"))
+      g_guiSettings.SetBool("services.airplay", false);
+    return;
+  }
   if(m_started)
     return;
   m_started = true;

--- a/xbmc/network/Zeroconf.h
+++ b/xbmc/network/Zeroconf.h
@@ -91,6 +91,9 @@ protected:
   //removes all services (short hand for "for i in m_service_map doRemoveService(i)")
   virtual void doStop() = 0;
 
+  // return true if the zeroconf daemon is running
+  virtual bool IsZCdaemonRunning() { return  true; }
+
 protected:
   //singleton: we don't want to get instantiated nor copied or deleted from outside
   CZeroconf();

--- a/xbmc/network/windows/ZeroconfWIN.cpp
+++ b/xbmc/network/windows/ZeroconfWIN.cpp
@@ -45,11 +45,11 @@ bool CZeroconfWIN::IsZCdaemonRunning()
   DNSServiceErrorType err = DNSServiceGetProperty(kDNSServiceProperty_DaemonVersion, &version, &size);
   if(err != kDNSServiceErr_NoError)
   {
-    CLog::Log(LOGERROR, "CZeroconfWIN: Zeroconf can't be started probably because Apple's Bonjour Service isn't installed. You can get it by either installing Itunes or Apple's Bonjour Print Service for Windows (http://support.apple.com/kb/DL999)");
+    CLog::Log(LOGERROR, "ZeroconfWIN: Zeroconf can't be started probably because Apple's Bonjour Service isn't installed. You can get it by either installing Itunes or Apple's Bonjour Print Service for Windows (http://support.apple.com/kb/DL999)");
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, "Failed to start zeroconf", "Is Apple's Bonjour Service installed? See log for more info.", 10000, true);
     return false;
   }
-  CLog::Log(LOGDEBUG,"CZeroconfWIN:Bonjour version is %d.%d\n", version / 10000, version / 100 % 100);
+  CLog::Log(LOGDEBUG, "ZeroconfWIN:Bonjour version is %d.%d\n", version / 10000, version / 100 % 100);
   return true;
 }
 
@@ -64,14 +64,14 @@ bool CZeroconfWIN::doPublishService(const std::string& fcr_identifier,
   TXTRecordRef txtRecord;
   TXTRecordCreate(&txtRecord, 0, NULL);
 
-  CLog::Log(LOGDEBUG, "CZeroconfWIN::doPublishService identifier: %s type: %s name:%s port:%i", fcr_identifier.c_str(), fcr_type.c_str(), fcr_name.c_str(), f_port);
+  CLog::Log(LOGDEBUG, __FUNCTION__ " identifier: %s type: %s name:%s port:%i", fcr_identifier.c_str(), fcr_type.c_str(), fcr_name.c_str(), f_port);
 
   //add txt records
   if(!txt.empty())
   {
     for(std::map<std::string, std::string>::const_iterator it = txt.begin(); it != txt.end(); ++it)
     {
-      CLog::Log(LOGDEBUG, "CZeroconfWIN: key:%s, value:%s",it->first.c_str(),it->second.c_str());
+      CLog::Log(LOGDEBUG, "ZeroconfWIN: key:%s, value:%s",it->first.c_str(),it->second.c_str());
       uint8_t txtLen = (uint8_t)strlen(it->second.c_str());
       TXTRecordSetValue(&txtRecord, it->first.c_str(), txtLen, it->second.c_str());
     }
@@ -85,7 +85,7 @@ bool CZeroconfWIN::doPublishService(const std::string& fcr_identifier,
     if (netService)
       DNSServiceRefDeallocate(netService);
 
-    CLog::Log(LOGERROR, __FUNCTION__  " DNSServiceRegister returned (error = %ld)\n", (int) err);
+    CLog::Log(LOGERROR, __FUNCTION__ " DNSServiceRegister returned (error = %ld)\n", (int) err);
   } 
   else
   {
@@ -134,13 +134,13 @@ void DNSSD_API CZeroconfWIN::registerCallback(DNSServiceRef sdref, const DNSServ
   if (errorCode == kDNSServiceErr_NoError)
   {
     if (flags & kDNSServiceFlagsAdd)
-      CLog::Log(LOGDEBUG, "CZeroconfWIN: %s.%s%s now registered and active", name, regtype, domain);
+      CLog::Log(LOGDEBUG, "ZeroconfWIN: %s.%s%s now registered and active", name, regtype, domain);
     else
-      CLog::Log(LOGDEBUG, "CZeroconfWIN: %s.%s%s registration removed", name, regtype, domain);
+      CLog::Log(LOGDEBUG, "ZeroconfWIN: %s.%s%s registration removed", name, regtype, domain);
   }
   else if (errorCode == kDNSServiceErr_NameConflict)
-     CLog::Log(LOGDEBUG, "CZeroconfWIN: %s.%s%s Name in use, please choose another", name, regtype, domain);
+     CLog::Log(LOGDEBUG, "ZeroconfWIN: %s.%s%s Name in use, please choose another", name, regtype, domain);
   else
-    CLog::Log(LOGDEBUG, "CZeroconfWIN: %s.%s%s error code %d", name, regtype, domain, errorCode);
+    CLog::Log(LOGDEBUG, "ZeroconfWIN: %s.%s%s error code %d", name, regtype, domain, errorCode);
 
 }

--- a/xbmc/network/windows/ZeroconfWIN.h
+++ b/xbmc/network/windows/ZeroconfWIN.h
@@ -43,6 +43,8 @@ protected:
 
   virtual void doStop();
 
+  bool IsZCdaemonRunning();
+
 private:
 
   static void DNSSD_API registerCallback(DNSServiceRef sdref, const DNSServiceFlags flags, DNSServiceErrorType errorCode, const char *name, const char *regtype, const char *domain, void *context);


### PR DESCRIPTION
If the daemon isn't running the guisettings of zeroconf and airplay are disabled (others as airtunes can be added too). This is only implemented for win32. For the other ports IsZCdaemonRunning() returns always true.

IsZCdaemonRunning() uses DNSServiceGetProperty once which should be fast enough for setups without bonjour.
