### PR TITLE
Fanart fixes

### DIFF
--- a/xbmc/ThumbnailCache.cpp
+++ b/xbmc/ThumbnailCache.cpp
@@ -209,7 +209,7 @@ CStdString CThumbnailCache::GetVideoThumb(const CFileItem &item)
 CStdString CThumbnailCache::GetFanart(const CFileItem &item)
 {
   // get the locally cached thumb
-  if (item.IsVideoDb() || item.HasVideoInfoTag())
+  if (item.IsVideoDb() || (item.HasVideoInfoTag() && !item.GetVideoInfoTag()->IsEmpty()))
   {
     if (!item.HasVideoInfoTag())
       return "";

--- a/xbmc/ThumbnailCache.cpp
+++ b/xbmc/ThumbnailCache.cpp
@@ -232,7 +232,7 @@ CStdString CThumbnailCache::GetFanart(const CFileItem &item)
       }
       return GetThumb(showPath,g_settings.GetVideoFanartFolder());
     }
-    CStdString path = item.GetVideoInfoTag()->m_strFileNameAndPath.IsEmpty() ? item.GetVideoInfoTag()->m_strPath : item.GetVideoInfoTag()->m_strFileNameAndPath;
+    CStdString path = item.GetVideoInfoTag()->GetPath();
     if (path.empty())
       return "";
     return GetThumb(path,g_settings.GetVideoFanartFolder());

--- a/xbmc/ThumbnailCache.cpp
+++ b/xbmc/ThumbnailCache.cpp
@@ -232,7 +232,7 @@ CStdString CThumbnailCache::GetFanart(const CFileItem &item)
       }
       return GetThumb(showPath,g_settings.GetVideoFanartFolder());
     }
-    CStdString path = item.m_bIsFolder ? item.GetVideoInfoTag()->m_strPath : item.GetVideoInfoTag()->m_strFileNameAndPath;
+    CStdString path = item.GetVideoInfoTag()->m_strFileNameAndPath.IsEmpty() ? item.GetVideoInfoTag()->m_strPath : item.GetVideoInfoTag()->m_strFileNameAndPath;
     if (path.empty())
       return "";
     return GetThumb(path,g_settings.GetVideoFanartFolder());


### PR DESCRIPTION
This fixes a couple of situations, both for the files node, both concerning a layout of <moviename>/<moviefile>-fanart.jpg for fanart.
1. We can now find this and assign to the <moviename> folder (regardless of stacking)
2. If user doesn't have stacking on, so that the <moviename> folder can be navigated into, then we can assign the same fanart to the <moviefile>.ext movie.

The trick is that previously if we had a videoinfotag object and the item was a folder we would use CVideoInfoTag::m_strPath.  This covers tvshows primarily.  Instead, we check whether m_strFileNameAndPath is empty - if not, we use it.  This also covers tvshows as they don't set m_strFileNameAndPath.
