### PR TITLE
Guard db upgrades

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -448,24 +448,32 @@ bool CDatabase::Connect(const DatabaseSettings &dbSettings, bool create)
 bool CDatabase::UpdateVersion(const CStdString &dbName)
 {
   int version = 0;
-  m_pDS->query("SELECT idVersion FROM version\n");
-  if (m_pDS->num_rows() > 0)
-    version = m_pDS->fv("idVersion").get_asInt();
-
-  if (version < GetMinVersion())
+  try
   {
-    CLog::Log(LOGNOTICE, "Attempting to update the database %s from version %i to %i", dbName.c_str(), version, GetMinVersion());
-    if (UpdateOldVersion(version) && UpdateVersionNumber())
-      CLog::Log(LOGINFO, "Update to version %i successfull", GetMinVersion());
-    else
+    m_pDS->query("SELECT idVersion FROM version\n");
+    if (m_pDS->num_rows() > 0)
+      version = m_pDS->fv("idVersion").get_asInt();
+
+    if (version < GetMinVersion())
     {
-      CLog::Log(LOGERROR, "Can't update the database %s from version %i to %i", dbName.c_str(), version, GetMinVersion());
+      CLog::Log(LOGNOTICE, "Attempting to update the database %s from version %i to %i", dbName.c_str(), version, GetMinVersion());
+      if (UpdateOldVersion(version) && UpdateVersionNumber())
+        CLog::Log(LOGINFO, "Update to version %i successfull", GetMinVersion());
+      else
+      {
+        CLog::Log(LOGERROR, "Can't update the database %s from version %i to %i", dbName.c_str(), version, GetMinVersion());
+        return false;
+      }
+    }
+    else if (version > GetMinVersion())
+    {
+      CLog::Log(LOGERROR, "Can't open the database %s as it is a NEWER version than what we were expecting?", dbName.c_str());
       return false;
     }
   }
-  else if (version > GetMinVersion())
+  catch (...)
   {
-    CLog::Log(LOGERROR, "Can't open the database %s as it is a NEWER version than what we were expecting?", dbName.c_str());
+    CLog::Log(LOGERROR, "%s - failed", __FUNCTION__);
     return false;
   }
   return true;

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -22,6 +22,7 @@
  */
 
 #include "utils/StdString.h"
+#include "threads/CriticalSection.h"
 
 namespace dbiplus {
   class Database;
@@ -132,4 +133,6 @@ private:
 
   bool m_bMultiWrite; /*!< True if there are any queries in the queue, false otherwise */
   unsigned int m_openCount;
+
+  static CCriticalSection s_openGuard;
 };


### PR DESCRIPTION
I'm not sure if this is required (see http://trac.xbmc.org/ticket/12157 for example) but it seems there's some potential for nastiness if 2 or more threads call in to do a db update.

Several things might happen:
1. Threads could compete to do the database copy (on update we copy the old db to a new one).
2. Thread B might open the "new" db while thread A is still copying it (not sure if sqlite/mysql is threadsafe in this respect - my guess is they are).
3. Thread B might copy after thread A has already copied the db, basically redoing anything that thread A has done.
4. Two threads might call into UpdateOldVersion at the same time.  They can't process at the same time as it's done in a transaction, however once thread A has finished updating (assuming successful) thread B would then run through the same code and fail as we've already updated.

I don't like the way it's been done as the lock is held in situations it doesn't need to be (eg when no update is needed at all) - a nicer solution might be to have CApplication do the db update (i.e. move the updating of db's out of CDatabase::Open), and then "just" check that we're not updating (guarded) in Open().  This keeps the guard held for a minimal length of time (effectively a boolean read).
