### PR TITLE
Cleanup the behaviour of assigning library data to file listings

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1862,7 +1862,7 @@
   <string id="20416">First aired</string>
   <string id="20417">Writer</string>
   <string id="20418"></string>
-  <string id="20419">Show metadata in files view</string>
+  <string id="20419">Replace file names with library titles</string>
 
   <string id="20420">Never</string>
   <string id="20421">If only one season</string>

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1994,7 +1994,7 @@ void CFileItemList::Stack(bool stackFiles /* = true */)
   if (IsVirtualDirectoryRoot() || IsLiveTV() || IsSourcesPath())
     return;
 
-  SetProperty("isstacked", "1");
+  SetProperty("isstacked", true);
 
   // items needs to be sorted for stuff below to work properly
   Sort(SORT_METHOD_LABEL, SORT_ORDER_ASC);
@@ -2150,7 +2150,7 @@ void CFileItemList::StackFiles()
     CFileItemPtr item1 = Get(i);
 
     // set property
-    item1->SetProperty("isstacked", "1");
+    item1->SetProperty("isstacked", true);
 
     // skip folders, nfo files, playlists
     if (item1->m_bIsFolder

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2730,61 +2730,41 @@ CStdString CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 #ifdef UNIT_TESTING
 bool CFileItem::testGetBaseMoviePath()
 {
-  CFileItem item;
-  CStdString path;
-  bool result = true;
-  
-  item.SetPath("c:\\dir\\filename.avi");
-  path = item.GetBaseMoviePath(false);
-  if (path != "c:\\dir\\filename.avi")
-    result = false;
+  typedef struct
+  {
+    const char *file;
+    bool use_folder;
+    const char *base;
+  } testfiles;
 
-  item.SetPath("c:\\dir\\filename.avi");
-  path = item.GetBaseMoviePath(true);
-  if (path != "c:\\dir\\")
-    result = false;
+  const testfiles test_files[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\filename.avi" },
+                                  { "c:\\dir\\filename.avi", true,  "c:\\dir\\" },
+                                  { "/dir/filename.avi", false, "/dir/filename.avi" },
+                                  { "/dir/filename.avi", true,  "/dir/" },
+                                  { "smb://somepath/file.avi", false, "smb://somepath/file.avi" },
+                                  { "smb://somepath/file.avi", true, "smb://somepath/" },
+                                  { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", false, "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi" },
+                                  { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", true,  "/path/to/movie_name/" },
+                                  { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01.avi" },
+                                  { "/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/" },
+                                  { "rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi", true, "g:\\multimedia\\movies\\" },
+                                  { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie_name/" },
+                                  { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie_name/" },
+                                  { "/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/" },
+                                  { "/home/user/movies/movie_name/BDMV/index.bdmv", true, "/home/user/movies/movie_name/" }};
 
-  item.SetPath("/dir/filename.avi");
-  path = item.GetBaseMoviePath(false);
-  if (path != "/dir/filename.avi")
-    result = false;
-
-  item.SetPath("/dir/filename.avi");
-  path = item.GetBaseMoviePath(true);
-  if (path != "/dir/")
-    result = false;
-
-  item.SetPath("smb://somepath/file.avi");
-  path = item.GetBaseMoviePath(false);
-  if (path != "smb://somepath/file.avi")
-    result = false;
-  
-  item.SetPath("smb://somepath/file.avi");
-  path = item.GetBaseMoviePath(true);
-  if (path != "smb://somepath/")
-    result = false;
-
-  item.SetPath("stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi");
-  path = item.GetBaseMoviePath(false);
-  if (path != "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi")
-    result = false;
-
-  item.SetPath("stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi");
-  path = item.GetBaseMoviePath(true);
-  if (path != "/path/to/movie_name/")
-    result = false;
-
-  item.SetPath("/home/user/TV Shows/Dexter/S1/1x01.avi");
-  path = item.GetBaseMoviePath(true);
-  if (path != "/home/user/TV Shows/Dexter/S1/")
-    result = false;
-  
-  item.SetPath("rar://g%3a%5cmultimedia%5cmovies%5cSphere%2erar/Sphere.avi");
-  path = item.GetBaseMoviePath(true);
-  if (path != "g:\\multimedia\\movies\\")
-    result = false;
-
-  return result;
+  for (unsigned int i = 0; i < sizeof(test_files) / sizeof(testfiles); i++)
+  {
+    CFileItem item;
+    item.SetPath(test_files[i].file);
+    CStdString path = item.GetBaseMoviePath(test_files[i].use_folder);
+    if (path != test_files[i].base)
+    {
+      CLog::Log(LOGFATAL, "%s failed ('%s' -> '%s' != '%s')", __FUNCTION__, test_files[i].file, path.c_str(), test_files[i].base);
+      return false;
+    }
+  }
+  return true;
 }
 #endif
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2149,9 +2149,6 @@ void CFileItemList::StackFiles()
   {
     CFileItemPtr item1 = Get(i);
 
-    // set property
-    item1->SetProperty("isstacked", true);
-
     // skip folders, nfo files, playlists
     if (item1->m_bIsFolder
       || item1->IsParentFolder()

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1158,7 +1158,7 @@ bool CFileItem::IsAlbum() const
   return m_bIsAlbum;
 }
 
-void CFileItem::UpdateInfo(const CFileItem &item)
+void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
 {
   if (item.HasVideoInfoTag())
   { // copy info across (TODO: premiered info is normally stored in m_dateTime by the db)
@@ -1170,9 +1170,9 @@ void CFileItem::UpdateInfo(const CFileItem &item)
   if (item.HasPictureInfoTag())
     *GetPictureInfoTag() = *item.GetPictureInfoTag();
 
-  if (!item.GetLabel().IsEmpty())
+  if (replaceLabels && !item.GetLabel().IsEmpty())
     SetLabel(item.GetLabel());
-  if (!item.GetLabel2().IsEmpty())
+  if (replaceLabels && !item.GetLabel2().IsEmpty())
     SetLabel2(item.GetLabel2());
   if (!item.GetThumbnailImage().IsEmpty())
     SetThumbnailImage(item.GetThumbnailImage());

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2709,16 +2709,14 @@ CStdString CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
   if (IsMultiPath())
     strMovieName = CMultiPathDirectory::GetFirstPath(m_strPath);
 
-  int pos;
-  if ((pos=strMovieName.Find("BDMV/")) != -1 ||
-      (pos=strMovieName.Find("BDMV\\")) != -1)
-    strMovieName = strMovieName.Mid(0,pos+5);
+  if (IsOpticalMediaFile())
+    return GetLocalMetadataPath();
 
-  if ((!m_bIsFolder || IsOpticalMediaFile() || URIUtils::IsInArchive(m_strPath)) && bUseFolderNames)
+  if ((!m_bIsFolder || URIUtils::IsInArchive(m_strPath)) && bUseFolderNames)
   {
     CStdString name2(strMovieName);
     URIUtils::GetParentPath(name2,strMovieName);
-    if (URIUtils::IsInArchive(m_strPath) || strMovieName.Find( "VIDEO_TS" ) != -1)
+    if (URIUtils::IsInArchive(m_strPath))
     {
       CStdString strArchivePath;
       URIUtils::GetParentPath(strMovieName, strArchivePath);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2919,7 +2919,7 @@ CStdString CFileItem::GetLocalMetadataPath() const
   CStdString parentFolder(parent);
   URIUtils::RemoveSlashAtEnd(parentFolder);
   parentFolder = URIUtils::GetFileName(parentFolder);
-  if (parentFolder == "VIDEO_TS" || parentFolder == "BDMV")
+  if (parentFolder.CompareNoCase("VIDEO_TS") == 0 || parentFolder.CompareNoCase("BDMV") == 0)
   { // go back up another one
     parent = URIUtils::GetParentPath(parent);
   }

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -239,8 +239,10 @@ public:
   // Gets the correct movie title
   CStdString GetMovieName(bool bUseFolderNames = false) const;
 
-  /*! \brief Find the base movie path (eg the folder if using "use foldernames for lookups")
-   Takes care of VIDEO_TS, BDMV, and rar:// listings
+  /*! \brief Find the base movie path (i.e. the item the user expects us to use to lookup the movie)
+   For folder items, with "use foldernames for lookups" it returns the folder.
+   Regardless of settings, for VIDEO_TS/BDMV it returns the parent of the VIDEO_TS/BDMV folder (if present)
+
    \param useFolderNames whether we're using foldernames for lookups
    \return the base movie folder
    */

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -293,8 +293,9 @@ public:
    Properties are appended, and labels, thumbnail and icon are updated if non-empty
    in the given item.
    \param item the item used to supplement information
+   \param replaceLabels whether to replace labels (defaults to true)
    */
-  void UpdateInfo(const CFileItem &item);
+  void UpdateInfo(const CFileItem &item, bool replaceLabels = true);
 
   bool IsSamePath(const CFileItem *item) const;
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1971,7 +1971,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
   {
     CGUIWindow *pWindow = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
     if (pWindow)
-      bReturn = ((CGUIMediaWindow*)pWindow)->CurrentDirectory().GetProperty("isstacked")=="1";
+      bReturn = ((CGUIMediaWindow*)pWindow)->CurrentDirectory().GetProperty("isstacked").asBoolean();
   }
   else if (condition == CONTAINER_HAS_THUMB)
   {

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -670,7 +670,7 @@ void CGUISettings::Initialize()
   AddInt(vid, "myvideos.selectaction", 22079, SELECT_ACTION_PLAY_OR_RESUME, myVideosSelectActions, SPIN_CONTROL_TEXT);
   AddBool(NULL, "myvideos.treatstackasfile", 20051, true);
   AddBool(vid, "myvideos.extractflags",20433, true);
-  AddBool(vid, "myvideos.filemetadata", 20419, true);
+  AddBool(vid, "myvideos.replacelabels", 20419, true);
   AddBool(NULL, "myvideos.extractthumb",20433, true);
 
   CSettingsCategory* sub = AddCategory(5, "subtitles", 287);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -698,16 +698,17 @@ private:
   int RunQuery(const CStdString &sql);
 
   /*! \brief Update routine for base path of videos
-   Only required for videodb version < 44
+   Only required for videodb version < 59
    \param table the table to update
    \param id the primary id in the given table
    \param column the basepath column to update
    \param shows whether we're fetching shows (defaults to false)
+   \param where restrict updating of items that match the where clause
    */
-  void UpdateBasePath(const char *table, const char *id, int column, bool shows = false);
+  void UpdateBasePath(const char *table, const char *id, int column, bool shows = false, const CStdString &where = "");
 
   /*! \brief Update routine for base path id of videos
-   Only required for videodb version < 52
+   Only required for videodb version < 59
    \param table the table to update
    \param id the primary id in the given table
    \param column the column of the basepath
@@ -721,7 +722,7 @@ private:
    */
   bool LookupByFolders(const CStdString &path, bool shows = false);
 
-  virtual int GetMinVersion() const { return 58; };
+  virtual int GetMinVersion() const { return 59; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1697,9 +1697,7 @@ bool CGUIWindowVideoBase::GetDirectory(const CStdString &strDirectory, CFileItem
     items.Add(newPlaylist);
   }
 
-  m_stackingAvailable = !(items.IsTuxBox() || items.IsPlugin() ||
-                          items.IsAddonsPath() || items.IsRSS() ||
-                          items.IsInternetStream() || items.IsVideoDb());
+  m_stackingAvailable = StackingAvailable(items);
   // we may also be in a tvshow files listing
   // (ideally this should be removed, and our stack regexps tidied up if necessary
   // No "normal" episodes should stack, and multi-parts should be supported)
@@ -1711,6 +1709,13 @@ bool CGUIWindowVideoBase::GetDirectory(const CStdString &strDirectory, CFileItem
     items.Stack();
 
   return bResult;
+}
+
+bool CGUIWindowVideoBase::StackingAvailable(const CFileItemList &items) const
+{
+  return !(items.IsTuxBox()         || items.IsPlugin()  ||
+           items.IsAddonsPath()     || items.IsRSS()     ||
+           items.IsInternetStream() || items.IsVideoDb());
 }
 
 void CGUIWindowVideoBase::OnPrepareFileItems(CFileItemList &items)

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -117,6 +117,8 @@ protected:
 
   static bool OnUnAssignContent(const CStdString &path, int label1, int label2, int label3);
 
+  bool StackingAvailable(const CFileItemList &items) const;
+
   CGUIDialogProgress* m_dlgProgress;
   CVideoDatabase m_database;
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -421,9 +421,19 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
   CStdString content = m_database.GetContentForPath(items.GetPath());
   items.SetContent(content.IsEmpty() ? "files" : content);
 
-  bool fileMetaData = (g_guiSettings.GetBool("myvideos.filemetadata") &&
-                      !content.IsEmpty() &&
-                       m_stackingAvailable && g_settings.m_videoStacking);
+  /*
+    If we have a matching item in the library, so we can assign the metadata to it. In addition, we can choose
+    * whether the item is stacked down (eg in the case of folders representing a single item)
+    * whether or not we assign the library's labels to the item, or leave the item as is.
+
+    As certain users (read: certain developers) don't want either of these to occur, we compromise by stacking
+    items down only if stacking is available and enabled.
+
+    Similarly, we assign the "clean" library labels to the item only if the "Replace filenames with library titles"
+    setting is enabled.
+    */
+  bool stackItems    = items.GetProperty("isstacked").asBoolean() || (StackingAvailable(items) && g_settings.m_videoStacking);
+  bool replaceLabels = g_guiSettings.GetBool("myvideos.replacelabels");
 
   CFileItemList dbItems;
   /* NOTE: In the future when GetItemsForPath returns all items regardless of whether they're "in the library"
@@ -443,11 +453,9 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
       match = dbItems.Get(pItem->GetPath());
     if (match)
     {
-      CStdString label (pItem->GetLabel ());
-      CStdString label2(pItem->GetLabel2());
-      pItem->UpdateInfo(*match);
-      
-      if (fileMetaData)
+      pItem->UpdateInfo(*match, replaceLabels);
+
+      if (stackItems)
       {
         if (match->m_bIsFolder)
           pItem->SetPath(match->GetVideoInfoTag()->m_strPath);
@@ -465,9 +473,6 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
       {
         if (CFile::Exists(match->GetCachedFanart()))
           pItem->SetProperty("fanart_image", match->GetCachedFanart());
-
-        pItem->SetLabel (label);
-        pItem->SetLabel2(label2);
       }
     }
     else
@@ -485,8 +490,8 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
       if (pItem->IsVideo())
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_playCount > 0);
 
-      // Since the item is not in our db, as an alternative clean its name
-      if (fileMetaData)
+      // Since the item is not in our db but the user wants a clean label we should clean it up (stacking may do some cleaning as well)
+      if (replaceLabels)
         pItem->CleanString();
     }
   }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -449,8 +449,8 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
   {
     CFileItemPtr pItem = items[i];
     CFileItemPtr match;
-    if (!content.IsEmpty())
-      match = dbItems.Get(pItem->GetPath());
+    if (!content.IsEmpty()) /* optical media will be stacked down, so it's path won't match the base path */
+      match = dbItems.Get(pItem->IsOpticalMediaFile() ? pItem->GetLocalMetadataPath() : pItem->GetPath());
     if (match)
     {
       pItem->UpdateInfo(*match, replaceLabels);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -469,11 +469,6 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
           pItem->m_bIsFolder = match->m_bIsFolder;
         }
       }
-      else
-      {
-        if (CFile::Exists(match->GetCachedFanart()))
-          pItem->SetProperty("fanart_image", match->GetCachedFanart());
-      }
     }
     else
     {


### PR DESCRIPTION
Before, metadata was assigned regardless of any settings, but items were stacked down and renamed based on whether stacking was available and enabled. This precluded tvshows (in particular, folder-based episodes) from being stacked down, and also meant that the UI-setting "Use metadata for files" was both inaccurately named, and also only applicable if stacking was also enabled.

Now, we split off the two controversial changes so they can be controlled separately:
1.  The stacking of folders to library based items is purely dependent on whether stacking is enabled, with the tvshow content check removed.
2.  The replacing of labels with the library label is purely dependent on the setting "Replace filenames with library titles" which replaces the incorrectly titlted "Use metadata for files".

This should (hopefully) keep a larger proportion of people happy.

Particularly keen on testing by elupus and arnova regarding #11783.
