### PR TITLE
Corrections to langinfo.xml

### DIFF
--- a/language/Bulgarian/langinfo.xml
+++ b/language/Bulgarian/langinfo.xml
@@ -53,9 +53,9 @@
   </charsets>
 
   <dvd>
-    <menu>bg</menu>
-    <audio>bg</audio>
-    <subtitle>bg</subtitle>
+    <menu>bul</menu>
+    <audio>bul</audio>
+    <subtitle>bul</subtitle>
   </dvd>
 
   <regions>
@@ -64,7 +64,8 @@
       <datelong>DDDD, D MMMM YYYY 'г.'</datelong>
       <time symbolAM="" symbolPM="">H:mm:ss</time>
       <tempunit>C</tempunit>
-      <speedunit>kph</speedunit>
+      <speedunit>kmh</speedunit>
+      <timezone>EET</timezone>
     </region>
   </regions>
 </language>

--- a/language/Bulgarian/langinfo.xml
+++ b/language/Bulgarian/langinfo.xml
@@ -53,9 +53,9 @@
   </charsets>
 
   <dvd>
-    <menu>bul</menu>
-    <audio>bul</audio>
-    <subtitle>bul</subtitle>
+    <menu>bg</menu>
+    <audio>bg</audio>
+    <subtitle>bg</subtitle>
   </dvd>
 
   <regions>


### PR DESCRIPTION
- language code correction (since ISO 639-2 the valid code is "bul")
- speed unit correction ("kmh")
- timezone added ("EET")
