### PR TITLE
Addon install redo

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -69,6 +69,9 @@ CAddonInstaller &CAddonInstaller::Get()
 
 void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
 {
+  if (success)
+    CAddonMgr::Get().FindAddons();
+
   CSingleLock lock(m_critSection);
   if (strncmp(job->GetType(), "repoupdate", 10) == 0)
   { // repo job finished
@@ -80,11 +83,8 @@ void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
     JobMap::iterator i = find_if(m_downloadJobs.begin(), m_downloadJobs.end(), bind2nd(find_map(), jobID));
     if (i != m_downloadJobs.end())
       m_downloadJobs.erase(i);
-    lock.Leave();
   }
-
-  if (success)
-    CAddonMgr::Get().FindAddons();
+  lock.Leave();
 
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
   g_windowManager.SendThreadMessage(msg);

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -156,6 +156,27 @@ bool CAddonInstaller::Cancel(const CStdString &addonID)
   return false;
 }
 
+bool CAddonInstaller::PromptForInstall(const CStdString &addonID, AddonPtr &addon)
+{
+  // we assume that addons that are enabled don't get to this routine (i.e. that GetAddon() has been called)
+  if (CAddonMgr::Get().GetAddon(addonID, addon, ADDON_UNKNOWN, false))
+    return false; // addon is installed but disabled, and the user has specifically activated something that needs
+                  // the addon - should we enable it?
+
+  // check we have it available
+  CAddonDatabase database;
+  database.Open();
+  if (database.GetAddon(addonID, addon))
+  { // yes - ask user if they want it installed
+    if (!CGUIDialogYesNo::ShowAndGetInput(g_localizeStrings.Get(24076), g_localizeStrings.Get(24100),
+                                          addon->Name().c_str(), g_localizeStrings.Get(24101)))
+      return false;
+    if (Install(addonID, true, "", false))
+      return CAddonMgr::Get().GetAddon(addonID, addon);
+  }
+  return false;
+}
+
 bool CAddonInstaller::Install(const CStdString &addonID, bool force, const CStdString &referer, bool background)
 {
   AddonPtr addon;

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -35,6 +35,14 @@ public:
   bool GetProgress(const CStdString &addonID, unsigned int &percent) const;
   bool Cancel(const CStdString &addonID);
 
+  /*! \brief Prompt the user as to whether they wish to install an addon.
+   \param addonID the addon ID of the item to install.
+   \param addon [out] the installed addon for later use.
+   \return true on successful install, false otherwise.
+   \sa Install
+   */
+  bool PromptForInstall(const CStdString &addonID, ADDON::AddonPtr &addon);
+
   /*! \brief Install an addon if it is available in a repository
    \param addonID the addon ID of the item to install
    \param force whether to force the install even if the addon is already installed (eg for updating). Defaults to false.

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -20,7 +20,6 @@
  */
 #include "AddonManager.h"
 #include "Addon.h"
-#include "AddonInstaller.h"
 #include "DllLibCPluff.h"
 #include "utils/StringUtils.h"
 #include "utils/JobManager.h"
@@ -32,7 +31,6 @@
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 #include "tinyXML/tinyxml.h"
-#include "dialogs/GUIDialogYesNo.h"
 
 
 #ifdef HAS_VISUALISATION
@@ -392,7 +390,7 @@ bool CAddonMgr::GetAddons(const TYPE &type, VECADDONS &addons, bool enabled /* =
   return addons.size() > 0;
 }
 
-bool CAddonMgr::GetAddon(const CStdString &str, AddonPtr &addon, const TYPE &type/*=ADDON_UNKNOWN*/, bool enabledOnly /*= true*/, bool install  /*= false*/)
+bool CAddonMgr::GetAddon(const CStdString &str, AddonPtr &addon, const TYPE &type/*=ADDON_UNKNOWN*/, bool enabledOnly /*= true*/)
 {
   CSingleLock lock(m_critSection);
 
@@ -406,25 +404,6 @@ bool CAddonMgr::GetAddon(const CStdString &str, AddonPtr &addon, const TYPE &typ
       return false;
     return NULL != addon.get();
   }
-  else
-  {
-    if (install)
-    {
-      if (!CGUIDialogYesNo::ShowAndGetInput(g_localizeStrings.Get(24076), g_localizeStrings.Get(24100),
-                                            str.c_str(), g_localizeStrings.Get(24101)))
-        return false;
-
-      if (CAddonInstaller::Get().Install(str.c_str(), true, "", false))
-      {
-        cp_plugin_info_t *cpaddon = m_cpluff->get_plugin_info(m_cp_context, str.c_str(), &status);
-        addon = GetAddonFromDescriptor(cpaddon);
-        m_cpluff->release_info(m_cp_context, cpaddon);
-        if (status == CP_OK && cpaddon)
-          return NULL != addon.get();
-      }
-    }
-  }
-
   if (cpaddon)
     m_cpluff->release_info(m_cp_context, cpaddon);
 

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -86,10 +86,9 @@ namespace ADDON
      \param addon [out] the retrieved addon pointer - only use if the function returns true.
      \param type type of addon to retrieve - defaults to any type.
      \param enabledOnly whether we only want enabled addons - set to false to allow both enabled and disabled addons - defaults to true.
-     \param install whether to install the requested addon in case it's not yet installed - defaults to false.
      \return true if an addon matching the id of the given type is available and is enabled (if enabledOnly is true).
      */
-    bool GetAddon(const CStdString &id, AddonPtr &addon, const TYPE &type = ADDON_UNKNOWN, bool enabledOnly = true, bool install = false);
+    bool GetAddon(const CStdString &id, AddonPtr &addon, const TYPE &type = ADDON_UNKNOWN, bool enabledOnly = true);
     bool HasAddons(const TYPE &type, bool enabled = true);
     bool GetAddons(const TYPE &type, VECADDONS &addons, bool enabled = true);
     bool GetAllAddons(VECADDONS &addons, bool enabled = true, bool allowRepos = false);

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -25,6 +25,7 @@
 #include "PluginDirectory.h"
 #include "utils/URIUtils.h"
 #include "addons/AddonManager.h"
+#include "addons/AddonInstaller.h"
 #include "addons/IAddon.h"
 #ifdef HAS_PYTHON
 #include "interfaces/python/XBPython.h"
@@ -77,7 +78,7 @@ bool CPluginDirectory::StartScript(const CStdString& strPath, bool retrievingDir
 {
   CURL url(strPath);
 
-  if (!CAddonMgr::Get().GetAddon(url.GetHostName(), m_addon, ADDON_PLUGIN, true, true))
+  if (!CAddonMgr::Get().GetAddon(url.GetHostName(), m_addon, ADDON_PLUGIN) && !CAddonInstaller::Get().PromptForInstall(url.GetHostName(), m_addon))
   {
     CLog::Log(LOGERROR, "Unable to find plugin %s", url.GetHostName().c_str());
     return false;
@@ -408,7 +409,7 @@ bool CPluginDirectory::RunScriptWithParams(const CStdString& strPath)
     return false;
 
   AddonPtr addon;
-  if (!CAddonMgr::Get().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN, true , true))
+  if (!CAddonMgr::Get().GetAddon(url.GetHostName(), addon, ADDON_PLUGIN) && !CAddonInstaller::Get().PromptForInstall(url.GetHostName(), addon))
   {
     CLog::Log(LOGERROR, "Unable to find plugin %s", url.GetHostName().c_str());
     return false;


### PR DESCRIPTION
This redoes the addon install commit 68309d3cd41f5455a6b59eb4f44671486e0d4594 to save circular includes between addon manager and installer, as well as some niceties such as using the addon name rather than ID in the UI and adding a progress bar for the download (+cancel) in case the user has no net access or addon is large.
