### PR TITLE
Don't forcefully disable avahi for arm, configure has checks for it already

### DIFF
--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -222,8 +222,6 @@
 
 // ARM does not support certain features... disable them here!
 #ifdef _ARMEL
-#undef HAS_AVAHI
-#undef HAS_ZEROCONF
 #undef HAS_VISUALISATION
 #undef HAS_FILESYSTEM_HTSP
 #endif


### PR DESCRIPTION
This fixes zeroconf on ARM platforms that do support avahi like Beagleboard/Angstrom

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
