### PR TITLE
Added defaultSeason attribute for tvshowmatchingregex

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -972,9 +972,15 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
   {
     if (pRegExp->FirstChild())
     {
+      int iDefaultSeason = -1;
       bool bByDate = false;
       if (pRegExp->ToElement())
       {
+        CStdString defaultSeason = pRegExp->ToElement()->Attribute("defaultSeason");
+        if(defaultSeason)
+        {
+          iDefaultSeason = atoi(defaultSeason.c_str());
+        }
         CStdString byDate = pRegExp->ToElement()->Attribute("bydate");
         if(byDate && stricmp(byDate, "true") == 0)
         {
@@ -984,9 +990,9 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
       CStdString regExp = pRegExp->FirstChild()->Value();
       regExp.MakeLower();
       if (iAction == 2)
-        settings.insert(settings.begin() + i++, 1, TVShowRegexp(bByDate,regExp));
+        settings.insert(settings.begin() + i++, 1, TVShowRegexp(iDefaultSeason,bByDate,regExp));
       else
-        settings.push_back(TVShowRegexp(bByDate,regExp));
+        settings.push_back(TVShowRegexp(iDefaultSeason,bByDate,regExp));
     }
     pRegExp = pRegExp->NextSibling("regexp");
   }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -151,19 +151,19 @@ void CAdvancedSettings::Initialize()
   //m_videoStackRegExps.push_back("(.*?)([ ._-]*[0-9])(.*?)(\\.[^.]+)$");
 
   // foo.s01.e01, foo.s01_e01, S01E02 foo, S01 - E02
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[Ss]([0-9]+)[][ ._-]*[Ee]([0-9]+)([^\\\\/]*)$"));
+  m_tvshowEnumRegExps.push_back(TVShowRegexp("[Ss]([0-9]+)[][ ._-]*[Ee]([0-9]+)([^\\\\/]*)$",false));
   // foo.ep01, foo.EP_01
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\._ -]()[Ee][Pp]_?([0-9]+)([^\\\\/]*)$"));
+  m_tvshowEnumRegExps.push_back(TVShowRegexp("[\\._ -]()[Ee][Pp]_?([0-9]+)([^\\\\/]*)$",false));
   // foo.yyyy.mm.dd.* (byDate=true)
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(true,"([0-9]{4})[\\.-]([0-9]{2})[\\.-]([0-9]{2})"));
+  m_tvshowEnumRegExps.push_back(TVShowRegexp("([0-9]{4})[\\.-]([0-9]{2})[\\.-]([0-9]{2})",true));
   // foo.mm.dd.yyyy.* (byDate=true)
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(true,"([0-9]{2})[\\.-]([0-9]{2})[\\.-]([0-9]{4})"));
+  m_tvshowEnumRegExps.push_back(TVShowRegexp("([0-9]{2})[\\.-]([0-9]{2})[\\.-]([0-9]{4})",true));
   // foo.1x09* or just /1x09*
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+)([^\\\\/]*)$"));
+  m_tvshowEnumRegExps.push_back(TVShowRegexp("[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+)([^\\\\/]*)$",false));
   // foo.103*, 103 foo
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\\\/\\._ -]([0-9]+)([0-9][0-9])([\\._ -][^\\\\/]*)$"));
+  m_tvshowEnumRegExps.push_back(TVShowRegexp("[\\\\/\\._ -]([0-9]+)([0-9][0-9])([\\._ -][^\\\\/]*)$",false));
   // Part I, Pt.VI
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\/._ -]p(?:ar)?t[_. -]()([ivx]+)([._ -][^\\/]*)$"));
+  m_tvshowEnumRegExps.push_back(TVShowRegexp("[\\/._ -]p(?:ar)?t[_. -]()([ivx]+)([._ -][^\\/]*)$",false));
 
   m_tvshowMultiPartEnumRegExp = "^[-_EeXx]+([0-9]+)";
 
