### PR TITLE
System Libav 0.8

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1188,6 +1188,9 @@ if test "$use_external_ffmpeg" = "yes"; then
   # libavcore is optional
   PKG_CHECK_EXISTS([libavcore], FFMPEG_LIBNAMES="$FFMPEG_LIBNAMES libavcore")
 
+  # libswresample doesn't exist in libav
+  PKG_CHECK_EXISTS([libswresample], [FFMPEG_LIBNAMES="$FFMPEG_LIBNAMES libswresample"; AC_DEFINE([HAVE_LIBSWRESAMPLE], [1], [Define to 1 if you have the `swresample' library (-lswresample).])])
+
   PKG_CHECK_MODULES([FFMPEG], [$FFMPEG_LIBNAMES],
                     [INCLUDES="$INCLUDES $FFMPEG_CFLAGS"; LIBS="$LIBS $FFMPEG_LIBS"],
                     AC_MSG_ERROR($missing_library))
@@ -1210,6 +1213,7 @@ if test "$use_external_ffmpeg" = "yes"; then
 
   # optional
   AC_CHECK_HEADERS([libavcore/avcore.h libavcore/samplefmt.h libavutil/mem.h libavutil/samplefmt.h])
+  AC_CHECK_HEADERS([libavfilter/buffersink.h libavfilter/avcodec.h])
 
   # old FFmpeg have this in libavcodec/opt.h instead:
   AC_CHECK_HEADERS([libavutil/opt.h])
@@ -1237,7 +1241,11 @@ if test "$use_external_ffmpeg" = "yes"; then
   AC_DEFINE([USE_EXTERNAL_FFMPEG], [1], [Whether to use external FFmpeg libraries.])
 
   # Disable vdpau support if external libavcodec doesn't have it
-  AC_CHECK_LIB([avcodec], [ff_vdpau_vc1_decode_picture],,
+  AC_RUN_IFELSE(
+    AC_LANG_PROGRAM([[#include <libavcodec/avcodec.h>]],
+      [[avcodec_register_all();
+        AVCodec *codec = avcodec_find_decoder_by_name("vc1_vdpau");
+        return (codec) ? 0 : 1;]]),,
     [if test "x$use_vdpau" = "xyes"; then
       AC_MSG_ERROR($ffmpeg_vdpau_not_supported)
     else
@@ -1245,6 +1253,23 @@ if test "$use_external_ffmpeg" = "yes"; then
       AC_MSG_RESULT($ffmpeg_vdpau_not_supported)
     fi])
 
+  # Other headers to include if available.
+  AC_CHECK_HEADERS([libavutil/mathematics.h],,)
+
+  # Check if <libavfilter/vsrc_buffer.h> exists and defines old
+  # av_vsrc_buffer_add_frame() from SoC. This avoids multiple declarations of
+  # av_vsrc_buffer_add_frame().
+  AC_COMPILE_IFELSE(
+    AC_LANG_SOURCE([[
+      #include <libavfilter/vsrc_buffer.h>
+      void foo(void)
+      {
+        AVRational a;
+        av_vsrc_buffer_add_frame(NULL, NULL, 0, a);
+      }
+      ]]), AC_DEFINE([USE_OLD_AV_VSRC_BUFFER_ADD_FRAME],
+        [1], [Check if SoC av_vsrc_buffer_add_frame() is defined in libavfilter/vsrc_buffer.h.]),)
+  
   # Check for 'PIX_FMT_VDPAU_MPEG4' from libavutil
   if test "x$use_vdpau" != "xno"; then
     AC_LANG_PUSH([C++])
@@ -1255,6 +1280,53 @@ if test "$use_external_ffmpeg" = "yes"; then
       [Whether AVUtil defines PIX_FMT_VDPAU_MPEG4.])],)
     AC_LANG_POP([C++])
   fi
+
+  # Check if ffmpeg/libav defines certain functions
+  AC_CHECK_FUNCS(avfilter_inout_alloc avfilter_inout_free)
+  AC_CHECK_FUNCS(av_get_default_channel_layout)
+
+  # Check parameters passed to avfilter_graph_parse()
+  AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE([#define __STDC_CONSTANT_MACROS
+      #include <libavfilter/avfiltergraph.h>
+      int test()
+      {
+        AVFilterInOut *inputs = NULL, *outputs = NULL;
+        return avfilter_graph_parse(NULL, NULL, inputs, outputs, NULL);
+      }
+    ])],
+    [AC_DEFINE([AVFILTER_GRAPH_PARSE_AVFILTERINOUT_SINGLE_POINTER], [1],
+    [Define to 1 if avfilter_graph_parse() accepts (AVFilterInOut*) parameters.])],)
+  AC_LANG_POP([C++])
+
+  # Check if libavfilter supports the "buffersink" filter
+  AC_LANG_PUSH([C++])
+  AC_RUN_IFELSE(
+    [AC_LANG_SOURCE([#define __STDC_CONSTANT_MACROS
+      extern "C"
+      {
+      #include <libavfilter/avfilter.h>
+      #include <libavfilter/buffersink.h>
+      }
+      void compile_test(void)
+      {
+        av_buffersink_get_buffer_ref(NULL, NULL, 0);
+        av_buffersink_poll_frame(NULL);
+        av_buffersink_params_alloc();
+      }
+      int main(int argc, char **argv)
+      {
+        (void)argc; (void)argv;
+        avfilter_register_all();
+        AVFilter *f = avfilter_get_by_name("buffersink");
+        return (f) ? 0 : 1;
+      }
+    ])],
+    [AC_DEFINE([LIBAVFILTER_SUPPORTS_BUFFERSINK], [1],
+    [Define to 1 if libavfilter supports the `buffersink' filter.])],)
+  AC_LANG_POP([C++])
+
   CPPFLAGS="$SAVE_CPPFLAGS"
 else
   AC_MSG_NOTICE($external_ffmpeg_disabled)

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -43,12 +43,20 @@ extern "C" {
 #if (defined USE_EXTERNAL_FFMPEG)
   #if (defined HAVE_LIBAVFILTER_AVFILTER_H)
     #include <libavfilter/avfiltergraph.h>
-    #include <libavfilter/buffersink.h>
-    #include <libavfilter/avcodec.h>
+    #if (defined USE_OLD_AV_VSRC_BUFFER_ADD_FRAME)
+      #include <libavfilter/vsrc_buffer.h>
+    #else
+      #include <libavfilter/buffersink.h>
+      #include <libavfilter/avcodec.h>
+    #endif
   #elif (defined HAVE_FFMPEG_AVFILTER_H)
     #include <ffmpeg/avfiltergraph.h>
-    #include <ffmpeg/buffersink.h>
-    #include <ffmpeg/avcodec.h>
+    #if (defined USE_OLD_AV_VSRC_BUFFER_ADD_FRAME)
+      #include <ffmpeg/vsrc_buffer.h>
+    #else
+      #include <ffmpeg/buffersink.h>
+      #include <ffmpeg/avcodec.h>
+    #endif
   #endif
 #else
   #include "libavfilter/avfiltergraph.h"
@@ -75,13 +83,19 @@ public:
   virtual int avfilter_graph_config(AVFilterGraph *graphctx, void *log_ctx)=0;
   virtual int avfilter_poll_frame(AVFilterLink *link)=0;
   virtual int avfilter_request_frame(AVFilterLink *link)=0;
+#if (defined USE_OLD_AV_VSRC_BUFFER_ADD_FRAME)
+  virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts, AVRational pixel_aspect)=0;
+#else
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
+#endif
   virtual AVFilterBufferRef *avfilter_get_video_buffer(AVFilterLink *link, int perms, int w, int h)=0;
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref)=0;
   virtual int avfilter_link(AVFilterContext *src, unsigned srcpad, AVFilterContext *dst, unsigned dstpad)=0;
+#ifdef LIBAVFILTER_SUPPORTS_BUFFERSINK
   virtual int av_buffersink_get_buffer_ref(AVFilterContext *buffer_sink, AVFilterBufferRef **bufref, int flags)=0;
   virtual AVBufferSinkParams *av_buffersink_params_alloc()=0;
   virtual int av_buffersink_poll_frame(AVFilterContext *ctx)=0;
+#endif
 };
 
 #if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN)
@@ -116,17 +130,34 @@ public:
   virtual AVFilterInOut *avfilter_inout_alloc()
   {
     CSingleLock lock(DllAvCodec::m_critSection);
+#ifdef HAVE_AVFILTER_INOUT_ALLOC
     return ::avfilter_inout_alloc();
+#else
+    return (AVFilterInOut*)::av_mallocz(sizeof(AVFilterInOut));
+#endif
   }
   virtual void avfilter_inout_free(AVFilterInOut **inout)
   {
     CSingleLock lock(DllAvCodec::m_critSection);
+#ifdef HAVE_AVFILTER_INOUT_FREE
     ::avfilter_inout_free(inout);
+#else
+    while (*inout) {
+      AVFilterInOut *next = (*inout)->next;
+      ::av_freep(&(*inout)->name);
+      ::av_freep(inout);
+      *inout = next;
+    }
+#endif
   }
   virtual int avfilter_graph_parse(AVFilterGraph *graph, const char *filters, AVFilterInOut **inputs, AVFilterInOut **outputs, void *log_ctx)
   {
     CSingleLock lock(DllAvCodec::m_critSection);
+#ifdef AVFILTER_GRAPH_PARSE_AVFILTERINOUT_SINGLE_POINTER
+    return ::avfilter_graph_parse(graph, filters, *inputs, *outputs, log_ctx);
+#else
     return ::avfilter_graph_parse(graph, filters, inputs, outputs, log_ctx);
+#endif
   }
   virtual int avfilter_graph_config(AVFilterGraph *graphctx, void *log_ctx)
   {
@@ -134,13 +165,19 @@ public:
   }
   virtual int avfilter_poll_frame(AVFilterLink *link) { return ::avfilter_poll_frame(link); }
   virtual int avfilter_request_frame(AVFilterLink *link) { return ::avfilter_request_frame(link); }
+#if (defined USE_OLD_AV_VSRC_BUFFER_ADD_FRAME)
+  virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts, AVRational pixel_aspect) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, pts, pixel_aspect); }
+#else
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, flags); }
+#endif
   virtual AVFilterBufferRef *avfilter_get_video_buffer(AVFilterLink *link, int perms, int w, int h) { return ::avfilter_get_video_buffer(link, perms, w, h); }
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref) { ::avfilter_unref_buffer(ref); }
   virtual int avfilter_link(AVFilterContext *src, unsigned srcpad, AVFilterContext *dst, unsigned dstpad) { return ::avfilter_link(src, srcpad, dst, dstpad); }
