### PR TITLE
changed: do TMSG_OPTICAL_MOUNT in job to prevent XBMC from freezing ...

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -743,6 +743,7 @@
     <ClCompile Include="..\..\xbmc\SortFileItem.cpp" />
     <ClCompile Include="..\..\xbmc\storage\AutorunMediaJob.cpp" />
     <ClCompile Include="..\..\xbmc\storage\cdioSupport.cpp" />
+    <ClCompile Include="..\..\xbmc\storage\DetectDVDType.cpp" />
     <ClCompile Include="..\..\xbmc\storage\IoSupport.cpp" />
     <ClCompile Include="..\..\xbmc\storage\MediaManager.cpp" />
     <ClCompile Include="..\..\xbmc\storage\windows\Win32StorageProvider.cpp" />
@@ -756,6 +757,7 @@
     <ClCompile Include="..\..\xbmc\threads\platform\Implementation.cpp" />
     <ClInclude Include="..\..\xbmc\cores\AudioRenderers\IAudioRenderer.h" />
     <ClInclude Include="..\..\xbmc\filesystem\FileUPnP.h" />
+    <ClInclude Include="..\..\xbmc\storage\DetectDVDType.h" />
     <ClInclude Include="..\..\xbmc\threads\platform\win\Implementation.cpp" />
     <ClCompile Include="..\..\xbmc\threads\SystemClock.cpp" />
     <ClCompile Include="..\..\xbmc\threads\Thread.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2565,6 +2565,9 @@
     <ClCompile Include="..\..\xbmc\filesystem\FileUPnP.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\storage\DetectDVDType.cpp">
+      <Filter>storage</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5151,6 +5154,9 @@
       <Filter>filesystem</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\AudioRenderers\IAudioRenderer.h" />
+    <ClInclude Include="..\..\xbmc\storage\DetectDVDType.h">
+      <Filter>storage</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\xbmc\win32\XBMC_PC.rc">

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -266,9 +266,10 @@
 #ifdef HAS_SDL_AUDIO
 #include <SDL/SDL_mixer.h>
 #endif
-#ifdef _WIN32
+#ifdef TARGET_WINDOWS
 #include <shlobj.h>
 #include "win32util.h"
+#include "storage/DetectDVDType.h"
 #endif
 #ifdef HAS_XRANDR
 #include "windowing/X11/XRandR.h"
@@ -1032,7 +1033,10 @@ bool CApplication::InitDirectoriesWin32()
   VECSOURCES::const_iterator it;
   for(it=vShare.begin();it!=vShare.end();++it)
     if(g_mediaManager.GetDriveStatus(it->strPath) == DRIVE_CLOSED_MEDIA_PRESENT)
-      g_application.getApplicationMessenger().OpticalMount(it->strPath);
+    {
+      CDetectDisc* discdetection = new CDetectDisc(it->strPath, false);
+      CJobManager::GetInstance().AddJob(discdetection, NULL);
+    }
   // remove end
 
   return true;

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -729,21 +729,6 @@ case TMSG_POWERDOWN:
       break;
 
 #ifdef HAS_DVD_DRIVE
