### PR TITLE
Fix finding of local thumbs/fanart for VIDEO_TS/BDMV items in parent folder

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2112,25 +2112,11 @@ void CFileItemList::StackFolders()
           if (!dvdPath.IsEmpty())
           {
             // NOTE: should this be done for the CD# folders too?
-            /* set the thumbnail based on folder */
-            item->SetCachedVideoThumb();
-            if (!item->HasThumbnail())
-              item->SetUserVideoThumb();
-
             item->m_bIsFolder = false;
             item->SetPath(dvdPath);
             item->SetLabel2("");
             item->SetLabelPreformated(true);
             m_sortMethod = SORT_METHOD_NONE; /* sorting is now broken */
-
-            /* override the previously set thumb if video_ts.ifo has any */
-            /* otherwise user can't set icon on the stacked file as that */
-            /* will allways be set on the video_ts.ifo file */
-            CStdString thumb(item->GetCachedVideoThumb());
-            if(CFile::Exists(thumb))
-              item->SetThumbnailImage(thumb);
-            else
-              item->SetUserVideoThumb();
           }
         }
       }
@@ -2646,6 +2632,15 @@ CStdString CFileItem::GetUserVideoThumb() const
   if (CFile::Exists(fileThumb))
     return fileThumb;
 
+  if (IsOpticalMediaFile())
+  { // special case for optical media "folders" - check the parent folder (or parent of parent)
+    // TODO: A better way to handle this would be to treat stacked folders as folders rather than files.
+    CFileItem item(GetLocalMetadataPath(), true);
+    CStdString thumb(item.GetUserVideoThumb());
+    if (!thumb.IsEmpty())
+      return thumb;
+  }
+
   // 2. - check movie.tbn, as long as it's not a folder
   if (!m_bIsFolder)
   {
@@ -2886,6 +2881,12 @@ CStdString CFileItem::GetLocalFanart() const
 
   CFileItemList items;
   CDirectory::GetDirectory(strDir, items, g_settings.m_pictureExtensions, false, false, DIR_CACHE_ALWAYS, false, true);
+  if (IsOpticalMediaFile())
+  { // grab from the optical media parent folder as well - see GetUserVideoThumb
+    CFileItemList moreItems;
+    CDirectory::GetDirectory(GetLocalMetadataPath(), moreItems, g_settings.m_pictureExtensions, false, false, DIR_CACHE_ALWAYS, false, true);
+    items.Append(moreItems);
+  }
 
   CStdStringArray fanarts;
   StringUtils::SplitString(g_advancedSettings.m_fanartImages, "|", fanarts);
@@ -2910,6 +2911,22 @@ CStdString CFileItem::GetLocalFanart() const
   }
 
   return "";
+}
+
+CStdString CFileItem::GetLocalMetadataPath() const
+{
+  if (m_bIsFolder && !IsFileFolder())
+    return m_strPath;
+
+  CStdString parent(URIUtils::GetParentPath(m_strPath));
+  CStdString parentFolder(parent);
+  URIUtils::RemoveSlashAtEnd(parentFolder);
+  parentFolder = URIUtils::GetFileName(parentFolder);
+  if (parentFolder == "VIDEO_TS" || parentFolder == "BDMV")
+  { // go back up another one
+    parent = URIUtils::GetParentPath(parent);
+  }
+  return parent;
 }
 
 CStdString CFileItem::GetCachedFanart() const

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -258,6 +258,20 @@ public:
   void SetUserVideoThumb();
   void SetUserMusicThumb(bool alwaysCheckRemote = false);
 
+  /*! \brief Get the path where we expect local metadata to reside.
+   For a folder, this is just the existing path (eg tvshow folder)
+   For a file, this is the parent path, with exceptions made for VIDEO_TS and BDMV files
+
+   Three cases are handled:
+
+     /foo/bar/movie_name/file_name          -> /foo/bar/movie_name/
+     /foo/bar/movie_name/VIDEO_TS/file_name -> /foo/bar/movie_name/
+     /foo/bar/movie_name/BDMV/file_name     -> /foo/bar/movie_name/
+
+     \sa URIUtils::GetParentPath
+   */
+  CStdString GetLocalMetadataPath() const;
+
   // finds a matching local trailer file
   CStdString FindTrailer() const;
 


### PR DESCRIPTION
This fixes the case where we have:

/foo/bar/movie_name/VIDEO_TS/VIDEO_TS.IFO
/foo/bar/movie_name/folder.jpg
/foo/bar/movie_name/fanart.jpg

and the same case without the VIDEO_TS folder, and similarly with or without BDMV.

I'm sure there's plenty of cleanup that can be done, but this is meant as an Eden fix primarily.  It'd be nice for b2, but no problem if not.

I'm awaiting pike's dummy filesystems for full testing.