+#ifdef LIBAVFILTER_SUPPORTS_BUFFERSINK
   virtual int av_buffersink_get_buffer_ref(AVFilterContext *buffer_sink, AVFilterBufferRef **bufref, int flags) { return ::av_buffersink_get_buffer_ref(buffer_sink, bufref, flags); }
   virtual AVBufferSinkParams *av_buffersink_params_alloc() { return ::av_buffersink_params_alloc(); }
   virtual int av_buffersink_poll_frame(AVFilterContext *ctx) { return ::av_buffersink_poll_frame(ctx); }
+#endif
   // DLL faking.
   virtual bool ResolveExports() { return true; }
   virtual bool Load() {

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -59,6 +59,10 @@ extern "C" {
   #else
     #include <ffmpeg/mem.h>
   #endif
+  /* For AVRounding */
+  #if (defined HAVE_LIBAVUTIL_MATHEMATICS_H)
+    #include <libavutil/mathematics.h>
+  #endif
 #else
   #include "libavutil/avutil.h"
   #include "libavutil/crc.h"
@@ -138,7 +142,24 @@ public:
   virtual int av_dict_set(AVDictionary **pm, const char *key, const char *value, int flags) { return ::av_dict_set(pm, key, value, flags); }
   virtual int av_samples_get_buffer_size (int *linesize, int nb_channels, int nb_samples, enum AVSampleFormat sample_fmt, int align)
     { return ::av_samples_get_buffer_size(linesize, nb_channels, nb_samples, sample_fmt, align); }
-  virtual int64_t av_get_default_channel_layout(int nb_channels) { return ::av_get_default_channel_layout(nb_channels); }
+  virtual int64_t av_get_default_channel_layout(int nb_channels)
+  {
+#ifdef HAVE_AV_GET_DEFAULT_CHANNEL_LAYOUT
+    return ::av_get_default_channel_layout(nb_channels);
+#else
+    switch(nb_channels) {
+    case 1: return AV_CH_LAYOUT_MONO;
+    case 2: return AV_CH_LAYOUT_STEREO;
+    case 3: return AV_CH_LAYOUT_SURROUND;
+    case 4: return AV_CH_LAYOUT_QUAD;
+    case 5: return AV_CH_LAYOUT_5POINT0;
+    case 6: return AV_CH_LAYOUT_5POINT1;
+    case 7: return AV_CH_LAYOUT_6POINT1;
+    case 8: return AV_CH_LAYOUT_7POINT1;
+    default: return 0;
+    }
+#endif
+  }
 
    // DLL faking.
    virtual bool ResolveExports() { return true; }

--- a/lib/DllSwResample.h
+++ b/lib/DllSwResample.h
@@ -36,7 +36,9 @@ extern "C" {
 #pragma warning(disable:4244)
 #endif
 #if (defined USE_EXTERNAL_FFMPEG)
-  #include <libswresample/swresample.h>
+  #ifdef HAVE_LIBSWRESAMPLE
+    #include <libswresample/swresample.h>
+  #endif
 #else
   #include "libswresample/swresample.h"
 #endif
@@ -54,7 +56,11 @@ public:
   // DLL faking.
   virtual bool ResolveExports() { return true; }
   virtual bool Load() {
+  #ifdef HAVE_LIBSWRESAMPLE
     CLog::Log(LOGDEBUG, "DllAvFormat: Using libswresample system library");
+  #else
+    CLog::Log(LOGDEBUG, "DllAvFormat: libswresample unavailable");
+  #endif
     return true;
   }
   virtual void Unload() {}


### PR DESCRIPTION
These changes allow xbmc to build and run with system libav-0.8. I've checked and made sure that xbmc can still use internal ffmpeg as well as system libav 0.7.
