### PR TITLE
Make sure keymaps are always loaded when a profile is loaded

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -416,7 +416,7 @@ void CButtonTranslator::RemoveDevice(CStdString& strDevice)
   Load();
 }
 
-bool CButtonTranslator::Load(void)
+bool CButtonTranslator::Load(bool AlwaysLoad)
 {
   m_translatorMap.clear();
 
@@ -429,8 +429,11 @@ bool CButtonTranslator::Load(void)
   };
   bool success = false;
 
-  // If we've already loaded the m_baseMap we don't need to load it again
-  if (m_Loaded)
+  // If we've already loaded the m_baseMap we don't need to load it
+  // again - this speeds up reloads caused by plugging and unplugging
+  // HID devices. However if AlwaysLoad is true always load the keymaps
+  // from scratch.
+  if (m_Loaded && !AlwaysLoad)
   {
     m_translatorMap = m_baseMap;
   }

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -69,7 +69,7 @@ public:
   void RemoveDevice(CStdString& strDevice);
 
   /// loads Lircmap.xml/IRSSmap.xml (if enabled) and Keymap.xml
-  bool Load(void);
+  bool Load(bool AlwaysLoad = false);
   /// clears the maps
   void Clear();
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -952,7 +952,7 @@ bool CSettings::LoadProfile(unsigned int index)
     CStdString strLanguagePath;
     strLanguagePath.Format("special://xbmc/language/%s/strings.xml", strLanguage.c_str());
 
-    CButtonTranslator::GetInstance().Load();
+    CButtonTranslator::GetInstance().Load(true);
     g_localizeStrings.Load(strLanguagePath);
 
     g_Mouse.SetEnabled(g_guiSettings.GetBool("input.enablemouse"));


### PR DESCRIPTION
To speed up plugging and unplugging of HID devices an optimisation to loading of the keymap was added in https://github.com/xbmc/xbmc/commit/1e709b050676f71f3df539dc7ce70b3479d36e7c. A side effect of this is that keymaps are not reloaded when the profile changes. This patch corrects the problem.
