### PR TITLE
Added missing string id's

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -874,9 +874,10 @@
   <string id="10019">Settings - Appearance</string>
   <string id="10020">Scripts</string>
   <string id="10021">Web Browser</string>
-
   <string id="10028">Videos/Playlist</string>
+  <string id="10029">Login screen</string>
   <string id="10034">Settings - Profiles</string>
+  <string id="10040">Addon browser</string>
 
   <string id="10100">Yes/No dialog</string>
   <string id="10101">Progress dialog</string>

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -874,6 +874,7 @@
   <string id="10019">Settings - Appearance</string>
   <string id="10020">Scripts</string>
   <string id="10021">Web Browser</string>
+  <string id="10025">Videos</string>
   <string id="10028">Videos/Playlist</string>
   <string id="10029">Login screen</string>
   <string id="10034">Settings - Profiles</string>


### PR DESCRIPTION
System.CurentWindow gets it's information from the window id's in the language files. Videos, Login screen and Addon browser were missing and therefore returned empty with use of that infolabel.
