### PR TITLE
[Windows] Fix stale edge pixels when changing OSD zoom setting

### DIFF
--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -164,6 +164,7 @@ public:
 protected:
   virtual bool ChooseIntermediateD3DFormat();
   virtual bool CreateIntermediateRenderTarget(unsigned int width, unsigned int height);
+  virtual bool ClearIntermediateRenderTarget();
   virtual void PrepareParameters(unsigned int sourceWidth, unsigned int sourceHeight,
                                unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,


### PR DESCRIPTION
With the new two-pass scalers, stale pixels left in the intermediate render target by a different zoom value are sometimes displayed (pixels at the edge of the final picture)

For some reason I didn't succeed in fixing by playing with the texture coordinates... With Eden happening soon, I took out the sledgehammer and this PR completely clears the intermediate render target when the rects change.
It works but does more work than necessary. The change is safe but I did a PR in case someone else figures out the better fix with the coordinates manipulation. I'll merge this in a few days. 
