### PR TITLE
start zeroconf publishing via a job

### DIFF
--- a/xbmc/network/Zeroconf.cpp
+++ b/xbmc/network/Zeroconf.cpp
@@ -77,10 +77,8 @@ bool CZeroconf::PublishService(const std::string& fcr_identifier,
   if(!ret.second) //identifier exists
     return false;
   if(m_started)
-  {
-    CPublish* publish = new CPublish(fcr_identifier, info);
-    CJobManager::GetInstance().AddJob(publish, NULL);
-  }
+    CJobManager::GetInstance().AddJob(new CPublish(fcr_identifier, info), NULL);
+
   //not yet started, so its just queued
   return true;
 }
@@ -117,8 +115,7 @@ void CZeroconf::Start()
     return;
   m_started = true;
 
-  CPublish* publish = new CPublish(m_service_map);
-  CJobManager::GetInstance().AddJob(publish, NULL);
+  CJobManager::GetInstance().AddJob(new CPublish(m_service_map), NULL);
 }
 
 void CZeroconf::Stop()
@@ -158,14 +155,14 @@ void CZeroconf::ReleaseInstance()
   smp_instance = 0;
 }
 
-CZeroconf::CPublish::CPublish(const std::string& fcr_identifier, PublishInfo& pubinfo)
+CZeroconf::CPublish::CPublish(const std::string& fcr_identifier, const PublishInfo& pubinfo)
 {
   m_servmap.insert(std::make_pair(fcr_identifier, pubinfo));
 }
 
-CZeroconf::CPublish::CPublish(tServiceMap& servmap)
+CZeroconf::CPublish::CPublish(const tServiceMap& servmap) 
+  : m_servmap(servmap)
 {
-  m_servmap = servmap;
 }
 
 bool CZeroconf::CPublish::DoWork()

--- a/xbmc/network/Zeroconf.h
+++ b/xbmc/network/Zeroconf.h
@@ -122,8 +122,8 @@ private:
   class CPublish : public CJob
   {
   public:
-    CPublish(const std::string& fcr_identifier, PublishInfo& pubinfo);
-    CPublish(tServiceMap& servmap);
+    CPublish(const std::string& fcr_identifier, const PublishInfo& pubinfo);
+    CPublish(const tServiceMap& servmap);
 
     bool DoWork();
 

--- a/xbmc/network/Zeroconf.h
+++ b/xbmc/network/Zeroconf.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <map>
+#include "utils/Job.h"
 
 class CCriticalSection;
 /// this class provides support for zeroconf
@@ -117,4 +118,16 @@ private:
   //protects singleton creation/destruction
   static long sm_singleton_guard;
   static CZeroconf* smp_instance;
+
+  class CPublish : public CJob
+  {
+  public:
+    CPublish(const std::string& fcr_identifier, PublishInfo& pubinfo);
+    CPublish(tServiceMap& servmap);
+
+    bool DoWork();
+
+  private:
+    tServiceMap m_servmap;
+  };
 };

--- a/xbmc/network/windows/ZeroconfWIN.cpp
+++ b/xbmc/network/windows/ZeroconfWIN.cpp
@@ -65,7 +65,7 @@ bool CZeroconfWIN::doPublishService(const std::string& fcr_identifier,
   TXTRecordRef txtRecord;
   TXTRecordCreate(&txtRecord, 0, NULL);
 
-  CLog::Log(LOGDEBUG, __FUNCTION__ " identifier: %s type: %s name:%s port:%i", fcr_identifier.c_str(), fcr_type.c_str(), fcr_name.c_str(), f_port);
+  CLog::Log(LOGDEBUG, "ZeroconfWIN: identifier: %s type: %s name:%s port:%i", fcr_identifier.c_str(), fcr_type.c_str(), fcr_name.c_str(), f_port);
 
   //add txt records
   if(!txt.empty())
@@ -86,14 +86,14 @@ bool CZeroconfWIN::doPublishService(const std::string& fcr_identifier,
     if (netService)
       DNSServiceRefDeallocate(netService);
 
-    CLog::Log(LOGERROR, __FUNCTION__ " DNSServiceRegister returned (error = %ld)", (int) err);
+    CLog::Log(LOGERROR, "ZeroconfWIN: DNSServiceRegister returned (error = %ld)", (int) err);
   } 
   else
   {
     err = DNSServiceProcessResult(netService);
 
     if (err != kDNSServiceErr_NoError)
-      CLog::Log(LOGERROR, __FUNCTION__ " DNSServiceProcessResult returned (error = %ld)", (int) err);
+      CLog::Log(LOGERROR, "ZeroconfWIN: DNSServiceProcessResult returned (error = %ld)", (int) err);
 
     CSingleLock lock(m_data_guard);
     m_services.insert(make_pair(fcr_identifier, netService));

--- a/xbmc/network/windows/ZeroconfWIN.cpp
+++ b/xbmc/network/windows/ZeroconfWIN.cpp
@@ -121,6 +121,7 @@ bool CZeroconfWIN::doRemoveService(const std::string& fcr_ident)
 void CZeroconfWIN::doStop()
 {
   CSingleLock lock(m_data_guard);
+  CLog::Log(LOGDEBUG, "ZeroconfWIN: Shutdown services");
   for(tServiceMap::iterator it = m_services.begin(); it != m_services.end(); ++it)
     DNSServiceRefDeallocate(it->second);
   m_services.clear();


### PR DESCRIPTION
this is for discussion first as I dunno if the critsections are in the right place and if we need it static. If yes Linux/OSX need to change their platform code as well. Since we doesn't check for the return code of CZeroconf::PublishService yet it seems fine to start doPublishService via a job.

Probably not for eden (if its done right) although it's not a new feature but an optimisation ;)
