### PR TITLE
Global A/V Delay based on refresh rate (fixes 24htz ~250ms OOS issue)

### DIFF
--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -24,6 +24,7 @@
 #include "system.h" // until we get sane int types used here
 #include "IAudioCallback.h"
 #include "utils/StdString.h"
+#include "guilib/Resolution.h"
 
 struct TextCacheStruct_t;
 class TiXmlElement;
@@ -103,6 +104,7 @@ public:
   virtual bool IsRecording() { return false;};
   virtual bool Record(bool bOnOff) { return false;};
 
+  virtual void SetGlobalAVDelay(RESOLUTION res, bool apply) { return; };
   virtual void  SetAVDelay(float fValue = 0.0f) { return; }
   virtual float GetAVDelay()                    { return 0.0f;};
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -171,6 +171,7 @@ public:
   virtual bool CanRecord();
   virtual bool IsRecording();
   virtual bool Record(bool bOnOff);
+  virtual void SetGlobalAVDelay(RESOLUTION res, bool apply);
   virtual void SetAVDelay(float fValue = 0.0f);
   virtual float GetAVDelay();
 
@@ -306,6 +307,7 @@ protected:
   void UpdatePlayState(double timeout);
   double m_UpdateApplication;
 
+  float m_GlobalAVDelay;
   bool m_bAbortRequest;
 
   std::string m_filename; // holds the actual filename

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -349,6 +349,10 @@ void CGraphicContext::SetVideoResolution(RESOLUTION res, bool forceUpdate)
     }
   }
 
+  // Update global AV delay
+  if (g_application.IsPlayingVideo())
+    g_application.m_pPlayer->SetGlobalAVDelay(res, true);
+
   if (res >= RES_DESKTOP)
   {
     g_advancedSettings.m_fullScreen = true;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -534,6 +534,47 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
       }
     }
 
+    // Store global AV delay settings
+    m_videoAVDefaultDelay = 0;
+    TiXmlElement* pAdjustAVDelay = pElement->FirstChildElement("globalavdelay");
+    if (pAdjustAVDelay)
+    {
+      TiXmlElement* pRefreshAVDelay = pAdjustAVDelay->FirstChildElement("refresh");
+      while (pRefreshAVDelay)
+      {
+        RefreshAVDelay avdelay = {0};
+
+        float refresh;
+        if (XMLUtils::GetFloat(pRefreshAVDelay, "rate", refresh))
+        {
+          avdelay.refreshmin = refresh - 0.01f;
+          avdelay.refreshmax = refresh + 0.01f;
+        }
+
+        float refreshmin, refreshmax;
+        if (XMLUtils::GetFloat(pRefreshAVDelay, "min", refreshmin) &&
+            XMLUtils::GetFloat(pRefreshAVDelay, "max", refreshmax))
+        {
+          avdelay.refreshmin = refreshmin;
+          avdelay.refreshmax = refreshmax;
+        }
+
+        float delay;
+        if (XMLUtils::GetFloat(pRefreshAVDelay, "delay", delay, -600.0f, 600.0f))
+          avdelay.delay = delay;
+
+        if (avdelay.refreshmin > 0.0f && avdelay.refreshmax >= avdelay.refreshmin)
+          m_videoRefreshAVDelay.push_back(avdelay);
+        else
+          CLog::Log(LOGWARNING, "Ignoring malformed global AV delay entry, min:%f max:%f", avdelay.refreshmin, avdelay.refreshmax);
+
+        pRefreshAVDelay = pRefreshAVDelay->NextSiblingElement("refresh");
+      }
+
+      // Get default global AV delay
+      XMLUtils::GetFloat(pAdjustAVDelay, "delay", m_videoAVDefaultDelay, -600.0f, 600.0f);
+    }
+
     m_DXVACheckCompatibilityPresent = XMLUtils::GetBoolean(pElement,"checkdxvacompatibility", m_DXVACheckCompatibility);
 
     XMLUtils::GetBoolean(pElement,"forcedxvarenderer", m_DXVAForceProcessorRenderer);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -59,6 +59,15 @@ struct RefreshOverride
   bool  fallback;
 };
 
+
+struct RefreshAVDelay
+{
+  float refreshmin;
+  float refreshmax;
+
+  float delay;
+};
+
 typedef std::vector<TVShowRegexp> SETTINGS_TVSHOWLIST;
 
 class CAdvancedSettings
@@ -125,6 +134,8 @@ class CAdvancedSettings
     bool  m_videoAllowMpeg4VDPAU;
     bool  m_videoAllowMpeg4VAAPI;
     std::vector<RefreshOverride> m_videoAdjustRefreshOverrides;
+    std::vector<RefreshAVDelay> m_videoRefreshAVDelay;
+    float m_videoAVDefaultDelay;
     bool m_videoDisableBackgroundDeinterlace;
     int  m_videoCaptureUseOcclusionQuery;
     bool m_DXVACheckCompatibility;


### PR DESCRIPTION
OK first time ive done this dont know if i'm breaking ruse or anything just figured i would do it as everyone in the thread keeps saying someone to set up a PR

see thread: http://forum.xbmc.org/showthread.php?t=96916

basically a11599 made a nice patch that basically checks the refresh rate of currrently playing vdeo (not fps) and sets a global a/v delay based on some settings in the advancedsettings.xml. this is especially helpful to two distinct groups. A: people who expierience the 24htz playback oos bug. basically all .mkv videos i play exhibit the same delay about 250 ms. anything at 60 htz is fine. B: people who have AVRs with no a/v sync setting and get an all around delay. also with the way its setup via as.xml it wont impact users who dont see the bug dont use 24htz or for whatever other reason. Now i know a lot of people were holding off on tackling this bug do to AE being merged soon and the asumption that would fix it. well i'm here to say myself and others are testing the AE branch gnif is currently working on (huge progress by the way) and the bug is still present, also gnif doesnt seem to want to be bothered with having to worry about this issue. so sadly AE will probably still have teh same bug, but hey guess what. the patch works just the same in AE as it does in current master.

So tell me what you guys think and thank a11599 for writing this i just did the grunt work.

here is the layout for your as.xml

<advancedsettings>
  <video>

```
<!-- Settings to configure global AV (audio) delay. Some displays have complex video processing -->
<!-- and can introduce a noticeable delay in video. -->

<globalavdelay>

  <!-- Default global AV delay. If not specified, default is 0. -->

  <delay>20</delay>

  <!-- AV delay may depend on display refresh rate (not movie fps!). -->

  <refresh>
    <min>23</min>             <!-- Define a range between 23-24 Hz -->
    <max>24</max>
    <delay>-250</delay>       <!-- Workaround for the infamous 24p 250 msec audio delay bug -->
  </refresh>

  <refresh>
    <rate>60</rate>           <!-- This matches 60 +- 0.01 Hz -->
    <delay>80</delay>         <!-- Compensate for video processing -->
  </refresh>

</globalavdelay>
```

  </video>
</advancedsettings>

and when playing a video if you press O to bring up the output information on the 3rd line above the current fps there is a marker a/vd i beleive and it will show what your delay is set to (i.e. -0.250 or 0.0 if using that xml depending on refresh rate)
