### PR TITLE
dvdplayer: prefer external over embedded subtitles with default flag set (fixes #11724)

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -703,6 +703,15 @@ void CDVDPlayer::OpenDefaultStreams()
       CLog::Log(LOGWARNING, "%s - failed to restore selected subtitle stream (%d)", __FUNCTION__, g_settings.m_currentVideoSettings.m_SubtitleStream);
   }
 
+  // check if there are external subtitles available
+  for(int i = 0;i<count && !valid; i++)
+  {
+    SelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, i);
+    if ((s.source == STREAM_SOURCE_DEMUX_SUB || s.source == STREAM_SOURCE_TEXT)
+    && OpenSubtitleStream(s.id, s.source))
+      valid = true;
+  }
+
   // select default
   if(!valid
   && m_SelectionStreams.Get(STREAM_SUBTITLE, CDemuxStream::FLAG_DEFAULT, st))


### PR DESCRIPTION
This commit changes the behaviour of subtitle selection back to how it worked in Dharma. There is more information about the problem and where it changed between Dharma and Eden in this thread: http://forum.xbmc.org/showthread.php?t=121091. I have tested this implementation with the test file provided by olympia and with some modified versions of it.

Basically what changes is, that when subtitles are enabled and there is an external subtitle available, it will always choose that subtitle (independent of how many embedded subtitles there are and what flags (forced, default) they have set). That's how it worked in Dharma but after that it was changed and we always chose the (embedded ) subtitle with the default flag.
