### PR TITLE
Always set repo update time even if repo failed to update

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -255,10 +255,8 @@ VECADDONS CRepositoryUpdateJob::GrabAddons(RepositoryPtr& repo)
       CLog::Log(LOGERROR,"Repository %s returned no add-ons, listing may have failed",repo->Name().c_str());
   }
   else
-  {
     database.GetRepository(repo->ID(),addons);
-    database.SetRepoTimestamp(repo->ID(),CDateTime::GetCurrentDateTime().GetAsDBDateTime());
-  }
+  database.SetRepoTimestamp(repo->ID(),CDateTime::GetCurrentDateTime().GetAsDBDateTime());
 
   return addons;
 }


### PR DESCRIPTION
This saves retrying dead/missing repos every 10 minutes (bumps it to every 6 hours instead)
