### PR TITLE
Tiny change - extend weather forecast icon support to 7 days - eden??

### DIFF
--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -323,7 +323,7 @@ void CWeatherJob::SetFromProperties()
   else
     m_info.currentHumidity.Format("%s%%",window->GetProperty("Current.Humidity").asString().c_str());
   m_info.location           = window->GetProperty("Current.Location").asString();
-  for (int i=0;i<4;++i)
+  for (int i=0;i<NUM_DAYS;++i)
   {
     CStdString strDay;
     strDay.Format("Day%i.Title",i);

--- a/xbmc/utils/Weather.h
+++ b/xbmc/utils/Weather.h
@@ -48,7 +48,7 @@ struct day_forecast
   CStdString m_low;
 };
 
-#define NUM_DAYS 4
+#define NUM_DAYS 7
 
 class CWeatherInfo
 {


### PR DESCRIPTION
First pull request - be gentle with me!

Very minor change (some would call it Eden friendly!) - this just ups the NUM_DAYS constant to 7 to support 7 days forecasts - all those new weather add ons that are/will pop up with the new system will mean desire for standard 7 day forecasts will be common.

Removed the use of literal '4' in weather.cpp - now uses the same defined constant NUM_DAYS as elsewhere.

Tested on Win64, can't see any side effects at all.

Icons appear as they should.  Without this seven day forecasts will be a lot more work to implement.
