### PR TITLE
change setting string to be more reflective of what it does

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1772,7 +1772,7 @@
   <string id="20326">This will reset the calibration values for %s</string>
   <string id="20327">to it's default values.</string>
   <string id="20328">Browse for destination</string>
-
+  <string id="20329">Movies are in separate folders that match the movie title</string>
   <string id="20330">Use folder names for lookups</string>
   <string id="20331">File</string>
   <string id="20332">Use file or folder names in lookups?</string>

--- a/xbmc/settings/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/GUIDialogContentSettings.cpp
@@ -170,7 +170,7 @@ void CGUIDialogContentSettings::CreateSettings()
   case CONTENT_MOVIES:
     {
       AddBool(1,20345,&m_bRunScan, m_bShowScanSettings);
-      AddBool(2,20330,&m_bUseDirNames, m_bShowScanSettings);
+      AddBool(2,20329,&m_bUseDirNames, m_bShowScanSettings);
       AddBool(3,20346,&m_bScanRecursive, m_bShowScanSettings && ((m_bUseDirNames && !m_bSingleItem) || !m_bUseDirNames));
       AddBool(4,20383,&m_bSingleItem, m_bShowScanSettings && (m_bUseDirNames && !m_bScanRecursive));
       AddBool(5,20432,&m_bNoUpdate, m_bShowScanSettings);


### PR DESCRIPTION
The wording should better reflect what the setting does.

Could consider whether this string is different enough to warrant a new id?
