### PR TITLE
fix movies being part of multiple 1-movie-set being listed multiple times

### DIFF
--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -264,12 +264,15 @@ vector<CSmartPlaylistRule::DATABASE_FIELD> CSmartPlaylistRule::GetFields(const C
     fields.push_back(FIELD_AIRDATE);
     fields.push_back(FIELD_PLAYCOUNT);
     fields.push_back(FIELD_LASTPLAYED);
-    fields.push_back(FIELD_INPROGRESS);
     if (!sortOrders)
+    {
+      fields.push_back(FIELD_INPROGRESS);
       fields.push_back(FIELD_GENRE);
+    }
     fields.push_back(FIELD_YEAR); // premiered
     fields.push_back(FIELD_DIRECTOR);
-    fields.push_back(FIELD_ACTOR);
+    if (!sortOrders)
+      fields.push_back(FIELD_ACTOR);
     fields.push_back(FIELD_EPISODE);
     fields.push_back(FIELD_SEASON);
     fields.push_back(FIELD_FILENAME);
@@ -291,7 +294,8 @@ vector<CSmartPlaylistRule::DATABASE_FIELD> CSmartPlaylistRule::GetFields(const C
     fields.push_back(FIELD_WRITER);
     fields.push_back(FIELD_PLAYCOUNT);
     fields.push_back(FIELD_LASTPLAYED);
-    fields.push_back(FIELD_INPROGRESS);
+    if (!sortOrders)
+      fields.push_back(FIELD_INPROGRESS);
     fields.push_back(FIELD_GENRE);
     fields.push_back(FIELD_COUNTRY);
     fields.push_back(FIELD_YEAR); // premiered
@@ -304,7 +308,8 @@ vector<CSmartPlaylistRule::DATABASE_FIELD> CSmartPlaylistRule::GetFields(const C
     fields.push_back(FIELD_HASTRAILER);
     fields.push_back(FIELD_FILENAME);
     fields.push_back(FIELD_PATH);
-    fields.push_back(FIELD_SET);
+    if (!sortOrders)
+      fields.push_back(FIELD_SET);
     isVideo = true;
 //    fields.push_back(FIELD_DATEADDED);  // no date added yet in db
   }
@@ -677,7 +682,7 @@ CStdString CSmartPlaylistRule::GetDatabaseField(DATABASE_FIELD field, const CStd
     else if (field == FIELD_PATH) result = "strPath";
     else if (field == FIELD_RANDOM) result = "RANDOM()";      // only used for order clauses
     else if (field == FIELD_DATEADDED) result = "idMovie";       // only used for order clauses
-    else if (field == FIELD_SET) result = "strSet";
+    else if (field == FIELD_SET) result = "cant_order_by_set";
     return result;
   }
   else if (type == "musicvideos")
@@ -719,7 +724,7 @@ CStdString CSmartPlaylistRule::GetDatabaseField(DATABASE_FIELD field, const CStd
     else if (field == FIELD_PLAYCOUNT) result = "watched";
     else if (field == FIELD_RANDOM) result = "RANDOM()";      // only used for order clauses
     else if (field == FIELD_DATEADDED) result = "idShow";       // only used for order clauses
-    else if (field == FIELD_PATH) return "strPath";
+    else if (field == FIELD_PATH) result = "strPath";
     return result;
   }
   if (type == "episodes")

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -677,7 +677,7 @@ CStdString CSmartPlaylistRule::GetDatabaseField(DATABASE_FIELD field, const CStd
     else if (field == FIELD_PATH) result = "strPath";
     else if (field == FIELD_RANDOM) result = "RANDOM()";      // only used for order clauses
     else if (field == FIELD_DATEADDED) result = "idMovie";       // only used for order clauses
-    else if (field == FIELD_SET) result = "idSet";  // only used for order clauses
+    else if (field == FIELD_SET) result = "strSet";
     return result;
   }
   else if (type == "musicvideos")

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -363,21 +363,8 @@ void CVideoDatabase::CreateViews()
 
   CLog::Log(LOGINFO, "create movieview");
   m_pDS->exec("DROP VIEW IF EXISTS movieview");
-  CStdString movieview = PrepareSQL("CREATE VIEW movieview AS SELECT "
-                                    "movie.*,"
-                                    "files.strFileName AS strFileName,"
-                                    "path.strPath AS strPath,"
-                                    "files.playCount AS playCount,"
-                                    "files.lastPlayed AS lastPlayed,"
-                                    "  NULLIF(setlinkmovie.idSet, 0) AS idSet "
-                                    "FROM movie"
-                                    "  LEFT JOIN setlinkmovie ON"
-                                    "    setlinkmovie.idMovie=movie.idMovie"
-                                    "  LEFT JOIN files ON"
-                                    "    files.idFile=movie.idFile"
-                                    "  LEFT JOIN path ON"
-                                    "    path.idPath=files.idPath");
-  m_pDS->exec(movieview.c_str());
+  m_pDS->exec("create view movieview as select movie.*,files.strFileName as strFileName,path.strPath as strPath,files.playCount as playCount,files.lastPlayed as lastPlayed "
+              "from movie join files on files.idFile=movie.idFile join path on path.idPath=files.idPath");
 }
 
 //********************************************************************************************************************************

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -722,7 +722,7 @@ private:
    */
   bool LookupByFolders(const CStdString &path, bool shows = false);
 
-  virtual int GetMinVersion() const { return 59; };
+  virtual int GetMinVersion() const { return 60; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 


### PR DESCRIPTION
These commits take a different (better) approach to the same problem described in PR #653 by reverting the commit that caused the problem to appear in the first place. Furthermore it also cleans up some fields in the SmartPlaylist implementation which appeared as sorting options in the Smartplaylist Editor even though XBMC doesn't support sorting by those fields.

It also reverts sorting by sets as IMO this does not make any sense at all. IMO sorting by a many-to-one relation never does make any sense furthermore not every movie is part of a set so sorting by sets can result in very odd listings. There's a (closed) ticket for this problem at http://trac.xbmc.org/ticket/12251 but we didn't get any response so far on why the ticket owner would really want this.
