### PR TITLE
fix overwrite of a single byte of memory when reading pre-2.4 PIC tags

### DIFF
--- a/lib/libid3tag/libid3tag/compat.gperf
+++ b/lib/libid3tag/libid3tag/compat.gperf
@@ -141,7 +141,7 @@ int translate_APIC(struct id3_frame *frame, char const *oldid,
 		   id3_byte_t const *data, id3_length_t length)
 {
   id3_byte_t const *end;
-  char type[3];
+  char type[4];
   enum id3_field_textencoding encoding;
   int result = 0;
   

--- a/lib/libid3tag/libid3tag/compat2.c
+++ b/lib/libid3tag/libid3tag/compat2.c
@@ -276,7 +276,7 @@ id3_compat_lookup (str, len)
 #line 96 "compat.gperf"
       {"TIME", OBSOLETE  /* Time [obsolete] */},
 #line 75 "compat.gperf"
-      {"PIC",  EQ(APIC)  /* Attached picture */},
+      {"PIC",  TX(APIC)  /* Attached picture */},
 #line 127 "compat.gperf"
       {"UFI",  EQ(UFID)  /* Unique file identifier */},
 #line 72 "compat.gperf"

--- a/lib/libid3tag/libid3tag/compat2.c
+++ b/lib/libid3tag/libid3tag/compat2.c
@@ -346,7 +346,7 @@ int translate_APIC(struct id3_frame *frame, char const *oldid,
 		   id3_byte_t const *data, id3_length_t length)
 {
   id3_byte_t const *end;
-  char type[3];
+  char type[4];
   enum id3_field_textencoding encoding;
   int result = 0;
   

--- a/lib/libid3tag/libid3tag/metadata.c
+++ b/lib/libid3tag/libid3tag/metadata.c
@@ -322,7 +322,7 @@ const id3_ucs4_t* id3_metadata_getcomment(const struct id3_tag* tag, enum id3_fi
   }
   while (*ucs4 == 0);
 #else
-  const id3_ucs4_t* ucs4 = id3_ucs4_empty;
+  const id3_ucs4_t* ucs4 = 0;
 
   // return the first non-empty comment
   do
@@ -355,17 +355,16 @@ const id3_ucs4_t* id3_metadata_getcomment(const struct id3_tag* tag, enum id3_fi
         //finally fetch the comment
         field = id3_frame_field(frame, 3);
         if (field == 0)
-          break;
+          continue;
     
-        ucs4 = id3_field_getfullstring(field);
-        //done
-        break;  
+        return id3_field_getfullstring(field);
       }
     }
   }
   while (frame);
 #endif//else TARGET_DARWIN_IOS
   return ucs4;
+//  return id3_ucs4_empty;
 }
 
 int id3_metadata_setcomment(struct id3_tag* tag, id3_ucs4_t* value)


### PR DESCRIPTION
Pre v2.4 tags use PIC frames for embedded images.  These are updated internally by libid3tag to v2.4 APIC frames.  In the process, the 3-byte picture identifier (PNG or JPG) is read using id3_parse_immediate, which is passed a 3 byte buffer to read 3 bytes.  However, the function also writes to the fourth byte to null-terminate.

Fix is to simply increase the buffer size to 4.

I suspect that this will fix the issues that some have had on IOS with the recent comment change.  It is certainly worth testing.

In addition, there's additional issues (though not crash issues) with the comment tag reading, which I'll address with an update to this pull req.
