### PR TITLE
add option to disable mysql as a dependancy

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -130,12 +130,16 @@ endif
 LIB_DIRS=\
 	lib/cximage-6.0 \
 	lib/libexif \
-	lib/cmyth \
 	lib/libhdhomerun \
 	lib/libid3tag \
 	lib/libapetag \
 	lib/cpluff \
 	lib/xbmc-dll-symbols
+
+ifeq (@USE_MYSQL@,1)
+LIB_DIRS+= \
+	lib/cmyth
+endif
 
 SS_DIRS=
 ifneq (@DISABLE_RSXS@,1)
@@ -266,7 +270,9 @@ endif
 libexif: dllloader
 	$(MAKE) -C lib/libexif
 cmyth: dllloader
+ifeq (@USE_MYSQL@,1)
 	$(MAKE) -C lib/cmyth
+endif
 libhdhomerun: dllloader
 	$(MAKE) -C lib/libhdhomerun
 libid3tag: dllloader

--- a/configure.in
+++ b/configure.in
@@ -127,6 +127,9 @@ libusb_disabled_udev_found="== libusb disabled. =="
 libcec_enabled="== libcec enabled. =="
 libcec_disabled="== libcec disabled. CEC adapter support will not be available. =="
 libcec_disabled_missing_libs="== libcec disabled because both libudev and libusb are not available. CEC adapter support will not be available. =="
+mysql_enabled="== mysql enabled. =="
+mysql_disabled="== mysql disabled. =="
+mysql_disabled_missing_libs="== Could not find mysql. mysql db and mythtv support disabled. =="
 
 # External library message strings
 external_libraries_enabled="== Use of all supported external libraries enabled. =="
@@ -410,6 +413,12 @@ AC_ARG_ENABLE([libcec],
   [use_libcec=$enableval],
   [use_libcec=auto])
 
