### PR TITLE
Gles fixes

### DIFF
--- a/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
@@ -65,7 +65,9 @@ static void LoadTexture(GLenum target
   int bytesPerPixel;
   switch (externalFormat)
   {
+#ifndef HAS_GLES
   case GL_BGRA:
+#endif
   case GL_RGBA:
     bytesPerPixel = 4;
     break;


### PR DESCRIPTION
The GLES implementation that TI supports for the catalog chips lacks GL_BGRA

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
