### PR TITLE
Allow ASCII character input through EventServer (and JSON-RPC)

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2260,7 +2260,7 @@ bool CApplication::OnKey(const CKey& key)
       if (!action.GetID())
       {
         // keyboard entry - pass the keys through directly
-        if (key.GetFromHttpApi())
+        if (key.GetFromService())
           action = CAction(key.GetButtonCode() != KEY_INVALID ? key.GetButtonCode() : 0, key.GetUnicode());
         else
         { // see if we've got an ascii key
@@ -2277,7 +2277,7 @@ bool CApplication::OnKey(const CKey& key)
         return true;
       // failed to handle the keyboard action, drop down through to standard action
     }
-    if (key.GetFromHttpApi())
+    if (key.GetFromService())
     {
       if (key.GetButtonCode() != KEY_INVALID)
         action = CButtonTranslator::GetInstance().GetAction(iWin, key);

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2997,7 +2997,10 @@ bool CApplication::ProcessJsonRpcButtons()
 #ifdef HAS_JSONRPC
   CKey tempKey(JSONRPC::CInputOperations::GetKey());
   if (tempKey.GetButtonCode() != KEY_INVALID)
+  {
+    tempKey.SetFromService(true);
     return OnKey(tempKey);
+  }
 #endif
   return false;
 }
@@ -3069,6 +3072,7 @@ bool CApplication::ProcessEventServer(float frameTime)
         key = CKey(wKeyID, 0, 0, 0.0, 0.0, 0.0, -fAmount, frameTime);
       else
         key = CKey(wKeyID);
+      key.SetFromService(true);
       return OnKey(key);
     }
   }

--- a/xbmc/guilib/Key.cpp
+++ b/xbmc/guilib/Key.cpp
@@ -79,7 +79,7 @@ void CKey::Reset()
   m_rightThumbX = 0.0f;
   m_rightThumbY = 0.0f;
   m_repeat = 0.0f;
-  m_fromHttpApi = false;
+  m_fromService = false;
   m_buttonCode = KEY_INVALID;
   m_vkey = 0;
   m_unicode = 0;
@@ -98,7 +98,7 @@ const CKey& CKey::operator=(const CKey& key)
   m_rightThumbX  = key.m_rightThumbX;
   m_rightThumbY  = key.m_rightThumbY;
   m_repeat       = key.m_repeat;
-  m_fromHttpApi  = key.m_fromHttpApi;
+  m_fromService  = key.m_fromService;
   m_buttonCode   = key.m_buttonCode;
   m_vkey         = key.m_vkey;
   m_unicode     = key.m_unicode;
@@ -164,19 +164,12 @@ float CKey::GetRepeat() const
   return m_repeat;
 }
 
-bool CKey::GetFromHttpApi() const
+void CKey::SetFromService(bool fromService)
 {
-  return m_fromHttpApi;
-}
-
-void CKey::SetFromHttpApi(bool bFromHttpApi)
-{
-  if(bFromHttpApi && (m_buttonCode & KEY_ASCII) )
-  {
-      m_unicode = m_buttonCode - KEY_ASCII;      
-  }
+  if (fromService && (m_buttonCode & KEY_ASCII))
+    m_unicode = m_buttonCode - KEY_ASCII;
     
-  m_fromHttpApi = bFromHttpApi;
+  m_fromService = fromService;
 }
 
 CAction::CAction(int actionID, float amount1 /* = 1.0f */, float amount2 /* = 0.0f */, const CStdString &name /* = "" */)

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -543,8 +543,8 @@ public:
   bool FromKeyboard() const;
   bool IsAnalogButton() const;
   bool IsIRRemote() const;
-  void SetFromHttpApi(bool);
-  bool GetFromHttpApi() const;
+  void SetFromService(bool fromService);
+  bool GetFromService() const { return m_fromService; }
 
   inline uint32_t GetButtonCode() const { return m_buttonCode; }
   inline uint8_t  GetVKey() const       { return m_vkey; }
@@ -578,7 +578,7 @@ private:
   float m_rightThumbX;
   float m_rightThumbY;
   float m_repeat; // time since last keypress
-  bool m_fromHttpApi;
+  bool m_fromService;
 };
 #endif
 

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -2085,7 +2085,7 @@ int CXbmcHttp::xbmcSetKey(int numParas, CStdString paras[])
       }
     }
     CKey tempKey(buttonCode, leftTrigger, rightTrigger, fLeftThumbX, fLeftThumbY, fRightThumbX, fRightThumbY) ;
-    tempKey.SetFromHttpApi(true);
+    tempKey.SetFromService(true);
     key = tempKey;
     lastKey = key;
     return SetResponse(openTag+"OK");


### PR DESCRIPTION
I'm creating this PR to get some help on how the virtual keyboard input stuff is handled (mainly) for the EventServer. Currently it is not possible to use the EventServer to send ASCII characters to XBMC so that they get added to a text field when e.g. using the library filter. The HTTP-API has special handling for this case with the CKey::GetFromHttpApi() method which I renamed to GetFromService().

My primary question is whether this behaviour of the eventserver is by design and has some reason I don't know or if this is a bug and should actually be supported. If it is a bug this PR should fix it by also using the Set/GetFromService() methods for virtual key presses from the EventServer and from JSON-RPC (for use in the future).
