### PR TITLE
CUtil::GetQualifiedFilename should not prefix the path to UNC filenames

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -407,12 +407,12 @@ void CUtil::GetQualifiedFilename(const CStdString &strBasePath, CStdString &strF
   if (!plItemUrl.GetProtocol().IsEmpty())
     return;
 
-  // If the filename starts "x:" or "/" it's already fully qualified so return
+  // If the filename starts "x:", "\\" or "/" it's already fully qualified so return
   if (strFilename.size() > 1)
 #ifdef _LINUX
     if ( (strFilename[1] == ':') || (strFilename[0] == '/') )
 #else
-    if ( strFilename[1] == ':' )
+    if ( strFilename[1] == ':' || (strFilename[0] == '\\' && strFilename[1] == '\\'))
 #endif
       return;
 


### PR DESCRIPTION
No-one likes changes to change code in CUtil as it potentially affects so many areas, however the current behaviour of CUtil::GetQualifiedFilename is clearly wrong. If a filename starts with "\\" then it's a UNC name and should not have any path prefixed to it.
