### PR TITLE
add geoip support and fetch 7 day forecast

### DIFF
--- a/addons/weather.wunderground/addon.xml
+++ b/addons/weather.wunderground/addon.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.wunderground" name="Weather Underground" version="0.0.4" provider-name="Team XBMC">
+<addon id="weather.wunderground" name="Weather Underground" version="0.0.5" provider-name="Team XBMC">
 	<requires>
 		<import addon="xbmc.python" version="2.0"/>
 		<import addon="script.module.simplejson" version="2.0.10"/>

--- a/addons/weather.wunderground/changelog.txt
+++ b/addons/weather.wunderground/changelog.txt
@@ -1,3 +1,8 @@
+v0.0.5
+- add geoip support
+- fetch 7 day forecast
+- workaround: when user switches weather addon, xbmc may call the script with a location id that has not been setup. try to fallback to id 1 in this case.
+
 v0.0.4
 - don't fetch weather when no locations are set up
 - fix incrementing values on each weather refresh when no locations are set up


### PR DESCRIPTION
- add geoip support
- fetch 7 day forecast (since it's supported by xbmc now)
- workaround: when a user switches weather addons, xbmc may call the script with a location id that has not been setup. try to fallback to id 1 in this case.
- remove the workaround to stop xbmc from running the script in a loop,
  this has been fixed in core: 
  https://github.com/xbmc/xbmc/commit/eb04799deae2e397ac6f554dd0a45a786b05027c
