### PR TITLE
fix movies being part of a 1-movie-set being listed multiple times

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -376,7 +376,8 @@ void CVideoDatabase::CreateViews()
                                     "  LEFT JOIN files ON"
                                     "    files.idFile=movie.idFile"
                                     "  LEFT JOIN path ON"
-                                    "    path.idPath=files.idPath");
+                                    "    path.idPath=files.idPath "
+                                    "GROUP BY movie.idMovie");
   m_pDS->exec(movieview.c_str());
 }
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -721,7 +721,7 @@ private:
    */
   bool LookupByFolders(const CStdString &path, bool shows = false);
 
-  virtual int GetMinVersion() const { return 58; };
+  virtual int GetMinVersion() const { return 59; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 


### PR DESCRIPTION
There were reports on the forum that with the latest tmdb scraper there was an issue with movies showing up multiple times in the video library. The reporter (and vdrfan) tracked it down to it only happening for movies which are part of multiple sets in which there is only this one movie. The problem is not really with the tmdb scraper, it already existed before, but as the new tmdb scraper also scrapes movie sets by default, the problem is forced to appear.

The problem lies in the CREATE VIEW query for the movieview where the movies table is joined with the setlinkmovie table and it doesn't care how the particular sets look like. vdrfan and I came up with the "GROUP BY movie.idMovie" solution and it works perfectly fine on my test installation.