-    case TMSG_OPTICAL_MOUNT:
-      {
-        CDetectDisc* discdetection = new CDetectDisc(pMsg->strParam, pMsg->dwParam1 != 0);
-        CJobManager::GetInstance().AddJob(discdetection, NULL);
-      }
-      break;
-
-    case TMSG_OPTICAL_UNMOUNT:
-      {
-        CMediaSource share;
-        share.strPath = pMsg->strParam;
-        share.strName = share.strPath;
-        g_mediaManager.RemoveAutoSource(share);
-      }
-      break;
     case TMSG_CALLBACK:
       {
         ThreadMessageCallback *callback = (ThreadMessageCallback*)pMsg->lpVoid;
@@ -1171,21 +1156,6 @@ vector<bool> CApplicationMessenger::GetInfoBooleans(const vector<CStdString> &pr
   tMsg.lpVoid = (void*)&infoLabels;
   SendMessage(tMsg, true);
   return infoLabels;
-}
-
-void CApplicationMessenger::OpticalMount(CStdString device, bool bautorun)
-{
-  ThreadMessage tMsg = {TMSG_OPTICAL_MOUNT};
-  tMsg.strParam = device;
-  tMsg.dwParam1 = (DWORD)bautorun;
-  SendMessage(tMsg, false);
-}
-
-void CApplicationMessenger::OpticalUnMount(CStdString device)
-{
-  ThreadMessage tMsg = {TMSG_OPTICAL_UNMOUNT};
-  tMsg.strParam = device;
-  SendMessage(tMsg, false);
 }
 
 void CApplicationMessenger::ShowVolumeBar(bool up)

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -68,6 +68,9 @@
 #include "playlists/PlayList.h"
 #include "FileItem.h"
 
+#include "utils/JobManager.h"
+#include "storage/DetectDVDType.h"
+
 using namespace std;
 
 CDelayedMessage::CDelayedMessage(ThreadMessage& msg, unsigned int delay)
@@ -728,18 +731,8 @@ case TMSG_POWERDOWN:
 #ifdef HAS_DVD_DRIVE
     case TMSG_OPTICAL_MOUNT:
       {
-        CMediaSource share;
-        share.strPath = pMsg->strParam;
-        share.strStatus = g_mediaManager.GetDiskLabel(share.strPath);
-        share.strDiskUniqueId = g_mediaManager.GetDiskUniqueId(share.strPath);
-        if(g_mediaManager.IsAudio(share.strPath))
-          share.strStatus = "Audio-CD";
-        else if(share.strStatus == "")
-          share.strStatus = g_localizeStrings.Get(446);
-        share.strName = share.strPath;
-        share.m_ignore = true;
-        share.m_iDriveType = CMediaSource::SOURCE_TYPE_DVD;
-        g_mediaManager.AddAutoSource(share, pMsg->dwParam1 != 0);
+        CDetectDisc* discdetection = new CDetectDisc(pMsg->strParam, pMsg->dwParam1 != 0);
+        CJobManager::GetInstance().AddJob(discdetection, NULL);
       }
       break;
 

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -91,9 +91,6 @@ class CGUIWindow;
 #define TMSG_GUI_INFOLABEL            608
 #define TMSG_GUI_INFOBOOL             609
 
-#define TMSG_OPTICAL_MOUNT        700
-#define TMSG_OPTICAL_UNMOUNT      701
-
 #define TMSG_CALLBACK             800
 
 #define TMSG_VOLUME_SHOW          900
@@ -196,9 +193,6 @@ public:
   void SendAction(const CAction &action, int windowID = WINDOW_INVALID, bool waitResult=true);
   std::vector<CStdString> GetInfoLabels(const std::vector<CStdString> &properties);
   std::vector<bool> GetInfoBooleans(const std::vector<CStdString> &properties);
-
-  void OpticalMount(CStdString device, bool bautorun=false);
-  void OpticalUnMount(CStdString device);
 
   void ShowVolumeBar(bool up);
 

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -530,7 +530,7 @@ const CStdString &CDetectDVDMedia::GetDVDPath()
   return m_diskPath;
 }
 
-CDetectDisc::CDetectDisc(CStdString &strPath, bool bautorun)
+CDetectDisc::CDetectDisc(const CStdString &strPath, bool bautorun)
 {
   m_strPath  = strPath;
   m_bautorun = bautorun;

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -51,6 +51,7 @@
 #include "Application.h"
 #include "IoSupport.h"
 #include "cdioSupport.h"
+#include "storage/MediaManager.h"
 
 
 using namespace XFILE;
@@ -527,6 +528,29 @@ const CStdString &CDetectDVDMedia::GetDVDLabel()
 const CStdString &CDetectDVDMedia::GetDVDPath()
 {
   return m_diskPath;
+}
+
+CDetectDisc::CDetectDisc(CStdString &strPath, bool bautorun)
+{
+  m_strPath  = strPath;
+  m_bautorun = bautorun;
+}
+
+bool CDetectDisc::DoWork()
+{
+  CMediaSource share;
+  share.strPath = m_strPath;
+  share.strStatus = g_mediaManager.GetDiskLabel(share.strPath);
+  share.strDiskUniqueId = g_mediaManager.GetDiskUniqueId(share.strPath);
+  if(g_mediaManager.IsAudio(share.strPath))
+    share.strStatus = "Audio-CD";
+  else if(share.strStatus == "")
+    share.strStatus = g_localizeStrings.Get(446);
+  share.strName = share.strPath;
+  share.m_ignore = true;
+  share.m_iDriveType = CMediaSource::SOURCE_TYPE_DVD;
+  g_mediaManager.AddAutoSource(share, m_bautorun);
+  return true;
 }
 
 #endif

--- a/xbmc/storage/DetectDVDType.h
+++ b/xbmc/storage/DetectDVDType.h
@@ -37,6 +37,7 @@
 
 #include "threads/Thread.h"
 #include "utils/StdString.h"
+#include "utils/Job.h"
 
 namespace MEDIA_DETECT
 {
@@ -92,5 +93,16 @@ private:
   CLibcdio* m_cdio;
 };
 }
