### PR TITLE
GUIMediaWindow: store requested path in history instead of path of returned fileitems

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -643,6 +643,10 @@ bool CGUIMediaWindow::GetDirectory(const CStdString &strDirectory, CFileItemList
     if (!m_rootDir.GetDirectory(strDirectory, items))
       return false;
 
+    // path added to m_history should be requested path
+    // instead of path that could be changed by IDirectory implementation
+    items.SetPath(strDirectory);
+
     // took over a second, and not normally cached, so cache it
     if ((XbmcThreads::SystemClockMillis() - time) > 1000  && items.CacheToDiscIfSlow())
       items.Save(GetID());


### PR DESCRIPTION
This is fix for issue described in http://forum.xbmc.org/showthread.php?t=117181 . Basicly, if we have flatten tvshows enabled, enter some tvshow, exit window and re-enter video nav - "Container.Foldername" infolabel will change from initial tvshow title to "*All seasons" when we re-enter video nav window.

I think that this fix is good (we store path that we wanted to go to, not the path we ended up in) and didn't notice any regressions but this kind of changes tends to produce other bugs.

Thoughts?
