### PR TITLE
Getdirectory: Use flags rather than a bunch of bools

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1866,7 +1866,7 @@ bool CApplication::LoadUserWindows()
   {
     CLog::Log(LOGINFO, "Loading user windows, path %s", vecSkinPath[i].c_str());
     CFileItemList items;
-    if (CDirectory::GetDirectory(vecSkinPath[i], items, ".xml", false))
+    if (CDirectory::GetDirectory(vecSkinPath[i], items, ".xml", DIR_FLAG_NO_FILE_DIRS))
     {
       for (int i = 0; i < items.Size(); ++i)
       {

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2071,7 +2071,7 @@ void CFileItemList::StackFolders()
           if (bMatch)
           {
             CFileItemList items;
-            CDirectory::GetDirectory(item->GetPath(),items,g_settings.m_videoExtensions,true);
+            CDirectory::GetDirectory(item->GetPath(),items,g_settings.m_videoExtensions);
             // optimized to only traverse listing once by checking for filecount
             // and recording last file item for later use
             int nFiles = 0;
@@ -2874,11 +2874,11 @@ CStdString CFileItem::GetLocalFanart() const
     return "";
 
   CFileItemList items;
-  CDirectory::GetDirectory(strDir, items, g_settings.m_pictureExtensions, false, false, DIR_CACHE_ALWAYS, false, true);
+  CDirectory::GetDirectory(strDir, items, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO, true);
   if (IsOpticalMediaFile())
   { // grab from the optical media parent folder as well - see GetUserVideoThumb
     CFileItemList moreItems;
-    CDirectory::GetDirectory(GetLocalMetadataPath(), moreItems, g_settings.m_pictureExtensions, false, false, DIR_CACHE_ALWAYS, false, true);
+    CDirectory::GetDirectory(GetLocalMetadataPath(), moreItems, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO, true);
     items.Append(moreItems);
   }
 
@@ -3127,7 +3127,7 @@ CStdString CFileItem::FindTrailer() const
   CStdString strDir;
   URIUtils::GetDirectory(strFile, strDir);
   CFileItemList items;
-  CDirectory::GetDirectory(strDir, items, g_settings.m_videoExtensions, true, false, DIR_CACHE_ALWAYS, false, true);
+  CDirectory::GetDirectory(strDir, items, g_settings.m_videoExtensions, DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO, true);
   URIUtils::RemoveExtension(strFile);
   strFile += "-trailer";
   CStdString strFile3 = URIUtils::AddFileToFolder(strDir, "movie-trailer");

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2874,11 +2874,11 @@ CStdString CFileItem::GetLocalFanart() const
     return "";
 
   CFileItemList items;
-  CDirectory::GetDirectory(strDir, items, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO, true);
+  CDirectory::GetDirectory(strDir, items, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
   if (IsOpticalMediaFile())
   { // grab from the optical media parent folder as well - see GetUserVideoThumb
     CFileItemList moreItems;
-    CDirectory::GetDirectory(GetLocalMetadataPath(), moreItems, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO, true);
+    CDirectory::GetDirectory(GetLocalMetadataPath(), moreItems, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
     items.Append(moreItems);
   }
 
@@ -3127,7 +3127,7 @@ CStdString CFileItem::FindTrailer() const
   CStdString strDir;
   URIUtils::GetDirectory(strFile, strDir);
   CFileItemList items;
-  CDirectory::GetDirectory(strDir, items, g_settings.m_videoExtensions, DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO, true);
+  CDirectory::GetDirectory(strDir, items, g_settings.m_videoExtensions, DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
   URIUtils::RemoveExtension(strFile);
   strFile += "-trailer";
   CStdString strFile3 = URIUtils::AddFileToFolder(strDir, "movie-trailer");

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -710,7 +710,7 @@ void CUtil::RemoveTempFiles()
 {
   CStdString searchPath = g_settings.GetDatabaseFolder();
   CFileItemList items;
-  if (!XFILE::CDirectory::GetDirectory(searchPath, items, ".tmp", false))
+  if (!XFILE::CDirectory::GetDirectory(searchPath, items, ".tmp", DIR_FLAG_NO_FILE_DIRS))
     return;
 
   for (int i = 0; i < items.Size(); ++i)
@@ -747,7 +747,7 @@ void CUtil::ClearTempFonts()
     return;
 
   CFileItemList items;
-  CDirectory::GetDirectory(searchPath, items, "", false, false, XFILE::DIR_CACHE_NEVER);
+  CDirectory::GetDirectory(searchPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_BYPASS_CACHE);
 
   for (int i=0; i<items.Size(); ++i)
   {
@@ -801,7 +801,7 @@ CStdString CUtil::GetNextFilename(const CStdString &fn_template, int max)
   name.Format(fn_template.c_str(), 0);
 
   CFileItemList items;
-  if (!CDirectory::GetDirectory(searchPath, items, mask, false))
+  if (!CDirectory::GetDirectory(searchPath, items, mask, DIR_FLAG_NO_FILE_DIRS))
     return name;
 
   items.SetFastLookup(true);
@@ -1651,7 +1651,7 @@ void CUtil::DeleteDirectoryCache(const CStdString &prefix)
 {
   CStdString searchPath = "special://temp/";
   CFileItemList items;
-  if (!XFILE::CDirectory::GetDirectory(searchPath, items, ".fi", false))
+  if (!XFILE::CDirectory::GetDirectory(searchPath, items, ".fi", DIR_FLAG_NO_FILE_DIRS))
     return;
 
   for (int i = 0; i < items.Size(); ++i)
@@ -1776,7 +1776,10 @@ int CUtil::GMTZoneCalc(int iRescBiases, int iHour, int iMinute, int &iMinuteNew)
 void CUtil::GetRecursiveListing(const CStdString& strPath, CFileItemList& items, const CStdString& strMask, bool bUseFileDirectories)
 {
   CFileItemList myItems;
-  CDirectory::GetDirectory(strPath,myItems,strMask,bUseFileDirectories);
+  int flags = DIR_FLAG_DEFAULTS;
+  if (!bUseFileDirectories)
+    flags |= DIR_FLAG_NO_FILE_DIRS;
+  CDirectory::GetDirectory(strPath,myItems,strMask,flags);
   for (int i=0;i<myItems.Size();++i)
   {
     if (myItems[i]->m_bIsFolder)
@@ -1789,7 +1792,7 @@ void CUtil::GetRecursiveListing(const CStdString& strPath, CFileItemList& items,
 void CUtil::GetRecursiveDirsListing(const CStdString& strPath, CFileItemList& item)
 {
   CFileItemList myItems;
-  CDirectory::GetDirectory(strPath,myItems,"",false);
+  CDirectory::GetDirectory(strPath,myItems,"",DIR_FLAG_NO_FILE_DIRS);
   for (int i=0;i<myItems.Size();++i)
   {
     if (myItems[i]->m_bIsFolder && !myItems[i]->GetPath().Equals(".."))
@@ -2358,7 +2361,7 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
     {
       CFileItemList items;
       
-      CDirectory::GetDirectory(strLookInPaths[step], items,".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|.ass|.idx|.ifo|.rar|.zip",false);
+      CDirectory::GetDirectory(strLookInPaths[step], items,".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|.ass|.idx|.ifo|.rar|.zip",DIR_FLAG_NO_FILE_DIRS);
       int fnl = strMovieFileNameNoExt.size();
       
       for (int j = 0; j < items.Size(); j++)
@@ -2430,7 +2433,7 @@ int CUtil::ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStd
   {
    CStdString strZipPath;
    URIUtils::CreateArchivePath(strZipPath,"zip",strArchivePath,"");
-   if (!CDirectory::GetDirectory(strZipPath,ItemList,"",false))
+   if (!CDirectory::GetDirectory(strZipPath,ItemList,"",DIR_FLAG_NO_FILE_DIRS))
     return false;
   }
   else

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2389,7 +2389,6 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
           }
         }
       }
-      g_directoryCache.ClearDirectory(strLookInPaths[step]);
     }
   }
 

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -377,7 +377,7 @@ void CGUIDialogAddonInfo::OnJobComplete(unsigned int jobID, bool success,
 void CGUIDialogAddonInfo::GrabRollbackVersions()
 {
   CFileItemList items;
-  XFILE::CDirectory::GetDirectory("special://home/addons/packages/",items,".zip",false);
+  XFILE::CDirectory::GetDirectory("special://home/addons/packages/",items,".zip",DIR_FLAG_NO_FILE_DIRS);
   items.Sort(SORT_METHOD_LABEL,SORT_ORDER_ASC);
   for (int i=0;i<items.Size();++i)
   {

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -916,9 +916,9 @@ vector<CStdString> CGUIDialogAddonSettings::GetFileEnumValues(const CStdString &
   // fetch directory
   CFileItemList items;
   if (!mask.IsEmpty())
-    CDirectory::GetDirectory(fullPath, items, mask, false);
+    CDirectory::GetDirectory(fullPath, items, mask, XFILE::DIR_FLAG_NO_FILE_DIRS);
   else
-    CDirectory::GetDirectory(fullPath, items, "", false);
+    CDirectory::GetDirectory(fullPath, items, "", XFILE::DIR_FLAG_NO_FILE_DIRS);
 
   vector<CStdString> values;
   for (int i = 0; i < items.Size(); ++i)

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -105,7 +105,7 @@ void CSkinInfo::Start(const CStdString &strBaseDir)
   if (!m_resolutions.size())
   { // try falling back to whatever resolutions exist in the directory
     CFileItemList items;
-    CDirectory::GetDirectory(Path(), items, "", false);
+    CDirectory::GetDirectory(Path(), items, "", DIR_FLAG_NO_FILE_DIRS);
     for (int i = 0; i < items.Size(); i++)
     {
       RESOLUTION_INFO res;

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -893,7 +893,7 @@ void CGUIDialogFileBrowser::OnAddNetworkLocation()
   {
     // verify the path by doing a GetDirectory.
     CFileItemList items;
-    if (CDirectory::GetDirectory(path, items, "", false, true) || CGUIDialogYesNo::ShowAndGetInput(1001,1002,1003,1004))
+    if (CDirectory::GetDirectory(path, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) || CGUIDialogYesNo::ShowAndGetInput(1001,1002,1003,1004))
     { // add the network location to the shares list
       CMediaSource share;
       share.strPath = path; //setPath(path);

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -327,7 +327,7 @@ void CGUIDialogMediaSource::OnOK()
   VECSOURCES *shares = g_settings.GetSourcesFromType(m_type);
   if (shares)
     shares->push_back(share);
-  if (share.strPath.Left(9).Equals("plugin://") || CDirectory::GetDirectory(share.strPath, items, "", false, true) || CGUIDialogYesNo::ShowAndGetInput(1001,1025,1003,1004))
+  if (share.strPath.Left(9).Equals("plugin://") || CDirectory::GetDirectory(share.strPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_ALLOW_PROMPT) || CGUIDialogYesNo::ShowAndGetInput(1001,1025,1003,1004))
   {
     m_confirmed = true;
     Close();

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -184,7 +184,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     CStdString path = "special://videoplaylists/";
     if (m_type.Equals("songs") || m_type.Equals("albums"))
       path = "special://musicplaylists/";
-    XFILE::CDirectory::GetDirectory(path, items, ".xsp",false,false,XFILE::DIR_CACHE_ONCE,true,true);
+    XFILE::CDirectory::GetDirectory(path, items, ".xsp", XFILE::DIR_FLAG_NO_FILE_DIRS, true);
     for (int i = 0; i < items.Size(); i++)
     {
       CFileItemPtr item = items[i];

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -184,7 +184,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     CStdString path = "special://videoplaylists/";
     if (m_type.Equals("songs") || m_type.Equals("albums"))
       path = "special://musicplaylists/";
-    XFILE::CDirectory::GetDirectory(path, items, ".xsp", XFILE::DIR_FLAG_NO_FILE_DIRS, true);
+    XFILE::CDirectory::GetDirectory(path, items, ".xsp", XFILE::DIR_FLAG_NO_FILE_DIRS);
     for (int i = 0; i < items.Size(); i++)
     {
       CFileItemPtr item = items[i];

--- a/xbmc/filesystem/AFPDirectory.cpp
+++ b/xbmc/filesystem/AFPDirectory.cpp
@@ -132,7 +132,7 @@ bool CAFPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
   {
     if (afpError == CAfpConnection::AfpAuth)
     {
-       if (m_allowPrompting)
+       if (m_flags & DIR_FLAG_ALLOW_PROMPT)
        {
          RequireAuthentication(url.Get());
        }
@@ -200,7 +200,7 @@ bool CAFPDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
       {
         struct stat info = {0};
 
-        if (m_extFileInfo && g_advancedSettings.m_sambastatfiles)
+        if ((m_flags & DIR_FLAG_NO_FILE_INFO)==0 && g_advancedSettings.m_sambastatfiles)
         {
           // make sure we use the authenticated path wich contains any default username
           CStdString strFullName = strDirName + strFile;

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -40,8 +40,6 @@ namespace XFILE
 
 CAddonsDirectory::CAddonsDirectory(void)
 {
-  m_allowPrompting = true;
-  m_cacheDirectory = DIR_CACHE_ONCE;
 }
 
 CAddonsDirectory::~CAddonsDirectory(void)

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -34,15 +34,26 @@ public:
   CDirectory(void);
   virtual ~CDirectory(void);
 
+  class CHints
+  {
+  public:
+    CHints() : flags(DIR_FLAG_DEFAULTS)
+    {
+    };
+    CStdString mask;
+    int flags;
+  };
+
   static bool GetDirectory(const CStdString& strPath
-                         , CFileItemList &items
-                         , CStdString strMask=""
-                         , bool bUseFileDirectories=true
-                         , bool allowPrompting=false
-                         , DIR_CACHE_TYPE cacheDirectory=DIR_CACHE_ONCE
-                         , bool extFileInfo=true
-                         , bool allowThreads=false
-                         , bool getHidden=false);
+                           , CFileItemList &items
+                           , const CStdString &strMask=""
+                           , int flags=DIR_FLAG_DEFAULTS
+                           , bool allowThreads=false);
+
+  static bool GetDirectory(const CStdString& strPath
+                           , CFileItemList &items
+                           , const CHints &hints
+                           , bool allowThreads=false);
 
   static bool Create(const CStdString& strPath);
   static bool Exists(const CStdString& strPath);

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -222,7 +222,7 @@ void CDirectoryCache::InitCache(set<CStdString>& dirs)
   {
     const CStdString& strDir = *it;
     CFileItemList items;
-    CDirectory::GetDirectory(strDir, items, "", false);
+    CDirectory::GetDirectory(strDir, items, "", DIR_FLAG_NO_FILE_DIRS);
     items.Clear();
   }
 }

--- a/xbmc/filesystem/IDirectory.cpp
+++ b/xbmc/filesystem/IDirectory.cpp
@@ -33,10 +33,7 @@ using namespace XFILE;
 IDirectory::IDirectory(void)
 {
   m_strFileMask = "";
-  m_allowPrompting = false;
-  m_cacheDirectory = DIR_CACHE_NEVER;
-  m_useFileDirectories = false;
-  m_extFileInfo = true;
+  m_flags = DIR_FLAG_DEFAULTS;
 }
 
 IDirectory::~IDirectory(void)
@@ -103,46 +100,12 @@ void IDirectory::SetMask(const CStdString& strMask)
 }
 
 /*!
- \brief Set whether the directory handlers can prompt the user.
- \param allowPrompting Set true to allow prompting to occur (default is false).
-
- Directory handlers should only prompt the user as a direct result of the
- users actions.
+ \brief Set the flags for this directory handler.
+ \param flags - \sa XFILE::DIR_FLAG for a description.
  */
-
-void IDirectory::SetAllowPrompting(bool allowPrompting)
+void IDirectory::SetFlags(int flags)
 {
-  m_allowPrompting = allowPrompting;
-}
-
-/*!
- \brief Set whether the directory should be cached by our directory cache.
- \param cacheDirectory Set DIR_CACHE_NEVER or DIR_CACHE_ALWAYS to enable or disable caching (default is DIR_CACHE_ONCE).
- */
-
-void IDirectory::SetCacheDirectory(DIR_CACHE_TYPE cacheDirectory)
-{
-  m_cacheDirectory = cacheDirectory;
-}
-
-/*!
- \brief Set whether the directory should allow file directories.
- \param useFileDirectories Set true to enable file directories (default is true).
- */
-
-void IDirectory::SetUseFileDirectories(bool useFileDirectories)
-{
-  m_useFileDirectories = useFileDirectories;
-}
-
-/*!
- \brief Set whether the GetDirectory call will retrieve extended file information (stat calls for example).
- \param extFileInfo Set true to enable extended file info (default is true).
- */
-
-void IDirectory::SetExtFileInfo(bool extFileInfo)
-{
-  m_extFileInfo = extFileInfo;
+  m_flags = flags;
 }
 
 bool IDirectory::ProcessRequirements()

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -34,6 +34,20 @@ namespace XFILE
     DIR_CACHE_ALWAYS     ///< Always cache this directory to memory, so that each additional fetch of this folder will utilize the cache (until it's cleared)
   };
 
+  /*! \brief Available directory flags
+   The defaults are to allow file directories, no prompting, retrieve file information, hide hidden files, and utilise the directory cache
+   based on the implementation's wishes.
+   */
+  enum DIR_FLAG
+  {
+    DIR_FLAG_DEFAULTS      = 0,
+    DIR_FLAG_NO_FILE_DIRS  = (2 << 0), ///< Don't convert files (zip, rar etc.) to directories
+    DIR_FLAG_ALLOW_PROMPT  = (2 << 1), ///< Allow prompting for further info (passwords etc.)
+    DIR_FLAG_NO_FILE_INFO  = (2 << 2), ///< Don't read additional file info (stat for example)
+    DIR_FLAG_GET_HIDDEN    = (2 << 3), ///< Get hidden files
+    DIR_FLAG_READ_CACHE    = (2 << 4), ///< Force reading from the directory cache (if available)
+    DIR_FLAG_BYPASS_CACHE  = (2 << 5)  ///< Completely bypass the directory cache (no reading, no writing)
+  };
 /*!
  \ingroup filesystem
  \brief Interface to the directory on a file system.
@@ -91,10 +105,7 @@ public:
   virtual DIR_CACHE_TYPE GetCacheType(const CStdString& strPath) const { return DIR_CACHE_ONCE; };
 
   void SetMask(const CStdString& strMask);
-  void SetAllowPrompting(bool allowPrompting);
-  void SetCacheDirectory(DIR_CACHE_TYPE cacheDirectory);
-  void SetUseFileDirectories(bool useFileDirectories);
-  void SetExtFileInfo(bool extFileInfo);
+  void SetFlags(int flags);
 
   /*! \brief Process additional requirements before the directory fetch is performed.
    Some directory fetches may require authentication, keyboard input etc.  The IDirectory subclass
@@ -137,10 +148,8 @@ protected:
   void RequireAuthentication(const CStdString &url);
 
   CStdString m_strFileMask;  ///< Holds the file mask specified by SetMask()
-  bool m_allowPrompting;    ///< If true, the directory handlers may prompt the user
-  DIR_CACHE_TYPE m_cacheDirectory;    ///< If !DIR_CACHE_NEVER the directory is cached by g_directoryCache (defaults to DIR_CACHE_ONCE)
-  bool m_useFileDirectories; ///< If true the directory may allow file directories (defaults to false)
-  bool m_extFileInfo;       ///< If true the GetDirectory call can retrieve extra file information (defaults to true)
+
+  int m_flags; ///< Directory flags - see DIR_FLAG
 
   CVariant m_requirements;
 };

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -88,7 +88,7 @@ bool CMultiPathDirectory::GetDirectory(const CStdString& strPath, CFileItemList 
 
     CFileItemList tempItems;
     CLog::Log(LOGDEBUG,"Getting Directory (%s)", vecPaths[i].c_str());
-    if (CDirectory::GetDirectory(vecPaths[i], tempItems, m_strFileMask, m_useFileDirectories, m_allowPrompting, m_cacheDirectory, m_extFileInfo))
+    if (CDirectory::GetDirectory(vecPaths[i], tempItems, m_strFileMask, m_flags))
       items.Append(tempItems);
     else
     {

--- a/xbmc/filesystem/RSSDirectory.cpp
+++ b/xbmc/filesystem/RSSDirectory.cpp
@@ -72,7 +72,6 @@ CCriticalSection CRSSDirectory::m_section;
 
 CRSSDirectory::CRSSDirectory()
 {
-  SetCacheDirectory(DIR_CACHE_ONCE);
 }
 
 CRSSDirectory::~CRSSDirectory()

--- a/xbmc/filesystem/SMBDirectory.cpp
+++ b/xbmc/filesystem/SMBDirectory.cpp
@@ -150,7 +150,7 @@ bool CSMBDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items
 #else
         struct stat info = {0};
 #endif
-        if (m_extFileInfo && g_advancedSettings.m_sambastatfiles)
+        if ((m_flags & DIR_FLAG_NO_FILE_INFO)==0 && g_advancedSettings.m_sambastatfiles)
         {
           // make sure we use the authenticated path wich contains any default username
           CStdString strFullName = strAuth + smb.URLEncode(strFile);
@@ -305,7 +305,7 @@ int CSMBDirectory::OpenDir(const CURL& url, CStdString& strAuth)
       if (errno == EACCES)
 #endif
       {
-        if (m_allowPrompting)
+        if (m_flags & DIR_FLAG_ALLOW_PROMPT)
           RequireAuthentication(urlIn.Get());
         break;
       }
@@ -324,7 +324,7 @@ int CSMBDirectory::OpenDir(const CURL& url, CStdString& strAuth)
           cError = strerror(errno);
 #endif
 
-        if (m_allowPrompting)
+        if (m_flags & DIR_FLAG_ALLOW_PROMPT)
           SetErrorDialog(257, cError.c_str());
         break;
       }

--- a/xbmc/filesystem/SmbFile.cpp
+++ b/xbmc/filesystem/SmbFile.cpp
@@ -493,7 +493,7 @@ int CSmbFile::OpenFile(const CURL &url, CStdString& strAuth)
     CSMBDirectory smbDir;
     // TODO: Currently we always allow prompting on files.  This may need to
     // change in the future as background scanners are more prolific.
-    smbDir.SetAllowPrompting(true);
+    smbDir.SetFlags(DIR_FLAG_ALLOW_PROMPT);
     fd = smbDir.Open(urlshare);
 
     // directory open worked, try opening the file again

--- a/xbmc/filesystem/SpecialProtocolDirectory.cpp
+++ b/xbmc/filesystem/SpecialProtocolDirectory.cpp
@@ -39,7 +39,7 @@ bool CSpecialProtocolDirectory::GetDirectory(const CStdString& strPath, CFileIte
 {
   CStdString untranslatedPath = strPath;  // Why do I need a copy??? - the GetDirectory() call below will override strPath???
   CStdString translatedPath = CSpecialProtocol::TranslatePath(strPath);
-  if (CDirectory::GetDirectory(translatedPath, items, m_strFileMask, m_useFileDirectories, m_allowPrompting, m_cacheDirectory, m_extFileInfo, false, true))
+  if (CDirectory::GetDirectory(translatedPath, items, m_strFileMask, m_flags | DIR_FLAG_GET_HIDDEN))
   { // replace our paths as necessary
     items.SetPath(untranslatedPath);
     for (int i = 0; i < items.Size(); i++)

--- a/xbmc/filesystem/VirtualDirectory.cpp
+++ b/xbmc/filesystem/VirtualDirectory.cpp
@@ -42,8 +42,7 @@ namespace XFILE
 
 CVirtualDirectory::CVirtualDirectory(void)
 {
-  m_allowPrompting = true;  // by default, prompting is allowed.
-  m_cacheDirectory = DIR_CACHE_ONCE;  // by default, caching is done.
+  m_flags = DIR_FLAG_ALLOW_PROMPT;
   m_allowNonLocalSources = true;
   m_allowThreads = true;
 }
@@ -76,8 +75,11 @@ bool CVirtualDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
 }
 bool CVirtualDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, bool bUseFileDirectories)
 {
+  int flags = m_flags;
+  if (!bUseFileDirectories)
+    flags |= DIR_FLAG_NO_FILE_DIRS;
   if (!strPath.IsEmpty() && strPath != "files://")
-    return CDirectory::GetDirectory(strPath, items, m_strFileMask, bUseFileDirectories, m_allowPrompting, m_cacheDirectory, m_extFileInfo, m_allowThreads);
+    return CDirectory::GetDirectory(strPath, items, m_strFileMask, flags, m_allowThreads);
 
   // if strPath is blank, clear the list (to avoid parent items showing up)
   if (strPath.IsEmpty())

--- a/xbmc/filesystem/ZeroconfDirectory.cpp
+++ b/xbmc/filesystem/ZeroconfDirectory.cpp
@@ -241,7 +241,7 @@ bool CZeroconfDirectory::GetDirectory(const CStdString& strPath, CFileItemList &
         }
         else//no txt record path - so let the CDirectory handler show the folders
         {          
-          return CDirectory::GetDirectory(service.Get(), items, "", true, true); 
+          return CDirectory::GetDirectory(service.Get(), items, "", DIR_FLAG_ALLOW_PROMPT); 
         }
       }
     } catch (std::runtime_error& e) {

--- a/xbmc/filesystem/windows/WINSMBDirectory.cpp
+++ b/xbmc/filesystem/windows/WINSMBDirectory.cpp
@@ -379,7 +379,7 @@ bool CWINSMBDirectory::ConnectToShare(const CURL& url)
     if(dwRet == ERROR_ACCESS_DENIED || dwRet == ERROR_INVALID_PASSWORD || dwRet == ERROR_LOGON_FAILURE)
     {
       CLog::Log(LOGERROR,"Couldn't connect to %s, access denied", strUNC.c_str());
-      if (m_allowPrompting)
+      if (m_flags & DIR_FLAG_ALLOW_PROMPT)
         RequireAuthentication(urlIn.Get());
       break;
     }

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -569,7 +569,7 @@ VECSOURCES& CGUIViewStateWindowMusicNav::GetSources()
   m_sources.clear();
   //  Musicdb shares
   CFileItemList items;
-  CDirectory::GetDirectory("musicdb://", items, "", true, false, DIR_CACHE_ONCE, true, false);
+  CDirectory::GetDirectory("musicdb://", items, "");
   for (int i=0; i<items.Size(); ++i)
   {
     CFileItemPtr item=items[i];

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2462,7 +2462,7 @@ void CMusicDatabase::DeleteCDDBInfo()
 {
 #ifdef HAS_DVD_DRIVE
   CFileItemList items;
-  if (!CDirectory::GetDirectory(g_settings.GetCDDBFolder(), items, ".cddb", false))
+  if (!CDirectory::GetDirectory(g_settings.GetCDDBFolder(), items, ".cddb", DIR_FLAG_NO_FILE_DIRS))
   {
     CGUIDialogOK::ShowAndGetInput(313, 426, 0, 0);
     return ;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -740,7 +740,7 @@ int CMusicInfoScanner::CountFilesRecursively(const CStdString& strPath)
   // load subfolder
   CFileItemList items;
 //  CLog::Log(LOGDEBUG, __FUNCTION__" - processing dir: %s", strPath.c_str());
-  CDirectory::GetDirectory(strPath, items, g_settings.m_musicExtensions, false);
+  CDirectory::GetDirectory(strPath, items, g_settings.m_musicExtensions, DIR_FLAG_NO_FILE_DIRS);
 
   if (m_bStop)
     return 0;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -969,7 +969,7 @@ void CGUIWindowSlideShow::AddItems(const CStdString &strPath, path_set *recursiv
 
   // fetch directory and sort accordingly
   CFileItemList items;
-  if (!CDirectory::GetDirectory(strPath, items, m_strExtensions.IsEmpty()?g_settings.m_pictureExtensions:m_strExtensions,false,false,DIR_CACHE_ONCE,true,true))
+  if (!CDirectory::GetDirectory(strPath, items, m_strExtensions.IsEmpty()?g_settings.m_pictureExtensions:m_strExtensions,DIR_FLAG_NO_FILE_DIRS,true))
     return;
 
   items.Sort(method, order);

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -174,7 +174,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
 
       CFileItemList items;
 
-      CDirectory::GetDirectory(strPath, items, g_settings.m_pictureExtensions, false, false);
+      CDirectory::GetDirectory(strPath, items, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS);
       
       // create the folder thumb by choosing 4 random thumbs within the folder and putting
       // them into one thumb.
@@ -193,7 +193,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       {
         if (pItem->IsCBZ() || pItem->IsCBR())
         {
-          CDirectory::GetDirectory(strPath, items, g_settings.m_pictureExtensions, false, false);
+          CDirectory::GetDirectory(strPath, items, g_settings.m_pictureExtensions, DIR_FLAG_NO_FILE_DIRS);
           for (int i=0;i<items.Size();++i)
           {
             CFileItemPtr item = items[i];

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -104,7 +104,7 @@ bool CFileOperationJob::DoProcessFolder(FileAction action, const CStdString& str
   CLog::Log(LOGDEBUG,"FileManager, processing folder: %s",strPath.c_str());
   CFileItemList items;
   //m_rootDir.GetDirectory(strPath, items);
-  CDirectory::GetDirectory(strPath, items, "", false, false, DIR_CACHE_ONCE, true, false, true);
+  CDirectory::GetDirectory(strPath, items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_GET_HIDDEN);
   for (int i = 0; i < items.Size(); i++)
   {
     CFileItemPtr pItem = items[i];

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -411,7 +411,7 @@ VECSOURCES& CGUIViewStateWindowVideoNav::GetSources()
   m_sources.clear();
   //  Musicdb shares
   CFileItemList items;
-  CDirectory::GetDirectory("videodb://", items, "", true, false, DIR_CACHE_ONCE, true, false);
+  CDirectory::GetDirectory("videodb://", items, "");
   for (int i=0; i<items.Size(); ++i)
   {
     CFileItemPtr item=items[i];

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -278,7 +278,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
     if (item.m_bIsFolder && scraper && scraper->Content() != CONTENT_TVSHOWS)
     {
       CFileItemList items;
-      CDirectory::GetDirectory(item.GetPath(), items, g_settings.m_videoExtensions, DIR_FLAG_DEFAULTS,true);
+      CDirectory::GetDirectory(item.GetPath(), items, g_settings.m_videoExtensions);
       items.Stack();
 
       // check for media files

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -278,7 +278,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
     if (item.m_bIsFolder && scraper && scraper->Content() != CONTENT_TVSHOWS)
     {
       CFileItemList items;
-      CDirectory::GetDirectory(item.GetPath(), items, g_settings.m_videoExtensions,true,false,DIR_CACHE_ONCE,true,true);
+      CDirectory::GetDirectory(item.GetPath(), items, g_settings.m_videoExtensions, DIR_FLAG_DEFAULTS,true);
       items.Stack();
 
       // check for media files

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -282,7 +282,6 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
   if (m_thumbLoader.IsLoading())
     m_thumbLoader.StopThread();
 
-  m_rootDir.SetCacheDirectory(DIR_CACHE_ONCE);
   items.ClearProperties();
 
   bool bResult = CGUIWindowVideoBase::GetDirectory(strDirectory, items);
@@ -684,7 +683,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
     if (pDialog->IsConfirmed())
     {
       CFileItemList items;
-      CDirectory::GetDirectory(pItem->GetPath(),items,"",false,false,DIR_CACHE_ONCE,true,true);
+      CDirectory::GetDirectory(pItem->GetPath(),items,"",DIR_FLAG_NO_FILE_DIRS,true);
       for (int i=0;i<items.Size();++i)
         OnDeleteItem(items[i]);
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -683,7 +683,7 @@ void CGUIWindowVideoNav::OnDeleteItem(CFileItemPtr pItem)
     if (pDialog->IsConfirmed())
     {
       CFileItemList items;
-      CDirectory::GetDirectory(pItem->GetPath(),items,"",DIR_FLAG_NO_FILE_DIRS,true);
+      CDirectory::GetDirectory(pItem->GetPath(),items,"",DIR_FLAG_NO_FILE_DIRS);
       for (int i=0;i<items.Size();++i)
         OnDeleteItem(items[i]);
 


### PR DESCRIPTION
This does exactly what it says: implements all the bools (except the "allow threading" one) in CDirectory::GetDirectory as flags instead.

The defaults for the flags are the same as the previous defaults, so this is mostly code-shuffle.  I've carefully reviewed each change, but still might have missed one - just running through and comparing the previous defaults with what is there now.

The second commit is a change in behaviour.  Basically I reviewed cases where we were setting allowThreads to true.  Anything that was either already threaded, or should be threaded through different means (eg throw off a job to do the whole function) was removed.  The remaining cases are UI dir fetches, slideshow dir fetches, and smartplaylist dir fetches.

The last commit is removing a clearing of the cache during subtitle fetching which was a left over from the refactor that caused a bunch of confusion in the beginning.

One final thing for consideration: Are the defaults sane?  Primarily, should we be fetching filedirectories by default with every CDirectory::GetDirectory() call?  This is currently the largest flag that we specify (turning off that feature) and I suspect there's a bunch of places where we're needlessly doing this.

Not for Eden.
