### PR TITLE
Allow uPnP sort order to be set in advancedsettings.xml

### DIFF
--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -1096,15 +1096,32 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
         }
     }
 
-    // The sort method can be set in the advanced settings
-    if (g_advancedSettings.m_upnpServerSort == "label")
-      items.Sort(SORT_METHOD_LABEL, SORT_ORDER_ASC);
-    else if (g_advancedSettings.m_upnpServerSort == "fullpath")
-      items.Sort(SORT_METHOD_FULLPATH, SORT_ORDER_ASC);
-    else if (g_advancedSettings.m_upnpServerSort == "none")
+    // Get the sort order
+    CStdString sortorder;
+    if (parent_id.Left(5) == "video")
+    {
+      sortorder = g_advancedSettings.m_upnpVideoServerSort;
+      if (sortorder == "default") sortorder = "title";
+    }
+    else
+    {
+      sortorder = g_advancedSettings.m_upnpMusicServerSort;
+      if (sortorder == "default") sortorder = "track";
+    }
+
+    // Sort the list
+    if (sortorder == "title")
+      items.Sort(SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, SORT_ORDER_ASC);
+    else if (sortorder == "track")
+      items.Sort(SORT_METHOD_TRACKNUM, SORT_ORDER_ASC);
+    else if (sortorder == "none")
       ; // no sorting 
+    else if (sortorder == "label")
+      items.Sort(SORT_METHOD_LABEL_IGNORE_THE, SORT_ORDER_ASC);
+    else if (sortorder == "fullpath")
+      items.Sort(SORT_METHOD_FULLPATH, SORT_ORDER_ASC);
     else // If the sort method is unre
-      CLog::Log(LOGERROR, "%s - Unknown sort order: %s", __FUNCTION__, g_advancedSettings.m_upnpServerSort);
+      CLog::Log(LOGERROR, "%s - Unknown sort order: %s", __FUNCTION__, sortorder);
 
     // Don't pass parent_id if action is Search not BrowseDirectChildren, as
     // we want the engine to determine the best parent id, not necessarily the one

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -1106,21 +1106,25 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
     else
     {
       sortorder = g_advancedSettings.m_upnpMusicServerSort;
-      if (sortorder == "default") sortorder = "track";
+      if (sortorder == "default") sortorder = "album";
     }
 
     // Sort the list
     if (sortorder == "title")
       items.Sort(SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, SORT_ORDER_ASC);
-    else if (sortorder == "track")
-      items.Sort(SORT_METHOD_TRACKNUM, SORT_ORDER_ASC);
+    else if (sortorder == "album")
+      items.Sort(SORT_METHOD_ALBUM_IGNORE_THE, SORT_ORDER_ASC);
     else if (sortorder == "none")
       ; // no sorting 
     else if (sortorder == "label")
       items.Sort(SORT_METHOD_LABEL_IGNORE_THE, SORT_ORDER_ASC);
+    else if (sortorder == "file")
+      items.Sort(SORT_METHOD_FILE, SORT_ORDER_ASC);
     else if (sortorder == "fullpath")
       items.Sort(SORT_METHOD_FULLPATH, SORT_ORDER_ASC);
-    else // If the sort method is unre
+    else if (sortorder == "track")
+      items.Sort(SORT_METHOD_TRACKNUM, SORT_ORDER_ASC);
+    else // If the sort method is unrecognised
       CLog::Log(LOGERROR, "%s - Unknown sort order: %s", __FUNCTION__, sortorder);
 
     // Don't pass parent_id if action is Search not BrowseDirectChildren, as

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -57,6 +57,7 @@
 #include "utils/TimeUtils.h"
 #include "utils/md5.h"
 #include "guilib/Key.h"
+#include "settings/AdvancedSettings.h"
 
 using namespace std;
 using namespace MUSIC_INFO;
@@ -1095,8 +1096,15 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
         }
     }
 
-    // Always sort by label
-    items.Sort(SORT_METHOD_LABEL, SORT_ORDER_ASC);
+    // The sort method can be set in the advanced settings
+    if (g_advancedSettings.m_upnpServerSort == "label")
+      items.Sort(SORT_METHOD_LABEL, SORT_ORDER_ASC);
+    else if (g_advancedSettings.m_upnpServerSort == "fullpath")
+      items.Sort(SORT_METHOD_FULLPATH, SORT_ORDER_ASC);
+    else if (g_advancedSettings.m_upnpServerSort == "none")
+      ; // no sorting 
+    else // If the sort method is unre
+      CLog::Log(LOGERROR, "%s - Unknown sort order: %s", __FUNCTION__, g_advancedSettings.m_upnpServerSort);
 
     // Don't pass parent_id if action is Search not BrowseDirectChildren, as
     // we want the engine to determine the best parent id, not necessarily the one

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -114,7 +114,8 @@ void CAdvancedSettings::Initialize()
   m_slideshowZoomAmount = 5.0f;
   m_slideshowBlackBarCompensation = 20.0f;
 
-  m_upnpServerSort = "label";
+  m_upnpVideoServerSort = "default";
+  m_upnpMusicServerSort = "default";
 
   m_lcdRows = 4;
   m_lcdColumns = 20;
@@ -595,8 +596,10 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   pElement = pRootElement->FirstChildElement("upnpserver");
   if (pElement)
   {
-    XMLUtils::GetString(pElement,  "sort",   m_upnpServerSort);
-    m_upnpServerSort.ToLower();
+    XMLUtils::GetString(pElement,  "videosort",   m_upnpVideoServerSort);
+    m_upnpVideoServerSort.ToLower();
+    XMLUtils::GetString(pElement,  "musicsort",   m_upnpMusicServerSort);
+    m_upnpMusicServerSort.ToLower();
   }
 
   pElement = pRootElement->FirstChildElement("lcd");

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -114,6 +114,8 @@ void CAdvancedSettings::Initialize()
   m_slideshowZoomAmount = 5.0f;
   m_slideshowBlackBarCompensation = 20.0f;
 
+  m_upnpServerSort = "label";
+
   m_lcdRows = 4;
   m_lcdColumns = 20;
   m_lcdAddress1 = 0;
@@ -588,6 +590,13 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetFloat(pElement, "panamount", m_slideshowPanAmount, 0.0f, 20.0f);
     XMLUtils::GetFloat(pElement, "zoomamount", m_slideshowZoomAmount, 0.0f, 20.0f);
     XMLUtils::GetFloat(pElement, "blackbarcompensation", m_slideshowBlackBarCompensation, 0.0f, 50.0f);
+  }
+
+  pElement = pRootElement->FirstChildElement("upnpserver");
+  if (pElement)
+  {
+    XMLUtils::GetString(pElement,  "sort",   m_upnpServerSort);
+    m_upnpServerSort.ToLower();
   }
 
   pElement = pRootElement->FirstChildElement("lcd");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -138,6 +138,8 @@ class CAdvancedSettings
     float m_slideshowZoomAmount;
     float m_slideshowPanAmount;
 
+    CStdString m_upnpServerSort;
+
     int m_lcdRows;
     int m_lcdColumns;
     int m_lcdAddress1;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -138,7 +138,8 @@ class CAdvancedSettings
     float m_slideshowZoomAmount;
     float m_slideshowPanAmount;
 
-    CStdString m_upnpServerSort;
+    CStdString m_upnpVideoServerSort;
+    CStdString m_upnpMusicServerSort;
 
     int m_lcdRows;
     int m_lcdColumns;


### PR DESCRIPTION
See http://trac.xbmc.org/ticket/10974

This is a bit of a hack, but it will at least provide a fix until we can think of something more elegant.