+
+class CDetectDisc : public CJob
+{
+public:
+  CDetectDisc(CStdString &strPath, bool bautorun);
+  bool DoWork();
+
+private:
+  CStdString  m_strPath;
+  bool        m_bautorun;
+};
 
 #endif

--- a/xbmc/storage/DetectDVDType.h
+++ b/xbmc/storage/DetectDVDType.h
@@ -97,7 +97,7 @@ private:
 class CDetectDisc : public CJob
 {
 public:
-  CDetectDisc(CStdString &strPath, bool bautorun);
+  CDetectDisc(const CStdString &strPath, bool bautorun);
   bool DoWork();
 
 private:

--- a/xbmc/win32/WIN32Util.cpp
+++ b/xbmc/win32/WIN32Util.cpp
@@ -522,7 +522,10 @@ HRESULT CWIN32Util::ToggleTray(const char cDriveLetter)
   if(dwReq == IOCTL_STORAGE_EJECT_MEDIA && bRet == 1)
   {
     strRootFormat.Format( _T("%c:"), cDL);
-    g_application.getApplicationMessenger().OpticalUnMount(strRootFormat);
+    CMediaSource share;
+    share.strPath = strRootFormat;
+    share.strName = share.strPath;
+    g_mediaManager.RemoveAutoSource(share);
   }
   return bRet? S_OK : S_FALSE;
 }

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -39,6 +39,8 @@
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "peripherals/Peripherals.h"
+#include "storage/DetectDVDType.h"
+#include "utils/JobManager.h"
 
 #ifdef _WIN32
 
@@ -640,7 +642,10 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
             case SHCNE_MEDIAINSERTED:
               CLog::Log(LOGDEBUG, __FUNCTION__": Drive %s Media has arrived.", drivePath);
               if (GetDriveType(drivePath) == DRIVE_CDROM)
-                g_application.getApplicationMessenger().OpticalMount(drivePath, true);
+              {
+                CDetectDisc* discdetection = new CDetectDisc(drivePath, true);
+                CJobManager::GetInstance().AddJob(discdetection, NULL);
+              }
               else
                 CWin32StorageProvider::SetEvent();
               break;
@@ -649,7 +654,12 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
             case SHCNE_MEDIAREMOVED:
               CLog::Log(LOGDEBUG, __FUNCTION__": Drive %s Media was removed.", drivePath);
               if (GetDriveType(drivePath) == DRIVE_CDROM)
-                g_application.getApplicationMessenger().OpticalUnMount(drivePath);
+              {
+                CMediaSource share;
+                share.strPath = drivePath;
+                share.strName = share.strPath;
+                g_mediaManager.RemoveAutoSource(share);
+              }
               else
                 CWin32StorageProvider::SetEvent();
               break;


### PR DESCRIPTION
during CD/DVD detection (currently only in use by win32 as Linux and OSX? are using the DetectDVDType thread).

Some user reports problems with some bluray drives (USB only?) where it takes a long time for libcdio to detect the inserted disc. It seems to be that libcdio could have problems with some drives. This PR doesn't solve it but decreases the noticeable problems. 
