### PR TITLE
fix Container.FolderName infolabel when re-updating content of flattened tvshow

### DIFF
--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
@@ -41,7 +41,12 @@ bool CDirectoryNodeEpisodes::GetContent(CFileItemList& items) const
   CollectQueryParams(params);
 
   CStdString strBaseDir=BuildPath();
-  bool bSuccess=videodatabase.GetEpisodesNav(strBaseDir, items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetTvShowId(), params.GetSeason());
+
+  int season = (int)params.GetSeason();
+  if (season == -2)
+    season = -1;
+
+  bool bSuccess=videodatabase.GetEpisodesNav(strBaseDir, items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetTvShowId(), season);
 
   videodatabase.Close();
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -48,6 +48,13 @@ CStdString CDirectoryNodeSeasons::GetLocalizedName() const
     return g_localizeStrings.Get(20381); // Specials
   case -1:
     return g_localizeStrings.Get(20366); // All Seasons
+  case -2:
+  {
+    CDirectoryNode *pParent = GetParent();
+    if (pParent)
+      return pParent->GetLocalizedName();
+    return "";
+  }
   default:
     CStdString season;
     season.Format(g_localizeStrings.Get(20358), GetID()); // Season <season>
@@ -85,8 +92,8 @@ bool CDirectoryNodeSeasons::GetContent(CFileItemList& items) const
   if (bFlatten)
   { // flatten if one season or flatten always
     items.Clear();
-    bSuccess=videodatabase.GetEpisodesNav(BuildPath()+"-1/",items,params.GetGenreId(),params.GetYear(),params.GetActorId(),params.GetDirectorId(),params.GetTvShowId());
-    items.SetPath(BuildPath()+"-1/");
+    bSuccess=videodatabase.GetEpisodesNav(BuildPath()+"-2/",items,params.GetGenreId(),params.GetYear(),params.GetActorId(),params.GetDirectorId(),params.GetTvShowId());
+    items.SetPath(BuildPath()+"-2/");
   }
 
   videodatabase.Close();

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -339,7 +339,7 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
           // grab the season thumb as the folder thumb
           CStdString strLabel;
           CStdString strPath;
-          if (params.GetSeason() == -1 && items.Size() > 0)
+          if (params.GetSeason() <= -1 && items.Size() > 0)
           {
             CQueryParams params2;
             dir.GetQueryParams(items[0]->GetPath(),params2);
@@ -655,7 +655,7 @@ bool CGUIWindowVideoNav::CanDelete(const CStdString& strPath)
   if (params.GetMovieId()   != -1 ||
       params.GetEpisodeId() != -1 ||
       params.GetMVideoId()  != -1 ||
-      (params.GetTvShowId() != -1 && params.GetSeason() == -1
+      (params.GetTvShowId() != -1 && params.GetSeason() <= -1
               && !CVideoDatabaseDirectory::IsAllItem(strPath)))
     return true;
 


### PR DESCRIPTION
Second attempt to fix same issue as in [pr 621](https://github.com/xbmc/xbmc/pull/621)