+AC_ARG_ENABLE([mysql],
+  [AS_HELP_STRING([--enable-mysql],
+  [enable mysql support (default is auto)])],
+  [use_mysql=$enableval],
+  [use_mysql=auto])
+
 ### External libraries options
 AC_ARG_ENABLE([external-libraries],
   [AS_HELP_STRING([--enable-external-libraries],
@@ -675,15 +684,6 @@ else
 fi
 
 # platform common libraries
-AC_CHECK_PROG(MYSQL_CONFIG, mysql_config, "yes", "no")
-if test $MYSQL_CONFIG = "yes"; then
-  INCLUDES="$INCLUDES `mysql_config --include`"
-  MYSQL_LIBS=`mysql_config --libs`
-  LIBS="$LIBS $MYSQL_LIBS"
-  AC_SUBST(MYSQL_LIBS)
-else
-  AC_MSG_ERROR($missing_program)
-fi
 AC_CHECK_HEADER([ass/ass.h],, AC_MSG_ERROR($missing_library))
 AC_CHECK_HEADER([mpeg2dec/mpeg2.h],, AC_MSG_ERROR($missing_library))
 AC_CHECK_HEADER([mpeg2dec/mpeg2convert.h],, AC_MSG_ERROR($missing_library),
@@ -718,7 +718,6 @@ AC_CHECK_LIB([lzo2],        [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([z],           [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([crypto],      [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([ssl],         [main],, AC_MSG_ERROR($missing_library))
-AC_CHECK_LIB([mysqlclient], [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([ssh],         [sftp_tell64],, AC_MSG_RESULT([Could not find suitable version of libssh]))
 AC_CHECK_LIB([bluetooth],   [hci_devid],, AC_MSG_RESULT([Could not find suitable version of libbluetooth]))
 AC_CHECK_LIB([yajl],        [main],, AC_MSG_ERROR($missing_library))
@@ -1188,6 +1187,29 @@ if test "x$use_libcec" != "xno"; then
 else
   use_libcec="no"
   AC_MSG_NOTICE($libcec_disabled)
+fi
+
+# mysql
+USE_MYSQL=0
+if test "x$use_mysql" != "xno"; then
+  AC_CHECK_PROG(MYSQL_CONFIG, mysql_config, "yes", "no")
+  if test $MYSQL_CONFIG = "yes"; then
+    INCLUDES="$INCLUDES `mysql_config --include`"
+    MYSQL_LIBS=`mysql_config --libs`
+    LIBS="$LIBS $MYSQL_LIBS"
+    AC_SUBST(MYSQL_LIBS)
+    AC_CHECK_LIB([mysqlclient],[main],, AC_MSG_ERROR($missing_library))
+    USE_MYSQL=1;AC_DEFINE([HAVE_MYSQL],[1],["Define to 1 if mysql is installed"])
+  else
+    if test "x$use_mysql" != "xauto"; then
+      AC_MSG_ERROR($mysql_disabled_missing_libs)
+    fi
+    AC_MSG_NOTICE($mysql_disabled_missing_libs)
+    use_mysql="no"
+  fi
+else
+  use_mysql="no"
+  AC_MSG_NOTICE($mysql_disabled)
 fi
 
 ### External libraries checks
@@ -1832,6 +1854,13 @@ else
   final_message="$final_message\n  libcec support:\tNo"
 fi
 
+if test "x$use_mysql" != "xno"; then
+  USE_MYSQL=1
+  final_message="$final_message\n  mysql support:\tYes"
+else
+  final_message="$final_message\n  mysql support:\tNo"
+fi
+
 ### External libraries messages
 
 if test "$use_external_ffmpeg" = "yes"; then
@@ -1927,6 +1956,7 @@ AC_SUBST(PYTHON_VERSION)
 AC_SUBST(OUTPUT_FILES)
 AC_SUBST(HAVE_XBMC_NONFREE)
 AC_SUBST(USE_ASAP_CODEC)
+AC_SUBST(USE_MYSQL)
 AC_SUBST(LIBCURL_BASENAME)
 AC_SUBST(LIBFLAC_BASENAME)
 AC_SUBST(LIBVORBISFILE_BASENAME)

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -816,10 +816,14 @@ bool CFileItem::IsTuxBox() const
   return URIUtils::IsTuxBox(m_strPath);
 }
 
+#ifdef HAS_MYSQL
+
 bool CFileItem::IsMythTV() const
 {
   return URIUtils::IsMythTV(m_strPath);
 }
+
+#endif
 
 bool CFileItem::IsHDHomeRun() const
 {

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1900,12 +1900,14 @@ bool CUtil::SupportsFileOperations(const CStdString& strPath)
     return true;
   if (URIUtils::IsMythTV(strPath))
   {
+#ifdef HAS_MYSQL
     /*
      * Can't use CFile::Exists() to check whether the myth:// path supports file operations because
      * it hits the directory cache on the way through, which has the Live Channels and Guide
      * items cached.
      */
     return CMythDirectory::SupportsFileOperations(strPath);
+#endif
   }
   if (URIUtils::IsStack(strPath))
     return SupportsFileOperations(CStackDirectory::GetFirstStackedFile(strPath));

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -266,6 +266,7 @@ bool CDatabase::Open(const DatabaseSettings &settings)
 
   m_sqlite = true;
 
+#ifdef HAS_MYSQL
   if ( dbSettings.type.Equals("mysql") )
   {
     // check we have all information before we cancel the fallback
@@ -277,10 +278,13 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   }
   else
   {
+#endif
     dbSettings.type = "sqlite3";
     dbSettings.host = _P(g_settings.GetDatabaseFolder());
     dbSettings.name = GetBaseDBName();
+#ifdef HAS_MYSQL
   }
+#endif
 
   // use separate, versioned database
   int version = GetMinVersion();
@@ -369,10 +373,12 @@ bool CDatabase::Connect(const DatabaseSettings &dbSettings, bool create)
   {
     m_pDB.reset( new SqliteDatabase() ) ;
   }
+#ifdef HAS_MYSQL
   else if (dbSettings.type.Equals("mysql"))
   {
     m_pDB.reset( new MysqlDatabase() ) ;
   }
+#endif
   else
   {
     CLog::Log(LOGERROR, "Unable to determine database type: %s", dbSettings.type.c_str());

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -18,12 +18,14 @@
  *  http://www.gnu.org/copyleft/gpl.html
  *
  */
+#include "mysqldataset.h"
+
+#ifdef HAS_MYSQL
 
 #include <iostream>
 #include <string>
 #include <set>
 
-#include "mysqldataset.h"
 #include "utils/log.h"
 #include "system.h" // for GetLastError()
 #include "mysql/errmsg.h"
@@ -1562,3 +1564,4 @@ void MysqlDataset::interrupt() {
 
 }//namespace
 
+#endif

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -18,6 +18,9 @@
  *  http://www.gnu.org/copyleft/gpl.html
  *
  */
+#include "system.h"
+
+#ifdef HAS_MYSQL
 
 #ifndef _MYSQLDATASET_H
 #define _MYSQLDATASET_H
@@ -179,4 +182,5 @@ or insert() operations default = false) */
   virtual bool dropIndex(const char *table, const char *index);
 };
 } //namespace
+#endif
 #endif

--- a/xbmc/filesystem/FactoryDirectory.cpp
+++ b/xbmc/filesystem/FactoryDirectory.cpp
@@ -175,8 +175,10 @@ IDirectory* CFactoryDirectory::Create(const CStdString& strPath)
 #endif
     if (strProtocol == "hdhomerun") return new CDirectoryHomeRun();
     if (strProtocol == "sling") return new CSlingboxDirectory();
+#ifdef HAS_MYSQL
     if (strProtocol == "myth") return new CMythDirectory();
     if (strProtocol == "cmyth") return new CMythDirectory();
+#endif
     if (strProtocol == "rss") return new CRSSDirectory();
 #ifdef HAS_FILESYSTEM_SAP
     if (strProtocol == "sap") return new CSAPDirectory();

--- a/xbmc/filesystem/MythDirectory.cpp
+++ b/xbmc/filesystem/MythDirectory.cpp
@@ -19,6 +19,10 @@
  *
  */
 
+#include "system.h"
+
+#ifdef HAS_MYSQL
+
 #include "MythDirectory.h"
 #include "MythSession.h"
 #include "utils/URIUtils.h"
@@ -658,3 +662,4 @@ bool CMythDirectory::IsLiveTV(const CStdString& strPath)
   CURL url(strPath);
   return url.GetFileName().Left(9) == "channels/";
 }
+#endif

--- a/xbmc/filesystem/MythDirectory.h
+++ b/xbmc/filesystem/MythDirectory.h
@@ -20,6 +20,8 @@
  *
  */
 
+#ifdef HAS_MYSQL
+
 #include "IDirectory.h"
 #include "MythSession.h"
 #include "XBDateTime.h"
@@ -71,3 +73,4 @@ private:
 };
 
 }
+#endif

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -80,6 +80,10 @@
   #define HAS_AIRTUNES
 #endif
 
+#ifdef HAVE_MYSQL
+  #define HAS_MYSQL
+#endif
+
 /**********************
  * Non-free Components
  **********************/

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -730,8 +730,10 @@ bool URIUtils::IsLiveTV(const CStdString& strFile)
   || strFile.Left(4).Equals("sap:"))
     return true;
 
+#ifdef HAS_MYSQL
   if (IsMythTV(strFile) && CMythDirectory::IsLiveTV(strFile))
     return true;
+#endif
 
   return false;
 }


### PR DESCRIPTION
This patch enables a --disable-mysql and --enable-mysql configure flag.
