### PR TITLE
Set nfo scraping - fixes for Eden

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1902,6 +1902,7 @@
   <string id="20455">Listeners</string>
   <string id="20456">Set movieset fanart</string>
   <string id="20457">Movie set</string>
+  <string id="20458">Group movies in sets</string>
   <!-- up to 21329 is reserved for the video db !! !-->
 
   <string id="21330">Show hidden files and directories</string>

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -51,7 +51,7 @@ public:
   NFOResult Create(const CStdString&, const ADDON::ScraperPtr&, int episode=-1,
                    const CStdString& strPath2="");
   template<class T>
-    bool GetDetails(T& details,const char* document=NULL, bool prefix=false)
+    bool GetDetails(T& details,const char* document=NULL, bool prioritise=false)
   {
     TiXmlDocument doc;
     CStdString strDoc;
@@ -64,7 +64,7 @@ public:
       g_charsetConverter.unknownToUTF8(strDoc);
 
     doc.Parse(strDoc.c_str());
-    return details.Load(doc.RootElement(),true,prefix);
+    return details.Load(doc.RootElement(), true, prioritise);
   }
 
   void Close();

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -28,19 +28,19 @@
 using namespace std;
 using namespace MUSIC_INFO;
 
-bool CAlbum::Load(const TiXmlElement *album, bool chained, bool prefix)
+bool CAlbum::Load(const TiXmlElement *album, bool append, bool prioritise)
 {
   if (!album) return false;
-  if (!chained)
+  if (!append)
     Reset();
 
   XMLUtils::GetString(album,"title",strAlbum);
 
-  XMLUtils::GetAdditiveString(album, "artist", g_advancedSettings.m_musicItemSeparator, strArtist, prefix);
-  XMLUtils::GetAdditiveString(album, "genre", g_advancedSettings.m_musicItemSeparator, strGenre, prefix);
-  XMLUtils::GetAdditiveString(album, "style", g_advancedSettings.m_musicItemSeparator, strStyles, prefix);
-  XMLUtils::GetAdditiveString(album, "mood", g_advancedSettings.m_musicItemSeparator, strMoods, prefix);
-  XMLUtils::GetAdditiveString(album, "theme", g_advancedSettings.m_musicItemSeparator, strThemes, prefix);
+  XMLUtils::GetAdditiveString(album, "artist", g_advancedSettings.m_musicItemSeparator, strArtist, prioritise);
+  XMLUtils::GetAdditiveString(album, "genre", g_advancedSettings.m_musicItemSeparator, strGenre, prioritise);
+  XMLUtils::GetAdditiveString(album, "style", g_advancedSettings.m_musicItemSeparator, strStyles, prioritise);
+  XMLUtils::GetAdditiveString(album, "mood", g_advancedSettings.m_musicItemSeparator, strMoods, prioritise);
+  XMLUtils::GetAdditiveString(album, "theme", g_advancedSettings.m_musicItemSeparator, strThemes, prioritise);
 
   XMLUtils::GetString(album,"review",strReview);
   XMLUtils::GetString(album,"releasedate",m_strDateOfRelease);
@@ -65,7 +65,7 @@ bool CAlbum::Load(const TiXmlElement *album, bool chained, bool prefix)
   while (thumb)
   {
     thumbURL.ParseElement(thumb);
-    if (prefix)
+    if (prioritise)
     {
       CStdString temp;
       temp << *thumb;
@@ -73,8 +73,8 @@ bool CAlbum::Load(const TiXmlElement *album, bool chained, bool prefix)
     }
     thumb = thumb->NextSiblingElement("thumb");
   }
-  // prefix thumbs from nfos
-  if (prefix && iThumbCount && iThumbCount != thumbURL.m_url.size())
+  // prioritise thumbs from nfos
+  if (prioritise && iThumbCount && iThumbCount != thumbURL.m_url.size())
   {
     rotate(thumbURL.m_url.begin(),
            thumbURL.m_url.begin()+iThumbCount, 

--- a/xbmc/music/Album.cpp
+++ b/xbmc/music/Album.cpp
@@ -36,11 +36,11 @@ bool CAlbum::Load(const TiXmlElement *album, bool chained, bool prefix)
 
   XMLUtils::GetString(album,"title",strAlbum);
 
-  XMLUtils::GetAdditiveString(album,"artist",g_advancedSettings.m_musicItemSeparator,strArtist);
-  XMLUtils::GetAdditiveString(album,"genre",g_advancedSettings.m_musicItemSeparator,strGenre);
-  XMLUtils::GetAdditiveString(album,"style",g_advancedSettings.m_musicItemSeparator,strStyles);
-  XMLUtils::GetAdditiveString(album,"mood",g_advancedSettings.m_musicItemSeparator,strMoods);
-  XMLUtils::GetAdditiveString(album,"theme",g_advancedSettings.m_musicItemSeparator,strThemes);
+  XMLUtils::GetAdditiveString(album, "artist", g_advancedSettings.m_musicItemSeparator, strArtist, prefix);
+  XMLUtils::GetAdditiveString(album, "genre", g_advancedSettings.m_musicItemSeparator, strGenre, prefix);
+  XMLUtils::GetAdditiveString(album, "style", g_advancedSettings.m_musicItemSeparator, strStyles, prefix);
+  XMLUtils::GetAdditiveString(album, "mood", g_advancedSettings.m_musicItemSeparator, strMoods, prefix);
+  XMLUtils::GetAdditiveString(album, "theme", g_advancedSettings.m_musicItemSeparator, strThemes, prefix);
 
   XMLUtils::GetString(album,"review",strReview);
   XMLUtils::GetString(album,"releasedate",m_strDateOfRelease);

--- a/xbmc/music/Album.h
+++ b/xbmc/music/Album.h
@@ -62,7 +62,14 @@ public:
     songs.clear();
   }
 
-  bool Load(const TiXmlElement *movie, bool chained=false, bool prefix=false);
+  /*! \brief Load album information from an XML file.
+   See CVideoInfoTag::Load for a description of the types of elements we load.
+   \param element    the root XML element to parse.
+   \param append     whether information should be added to the existing tag, or whether it should be reset first.
+   \param prioritise if appending, whether additive tags should be prioritised (i.e. replace or prepend) over existing values. Defaults to false.
+   \sa CVideoInfoTag::Load
+   */
+  bool Load(const TiXmlElement *element, bool append = false, bool prioritise = false);
   bool Save(TiXmlNode *node, const CStdString &tag, const CStdString& strPath);
 
   long idAlbum;

--- a/xbmc/music/Artist.cpp
+++ b/xbmc/music/Artist.cpp
@@ -25,18 +25,18 @@
 
 using namespace std;
 
-bool CArtist::Load(const TiXmlElement *artist, bool chained, bool prefix)
+bool CArtist::Load(const TiXmlElement *artist, bool append, bool prioritise)
 {
   if (!artist) return false;
-  if (!chained)
+  if (!append)
     Reset();
 
   XMLUtils::GetString(artist,"name",strArtist);
-  XMLUtils::GetAdditiveString(artist, "genre", g_advancedSettings.m_musicItemSeparator, strGenre, prefix);
-  XMLUtils::GetAdditiveString(artist, "style", g_advancedSettings.m_musicItemSeparator, strStyles, prefix);
-  XMLUtils::GetAdditiveString(artist, "mood", g_advancedSettings.m_musicItemSeparator, strMoods, prefix);
-  XMLUtils::GetAdditiveString(artist, "yearsactive", g_advancedSettings.m_musicItemSeparator, strYearsActive, prefix);
-  XMLUtils::GetAdditiveString(artist, "instruments", g_advancedSettings.m_musicItemSeparator, strInstruments, prefix);
+  XMLUtils::GetAdditiveString(artist, "genre", g_advancedSettings.m_musicItemSeparator, strGenre, prioritise);
+  XMLUtils::GetAdditiveString(artist, "style", g_advancedSettings.m_musicItemSeparator, strStyles, prioritise);
+  XMLUtils::GetAdditiveString(artist, "mood", g_advancedSettings.m_musicItemSeparator, strMoods, prioritise);
+  XMLUtils::GetAdditiveString(artist, "yearsactive", g_advancedSettings.m_musicItemSeparator, strYearsActive, prioritise);
+  XMLUtils::GetAdditiveString(artist, "instruments", g_advancedSettings.m_musicItemSeparator, strInstruments, prioritise);
 
   XMLUtils::GetString(artist,"born",strBorn);
   XMLUtils::GetString(artist,"formed",strFormed);
@@ -51,7 +51,7 @@ bool CArtist::Load(const TiXmlElement *artist, bool chained, bool prefix)
   while (thumb)
   {
     thumbURL.ParseElement(thumb);
-    if (prefix)
+    if (prioritise)
     {
       CStdString temp;
       temp << *thumb;
@@ -60,7 +60,7 @@ bool CArtist::Load(const TiXmlElement *artist, bool chained, bool prefix)
     thumb = thumb->NextSiblingElement("thumb");
   }
   // prefix thumbs from nfos
-  if (prefix && iThumbCount && iThumbCount != thumbURL.m_url.size())
+  if (prioritise && iThumbCount && iThumbCount != thumbURL.m_url.size())
   {
     rotate(thumbURL.m_url.begin(),
            thumbURL.m_url.begin()+iThumbCount, 
@@ -88,7 +88,7 @@ bool CArtist::Load(const TiXmlElement *artist, bool chained, bool prefix)
   if (fanart2)
   {
     // we prefix to handle mixed-mode nfo's with fanart set
-    if (prefix)
+    if (prioritise)
     {
       CStdString temp;
       temp << *fanart2;

--- a/xbmc/music/Artist.cpp
+++ b/xbmc/music/Artist.cpp
@@ -32,11 +32,11 @@ bool CArtist::Load(const TiXmlElement *artist, bool chained, bool prefix)
     Reset();
 
   XMLUtils::GetString(artist,"name",strArtist);
-  XMLUtils::GetAdditiveString(artist,"genre",g_advancedSettings.m_musicItemSeparator,strGenre);
-  XMLUtils::GetAdditiveString(artist,"style",g_advancedSettings.m_musicItemSeparator,strStyles);
-  XMLUtils::GetAdditiveString(artist,"mood",g_advancedSettings.m_musicItemSeparator,strMoods);
-  XMLUtils::GetAdditiveString(artist,"yearsactive",g_advancedSettings.m_musicItemSeparator,strYearsActive);
-  XMLUtils::GetAdditiveString(artist,"instruments",g_advancedSettings.m_musicItemSeparator,strInstruments);
+  XMLUtils::GetAdditiveString(artist, "genre", g_advancedSettings.m_musicItemSeparator, strGenre, prefix);
+  XMLUtils::GetAdditiveString(artist, "style", g_advancedSettings.m_musicItemSeparator, strStyles, prefix);
+  XMLUtils::GetAdditiveString(artist, "mood", g_advancedSettings.m_musicItemSeparator, strMoods, prefix);
+  XMLUtils::GetAdditiveString(artist, "yearsactive", g_advancedSettings.m_musicItemSeparator, strYearsActive, prefix);
+  XMLUtils::GetAdditiveString(artist, "instruments", g_advancedSettings.m_musicItemSeparator, strInstruments, prefix);
 
   XMLUtils::GetString(artist,"born",strBorn);
   XMLUtils::GetString(artist,"formed",strFormed);

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -56,7 +56,14 @@ public:
     idArtist = -1;
   }
 
-  bool Load(const TiXmlElement *movie, bool chained=false, bool prefix=false);
+  /*! \brief Load artist information from an XML file.
+   See CVideoInfoTag::Load for a description of the types of elements we load.
+   \param element    the root XML element to parse.
+   \param append     whether information should be added to the existing tag, or whether it should be reset first.
+   \param prioritise if appending, whether additive tags should be prioritised (i.e. replace or prepend) over existing values. Defaults to false.
+   \sa CVideoInfoTag::Load
+   */
+  bool Load(const TiXmlElement *element, bool append = false, bool prioritise = false);
   bool Save(TiXmlNode *node, const CStdString &tag, const CStdString& strPath);
 
   CStdString strArtist;

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -554,7 +554,7 @@ void CGUISettings::Initialize()
   flattenTVShowOptions.insert(make_pair(20422, 2));
   AddInt(vdl, "videolibrary.flattentvshows", 20412, 1, flattenTVShowOptions, SPIN_CONTROL_TEXT);
 
-  AddBool(NULL, "videolibrary.flattenmoviesets", 22002, false);
+  AddBool(vdl, "videolibrary.groupmoviesets", 20458, false);
   AddBool(vdl, "videolibrary.updateonstartup", 22000, false);
   AddBool(vdl, "videolibrary.backgroundupdate", 22001, false);
   AddSeparator(vdl, "videolibrary.sep3");

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -133,11 +133,14 @@ bool XMLUtils::GetString(const TiXmlNode* pRootNode, const char* strTag, CStdStr
 }
 
 bool XMLUtils::GetAdditiveString(const TiXmlNode* pRootNode, const char* strTag,
-                                 const CStdString& strSeparator, CStdString& strStringValue)
+                                 const CStdString& strSeparator, CStdString& strStringValue,
+                                 bool clear)
 {
   CStdString strTemp;
   const TiXmlElement* node = pRootNode->FirstChildElement(strTag);
   bool bResult=false;
+  if (node && node->FirstChild() && clear)
+    strStringValue.clear();
   while (node)
   {
     if (node->FirstChild())

--- a/xbmc/utils/XMLUtils.h
+++ b/xbmc/utils/XMLUtils.h
@@ -38,7 +38,21 @@ public:
   static bool GetInt(const TiXmlNode* pRootNode, const char* strTag, int& iIntValue);
   static bool GetBoolean(const TiXmlNode* pRootNode, const char* strTag, bool& bBoolValue);
   static bool GetString(const TiXmlNode* pRootNode, const char* strTag, CStdString& strStringValue);
-  static bool GetAdditiveString(const TiXmlNode* pRootNode, const char* strTag, const CStdString& strSeparator, CStdString& strStringValue);
+  /*! \brief Get multiple tags, concatenating the values together.
+   Transforms
+     <tag>value1</tag>
+     <tag clear="true">value2</tag>
+     ...
+     <tag>valuen</tag>
+   into value2<sep>...<sep>valuen, appending it to the value string. Note that <value1> is overwritten by the clear="true" tag.
+
+   \param rootNode    the parent containing the <tag>'s.
+   \param tag         the <tag> in question.
+   \param separator   the separator to use when concatenating values.
+   \param value [out] the resulting string. Remains untouched if no <tag> is available, else is appended (or cleared based on the clear parameter).
+   \param clear       if true, clears the string prior to adding tags, if tags are available. Defaults to false.
+   */
+  static bool GetAdditiveString(const TiXmlNode* rootNode, const char* tag, const CStdString& separator, CStdString& value, bool clear = false);
   static bool GetEncoding(const TiXmlDocument* pDoc, CStdString& strEncoding);
   static bool GetPath(const TiXmlNode* pRootNode, const char* strTag, CStdString& strStringValue);
   static bool GetFloat(const TiXmlNode* pRootNode, const char* strTag, float& value, const float min, const float max);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4715,7 +4715,7 @@ bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const CStdSt
       strSQL += where;
     else
     {
-      if (fetchSets && !g_guiSettings.GetBool("videolibrary.flattenmoviesets"))
+      if (fetchSets && g_guiSettings.GetBool("videolibrary.groupmoviesets"))
       {
         GetSetsNav("videodb://1/7/", items, VIDEODB_CONTENT_MOVIES, "");
         strSQL += PrepareSQL("WHERE movieview.idMovie NOT IN (SELECT idMovie FROM setlinkmovie s1 JOIN(SELECT idSet, COUNT(1) AS c FROM setlinkmovie GROUP BY idSet HAVING c>1) s2 ON s2.idSet=s1.idSet)");

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -581,14 +581,16 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
     m_strPictureURL.m_xml = xmlAdd;
   }
 
-  XMLUtils::GetAdditiveString(movie,"genre",g_advancedSettings.m_videoItemSeparator,m_strGenre);
-  XMLUtils::GetAdditiveString(movie,"country",g_advancedSettings.m_videoItemSeparator,m_strCountry);
-  XMLUtils::GetAdditiveString(movie,"credits",g_advancedSettings.m_videoItemSeparator,m_strWritingCredits);
-  XMLUtils::GetAdditiveString(movie,"director",g_advancedSettings.m_videoItemSeparator,m_strDirector);
-  XMLUtils::GetAdditiveString(movie,"showlink",g_advancedSettings.m_videoItemSeparator,m_strShowLink);
+  XMLUtils::GetAdditiveString(movie, "genre", g_advancedSettings.m_videoItemSeparator, m_strGenre, prefix);
+  XMLUtils::GetAdditiveString(movie, "country", g_advancedSettings.m_videoItemSeparator, m_strCountry, prefix);
+  XMLUtils::GetAdditiveString(movie, "credits", g_advancedSettings.m_videoItemSeparator, m_strWritingCredits, prefix);
+  XMLUtils::GetAdditiveString(movie, "director", g_advancedSettings.m_videoItemSeparator, m_strDirector, prefix);
+  XMLUtils::GetAdditiveString(movie, "showlink", g_advancedSettings.m_videoItemSeparator, m_strShowLink, prefix);
 
   // cast
   const TiXmlElement* node = movie->FirstChildElement("actor");
+  if (node && node->FirstChild() && prefix)
+    m_cast.clear();
   while (node)
   {
     const TiXmlNode *actor = node->FirstChild("name");
@@ -614,6 +616,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
   }
 
   node = movie->FirstChildElement("set");
+  if (node && node->FirstChild() && prefix)
+    m_set.clear();
   while (node)
   {
     if (node->FirstChild())
@@ -622,9 +626,11 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
     node = node->NextSiblingElement("set");
   }
 
-  XMLUtils::GetAdditiveString(movie,"studio",g_advancedSettings.m_videoItemSeparator,m_strStudio);
+  XMLUtils::GetAdditiveString(movie, "studio", g_advancedSettings.m_videoItemSeparator, m_strStudio, prefix);
   // artists
   node = movie->FirstChildElement("artist");
+  if (node && node->FirstChild() && prefix)
+    m_strArtist.clear();
   while (node)
   {
     const TiXmlNode* pNode = node->FirstChild("name");

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -250,16 +250,13 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathIn
   return true;
 }
 
-bool CVideoInfoTag::Load(const TiXmlElement *movie, bool chained /* = false */,
-                         bool prefix /* = false */)
+bool CVideoInfoTag::Load(const TiXmlElement *element, bool append, bool prioritise)
 {
-  if (!movie) return false;
-
-  // reset our details if we aren't chained.
-  if (!chained) Reset();
-
-  ParseNative(movie,prefix);
-
+  if (!element)
+    return false;
+  if (!append)
+    Reset();
+  ParseNative(element, prioritise);
   return true;
 }
 
@@ -508,7 +505,7 @@ const CStdString CVideoInfoTag::GetCast(bool bIncludeRole /*= false*/) const
   return strLabel.TrimRight("\n");
 }
 
-void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
+void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
 {
   XMLUtils::GetString(movie, "title", m_strTitle);
   XMLUtils::GetString(movie, "originaltitle", m_strOriginalTitle);
@@ -563,7 +560,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
   while (thumb)
   {
     m_strPictureURL.ParseElement(thumb);
-    if (prefix)
+    if (prioritise)
     {
       CStdString temp;
       temp << *thumb;
@@ -572,8 +569,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
     thumb = thumb->NextSiblingElement("thumb");
   }
 
-  // prefix thumbs from nfos
-  if (prefix && iThumbCount && iThumbCount != m_strPictureURL.m_url.size())
+  // prioritise thumbs from nfos
+  if (prioritise && iThumbCount && iThumbCount != m_strPictureURL.m_url.size())
   {
     rotate(m_strPictureURL.m_url.begin(),
            m_strPictureURL.m_url.begin()+iThumbCount, 
@@ -581,15 +578,15 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
     m_strPictureURL.m_xml = xmlAdd;
   }
 
-  XMLUtils::GetAdditiveString(movie, "genre", g_advancedSettings.m_videoItemSeparator, m_strGenre, prefix);
-  XMLUtils::GetAdditiveString(movie, "country", g_advancedSettings.m_videoItemSeparator, m_strCountry, prefix);
-  XMLUtils::GetAdditiveString(movie, "credits", g_advancedSettings.m_videoItemSeparator, m_strWritingCredits, prefix);
-  XMLUtils::GetAdditiveString(movie, "director", g_advancedSettings.m_videoItemSeparator, m_strDirector, prefix);
-  XMLUtils::GetAdditiveString(movie, "showlink", g_advancedSettings.m_videoItemSeparator, m_strShowLink, prefix);
+  XMLUtils::GetAdditiveString(movie, "genre", g_advancedSettings.m_videoItemSeparator, m_strGenre, prioritise);
+  XMLUtils::GetAdditiveString(movie, "country", g_advancedSettings.m_videoItemSeparator, m_strCountry, prioritise);
+  XMLUtils::GetAdditiveString(movie, "credits", g_advancedSettings.m_videoItemSeparator, m_strWritingCredits, prioritise);
+  XMLUtils::GetAdditiveString(movie, "director", g_advancedSettings.m_videoItemSeparator, m_strDirector, prioritise);
+  XMLUtils::GetAdditiveString(movie, "showlink", g_advancedSettings.m_videoItemSeparator, m_strShowLink, prioritise);
 
   // cast
   const TiXmlElement* node = movie->FirstChildElement("actor");
-  if (node && node->FirstChild() && prefix)
+  if (node && node->FirstChild() && prioritise)
     m_cast.clear();
   while (node)
   {
@@ -616,7 +613,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
   }
 
   node = movie->FirstChildElement("set");
-  if (node && node->FirstChild() && prefix)
+  if (node && node->FirstChild() && prioritise)
     m_set.clear();
   while (node)
   {
@@ -626,10 +623,10 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
     node = node->NextSiblingElement("set");
   }
 
-  XMLUtils::GetAdditiveString(movie, "studio", g_advancedSettings.m_videoItemSeparator, m_strStudio, prefix);
+  XMLUtils::GetAdditiveString(movie, "studio", g_advancedSettings.m_videoItemSeparator, m_strStudio, prioritise);
   // artists
   node = movie->FirstChildElement("artist");
-  if (node && node->FirstChild() && prefix)
+  if (node && node->FirstChild() && prioritise)
     m_strArtist.clear();
   while (node)
   {
@@ -710,8 +707,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
   const TiXmlElement *fanart = movie->FirstChildElement("fanart");
   if (fanart)
   {
-    // we prefix to handle mixed-mode nfo's with fanart set
-    if (prefix)
+    // we prioritise mixed-mode nfo's with fanart set
+    if (prioritise)
     {
       CStdString temp;
       temp << *fanart;

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -643,7 +643,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prefix)
     {
       const char* clear=node->Attribute("clear");
       if (m_strArtist.IsEmpty() || (clear && stricmp(clear,"true")==0))
-        m_strArtist += pValue;
+        m_strArtist = pValue;
       else
         m_strArtist += g_advancedSettings.m_videoItemSeparator + pValue;
     }

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -43,7 +43,22 @@ class CVideoInfoTag : public IArchivable, public ISerializable
 public:
   CVideoInfoTag() { Reset(); };
   void Reset();
-  bool Load(const TiXmlElement *movie, bool chained = false, bool prefix=false);
+  /* \brief Load information to a videoinfotag from an XML element
+   There are three types of tags supported:
+    1. Single-value tags, such as <title>.  These are set if available, else are left untouched.
+    2. Additive tags, such as <set> or <genre>.  These are appended to or replaced (if available) based on the value
+       of the prioritise parameter.  In addition, a clear attribute is available in the XML to clear the current value prior
+       to appending.
+    3. Image tags such as <thumb> and <fanart>.  If the prioritise value is specified, any additional values are prepended
+       to the existing values.
+
+   \param element    the root XML element to parse.
+   \param append     whether information should be added to the existing tag, or whether it should be reset first.
+   \param prioritise if appending, whether additive tags should be prioritised (i.e. replace or prepend) over existing values. Defaults to false.
+
+   \sa ParseNative
+   */
+  bool Load(const TiXmlElement *element, bool append = false, bool prioritise = false);
   bool Save(TiXmlNode *node, const CStdString &tag, bool savePathInfo = true);
   virtual void Archive(CArchive& ar);
   virtual void Serialize(CVariant& value);
@@ -114,7 +129,14 @@ public:
   CBookmark m_resumePoint;
 
 private:
-  void ParseNative(const TiXmlElement* movie, bool prefix);
+  /* \brief Parse our native XML format for video info.
+   See Load for a description of the available tag types.
+
+   \param element    the root XML element to parse.
+   \param prioritise whether additive tags should be replaced (or prepended) by the content of the tags, or appended to.
+   \sa Load
+   */
+  void ParseNative(const TiXmlElement* element, bool prioritise);
 };
 
 typedef std::vector<CVideoInfoTag> VECMOVIES;


### PR DESCRIPTION
This pull req takes care of several related things:
1. Mixed .nfo tag content now overrides any content returned from the scraper.  In particular, additive information (genres, sets, cast etc.) is not just tacked on, but instead is overwritten should it be available in the .nfo.
2. The clear attribute was ignored for music video artists.
3. Cosmetic changes to the naming of variables in the infotag loaders.  Primarily I renamed chained to append (as chained is a scraper-specific term, and these functions are also used elsewhere) and prefix to prioritise, as not all information is actually prefixed.
4. Added a NEW setting (and NEW language string, as none was available) to the user interface to allow users to control the grouping/flattening of sets in movie title listings.  The rationale for doing so is that themoviedb now has the set information, the scraper returns it by default (more information == a good thing) but with the existing advancedsettings only being defaulted to group sets together, this would give anybody not previously using .nfo files (i.e. most users) a change in behaviour.  Downside is only the new string, as anyone using as.xml for this feature previously would have had it set to what is now the default.

Please review for stupids, as this is Eden material.
