### PR TITLE
[remote] remove double 'KEY_PLAYPAUSE' mapping. this mapping will not wo...

### DIFF
--- a/system/Lircmap.xml
+++ b/system/Lircmap.xml
@@ -425,7 +425,6 @@
 		<play>KEY_PLAY</play>
 		<play>KEY_PLAYPAUSE</play>
 		<pause>KEY_PAUSE</pause>
-		<pause>KEY_PLAYPAUSE</pause>
 		<stop>KEY_STOP</stop>
 		<stop>KEY_STOPCD</stop>
 		<forward>KEY_FASTFORWARD</forward>


### PR DESCRIPTION
...rk correct in this way because 'KEY_PLAYPAUSE' is already defined and is not needed because <play> already support 'pause' if pressing again.