@@ -965,7 +965,7 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
       if (pRegExp->ToElement())
       {
         CStdString defaultSeason = pRegExp->ToElement()->Attribute("defaultSeason");
-        if(defaultSeason)
+        if(!defaultSeason.empty())
         {
           iDefaultSeason = atoi(defaultSeason.c_str());
         }
@@ -978,9 +978,9 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
       CStdString regExp = pRegExp->FirstChild()->Value();
       regExp.MakeLower();
       if (iAction == 2)
-        settings.insert(settings.begin() + i++, 1, TVShowRegexp(iDefaultSeason,bByDate,regExp));
+        settings.insert(settings.begin() + i++, 1, TVShowRegexp(regExp,bByDate,iDefaultSeason));
       else
-        settings.push_back(TVShowRegexp(iDefaultSeason,bByDate,regExp));
+        settings.push_back(TVShowRegexp(regExp,bByDate,iDefaultSeason));
     }
     pRegExp = pRegExp->NextSibling("regexp");
   }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -39,10 +39,18 @@ public:
 
 struct TVShowRegexp
 {
+  int defaultSeason;
   bool byDate;
   CStdString regexp;
+  TVShowRegexp(int s, bool d, const CStdString& r)
+  {
+    defaultSeason = s;
+    byDate = d;
+    regexp = r;
+  }
   TVShowRegexp(bool d, const CStdString& r)
   {
+    defaultSeason = -1;
     byDate = d;
     regexp = r;
   }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -42,17 +42,11 @@ struct TVShowRegexp
   int defaultSeason;
   bool byDate;
   CStdString regexp;
-  TVShowRegexp(int s, bool d, const CStdString& r)
+  TVShowRegexp(const CStdString& r, bool d = false, int s = 1)
   {
+    regexp = r;
+    byDate = d;
     defaultSeason = s;
-    byDate = d;
-    regexp = r;
-  }
-  TVShowRegexp(bool d, const CStdString& r)
-  {
-    defaultSeason = -1;
-    byDate = d;
-    regexp = r;
   }
 };
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -958,14 +958,14 @@ namespace VIDEO
     if (season && episode)
     {
       if (strlen(season) == 0 && strlen(episode) > 0)
-      { // no season specified -> assume season 1 unless specified
-        episodeInfo.iSeason = (defaultSeason >= 0) ? defaultSeason : 1;
+      { // no season specified -> assume defaultSeason
+        episodeInfo.iSeason = defaultSeason;
         if ((episodeInfo.iEpisode = CUtil::TranslateRomanNumeral(episode)) == -1)
           episodeInfo.iEpisode = atoi(episode);
       }
       else if (strlen(season) > 0 && strlen(episode) == 0)
-      { // no episode specification -> assume season 1 unless specified
-        episodeInfo.iSeason = (defaultSeason >= 0) ? defaultSeason : 1;
+      { // no episode specification -> assume defaultSeason
+        episodeInfo.iSeason = defaultSeason;
         if ((episodeInfo.iEpisode = CUtil::TranslateRomanNumeral(season)) == -1)
           episodeInfo.iEpisode = atoi(season);
       }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -855,6 +855,7 @@ namespace VIDEO
       episode.cDate.SetValid(false);
       episode.isFolder = false;
 
+      int defaultSeason = expression[i].defaultSeason;
       bool byDate = expression[i].byDate ? true : false;
 
       if (byDate)
@@ -867,7 +868,7 @@ namespace VIDEO
       }
       else
       {
-        if (!GetEpisodeAndSeasonFromRegExp(reg, episode))
+        if (!GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason))
           continue;
 
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Found episode match %s (s%ie%i) [%s]", strLabel.c_str(),
@@ -898,7 +899,7 @@ namespace VIDEO
         }
         else
         {
-          GetEpisodeAndSeasonFromRegExp(reg, parent);
+          GetEpisodeAndSeasonFromRegExp(reg, parent, defaultSeason);
           if (episode.iSeason == parent.iSeason && episode.iEpisode == parent.iEpisode)
             episode.isFolder = true;
         }
@@ -919,7 +920,7 @@ namespace VIDEO
           if (((regexppos <= regexp2pos) && regexppos != -1) ||
              (regexppos >= 0 && regexp2pos == -1))
           {
-            GetEpisodeAndSeasonFromRegExp(reg, episode);
+            GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason);
 
             CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new season %u, multipart episode %u [%s]",
                       episode.iSeason, episode.iEpisode,
@@ -949,7 +950,7 @@ namespace VIDEO
     return false;
   }
 
-  bool CVideoInfoScanner::GetEpisodeAndSeasonFromRegExp(CRegExp &reg, SEpisode &episodeInfo)
+  bool CVideoInfoScanner::GetEpisodeAndSeasonFromRegExp(CRegExp &reg, SEpisode &episodeInfo, int defaultSeason)
   {
     char* season = reg.GetReplaceString("\\1");
     char* episode = reg.GetReplaceString("\\2");
@@ -957,14 +958,14 @@ namespace VIDEO
     if (season && episode)
     {
       if (strlen(season) == 0 && strlen(episode) > 0)
-      { // no season specified -> assume season 1
-        episodeInfo.iSeason = 1;
+      { // no season specified -> assume season 1 unless specified
+        episodeInfo.iSeason = (defaultSeason >= 0) ? defaultSeason : 1;
         if ((episodeInfo.iEpisode = CUtil::TranslateRomanNumeral(episode)) == -1)
           episodeInfo.iEpisode = atoi(episode);
       }
       else if (strlen(season) > 0 && strlen(episode) == 0)
-      { // no episode specification -> assume season 1
-        episodeInfo.iSeason = 1;
+      { // no episode specification -> assume season 1 unless specified
+        episodeInfo.iSeason = (defaultSeason >= 0) ? defaultSeason : 1;
         if ((episodeInfo.iEpisode = CUtil::TranslateRomanNumeral(season)) == -1)
           episodeInfo.iEpisode = atoi(season);
       }

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -176,7 +176,7 @@ namespace VIDEO
      \param episodeInfo Episode information to fill in.
      \return true on success (2 matches), false on failure (fewer than 2 matches)
      */
-    bool GetEpisodeAndSeasonFromRegExp(CRegExp &reg, SEpisode &episodeInfo);
+    bool GetEpisodeAndSeasonFromRegExp(CRegExp &reg, SEpisode &episodeInfo, int defaultSeason);
 
     /*! \brief Extract episode air-date from a processed regexp
      \param reg Regular expression object with at least 3 matches


### PR DESCRIPTION
As it stands right now, is there is no season specified it is forced to 1. I have updated the code found here [http://forum.xbmc.org/showpost.php?p=527537&postcount=52] with a few modifications.

This allows for patterns such as:

<pre>&lt;tvshowmatching action="append"&gt;
    &lt;regexp defaultSeason="1"&gt;[\._ \-]()E([0-9]{1,3})([^\\/]*)&lt;/regexp&gt; &lt;!-- foo E001 --&gt; // Absolute ordering episodes (season 1)
    &lt;regexp defaultSeason="0"&gt;[\._ \-]()S([0-9]{1,3})([^\\/]*)&lt;/regexp&gt; &lt;!-- foo S001 --&gt; // Absolute ordering specials (season 0)
&lt;/tvshowmatching&gt;</pre>


It is implemented in a very similar way to the bydate attribute.
