### PR TITLE
fix : can't play music addons items stored in the musicdb

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -66,6 +66,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/DllLibCurl.h"
 #include "filesystem/MythSession.h"
+#include "filesystem/FileMusicDatabase.h"
 #include "filesystem/PluginDirectory.h"
 #ifdef HAS_FILESYSTEM_SAP
 #include "filesystem/SAPDirectory.h"
@@ -3640,6 +3641,18 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
     CFileItem item_new(item);
     if (XFILE::CPluginDirectory::GetPluginResult(item.GetPath(), item_new))
       return PlayFile(item_new, false);
+    return false;
+  }
+
+  // resolve MusicDb url, needed to resolve plugin items in music database
+  if (item.IsMusicDb())
+  {
+    CURL url(item.GetPath());
+    if (CStdString mainFile = CFileMusicDatabase::TranslateUrl(url))
+    {
+      CFileItem item_new(mainFile.c_str(),false);
+      return PlayFile(item_new, false);
+    }
     return false;
   }
 


### PR DESCRIPTION
When trying to play a item in the musicdb that was scanned from an music addon, it fails (nothing resolve the  musicdb://1/2/3/12 url) this patch add the musicdb urlresolv in the application.cpp probably not the good place but it works. 
