### PR TITLE
fix VideoReferenceClock on ATI

### DIFF
--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -119,9 +119,12 @@ class CVideoReferenceClock : public CThread
     XVisualInfo *m_vInfo;
     Window       m_Window;
     GLXContext   m_Context;
+    Pixmap       m_pixmap;
+    GLXPixmap    m_glPixmap;
     int          m_RREventBase;
 
     bool         m_UseNvSettings;
+    bool         m_bIsATI;
 
 #elif defined(_WIN32) && defined(HAS_DX)
     bool   SetupD3D();


### PR DESCRIPTION
This patch fixes two issues I have been observing on ATI.

1)
glXWaitVideoSyncSGI works most unreliable on ATi (fglrx). It misses almost every second vblank. I have tried with two trivial GL applications. As soon as I have started the second app, glXWaitVideoSyncSGI and glXSwapBuffers started to miss vblanks.

2)
Opening a second Window with an GL context causes screen corruption. For a few cycles some old pictures or garbage is displayed after the video ref clock was started.

The polling method puts no noticeable load on the system and seems to be very accurate. I am wondering if we should drop glXWaitVideoSyncSGI in general.
