### PR TITLE
fix handling of music plugin items

### DIFF
--- a/language/Chinese (Simple)/strings.xml
+++ b/language/Chinese (Simple)/strings.xml
@@ -1768,7 +1768,7 @@
   <string id="20326">这个操作会重新校准%s的配置</string>
   <string id="20327">还原为初时配置</string>
   <string id="20328">选择指定位置</string>
-
+  <string id="20329">电影在以片名命名的单独目录中</string>
   <string id="20330">以文件夹名来查找</string>
   <string id="20331">文件</string>
   <string id="20332">用文件夹名或文件名进行查找？</string>
@@ -1858,7 +1858,7 @@
   <string id="20416">最初发表</string>
   <string id="20417">编剧</string>
   <string id="20418"></string>
-  <string id="20419">文件视图显示媒体标识信息</string>
+  <string id="20419">用资料库标题替换文件名</string>
 
   <string id="20420">从不</string>
   <string id="20421">如果只有一季</string>
@@ -1898,6 +1898,7 @@
   <string id="20455">听众</string>
   <string id="20456">设置影片集同人画</string>
   <string id="20457">影片集</string>
+  <string id="20458">电影按影片集分组</string>
   <!-- up to 21329 is reserved for the video db !! !-->
 
   <string id="21330">显示隐藏文件和目录</string>
@@ -2005,6 +2006,8 @@
   <string id="21451">需要访问互联网。</string>
   <string id="21452">获取更多...</string>
   <string id="21453">根文件系统</string>
+  <string id="21454">缓存满</string>
+  <string id="21455">缓存在达到连续播放所需数量之前已满</string>
 
   <string id="21460">字幕位置</string>
   <string id="21461">固定</string>
@@ -2325,6 +2328,8 @@
   <string id="33102">事件服务器</string>
   <string id="33103">远程通信服务器</string>
 
+  <string id="33200">检测到新的连接</string>
+
   <!-- translators: no need to add these to your language files -->
   <string id="34000">Lame</string>
   <string id="34001">Vorbis</string>
@@ -2348,6 +2353,14 @@
 
   <string id="34201">未找到下一播放项目</string>
   <string id="34202">未找到上一播放项目</string>
+
+  <string id="34300">启动 zeroconf 失败</string>
+  <string id="34301">Apple 的 Bonjour 服务是否已安装？更多信息见日志记录。</string>
+
+  <string id="34400">视频渲染</string>
+  <string id="34401">视频滤镜/缩放器初始化失败，使用双线性缩放</string>
+  <string id="34402">音频设备初始化失败</string>
+  <string id="34403">检查你的音频设置</string>
 
   <string id="35000">外部设备</string>
 

--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -874,9 +874,11 @@
   <string id="10019">Settings - Appearance</string>
   <string id="10020">Scripts</string>
   <string id="10021">Web Browser</string>
-
+  <string id="10025">Videos</string>
   <string id="10028">Videos/Playlist</string>
+  <string id="10029">Login screen</string>
   <string id="10034">Settings - Profiles</string>
+  <string id="10040">Addon browser</string>
 
   <string id="10100">Yes/No dialog</string>
   <string id="10101">Progress dialog</string>

--- a/language/German/strings.xml
+++ b/language/German/strings.xml
@@ -883,7 +883,9 @@
   <string id="10021">Webbrowser</string>
 
   <string id="10028">Videos/Playlisten</string>
+  <string id="10029">Anmeldebildschirm</string>
   <string id="10034">Einstellungen-&gt;Profile</string>
+  <string id="10040">Addon-Browser</string>
 
   <string id="10100">Ja/Nein Dialog</string>
   <string id="10101">Fortschrittsanzeige</string>
@@ -1802,6 +1804,7 @@
   <string id="20326">Dies setzt den Kalibrierwert für %s</string>
   <string id="20327">auf den Standardwert zurück</string>
   <string id="20328">Nach einem Speicherort durchsuchen...</string>
+  <string id="20329">Filme sind in seperaten Ordnern, welche Filmtitel entsprechen</string>
 
   <string id="20330">Ordnernamen für Anfragen verwenden</string>
   <string id="20331">Dateinamen</string>
@@ -1892,7 +1895,7 @@
   <string id="20416">Erstausstrahlung</string>
   <string id="20417">Autor</string>
   <string id="20418"></string>
-  <string id="20419">Metadaten im Datei-Modus anzeigen</string>
+  <string id="20419">Ersetze Dateinamen durch Datenbankeinträge</string>
 
   <string id="20420">Nie</string>
   <string id="20421">Nur bei einer Staffel</string>
@@ -1931,6 +1934,7 @@
 
   <string id="20456">Filmset Fanart setzen</string>
   <string id="20457">Zusammenstellung</string>
+  <string id="20458">Gruppiere Filme nach Zusammenstellungen</string>
 
   <string id="21330">Versteckte Ordner und Dateien anzeigen</string>
   <string id="21331">TuxBox Client</string>

--- a/language/Greek/strings.xml
+++ b/language/Greek/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<!--Translator: Ydatografida / Email: ydatografida@gmail.com / Date of translation: 12/25/2011 / Based on english strings version 1E+42-->
+<!--$Revision$--> <!--Translator: Ydatografida / Email: ydatografida@gmail.com / Date of translation: 12/25/2011 / Last update (by CutSickAss): 14/02/2012 / Based on english strings version 1E+42-->
 <strings>
   <string id="0">Εφαρμογές</string>
   <string id="1">Φωτογραφίες</string>
@@ -188,7 +188,7 @@
   <string id="216">Ποσοστό μεγέθυνσης</string>
   <string id="217">Λόγος εικονοστοιχείων</string>
   <string id="218">Μονάδα DVD</string>
-  <string id="219">Παρακαλώ, εισάγετε δίσκο</string>
+  <string id="219">Παρακαλώ εισάγετε δίσκο</string>
   <string id="220">Απομακρυσμένος κοινόχρηστος πόρος</string>
   <string id="221">Το δίκτυο είναι αποσυνδεμένο</string>
   <string id="222">Άκυρο</string>
@@ -432,7 +432,7 @@
   <string id="475">Μουσική μόνο</string>
   <string id="476">Μουσική &amp; βίντεο</string>
   <string id="477">Αδυναμία φόρτωσης της λίστας αναπαραγωγής</string>
-  <string id="478">Aπεικόνισεις οθόνης (OSD)</string>
+  <string id="478">Aπεικονίσεις οθόνης (OSD)</string>
   <string id="479">Κέλυφος &amp; γλώσσα</string>
   <string id="480">Εξατομίκευση</string>
   <string id="481">Ιδιότητες ήχου</string>
@@ -625,7 +625,7 @@
   <string id="719">- Διεύθυνση IP</string>
   <string id="720">- Μάσκα δικτύου</string>
   <string id="721">- Προεπιλεγμένη πύλη</string>
-  <string id="722">- Διακομιστή DNS</string>
+  <string id="722">- Διακομιστής DNS</string>
   <string id="723">Αποθήκευση &amp; επανεκκίνηση</string>
   <string id="724">Προσδιορίστηκε εσφαλμένη διεύθυνση. Η τιμή πρέπει να έχει τη μορφή AAA.BBB.CCC.DDD</string>
   <string id="725">με τιμές μεταξύ 0 και 255.</string>
@@ -801,7 +801,7 @@
   <string id="1254">Να απαιτείται επιβεβαίωση για να συνδεθεί</string>
   <string id="1255">Αποστολή ονόματος και κωδικού πρόσβασης χρήστη (FTP)</string>
   <string id="1256">Διάστημα μεταλλικού θορύβου</string>
-  <string id="1257">Να συνδεθείτε στο συστήμα που εντοπίστηκε;</string>
+  <string id="1257">Να συνδεθείτε στο σύστημα που εντοπίστηκε;</string>
 
   <string id="1260">Αναγγελία αυτών των υπηρεσιών σε άλλα συστήματα διαμέσου του Zeroconf</string>
   <string id="1270">Έγκριση στο XBMC να λαμβάνει περιεχόμενο AirPlay</string>
@@ -863,7 +863,7 @@
   <string id="10008">Ρυθμίσεις - Γενικά</string>
   <string id="10009">Ρυθμίσεις - Οθόνη</string>
   <string id="10010">Ρυθμίσεις - Αισθητικά - Βαθμονόμηση γραφικού περιβάλλοντος (GUI)</string>
-  <string id="10011">Ρυθμίσεις - Βίντεο - Βαθμονόμιση Οθόνης</string>
+  <string id="10011">Ρυθμίσεις - Βίντεο - Βαθμονόμηση Οθόνης</string>
   <string id="10012">Ρυθμίσεις - Φωτογραφίες</string>
   <string id="10013">Ρυθμίσεις - Εφαρμογές</string>
   <string id="10014">Ρυθμίσεις - Καιρός</string>
@@ -874,9 +874,11 @@
   <string id="10019">Ρυθμίσεις - Εξατομίκευση</string>
   <string id="10020">Scripts</string>
   <string id="10021">Περιηγητής ιστού</string>
-
+  <string id="10025">Βίντεο</string>
   <string id="10028">Βίντεο/Λίστα Αναπαραγωγής</string>
+  <string id="10029">Οθόνη σύνδεσης</string>
   <string id="10034">Ρυθμίσεις - Προφίλ</string>
+  <string id="10040">Περιηγητής Πρόσθετων</string>
 
   <string id="10100">Διάλογος Ναι/Όχι</string>
   <string id="10101">Διάλογος διαδικασίας</string>
@@ -917,7 +919,7 @@
 
   <string id="12008">Διάλογος στοιβαγμένου αρχείου</string>
   <string id="12009">Ανακατασκευή περιεχομένων...</string>
-  <string id="12010">Επιστροφή στην μουσική</string>
+  <string id="12010">Επιστροφή στη μουσική</string>
   <string id="12011">Επιστροφή στα βίντεο</string>
 
   <string id="12021">Εκκίνηση από την αρχή</string>
@@ -957,14 +959,14 @@
   <string id="12344">Ο κωδικός πρόσβασης δεν ταιριάζει.</string>
   <string id="12345">Δεν επιτράπηκε η πρόσβαση</string>
   <string id="12346">Οι δοκιμές εισαγωγής κωδικού πρόσβασης εξαντλήθηκαν.</string>
-  <string id="12347">Το συστήμα τώρα θα απενεργοποιηθεί.</string>
+  <string id="12347">Το σύστημα τώρα θα απενεργοποιηθεί.</string>
   <string id="12348">Το αντικείμενο κλειδώθηκε</string>
   <string id="12353">Επανενεργοποίηση κλειδώματος</string>
   <string id="12356">Αλλαγή κλειδώματος</string>
   <string id="12357">Πηγαίο κλείδωμα</string>
   <string id="12358">Το πεδίο του κωδικού πρόσβασης ήταν κενό. Ξαναπροσπαθήστε.</string>
   <string id="12360">Κεντρικό κλείδωμα</string>
-  <string id="12362">Απενεργοποίηση συστήματος όταν προσπάθειες εισαγωγής εξαντληθούν</string>
+  <string id="12362">Απενεργοποίηση συστήματος όταν εξαντληθούν οι προσπάθειες εισαγωγής</string>
   <string id="12367">Ο κεντρικός κωδικός δεν είναι έγκυρος</string>
   <string id="12368">Παρακαλώ, εισάγετε έναν έγκυρο κεντρικό κωδικό</string>
   <string id="12373">Ρυθμίσεις &amp;  διαχείριση αρχείων</string>
@@ -988,7 +990,7 @@
   <string id="12600">Ο καιρός</string>
 
   <string id="12900">Προφύλαξη οθόνης</string>
-  <string id="12901">Πλήρους οθόνης απεικονίσεις (OSD)</string>
+  <string id="12901">Απεικονίσεις πλήρους οθόνης (OSD)</string>
 
   <string id="13000">Σύστημα</string>
   <string id="13001">Άμεση ελάττωση περιστροφής (Spindown)</string>
@@ -1100,7 +1102,7 @@
   <string id="13283">Λειτουργικό σύστημα</string>
   <string id="13284">Ταχύτητα CPU</string>
 
-  <string id="13286">Βίντεο κωδικοποιητής</string>
+  <string id="13286">Κωδικοποιητής βίντεο:</string>
   <string id="13287">Ανάλυση οθόνης</string>
 
   <string id="13292">Καλώδιο A/V</string>
@@ -1205,7 +1207,7 @@
   <string id="13405">Μικρογραφία</string>
   <string id="13406">Πληροφορίες εικόνας</string>
   <string id="13407">%s προκαθορισμένα</string>
-  <string id="13408">(Αξιολόγηση χρήστη IMDb)</string>
+  <string id="13408">(Αξιολόγηση IMDb)</string>
   <string id="13409">250 κορυφαία</string>
   <string id="13410">Συντονισμός στο Last.FM</string>
   <string id="13411">Ελάχιστη ταχύτητα ανεμιστήρα</string>
@@ -1720,7 +1722,7 @@
   <string id="20182">Κενό</string>
   <string id="20183">Επαναφόρτωση κελύφους</string>
   <string id="20184">Περιστροφή εικόνων που χρησιμοποιούν τις πληροφορίες EXIF</string>
-  <string id="20185">Χρήση όψης αφίσας για τις τηλεοπτικές σειρές</string>
+  <string id="20185">Χρήση στυλ αφισών για τις τηλεοπτικές σειρές</string>
   <string id="20186">Απασχολημένο</string>
 
   <string id="20189">Ενεργοποίηση αυτόματης κύλισης στην επισκόπηση πλοκής &amp; κριτικής</string>
@@ -1862,7 +1864,7 @@
   <string id="20416">Πρεμιέρα</string>
   <string id="20417">Σενάριο</string>
   <string id="20418"></string>
-  <string id="20419">Εμφάνιση μεταδεδομένων κατά την προβολή αρχείων</string>
+  <string id="20419">Αντικατάσταση ονομάτων αρχείων με τίτλους συλλογών</string>
 
   <string id="20420">Ποτέ</string>
   <string id="20421">Eάν είναι ενός κύκλου</string>
@@ -1884,7 +1886,7 @@
   <string id="20437">Επιλεγμένο fanart</string>
   <string id="20438">Τοπικό fanart</string>
   <string id="20439">Χωρίς fanart</string>
-  <string id="20440">Tρέχον fanart</string>
+  <string id="20440">Τρέχον fanart</string>
   <string id="20441">Απομακρυσμένο fanart</string>
   <string id="20442">Αλλαγή περιεχομένου</string>
   <string id="20443">Επιθυμείτε να ανανεώσετε τις πληροφορίες</string>
@@ -1976,9 +1978,9 @@
   <string id="21417">- Ρυθμίσεις</string>
   <string id="21418">Πολύγλωσσο</string>
   <string id="21419">Δεν υπάρχει διαθέσιμος καταγραφέας</string>
-  <string id="21420">Τιμές για αντιστοίχηση</string>
+  <string id="21420">Τιμές για αντιστοίχιση</string>
   <string id="21421">Όροι έξυπνης λίστας αναπαραγωγής</string>
-  <string id="21422">Κριτήρια αντιστοίχησης αντικειμένων</string>
+  <string id="21422">Κριτήρια αντιστοίχισης αντικειμένων</string>
   <string id="21423">Νέοι κανόνες...</string>
   <string id="21424">Αντικείμενα με πολλές αντιστοιχίες</string>
   <string id="21425">με όλους τους κανόνες</string>
@@ -2401,5 +2403,5 @@
   <string id="36015">Αριθμός θύρας HDMI</string>
   <string id="36016">Συνδεδεμένη</string> <!-- max. 13 characters -->
   <string id="36017">O προσαρμογέας εντοπίσθηκε, αλλά  η libcec δεν είναι διαθέσιμη</string>
-  <string id="36018">Χρησιμοποιήστε τη γλώσσα της τηλεόρασης</string>
+  <string id="36018">Χρήση της γλώσσας της τηλεόρασης</string>
 </strings>

--- a/language/Italian/strings.xml
+++ b/language/Italian/strings.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <!--Translator: Succo, updated by Gulp-->
 <!--Email: succo69@libero.it, http://forum.xbmc.org/member.php?u=42290-->
-<!--Based on English 98d103ae66a1e81e379e65dd131341cd119cfcf2 (21.01.2012)-->
+<!--Based on English 5c8c939de7422db2427f37d5c26036138a9fe04e (03.02.2012)-->
 <strings>
   <string id="0">Programmi</string>
   <string id="1">Immagini</string>
@@ -1774,7 +1774,7 @@
   <string id="20326">Questo resetterà il valore di calibrazione per %s</string>
   <string id="20327">al suo valore originale.</string>
   <string id="20328">Cerca la destinazione</string>
-
+  <string id="20329">I film sono in cartelle separate che riportano il titolo del film</string>
   <string id="20330">Usa i nomi delle cartelle per le ricerche</string>
   <string id="20331">File</string>
   <string id="20332">Uso i nomi dei files o delle cartelle per le ricerche?</string>
@@ -1864,7 +1864,7 @@
   <string id="20416">Prima visione</string>
   <string id="20417">Scrittore</string>
   <string id="20418">Pulisci i nomi dei files e delle cartelle</string>
-  <string id="20419">Mostra i metadati nella vista files</string>
+  <string id="20419">Sostituisci i nomi dei files con i titoli presenti nella libreria</string>
 
   <string id="20420">Mai</string>
   <string id="20421">Se solo una stagione</string>
@@ -1903,7 +1903,8 @@
   <string id="20454">In Ascolto</string>
   <string id="20455">In Ascolto</string>
   <string id="20456">Imposta l'immagine fanart per un set di filmati</string>
-  <string id="20457">imposta filmato</string>
+  <string id="20457">Set di film</string>
+  <string id="20458">Raggruppa i film in set</string>
   <!-- up to 21329 is reserved for the video db !! !-->
 
   <string id="21330">Mostra i files e le cartelle nascoste</string>

--- a/language/Polish/strings.xml
+++ b/language/Polish/strings.xml
@@ -2,7 +2,7 @@
 <!--Language file translated with Team XBMC Translator-->
 <!--Translator: Rafał Wójcik-->
 <!--Email: rafal.wojcik@gmail.com-->
-<!--Date of translation: 12/25/2011-->
+<!--Date of translation: 02/14/2012-->
 <!--$Revision$-->
 <strings>
   <string id="0">Programy</string>
@@ -1572,6 +1572,7 @@
   <string id="20326">Spowoduje to reset ustawień kalibracji dla %s</string>
   <string id="20327">i zostaną przywrócone wartości domyślne.</string>
   <string id="20328">Wskaż katalog docelowy</string>
+  <string id="20329">Filmy są w oddzielnych katalogach, z nazwami tytułu filmu</string>
   <string id="20330">Nazwa folderu jako podstawa szukania</string>
   <string id="20331">Plik</string>
   <string id="20332">Użyć nazwy pliku lub folderu jako podstawy szukania?</string>
@@ -1698,6 +1699,7 @@
   <string id="20455">Słuchaczy</string>
   <string id="20456">Ustaw fanart dla kolekcji filmów</string>
   <string id="20457">Kolekcja filmów</string>
+  <string id="20458">Grupuj filmy w kolekcje</string>
   <string id="21330">Pokazuj ukryte pliki i foldery</string>
   <string id="21331">Klient TuxBox</string>
   <string id="21332">UWAGA: Urządzenie TuxBox jest w trybie nagrywania!</string>
@@ -1796,6 +1798,8 @@
   <string id="21451">Wymagane połączenie z Internetem.</string>
   <string id="21452">Pobierz więcej...</string>
   <string id="21453">Główny system plików</string>
+  <string id="21454">Pełny bufor</string>
+  <string id="21455">Bufor wypełniany zanim osiągnie wymagany poziom do ciągłego odtwarzania</string>
   <string id="21460">Położenie napisów</string>
   <string id="21461">Stałe</string>
   <string id="21462">Dół wideo</string>
@@ -2079,9 +2083,16 @@
   <string id="33101">Serwer WWW</string>
   <string id="33102">Serwer zdarzeń</string>
   <string id="33103">Serwer zdalnej komunikacji</string>
+  <string id="33200">Wykryto nowe połączenie</string>
   <string id="34100">System głośników</string>
   <string id="34201">Nie mogę znaleźć następnej pozycji do odtworzenia</string>
   <string id="34202">Nie mogę znaleźć poprzedniej pozycji do odtworzenia</string>
+  <string id="34300">Błąd podczas startu zeroconf</string>
+  <string id="34301">Usługa Apple Bonjour jest zainstalowana? Sprawdź log.</string>
+  <string id="34400">Rendering wideo</string>
+  <string id="34401">Błąd inicjalizacji filtrów/skalerów wideo, powracam do skalowania bilinearnego</string>
+  <string id="34402">Błąd inicjalizacji urządzenia audio</string>
+  <string id="34403">Sprawdź ustawienia dźwięku</string>
   <string id="35000">Peryferia</string>
   <string id="35001">Standardowe urządzenie HID</string>
   <string id="35002">Standardowy adapter sieciowy</string>
@@ -2089,7 +2100,13 @@
   <string id="35004">To urządzenie nie ma ustawień.</string>
   <string id="35005">Skonfigurowano nowe urządzenie</string>
   <string id="35006">Usunięto urządzenie</string>
+  <string id="35007">Mapa klawiszy do użycia z tym urządzeniem</string>
+  <string id="35008">Mapa klawiszy włączona</string>
   <string id="35500">Położenie</string>
+  <string id="35501">Klasa</string>
+  <string id="35502">Nazwa</string>
+  <string id="35503">Dostawca</string>
+  <string id="35504">ID produktu</string>
   <string id="36000">Adapter Pulse-Eight CEC</string>
   <string id="36006">Nie mogę połączyć się z adapterem</string>
   <string id="36007">Włącz TV, kiedy uruchomiany jest XBMC</string>

--- a/language/Portuguese (Brazil)/strings.xml
+++ b/language/Portuguese (Brazil)/strings.xml
@@ -2,11 +2,10 @@
 <!--Language file translated with Team XBMC Translator[wm] -->
 <!--Translator: Fabiano Santiago (fabianosan), bugre (wm) -->
 <!--Email: fabianosan@hotmail.com, wxxx333-nospam-at-gmail.com -->
-<!--Date of translation: 12/21/2009 -->
+<!--Updated on 15/02/2012 by wcampos -->
 <!--Updated on 28/08/2011 by fabianosan -->
 <!--Updated on 15/11/2010 by bugre -->
-<!--$Revision$-->
-<!--Based on english strings version 35193-->
+<!--Based on English 5c8c939de7422db2427f37d5c26036138a9fe04e (03.02.2012)-->
 <strings>
   <string id="0">Programas</string>
   <string id="1">Imagens</string>
@@ -18,6 +17,7 @@
   <string id="7">Arquivos</string>
   <string id="8">Tempo</string>
   <string id="9">xbmc media center</string>
+
   <string id="11">Segunda</string>
   <string id="12">Terça</string>
   <string id="13">Quarta</string>
@@ -25,6 +25,7 @@
   <string id="15">Sexta</string>
   <string id="16">Sábado</string>
   <string id="17">Domingo</string>
+
   <string id="21">Janeiro</string>
   <string id="22">Fevereiro</string>
   <string id="23">Março</string>
@@ -37,6 +38,7 @@
   <string id="30">Outubro</string>
   <string id="31">Novembro</string>
   <string id="32">Dezembro</string>
+
   <string id="41">Seg</string>
   <string id="42">Ter</string>
   <string id="43">Qua</string>
@@ -56,6 +58,7 @@
   <string id="60">Out</string>
   <string id="61">Nov</string>
   <string id="62">Dez</string>
+
   <string id="71">N</string>
   <string id="72">NNE</string>
   <string id="73">NO</string>
@@ -73,6 +76,7 @@
   <string id="85">NL</string>
   <string id="86">NNL</string>
   <string id="87">VAR</string>
+
   <string id="98">Ver: Auto</string>
   <string id="99">Ver: Auto grande</string>
   <string id="100">Ver: Icones</string>
@@ -142,13 +146,18 @@
   <string id="164">Sem disco</string>
   <string id="165">Disco presente</string>
   <string id="166">Skin</string>
+
   <string id="169">Resolução</string>
   <string id="170">Ajustar taxa de atualização para mesma da tela</string>
+
   <string id="171"></string>
+
   <string id="172">Data de lançamento:</string>
   <string id="173">Exibir videos 4:3 como</string>
+
   <string id="175">Modos</string>
   <string id="176">Estilos</string>
+
   <string id="179">Música</string>
   <string id="180">Duração</string>
   <string id="181">Selecionar álbum</string>
@@ -170,8 +179,10 @@
   <string id="197">Procurando informação de %s</string>
   <string id="198">Carregando detalhes do filme</string>
   <string id="199">Interface web</string>
+
   <string id="202">Título:</string>
   <string id="203">Sinopse:</string>
+
   <string id="205">Votos</string>
   <string id="206">Elenco</string>
   <string id="207">Enredo</string>
@@ -209,6 +220,7 @@
   <string id="243">Taxa de Atualização</string>
   <string id="244">Tela Cheia</string>
   <string id="245">Dimensionando: (%i,%i)-&gt;(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1)</string>
+
   <string id="247">Scripts</string>
   <string id="248">Idioma</string>
   <string id="249">Música</string>
@@ -247,6 +259,7 @@
   <string id="282">Encontrado(s) %i item(s)</string>
   <string id="283">Resultado(s) da busca</string>
   <string id="284">Nenhum resultado encontrado</string>
+
   <string id="287">Legendas</string>
   <string id="288">Fonte</string>
   <string id="289">- Tamanho</string>
@@ -266,6 +279,7 @@
   <string id="304">Idioma</string>
   <string id="305">Ativado</string>
   <string id="306">Não-intercalado</string>
+
   <string id="312">(0=auto)</string>
   <string id="313">Excluindo banco de dados</string>
   <string id="314">Preparando...</string>
@@ -358,6 +372,7 @@
   <string id="404">Vento</string>
   <string id="405">Pt. de orvalho</string>
   <string id="406">Umidade</string>
+
   <string id="409">Padrões</string>
   <string id="410">Acessando o serviço de meteorologia</string>
   <string id="411">Obtendo informações de tempo para:</string>
@@ -370,6 +385,7 @@
   <string id="418">Baixo</string>
   <string id="419">Alto</string>
   <string id="420">HDMI</string>
+
   <string id="422">Excluir informações do álbum</string>
   <string id="423">Excluir informações do CD</string>
   <string id="424">Selecionar</string>
@@ -383,6 +399,7 @@
   <string id="432">Excluir filme da coleção</string>
   <string id="433">Deseja excluir '%s'?</string>
   <string id="434">De %s até %i %s</string>
+
   <string id="437">Disco removível</string>
   <string id="438">Abrindo arquivo</string>
   <string id="439">Cache</string>
@@ -426,6 +443,7 @@
   <string id="480">Aparência</string>
   <string id="481">Opções de Áudio</string>
   <string id="482">Sobre o XBMC</string>
+
   <string id="485">Excluir álbum</string>
   <string id="486">Repetir</string>
   <string id="487">Repetir uma</string>
@@ -453,9 +471,11 @@
   <string id="513">Janela principal</string>
   <string id="514">Configurações manuais</string>
   <string id="515">Gênero</string>
+
   <string id="517">Álbuns reproduzidos recentemente</string>
   <string id="518">Iniciar</string>
   <string id="519">Iniciar em..</string>
+
   <string id="521">Compilações</string>
   <string id="522">Remover origem</string>
   <string id="523">Trocar mídia</string>
@@ -484,6 +504,7 @@
   <string id="546">Dispositivo de saída de passagem</string>
   <string id="547">Sem biografia para este artista</string>
   <string id="548">Converter áudio multicanal para estéreo</string>
+
   <string id="550">Ordenar por: %s</string>
   <string id="551">Nome</string>
   <string id="552">Data</string>
@@ -530,12 +551,14 @@
   <string id="595">Repetir: desl.</string>
   <string id="596">Repetir: uma</string>
   <string id="597">Repetir: todos</string>
+
   <string id="600">Extrair CD de áudio</string>
   <string id="601">Média</string>
   <string id="602">Padrão</string>
   <string id="603">Extrema</string>
   <string id="604">Taxa de bits constante</string>
   <string id="605">Extraindo...</string>
+
   <string id="607">Para:</string>
   <string id="608">Não foi possível extrair o CD ou faixa</string>
   <string id="609">CDDARipPath não foi definido.</string>
@@ -543,6 +566,7 @@
   <string id="611">Digite número</string>
   <string id="612">Bits/Amostra</string>
   <string id="613">Frequencia de amostra</string>
+
   <string id="620">CDs de áudio</string>
   <string id="621">Codificador</string>
   <string id="622">Qualidade</string>
@@ -580,24 +604,30 @@
   <string id="657">Busca pasta</string>
   <string id="658">Informação da música</string>
   <string id="659">Expansão não-linear</string>
+
   <string id="660">Amplificação de volume</string>
   <string id="661">Pasta de exportação</string>
   <string id="662">Este arquivo não está mais disponível.</string>
   <string id="663">Gostaria de remover da coleção?</string>
   <string id="664">Busca Script</string>
   <string id="665">Nível de Compressão</string>
+
   <string id="700">Limpando a coleção</string>
   <string id="701">Removendo músicas antigas da coleção</string>
   <string id="702">Este caminho já foi examinado anteriormente</string>
   <string id="705">Rede</string>
   <string id="706">- Servidor</string>
+
   <string id="708">Ativar proxy HTTP</string>
+
   <string id="711">Internet Protocol (IP)</string>
   <string id="712">Porta inválida. O valor deve ser entre 1 e 65535.</string>
   <string id="713">Proxy HTTP</string>
+
   <string id="715">- Atribuição</string>
   <string id="716">Automático (DHCP)</string>
   <string id="717">Manual (estático)</string>
+
   <string id="719">- Endereço IP:</string>
   <string id="720">- Máscara de sub-rede:</string>
   <string id="721">- Gateway padrão:</string>
@@ -608,7 +638,9 @@
   <string id="726">As mudanças não foram salvas. Deseja continuar mesmo assim?</string>
   <string id="727">Servidor Web</string>
   <string id="728">Servidor FTP</string>
+
   <string id="730">- Porta</string>
+
   <string id="732">Salvar &amp; aplicar</string>
   <string id="733">- Senha</string>
   <string id="734">Sem senha</string>
@@ -629,10 +661,12 @@
   <string id="749">Espelhar imagem</string>
   <string id="750">Tem certeza?</string>
   <string id="751">Removendo origem</string>
+
   <string id="754">Adicionar link de programa</string>
   <string id="755">Editar caminho do programa</string>
   <string id="756">Editar nome do programa</string>
   <string id="757">Editar a profundidade do caminho</string>
+
   <string id="759">Ver: lista grande</string>
   <string id="760">Amarelo</string>
   <string id="761">Branco</string>
@@ -642,7 +676,9 @@
   <string id="765">Ciano</string>
   <string id="766">Cinza claro</string>
   <string id="767">Cinza</string>
+
   <string id="770">Erro %i: compartilhamento não disponível</string>
+
   <string id="772">Saída de áudio</string>
   <string id="773">Procurando</string>
   <string id="774">Pasta de apresentação (slideshow)</string>
@@ -661,6 +697,7 @@
   <string id="787">Interface de rede desabilitada</string>
   <string id="788">Interface de rede desabilitada com sucesso.</string>
   <string id="789">Nome da rede sem fio (ESSID)</string>
+
   <string id="791">Permitir programas locais controlar o XBMC</string>
   <string id="792">Porta</string>
   <string id="793">Intervalo de portas</string>
@@ -669,14 +706,19 @@
   <string id="796">Atraso de repetição contínuo (ms)</string>
   <string id="797">Número máximo de clientes</string>
   <string id="798">Acesso internet</string>
+
   <string id="850">Número de porta inválido</string>
   <string id="851">Intervalor de portas válido 1-65535</string>
   <string id="852">Intervalor de portas válido 1024-65535</string>
+
+  <string id="998">Adicione Música...</string>
+  <string id="999">Adicione Vídeos...</string>
   <string id="1000">- Previsualização</string>
   <string id="1001">Incapaz de conectar</string>
   <string id="1002">O XBMC foi incapaz de conectar ao local de rede</string>
   <string id="1003">Isto pode ser devido a rede não estar conectada.</string>
   <string id="1004">Gostaria de adicionar assim mesmo?</string>
+
   <string id="1006">Endereço IP</string>
   <string id="1007">Adicionar Local de rede</string>
   <string id="1008">Protocolo</string>
@@ -723,12 +765,15 @@
   <string id="1049">Opções do Script</string>
   <string id="1050">Singles</string>
   <string id="1051">Digite a URL</string>
+
   <string id="1200">Cliente SMB</string>
   <string id="1202">Grupo de trabalho</string>
   <string id="1203">Usuário padrão</string>
   <string id="1204">Senha padrão</string>
+
   <string id="1207">Servidor WINS</string>
   <string id="1208">Montar compartilhamento SMB</string>
+
   <string id="1210">Remover</string>
   <string id="1211">Música</string>
   <string id="1212">Vídeo</string>
@@ -753,16 +798,24 @@
   <string id="1233">Programas &amp; vídeo &amp; música</string>
   <string id="1234">Programas &amp; imagens &amp; música</string>
   <string id="1235">Programas &amp; imagens &amp; vídeo</string>
+
   <string id="1250">Auto detecção</string>
   <string id="1251">Auto detectar sistemas</string>
   <string id="1252">Apelido</string>
+
   <string id="1254">Perguntar para conectar</string>
   <string id="1255">Enviar usuário e senha de FTP</string>
   <string id="1256">Intervalo de ping</string>
   <string id="1257">Gostaria de conectar ao sistema auto detectado?</string>
+
   <string id="1260">Anunciar estes serviços para outros sistemas via Zeroconf</string>
+  <string id="1270">Permitir ao XBMC receber contéudo AirPlay</string>
+  <string id="1271">Nome Equipamento</string>
+  <string id="1272">- Usar senha para proteção</string>
+
   <string id="1300">Dispositivo de áudio personalizado</string>
   <string id="1301">Dispositivo de passagem personalizado</string>
+
   <string id="1396">Correntes de ar</string>
   <string id="1397">e</string>
   <string id="1398">Congelando</string>
@@ -791,11 +844,16 @@
   <string id="1421">Muito Alto</string>
   <string id="1422">Ventoso</string>
   <string id="1423">Névoa</string>
+
   <string id="1450">Colocar tela em descanso quando inativo</string>
+
   <string id="2050">Executável</string>
+
   <string id="2100">Falha no Script! : %s</string>
   <string id="2101">Necessário versão mais nova - Veja o log</string>
+
   <string id="4501">Habilitar LCD/VFD</string>
+
   <string id="10000">Home</string>
   <string id="10001">Programas</string>
   <string id="10002">Imagens</string>
@@ -818,15 +876,19 @@
   <string id="10019">Configurações - Aparência</string>
   <string id="10020">Scripts</string>
   <string id="10021">Navegador Web</string>
+
   <string id="10028">Vídeos/lista de reprodução</string>
   <string id="10034">Configurações - Perfil</string>
+
   <string id="10100">Janela sim/não</string>
   <string id="10101">Janela de progresso</string>
+
   <string id="10210">Procurando legendas...</string>
   <string id="10211">Procurando ou armazenando legendas</string>
   <string id="10212">terminando</string>
   <string id="10213">carregando</string>
   <string id="10214">Abrindo sinal</string>
+
   <string id="10500">Música/lista de reprodução</string>
   <string id="10501">Música/arquivos</string>
   <string id="10502">Música/coleção</string>
@@ -834,16 +896,20 @@
   <string id="10504">As 100 melhores músicas</string>
   <string id="10505">Os 100 melhores álbuns</string>
   <string id="10506">Programas</string>
+
   <string id="10507">Configurações</string>
   <string id="10508">Previsão do tempo</string>
   <string id="10509">Jogos em rede</string>
   <string id="10510">Extensões</string>
   <string id="10511">Informações do sistema</string>
+
   <string id="10516">Músicas - Coleção</string>
   <string id="10517">Tocando agora - Músicas</string>
+
   <string id="10522">Tocando agora - Vídeos</string>
   <string id="10523">Informação do álbum</string>
   <string id="10524">Informação do filme</string>
+
   <string id="12000">Selec. janela</string>
   <string id="12001">Música/informação</string>
   <string id="12002">Janela OK</string>
@@ -851,12 +917,15 @@
   <string id="12004">Scripts/informação</string>
   <string id="12005">Vídeo em tela-cheia</string>
   <string id="12006">Visualização de áudio</string>
+
   <string id="12008">Janela agrupamento de arquivos</string>
   <string id="12009">Reconstruindo índice...</string>
   <string id="12010">Voltar para janela de músicas</string>
   <string id="12011">Voltar para janela de vídeos</string>
+
   <string id="12021">Iniciar/Reiniciar</string>
   <string id="12022">Retomar da posição %s</string>
+
   <string id="12310">0</string>
   <string id="12311">1</string>
   <string id="12312">2</string>
@@ -906,24 +975,31 @@
   <string id="12377">Isto irá zerar qualquer valor previamente salvo</string>
   <string id="12378">Exibir cada imagem por</string>
   <string id="12379">Usar efeitos de pan e zoom</string>
+
   <string id="12383">relógio 12 horas</string>
   <string id="12384">relógio 24 horas</string>
   <string id="12385">Dia/Mês</string>
   <string id="12386">Mês/Dia</string>
+
   <string id="12390">Uptime do sistema</string>
   <string id="12391">Minutos</string>
   <string id="12392">Horas</string>
   <string id="12393">Dias</string>
   <string id="12394">Uptime total</string>
+  <string id="12395">Nível Bateria</string>
+
   <string id="12600">Tempo</string>
+
   <string id="12900">Proteção de tela</string>
   <string id="12901">OSD em tela-cheia</string>
+
   <string id="13000">Sistema</string>
   <string id="13001">Diminuir rotação do HD</string>
   <string id="13002">Somente vídeos</string>
   <string id="13003">- Atraso</string>
   <string id="13004">- Tempo mínimo de duração</string>
   <string id="13005">Desligar</string>
+
   <string id="13008">Modo de desligamento</string>
   <string id="13009">Terminar</string>
   <string id="13010">Hibernar</string>
@@ -933,15 +1009,19 @@
   <string id="13014">Minimizar</string>
   <string id="13015">Ação do botão de Liga/Desliga</string>
   <string id="13016">Desligar o sistema</string>
+
   <string id="13020">Tem outra sessão ativa, talvez por ssh?</string>
   <string id="13021">Disco rígido removível montado</string>
   <string id="13022">Remoção insegura de dispositivo</string>
   <string id="13023">Dispositivo removido com sucesso</string>
   <string id="13024">Joystick conectado</string>
   <string id="13025">Joystick desconectado</string>
+
   <string id="13050">Bateria fraca</string>
+
   <string id="13100">Filtro de anti-oscilação</string>
   <string id="13101">Deixe driver escolher (necessita reinicializar)</string>
+
   <string id="13105">Sincronização vertical</string>
   <string id="13106">Desabilitado</string>
   <string id="13107">Habilitado durante execução de vídeo</string>
@@ -949,10 +1029,12 @@
   <string id="13109">Testar e aplicar resolução</string>
   <string id="13110">Salvar resolução?</string>
   <string id="13111">Manter esta resolução?</string>
+
   <string id="13112">Aumento de resolução em alta qualidade</string>
   <string id="13113">Desabilitado</string>
   <string id="13114">Habilitado para conteúdo SD</string>
   <string id="13115">Sempre habilitado</string>
+
   <string id="13116">Método de aumento de resolução</string>
   <string id="13117">Bicúbico</string>
   <string id="13118">Lanczos</string>
@@ -960,30 +1042,38 @@
   <string id="13120">VDPAU</string>
   <string id="13121">Nível VDPAU HQ Upscaling</string>
   <string id="13122">Nível de conversão de cores VDPAU Studio</string>
+
   <string id="13130">Escurecer outras telas</string>
   <string id="13131">Desabilitado</string>
   <string id="13132">Limpar telas</string>
+
   <string id="13140">Detectadas coneções ativas!</string>
   <string id="13141">Se continuar, poderá perder o controle do XBMC</string>
   <string id="13142">Tem certeza que quer parar o servidor de Eventos?</string>
+
   <string id="13144">Trocar o modo "Apple Remote"?</string>
   <string id="13145">Se está utilizando o "Apple Remote" agora para controlar</string>
   <string id="13146">XBMC, trocar esta configuração pode afetar sua habilidade</string>
   <string id="13147">de continuar controlando ele. Você deseja prosseguir?</string>
+
   <string id="13159">Máscara de sub-rede</string>
   <string id="13160">Gateway</string>
   <string id="13161">DNS primário</string>
   <string id="13162">Falha na inicialização</string>
+
   <string id="13170">Nunca</string>
   <string id="13171">Imediatamente</string>
   <string id="13172">Depois de %i segs</string>
   <string id="13173">Data de instalação do HDD:</string>
   <string id="13174">Re-ligamentos do HDD:</string>
+
   <string id="13200">Perfis</string>
   <string id="13201">Excluir perfil '%s'?</string>
+
   <string id="13204">Último perfil utilizado:</string>
   <string id="13205">Desconhecido</string>
   <string id="13206">Sobrescrever</string>
+
   <string id="13208">Alarme do relógio</string>
   <string id="13209">Intervalo do alarme (em minutos)</string>
   <string id="13210">Iniciado, alarmar em %im</string>
@@ -991,13 +1081,16 @@
   <string id="13212">Cancelado restando %im%is</string>
   <string id="13213">%2.0fm</string>
   <string id="13214">%2.0fs</string>
+
   <string id="13249">Procurar por legendas em RARs</string>
   <string id="13250">Buscar por legendas...</string>
   <string id="13251">Mover item</string>
   <string id="13252">Mover item aqui</string>
   <string id="13253">Cancelar mover</string>
+
   <string id="13270">Hardware: </string>
   <string id="13271">Uso da CPU:</string>
+
   <string id="13274">Conectado, mas nenhum DNS disponível.</string>
   <string id="13275">Disco rígido</string>
   <string id="13276">DVD-ROM</string>
@@ -1006,15 +1099,20 @@
   <string id="13279">Rede</string>
   <string id="13280">Vídeo</string>
   <string id="13281">Hardware</string>
+
   <string id="13283">Sistema Operacional:</string>
   <string id="13284">Velocidade da CPU:</string>
+
   <string id="13286">Encoder de vídeo:</string>
   <string id="13287">Resolução de tela:</string>
+
   <string id="13292">Cabo A/V:</string>
+
   <string id="13294">Região do DVD:</string>
   <string id="13295">Internet:</string>
   <string id="13296">Conectado</string>
   <string id="13297">Desconectado. Verifique as opções de rede.</string>
+
   <string id="13299">Temperatura desejada:</string>
   <string id="13300">Velocidade do ventilador</string>
   <string id="13301">Controle automático de temperatura</string>
@@ -1053,6 +1151,7 @@
   <string id="13334">Editar etiqueta</string>
   <string id="13335">Tornar padrão</string>
   <string id="13336">Remover botão</string>
+
   <string id="13340">Deixar como está</string>
   <string id="13341">Verde</string>
   <string id="13342">Laranja</string>
@@ -1075,6 +1174,7 @@
   <string id="13359">Definir ícone do artista</string>
   <string id="13360">Gerar ícones automaticamente</string>
   <string id="13361">Ativar voz</string>
+
   <string id="13375">Ativar dispositivo</string>
   <string id="13376">Volume</string>
   <string id="13377">Modo de visualização padrão</string>
@@ -1132,6 +1232,7 @@
   <string id="13430">Permitir aceleração por hardware (OpenMax)</string>
   <string id="13431">Pixel Shaders</string>
   <string id="13432">Permitir aceleração por hardware (VideoToolbox)</string>
+
   <string id="13500">Método de syncronização de A/V</string>
   <string id="13501">Relógio de áudio</string>
   <string id="13502">Relógio de vídeo (cortar/ignorar áudio)</string>
@@ -1143,19 +1244,25 @@
   <string id="13508">Alto</string>
   <string id="13509">Realmente alto(lento!)</string>
   <string id="13510">Sincronizar reprodução com a exibição</string>
+
   <string id="13550">Pausa durante alteração na taxa de atualização</string>
   <string id="13551">Desligado</string>
   <string id="13552">%.1f Segundo</string>
   <string id="13553">%.1f Segundos</string>
+
   <string id="13600">Controle Remoto Apple</string>
+
   <string id="13602">Permite iniciar o XBMC através do Controle Remoto</string>
   <string id="13603">Tempo de espera para sequenciamento</string>
+
   <string id="13610">Desabilitado</string>
   <string id="13611">Padrão</string>
   <string id="13612">Controle Remoto Universal</string>
   <string id="13613">Controle Remoto universal (Harmony)</string>
+
   <string id="13620">Erro Controle Remoto Apple</string>
   <string id="13621">Suporte ao Controle Remoto Apple pode ser habilitado.</string>
+
   <string id="14000">Agrupar</string>
   <string id="14001">Desagrupar</string>
   <string id="14003">Baixando lista de execução...</string>
@@ -1163,6 +1270,7 @@
   <string id="14005">Interpretando lista de canais...</string>
   <string id="14006">Recebimento da lista de canais falhou</string>
   <string id="14007">Recebimento de lista de execução falhou</string>
+
   <string id="14009">Diretório de jogos</string>
   <string id="14010">Troca automática para ícones baseado em</string>
   <string id="14011">Ativar troca automática para ícones</string>
@@ -1189,10 +1297,12 @@
   <string id="14034">Cache do DVD - DVD-ROM</string>
   <string id="14035">- Rede local</string>
   <string id="14036">Serviços</string>
+
   <string id="14038">Configurações de rede modificadas</string>
   <string id="14039">O XBMC precisa reiniciar para aplicar as suas</string>
   <string id="14040">configurações de rede.  Deseja reiniciar agora?</string>
   <string id="14041">Limitação de banda de Internet</string>
+
   <string id="14043">- Desligar durante a execução</string>
   <string id="14044">%i mins</string>
   <string id="14045">%i segs</string>
@@ -1204,6 +1314,7 @@
   <string id="14051">Formato da hora</string>
   <string id="14052">Formato da data</string>
   <string id="14053">Filtros de interface</string>
+
   <string id="14055">Usar busca em segundo plano</string>
   <string id="14056">Parar busca</string>
   <string id="14057">Impossível enquanto estiver buscando informações da mídia</string>
@@ -1221,6 +1332,7 @@
   <string id="14069">Aplicar as configurações agora?</string>
   <string id="14070">Aplicar mudanças agora</string>
   <string id="14071">Permitir renomear e excluir arquivos</string>
+
   <string id="14074">Selecionar fuso horário</string>
   <string id="14075">Ajustar para horário de verão</string>
   <string id="14076">Adicionar a favoritos</string>
@@ -1243,21 +1355,27 @@
   <string id="14093">Segurança</string>
   <string id="14094">Disp. de Entrada</string>
   <string id="14095">Econ. de energia</string>
+
   <string id="15015">Remove</string>
   <string id="15016">Jogos</string>
+
   <string id="15019">Adicionar</string>
+
   <string id="15052">Senha</string>
+
   <string id="15100">Coleção</string>
   <string id="15101">Banco de dados</string>
   <string id="15102">* Todos álbuns</string>
   <string id="15103">* Todos artistas</string>
   <string id="15104">* Todas as músicas</string>
   <string id="15105">* Todos gêneros</string>
+
   <string id="15107">Carregando...</string>
   <string id="15108">Sons de navegação</string>
   <string id="15109">Skin padrão</string>
   <string id="15111">- Tema</string>
   <string id="15112">Tema padrão</string>
+
   <string id="15200">Last.fm</string>
   <string id="15201">Enviar músicas para o Last.fm</string>
   <string id="15202">Nome de usuário Last.fm</string>
@@ -1280,6 +1398,7 @@
   <string id="15219">Senha do Libre.fm</string>
   <string id="15220">Libre.fm</string>
   <string id="15221">Scrobbler</string>
+
   <string id="15250">Enviar a rádio para o Last.fm</string>
   <string id="15251">Conectando ao Last.fm...</string>
   <string id="15252">Selecionando estação...</string>
@@ -1316,7 +1435,7 @@
   <string id="15283">Faixas ouvidas recentemente por %name%</string>
   <string id="15284">Ouça recomendações de %name%'s no Last.fm</string>
   <string id="15285">Melhores gêneros para usuário %name%</string>
-  <string id="15286">Ouvir lista de reprodução de %name%'s do Last.fm</string>
+
   <string id="15287">Você quer adicionar a faixa atual para as suas faixas prediletas?</string>
   <string id="15288">Você quer banir a faixa atual?</string>
   <string id="15289">Adicionado às suas faixas prediletas: '%s'.</string>
@@ -1329,16 +1448,21 @@
   <string id="15296">Desbanir</string>
   <string id="15297">Você quer remover esta faixa de suas faixas prediletas?</string>
   <string id="15298">Você quer desbanir esta faixa?</string>
+
   <string id="15300">Caminho não encontrado ou inválido</string>
   <string id="15301">Não foi possível conectar ao servidor da rede</string>
   <string id="15302">Não encontrou servidores</string>
   <string id="15303">Grupo de trabalho não encontrado</string>
+
   <string id="15310">Abrindo múltiplos caminhos para os marcadores</string>
   <string id="15311">Caminho:</string>
+
   <string id="16000">Geral</string>
+
   <string id="16002">Busca na internet</string>
   <string id="16003">Reprodutor</string>
   <string id="16004">Reproduzir mídia do disco</string>
+
   <string id="16008">Digite um novo título</string>
   <string id="16009">Nome do filme</string>
   <string id="16010">Nome do perfil</string>
@@ -1368,12 +1492,19 @@
   <string id="16034">Não pôde obter músicas do banco de dados.</string>
   <string id="16035">Lista de execução em modo-festa</string>
   <string id="16036">De-interlace (Half)</string>
+  <string id="16037">Desentrelaçamento video</string>
+  <string id="16038">Método de Desentrelaçamento</string>
+  <string id="16039">Desligado</string>
+  <string id="16040">Auto</string>
+  <string id="16041">Ligado</string>
+
   <string id="16100">Todos os vídeos</string>
   <string id="16101">Não-vistos </string>
   <string id="16102">Vistos</string>
   <string id="16103">Marcar como visto</string>
   <string id="16104">Marcar como não-visto</string>
   <string id="16105">Editar título</string>
+
   <string id="16200">Operação foi cancelada</string>
   <string id="16201">Cópia falhou</string>
   <string id="16202">Falha ao copiar pelo menos um arquivo</string>
@@ -1381,6 +1512,7 @@
   <string id="16204">Falha ao mover pelo menos um arquivo</string>
   <string id="16205">Remover falhou</string>
   <string id="16206">Falha ao remover pelo menos um arquivo</string>
+
   <string id="16300">Método para escalamento de vídeo</string>
   <string id="16301">Vizinho mais próximo</string>
   <string id="16302">Bilinear</string>
@@ -1401,21 +1533,29 @@
   <string id="16317">Temporal (Half)</string>
   <string id="16318">Temporal/Spatial (Half)</string>
   <string id="16319">DXVA</string>
+  <string id="16320">DXVA Bob</string>
+  <string id="16321">DXVA Best</string>
+  <string id="16322">Spline36</string>
+  <string id="16323">Spline36 otimizado</string>
+  <string id="16324">Software Blend</string>
+
   <string id="16400">Pós-processamento de video</string>
-  <string id="16401">Desabilitado</string>
-  <string id="16402">Ativar para Conteúdo SD</string>
-  <string id="16403">Sempre Ligado</string>
+ 
   <string id="17500">Exibir intervalo para descanso</string>
+
   <string id="19000">Trocar para canal</string>
+
   <string id="20000">Pasta de músicas salvas</string>
   <string id="20001">Usar DVD-player externo</string>
   <string id="20002">DVD-player externo</string>
   <string id="20003">Pasta de trainers</string>
   <string id="20004">Pasta para captura de tela</string>
+
   <string id="20006">Pasta lista de reprodução</string>
   <string id="20007">Gravações</string>
   <string id="20008">Screenshots</string>
   <string id="20009">Usar XBMC</string>
+
   <string id="20011">Lista de reprodução de músicas</string>
   <string id="20012">Lista de reprodução de vídeos</string>
   <string id="20013">Você gostaria de iniciar o jogo?</string>
@@ -1425,11 +1565,13 @@
   <string id="20017">Ícone local</string>
   <string id="20018">Nenhum ícone</string>
   <string id="20019">Selecionar ícone</string>
+
   <string id="20022"></string>
   <string id="20023">Conflito</string>
   <string id="20024">Examinar novo</string>
   <string id="20025">Examinar todos</string>
   <string id="20026">Região</string>
+
   <string id="20037">Resumo</string>
   <string id="20038">Bloquear seção de música</string>
   <string id="20039">Bloquear seção de vídeo</string>
@@ -1449,6 +1591,7 @@
   <string id="20053">Sair do modo-mestre</string>
   <string id="20054">Entrou no modo-mestre</string>
   <string id="20055">Ícone Allmusic.com</string>
+
   <string id="20057">Remover ícone</string>
   <string id="20058">Adicionar perfil...</string>
   <string id="20059">Obter informação para todos os álbuns</string>
@@ -1578,6 +1721,7 @@
   <string id="20184">Rotacionar imagens usando informação do EXIF</string>
   <string id="20185">Usar estilo de visualização poster para seriados</string>
   <string id="20186">Por favor aguarde</string>
+
   <string id="20189">Habilitar auto rolagem para enredo &amp; crítica</string>
   <string id="20190">Personalizado</string>
   <string id="20191">Habilitar registro de depuração</string>
@@ -1589,6 +1733,7 @@
   <string id="20197">Importar coleção de música</string>
   <string id="20198">Artista não encontrado!</string>
   <string id="20199">Erro ao baixar informação de artista</string>
+
   <string id="20250">Ativo! (vídeos)</string>
   <string id="20251">Misturando bebidas (vídeos)</string>
   <string id="20252">Enchendo os copos (vídeos)</string>
@@ -1598,24 +1743,33 @@
   <string id="20256">Cliente HTS Tvheadend</string>
   <string id="20257">Cliente VDR Streamdev</string>
   <string id="20258">Cliente MythTV</string>
+  <string id="20259">Sistema Arquivos Rede(NFS)</string>
+  <string id="20260">Secure Shell (SSH/SFTP)</string>
+  <string id="20261">Apple Filing Protocol (AFP)</string>
+
   <string id="20300">Diretório do servidor Web (HTTP)</string>
   <string id="20301">Diretório do servidor Web (HTTPS)</string>
   <string id="20302">Impossível gravar na pasta:</string>
   <string id="20303">Quer cancelar e prosseguir?</string>
   <string id="20304">Feed RSS</string>
+
   <string id="20307">DNS secundário</string>
   <string id="20308">Servidor DHCP:</string>
   <string id="20309">Criar nova pasta</string>
   <string id="20310">Escurecer LCD na reprodução</string>
   <string id="20311">Desconhecido ou onboard (protegido)</string>
   <string id="20312">Escurecer LCD na pausa</string>
+
   <string id="20314">Vídeos - Coleção</string>
+
   <string id="20316">Ordenar por: ID</string>
+
   <string id="20324">Reproduzir parte...</string>
   <string id="20325">Restaurar valores da calibração</string>
   <string id="20326">Isto irá restaurar os valores da calibração para %s</string>
   <string id="20327">para os valores padrões.</string>
   <string id="20328">Procurar destino</string>
+  <string id="20329">Filmes em pastas separadas que combinam com o título do filme</string>
   <string id="20330">Usar nomes de pastas para busca</string>
   <string id="20331">Arquivo</string>
   <string id="20332">Usar pasta ou nomes de arquivos em buscas?</string>
@@ -1690,6 +1844,7 @@
   <string id="20401">Reproduzir vídeo musical</string>
   <string id="20402">Baixar ícones de atores ao criar a coleção</string>
   <string id="20403">Selecionar ícone de ator</string>
+
   <string id="20405">Remover marcador do episódio</string>
   <string id="20406">Definir marcador do episódio</string>
   <string id="20407">Opções de scraper</string>
@@ -1704,6 +1859,8 @@
   <string id="20416">Primeira exibição</string>
   <string id="20417">Escritor</string>
   <string id="20418">Limpar nomes de arquivos e pastas</string>
+  <string id="20419">Substituir nome do arquivo pelo título da biblioteca</string>
+
   <string id="20420">Nunca</string>
   <string id="20421">Se só uma temporada</string>
   <string id="20422">Sempre</string>
@@ -1740,7 +1897,12 @@
   <string id="20453">episódios</string>
   <string id="20454">Ouvinte</string>
   <string id="20455">Ouvintes</string>
+  <string id="20456">Setar fanart coleções filmes</string>
+  <string id="20457">Conjunto de filmes</string>
+  <string id="20458">Agrupar filmes em conjuntos</string>
+
   <string id="21330">Exibir arquivos e diretórios ocultos</string>
+
   <string id="21331">Cliente TuxBox</string>
   <string id="21332">AVISO: dispositivo TuxBox está em modo de gravação!</string>
   <string id="21333">Este canal será interrompido!</string>
@@ -1748,12 +1910,16 @@
   <string id="21335">Tem certeza que deseja iniciar o canal?</string>
   <string id="21336">Conectando a: %s</string>
   <string id="21337">Dispositivo TuxBox</string>
+
   <string id="21359">Adicionar compartilhamento de mídia...</string>
   <string id="21360">Compartilhar coleções de vídeo e música através do UPnP</string>
+
   <string id="21364">Editar compartilhamento de mídia</string>
   <string id="21365">Remover compartilhamento de mídia</string>
   <string id="21366">Pasta de legendas</string>
   <string id="21367">Filme &amp; diretório de legenda alternativo</string>
+  <string id="21368">Substituir fontes da legendas em formato ASS/SSA</string>
+
   <string id="21369">Ativar mouse</string>
   <string id="21370">Permitir sons de navegação durante reprodução</string>
   <string id="21371">Ícone</string>
@@ -1839,6 +2005,9 @@
   <string id="21451">Necessário conexão com a Internet.</string>
   <string id="21452">Obter Mais</string>
   <string id="21453">Raiz</string>
+  <string id="21454">Cache cheio</string>
+  <string id="21455">Cache cheio antes de chegar a quantidade necessária para reprodução contínua</string>
+
 
   <string id="21460">Local da Legenda</string>
   <string id="21461">Fixado</string>
@@ -1856,6 +2025,7 @@
   <string id="21806">Comentário</string>
   <string id="21807">Colorido/B&amp;W</string>
   <string id="21808">Processamento JPEG</string>
+
   <string id="21820">Data/Hora</string>
   <string id="21821">Descrição</string>
   <string id="21822">Fabricante da câmera</string>
@@ -1880,6 +2050,7 @@
   <string id="21841">Longitude do GPS</string>
   <string id="21842">Altitude do GPS</string>
   <string id="21843">Orientação</string>
+
   <string id="21860">Categorias suplementares</string>
   <string id="21861">Palavras-chave</string>
   <string id="21862">Sub-título</string>
@@ -1921,9 +2092,11 @@
   <string id="21898">Anos de atividade</string>
   <string id="21899">Gravadora/marca</string>
   <string id="21900">Nascido/formado</string>
+
   <string id="22000">Atualizar coleção ao iniciar</string>
   <string id="22001">Ocultar progresso de atualizações de coleção</string>
   <string id="22002">- Sufixo de DNS</string>
+
   <string id="22003">%2.3fs</string>
   <string id="22004">Atrasado em: %2.3fs</string>
   <string id="22005">Adiantado em: %2.3fs</string>
@@ -1946,6 +2119,7 @@
   <string id="22022">Incluir arquivos de vídeo nas listagens</string>
   <string id="22023">Fabricante DirectX:</string>
   <string id="22024">Versão Direct3D:</string>
+
   <string id="22030">Fonte</string>
   <string id="22031">- Tamanho</string>
   <string id="22032">- Cores</string>
@@ -1960,24 +2134,30 @@
   <string id="22041">branco/vermelho</string>
   <string id="22042">branco/azul</string>
   <string id="22043">preto/branco</string>
+
   <string id="22079">Selecionar ação padrão</string>
   <string id="22080">Escolher</string>
   <string id="22081">Mostrar Informação</string>
   <string id="22082">Mais...</string>
   <string id="22083">Tocar Tudo</string>
+
   <string id="23049">Teletext indisponível</string>
   <string id="23050">Ativar Teletext</string>
   <string id="23051">Parte %i</string>
   <string id="23052">Acumulando %i bytes</string>
   <string id="23053">Parando</string>
   <string id="23054">Executando</string>
+
   <string id="23100">Player externo ativo</string>
   <string id="23101">Clique OK para sair do player</string>
+
   <string id="23104">Clique OK quando execução tiver terminado</string>
+
   <string id="24000">Add-on</string>
   <string id="24001">Add-ons</string>
   <string id="24002">Opções Add-on</string>
   <string id="24003">Informação do Add-on</string>
+
   <string id="24005">Locais de Midia</string>
   <string id="24007">Informação do Filme</string>
   <string id="24008">Proteção de Tela</string>
@@ -2034,28 +2214,33 @@
   <string id="24067">Baixando Add-ons</string>
   <string id="24068">Atualização Disponível</string>
   <string id="24069">Atualizar</string>
+
   <string id="24070">Add-on não utilizado</string>
   <string id="24071">Ocorreu um erro desconhecido</string>
   <string id="24072">Necessário configurações</string>
   <string id="24073">Não é possível conectar</string>
   <string id="24074">Necessário reiniciar</string>
   <string id="24075">Desativar</string>
+  <string id="24076">Add-on Necessário</string>
   <string id="24080">Reconectar?</string>
   <string id="24089">Add-on reiniciado</string>
   <string id="24090">Bloquear Gerenciador de Add-on</string>
+
   <string id="24091"></string>
   <string id="24092"></string>
   <string id="24093"></string>
-  <string id="24094"></string>
-  <string id="24095"></string>
+  <string id="24094">(atual)</string>
+  <string id="24095">(na lista negra)</string>
   <string id="24096">O Add-on foi marcado como indisponível no repositório.</string>
   <string id="24097">Você deseja desabilitar em seu sistema?</string>
   <string id="24098">Indisponível</string>
   <string id="24099">Gostaria de trocar para esta skin?</string>
   <string id="25000">Notificações</string>
+
   <string id="29800">Modo de coleção</string>
   <string id="29801">Teclado QWERTY</string>
   <string id="29802">Utilizando áudio em passthrough</string>
+
   <string id="33001">Qualidade do trailer</string>
   <string id="33002">Canal/sinal</string>
   <string id="33003">Baixar</string>
@@ -2134,5 +2319,66 @@
   <string id="33102">Servidor de Eventos</string>
   <string id="33103">Servidor de Comunicação Remota</string>
 
+  <string id="33200">Detectado Nova Conexão</string>
+
   <string id="34100">Configurar alto-falantes</string>
+  <string id="34101">2.0</string>
+  <string id="34102">2.1</string>
+  <string id="34103">3.0</string>
+  <string id="34104">3.1</string>
+  <string id="34105">4.0</string>
+  <string id="34106">4.1</string>
+  <string id="34107">5.0</string>
+  <string id="34108">5.1</string>
+  <string id="34109">7.0</string>
+  <string id="34110">7.1</string>
+  <!-- 34112-34200 reserved for future use -->
+
+  <string id="34201">Não foi possível encontrar um item posterior para tocar</string>
+  <string id="34202">Não foi possível encontrar um item anterior para tocar</string>
+
+  <string id="34300">Falha ao iniciar zeroconf</string>
+  <string id="34301">Se serviço Apple's Bonjour estiver instalado? Veja log para maiores informações.</string>
+
+  <string id="34400">Renderização de Video</string>
+  <string id="34401">Falha para inciar filtros e scalers de vídeo, voltando a usar bilinear scaling</string>
+  <string id="34402">Falha para inicializar o dispositivo de áudio</string>
+  <string id="34403">Verifique suas configurações de áudio</string>
+
+  <string id="35000">Periféricos</string>
+
+  <string id="35001">Disposito HID Genérico</string>
+  <string id="35002">Adaptador de Rede Genérico</string>
+  <string id="35003">Disco Genérico</string>
+  <string id="35004">Não existe ajustes disponíveis&#10;para este periférico.</string>
+  <string id="35005">Novo dispositivo configurado</string>
+  <string id="35006">Dispositivo removido</string>
+  <string id="35007">Keymap para uso com este dispositivo</string>
+  <string id="35008">Keymap ativado</string>
+
+  <string id="35500">Local</string>
+  <string id="35501">Classe</string>
+  <string id="35502">Nome</string>
+  <string id="35503">Fabricante</string>
+  <string id="35504">Produto ID</string>
+
+  <string id="36000">Adaptador CEC Pulse-Eight</string>
+  <string id="36001">Nyxboard Pulse-Eight</string>
+  <string id="36002">Trocar o comando para o lado do teclado</string>
+  <string id="36003">Trocar o comando para o lado do remoto</string>
+  <string id="36004">Pressione  botão de comando "usuário"</string>
+  <string id="36005">Enable switch side commands</string>
+  <string id="36006">Não pude abrir o adaptador</string>
+  <string id="36007">Ligar a TV ou projetor quando inicializar o XBMC</string>
+  <string id="36008">Desligar equipamentos quando parar o XBMC</string>
+  <string id="36009">Colocar os equipamentos em modo de espera quando ativando proteção de tela</string>
+  <string id="36010"></string>
+  <string id="36011">Não pude detectar a porta CEC. Seta manualmente.</string>
+  <string id="36012">Não pude detectar o adaptador CEC.</string>
+  <string id="36013">Versãod libcec da interface não suportada. %d é superior a versão que o XBMC suporta (%d)</string>
+  <string id="36014">Passar este PC para modo standby, quando a TV for desligada</string>
+  <string id="36015">Número da porta HDMI</string>
+  <string id="36016">Conectado</string> <!-- max. 13 characters -->
+  <string id="36017">Adaptador encontrado, mas libcec não esta disponível</string>
+  <string id="36018">Usar os ajustes de linguagem da TV</string>
 </strings>

--- a/language/Slovenian/strings.xml
+++ b/language/Slovenian/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--Translator: Tadej Novak-->
 <!--Email: tadej@tano.si-->
-<!--Date of translation: 20/11/2011-->
+<!--Date of translation: 18/02/2012-->
 <!--$Revision$-->
 <strings>
   <string id="0">Programi</string>
@@ -879,8 +879,11 @@
   <string id="10020">Skripte</string>
   <string id="10021">Spletni brskalnik</string>
 
+  <string id="10025">Videi</string>
   <string id="10028">Video/Predvajalni seznam</string>
+  <string id="10029">Prijavno okno</string>
   <string id="10034">Nastavitve - Profili</string>
+  <string id="10040">Brskalnik dodatkov</string>
 
   <string id="10100">Da/Ne dialog</string>
   <string id="10101">Dialog napredka</string>
@@ -1777,6 +1780,7 @@
   <string id="20327">na privzete vrednosti.</string>
   <string id="20328">Prebrskaj za ciljem</string>
 
+  <string id="20329">Filmi so v ločenih mapah, ki se ujemajo z naslovom filma</string>
   <string id="20330">Uporabi imena map za poizvedbe</string>
   <string id="20331">Datoteka</string>
   <string id="20332">Uporabi ime datoteke ali mape v poizvedbah?</string>
@@ -1866,7 +1870,7 @@
   <string id="20416">Prvič na sporedu</string>
   <string id="20417">Scenarist</string>
   <string id="20418"></string>
-  <string id="20419">Prikaži podrobnosti v pogledu datotek</string>
+  <string id="20419">Zamenjaj imena datotek z naslovi v knjižnici</string>
 
   <string id="20420">Nikoli</string>
   <string id="20421">Če vsebuje le eno sezono</string>
@@ -1906,6 +1910,7 @@
   <string id="20455">Listeners</string>
   <string id="20456">Nastavi ozadje filmske zbirke</string>
   <string id="20457">Filmska zbirka</string>
+  <string id="20458">Združi filme v zbirke</string>
   <!-- up to 21329 is reserved for the video db !! !-->
 
   <string id="21330">Prikaži skrite datoteke in mape</string>
@@ -2013,6 +2018,8 @@
   <string id="21451">Potrebna je internetna povezava.</string>
   <string id="21452">Prenesi več...</string>
   <string id="21453">Korenski datotečni sistem</string>
+  <string id="21454">Začasni pomnilnik poln</string>
+  <string id="21455">Začasni pomnilnik se je zapolnil, preden je bila dosežen nivo za tekoče predvajanje</string>
 
   <string id="21460">Položaj podnapisov</string>
   <string id="21461">Fiksno</string>
@@ -2332,6 +2339,8 @@
   <string id="33101">Spletni strežnik</string>
   <string id="33102">Strežnik dogodkov</string>
   <string id="33103">Strežnik oddaljene komunikacije</string>
+
+  <string id="33200">Zaznana nova povezava</string>
 
   <!-- translators: no need to add these to your language files -->
   <string id="34000">Lame</string>

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaBrowser.h
@@ -95,7 +95,7 @@ public:
                               NPT_UInt32               start_index,
                               NPT_UInt32               count = 30, // DLNA recommendations
                               bool                     browse_metadata = false,
-                              const char*              filter = "dc:date,upnp:genre,res@duration,res@size,upnp:albumArtURI,upnp:album,upnp:artist,upnp:author",
+                              const char*              filter = "dc:date,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:album,upnp:artist,upnp:author",
                               const char*              sort_criteria = "",
                               void*                    userdata = NULL);
 
@@ -104,7 +104,7 @@ public:
 							  const char*              search_criteria,
 				              NPT_UInt32               start_index,
 					          NPT_UInt32               count = 30, // DLNA recommendations
-						      const char*              filter = "dc:date,upnp:genre,res@duration,res@size,upnp:albumArtURI,upnp:album,upnp:artist,upnp:author",
+						      const char*              filter = "dc:date,upnp:genre,res,res@duration,res@size,upnp:albumArtURI,upnp:album,upnp:artist,upnp:author",
 						  	  void*                    userdata = NULL);
 	//BBMOD END
 

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp
@@ -284,7 +284,7 @@ PLT_SyncMediaBrowser::BrowseSync(PLT_DeviceDataReference&      device,
         // nothing is returned back by the server.
         // Unless we were told to stop after reaching a certain amount to avoid
         // length delays
-        if ((browse_data->info.tm && browse_data->info.tm == list->GetItemCount()) ||
+        if ((browse_data->info.tm && browse_data->info.tm <= list->GetItemCount()) ||
             (max_results && list->GetItemCount() >= max_results))
             break;
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -66,6 +66,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/DllLibCurl.h"
 #include "filesystem/MythSession.h"
+#include "filesystem/FileMusicDatabase.h"
 #include "filesystem/PluginDirectory.h"
 #ifdef HAS_FILESYSTEM_SAP
 #include "filesystem/SAPDirectory.h"
@@ -3640,6 +3641,18 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
     CFileItem item_new(item);
     if (XFILE::CPluginDirectory::GetPluginResult(item.GetPath(), item_new))
       return PlayFile(item_new, false);
+    return false;
+  }
+
+  // resolve MusicDb url, needed to resolve plugin items in music database
+  if (item.IsMusicDb())
+  {
+    CURL url(item.GetPath());
+    if (CStdString mainFile = CFileMusicDatabase::TranslateUrl(url))
+    {
+      CFileItem item_new(mainFile,false);
+      return PlayFile(item_new, false);
+    }
     return false;
   }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2261,7 +2261,7 @@ bool CApplication::OnKey(const CKey& key)
       if (!action.GetID())
       {
         // keyboard entry - pass the keys through directly
-        if (key.GetFromHttpApi())
+        if (key.GetFromService())
           action = CAction(key.GetButtonCode() != KEY_INVALID ? key.GetButtonCode() : 0, key.GetUnicode());
         else
         { // see if we've got an ascii key
@@ -2278,7 +2278,7 @@ bool CApplication::OnKey(const CKey& key)
         return true;
       // failed to handle the keyboard action, drop down through to standard action
     }
-    if (key.GetFromHttpApi())
+    if (key.GetFromService())
     {
       if (key.GetButtonCode() != KEY_INVALID)
         action = CButtonTranslator::GetInstance().GetAction(iWin, key);
@@ -2998,7 +2998,10 @@ bool CApplication::ProcessJsonRpcButtons()
 #ifdef HAS_JSONRPC
   CKey tempKey(JSONRPC::CInputOperations::GetKey());
   if (tempKey.GetButtonCode() != KEY_INVALID)
+  {
+    tempKey.SetFromService(true);
     return OnKey(tempKey);
+  }
 #endif
   return false;
 }
@@ -3070,6 +3073,7 @@ bool CApplication::ProcessEventServer(float frameTime)
         key = CKey(wKeyID, 0, 0, 0.0, 0.0, 0.0, -fAmount, frameTime);
       else
         key = CKey(wKeyID);
+      key.SetFromService(true);
       return OnKey(key);
     }
   }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4630,10 +4630,16 @@ bool CApplication::OnMessage(CGUIMessage& message)
         if (m_pPlayer) m_pPlayer->OnNothingToQueueNotify();
         return true; // nothing to do
       }
+
+      // handle plugin://
+      CFileItem file(*playlist[iNext]);
+      CURL url(file.GetPath());
+      if (url.GetProtocol() == "plugin")
+        XFILE::CPluginDirectory::GetPluginResult(url.Get(), file);
+
       // ok, grab the next song
-      CFileItemPtr item = playlist[iNext];
-      // ok - send the file to the player if it wants it
-      if (m_pPlayer && m_pPlayer->QueueNextFile(*item))
+
+      if (m_pPlayer && m_pPlayer->QueueNextFile(file))
       { // player wants the next file
         m_nextPlaylistItem = iNext;
       }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4634,6 +4634,8 @@ bool CApplication::OnMessage(CGUIMessage& message)
       // handle plugin://
       CFileItem file(*playlist[iNext]);
       CURL url(file.GetPath());
+      if (url.GetProtocol() == "musicdb" )
+        url = CFileMusicDatabase::TranslateUrl(url);
       if (url.GetProtocol() == "plugin")
         XFILE::CPluginDirectory::GetPluginResult(url.Get(), file);
 

--- a/xbmc/ThumbnailCache.cpp
+++ b/xbmc/ThumbnailCache.cpp
@@ -274,3 +274,17 @@ CStdString CThumbnailCache::GetMusicThumb(const CStdString& path)
   thumb.Format("%c/%s.tbn", hex[0], hex.c_str());
   return URIUtils::AddFileToFolder(g_settings.GetMusicThumbFolder(), thumb);
 }
+
+CStdString CThumbnailCache::GetMusicThumbHashPath(const CStdString &path, bool split) {
+  Crc32 crc;
+  crc.ComputeFromLowerCase(path);
+  CStdString thumb;
+  if (split) {
+    CStdString hex;
+    hex.Format("%08x", (__int32)crc);
+    thumb.Format("%s\\%c\\%08x.tbn", g_settings.GetMusicThumbFolder(), hex[0], (unsigned __int32)crc);
+  } else {
+    thumb.Format("%s\\%08x.tbn", g_settings.GetMusicThumbFolder(), (unsigned __int32)crc);
+  }
+  return thumb;
+}

--- a/xbmc/ThumbnailCache.h
+++ b/xbmc/ThumbnailCache.h
@@ -63,6 +63,7 @@ public:
   static CStdString GetEpisodeThumb(const CVideoInfoTag *videoInfo);
   static CStdString GetVideoThumb(const CFileItem &item);
   static CStdString GetFanart(const CFileItem &item);
+  static CStdString GetMusicThumbHashPath(const CStdString &path, bool split = false);
   static CStdString GetThumb(const CStdString &path, const CStdString &path2, bool split = false);
 protected:
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1576,7 +1576,7 @@ int CUtil::GetMatchingSource(const CStdString& strPath1, VECSOURCES& VECSOURCES,
       return GetMatchingSource(strPath, VECSOURCES, bDummy);
     }
 
-    CLog::Log(LOGWARNING,"CUtil::GetMatchingSource... no matching source found for [%s]", strPath1.c_str());
+    CLog::Log(LOGDEBUG,"CUtil::GetMatchingSource: no matching source found for [%s]", strPath1.c_str());
   }
   return iIndex;
 }

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -320,9 +320,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
         {
           // setup the shares
           VECSOURCES *shares = NULL;
-          if (!source || strcmpi(source, "") == 0)
-            shares = g_settings.GetSourcesFromType(type);
-          else
+          if (source && strcmpi(source, "") != 0)
             shares = g_settings.GetSourcesFromType(source);
 
           VECSOURCES localShares;
@@ -331,8 +329,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
             VECSOURCES networkShares;
             g_mediaManager.GetLocalDrives(localShares);
             if (!source || strcmpi(source, "local") != 0)
-              g_mediaManager.GetNetworkLocations(networkShares);
-            localShares.insert(localShares.end(), networkShares.begin(), networkShares.end());
+              g_mediaManager.GetNetworkLocations(localShares);
           }
           else // always append local drives
           {

--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -212,6 +212,7 @@ bool CGUIWindowAddonBrowser::OnClick(int iItem)
     // pop up filebrowser to grab an installed folder
     VECSOURCES shares = g_settings.m_fileSources;
     g_mediaManager.GetLocalDrives(shares);
+    g_mediaManager.GetNetworkLocations(shares);
     CStdString path;
     if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "*.zip", g_localizeStrings.Get(24041), path))
       CAddonInstaller::Get().InstallFromZip(path);

--- a/xbmc/cores/AudioRenderers/CoreAudioRenderer.cpp
+++ b/xbmc/cores/AudioRenderers/CoreAudioRenderer.cpp
@@ -26,6 +26,7 @@
 
 #include "CoreAudioRenderer.h"
 #include "Application.h"
+#include "Systeminfo.h"
 #include "guilib/AudioContext.h"
 #include "osx/CocoaInterface.h"
 #include "settings/GUISettings.h"
@@ -1010,7 +1011,15 @@ bool CCoreAudioRenderer::InitializePCM(UInt32 channels, UInt32 samplesPerSecond,
     
     // Get User-Configured (XBMC) Speaker Configuration
     AudioChannelLayout guiLayout;
-    guiLayout.mChannelLayoutTag = g_LayoutMap[(PCMLayout)g_guiSettings.GetInt("audiooutput.channellayout")];
+    if (g_sysinfo.IsAppleTV())
+    {
+      // Force ATV1 to a 2.0 layout (that is all it knows), since it does not provide a usable channel layout
+      guiLayout.mChannelLayoutTag = g_LayoutMap[(PCMLayout)g_guiSettings.GetInt("audiooutput.channellayout")];
+      CLog::Log(LOGDEBUG, "CCoreAudioRenderer::InitializePCM: AppleTV detected - Forcing channel layout to 2.0 (max available PCM channels)");  
+    }
+    else
+      guiLayout.mChannelLayoutTag = kAudioChannelLayoutTag_Stereo; 
+    
     CCoreAudioChannelLayout userLayout(guiLayout);
     CStdString strUserLayout;
     CLog::Log(LOGDEBUG, "CCoreAudioRenderer::InitializePCM: User-Configured Speaker Layout: %s", CCoreAudioChannelLayout::ChannelLayoutToString(*(AudioChannelLayout*)userLayout, strUserLayout));  

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -164,6 +164,7 @@ public:
 protected:
   virtual bool ChooseIntermediateD3DFormat();
   virtual bool CreateIntermediateRenderTarget(unsigned int width, unsigned int height);
+  virtual bool ClearIntermediateRenderTarget();
   virtual void PrepareParameters(unsigned int sourceWidth, unsigned int sourceHeight,
                                unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -220,7 +220,7 @@ void CDVDPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
   m_bFpsInvalid = (hint.fpsrate == 0 || hint.fpsscale == 0);
 
   m_bCalcFrameRate = g_guiSettings.GetBool("videoplayer.usedisplayasclock") ||
-                      g_guiSettings.GetBool("videoplayer.adjustrefreshrate");
+                     g_guiSettings.GetBool("videoplayer.adjustrefreshrate");
   ResetFrameRateCalc();
 
   m_iDroppedRequest = 0;
@@ -1467,9 +1467,11 @@ void CDVDPlayerVideo::ResetFrameRateCalc()
 {
   m_fStableFrameRate = 0.0;
   m_iFrameRateCount  = 0;
-  m_bAllowDrop       = !m_bCalcFrameRate && g_settings.m_currentVideoSettings.m_ScalingMethod != VS_SCALINGMETHOD_AUTO;
   m_iFrameRateLength = 1;
   m_iFrameRateErr    = 0;
+
+  m_bAllowDrop       = (!m_bCalcFrameRate && g_settings.m_currentVideoSettings.m_ScalingMethod != VS_SCALINGMETHOD_AUTO) ||
+                        g_advancedSettings.m_videoFpsDetect == 0;
 }
 
 #define MAXFRAMERATEDIFF   0.01
@@ -1477,8 +1479,8 @@ void CDVDPlayerVideo::ResetFrameRateCalc()
 
 void CDVDPlayerVideo::CalcFrameRate()
 {
-  if (m_iFrameRateLength >= 128)
-    return; //we're done calculating
+  if (m_iFrameRateLength >= 128 || g_advancedSettings.m_videoFpsDetect == 0)
+    return; //don't calculate the fps
 
   //only calculate the framerate if sync playback to display is on, adjust refreshrate is on,
   //or scaling method is set to auto
@@ -1495,7 +1497,8 @@ void CDVDPlayerVideo::CalcFrameRate()
   //and is able to calculate the correct frame duration from it
   double frameduration = m_pullupCorrection.GetFrameDuration();
 
-  if (frameduration == DVD_NOPTS_VALUE || m_pullupCorrection.GetPatternLength() > 1)
+  if (frameduration == DVD_NOPTS_VALUE ||
+      (g_advancedSettings.m_videoFpsDetect == 1 && m_pullupCorrection.GetPatternLength() > 1))
   {
     //reset the stored framerates if no good framerate was detected
     m_fStableFrameRate = 0.0;

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -237,28 +237,8 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     share1.m_ignore = true;
     extraShares.push_back(share1);
 
-#ifdef HAS_FILESYSTEM_SMB
-    share1.strPath = "smb://";
-    share1.strName = g_localizeStrings.Get(20171);
-    extraShares.push_back(share1);
-#endif
-
-#ifdef HAS_FILESYSTEM_NFS
-    share1.strPath = "nfs://";
-    share1.strName = g_localizeStrings.Get(20259);
-    extraShares.push_back(share1);
-#endif// HAS_FILESYSTEM_NFS
-
-    share1.strPath = "upnp://";
-    share1.strName = "UPnP Devices";
-    extraShares.push_back(share1);
-
     share1.strPath = "sap://";
     share1.strName = "SAP Streams";
-    extraShares.push_back(share1);
-
-    share1.strPath = "zeroconf://";
-    share1.strName = "Zeroconf Browser";
     extraShares.push_back(share1);
 
     if (g_guiSettings.GetString("audiocds.recordingpath",false) != "")
@@ -287,32 +267,12 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     share1.strName = "ReplayTV Devices";
     extraShares.push_back(share1);
 
-#ifdef HAS_FILESYSTEM_SMB
-    share1.strPath = "smb://";
-    share1.strName = g_localizeStrings.Get(20171);
-    extraShares.push_back(share1);
-#endif
-
-#ifdef HAS_FILESYSTEM_NFS
-    share1.strPath = "nfs://";
-    share1.strName = g_localizeStrings.Get(20259);
-    extraShares.push_back(share1);
-#endif// HAS_FILESYSTEM_NFS
-
     share1.strPath = "hdhomerun://";
     share1.strName = "HDHomerun Devices";
     extraShares.push_back(share1);
 
     share1.strPath = "sap://";
     share1.strName = "SAP Streams";
-    extraShares.push_back(share1);
-
-    share1.strPath = "upnp://";
-    share1.strName = "UPnP Devices";
-    extraShares.push_back(share1);
-
-    share1.strPath = "zeroconf://";
-    share1.strName = "Zeroconf Browser";
     extraShares.push_back(share1);
   }
   else if (m_type == "pictures")
@@ -325,26 +285,6 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
       share1.strName = g_localizeStrings.Get(20008);
       extraShares.push_back(share1);
     }
-
-#ifdef HAS_FILESYSTEM_SMB
-    share1.strPath = "smb://";
-    share1.strName = g_localizeStrings.Get(20171);
-    extraShares.push_back(share1);
-#endif
-
-#ifdef HAS_FILESYSTEM_NFS
-    share1.strPath = "nfs://";
-    share1.strName = g_localizeStrings.Get(20259);
-    extraShares.push_back(share1);
-#endif// HAS_FILESYSTEM_NFS
-
-    share1.strPath = "upnp://";
-    share1.strName = "UPnP Devices";
-    extraShares.push_back(share1);
-
-    share1.strPath = "zeroconf://";
-    share1.strName = "Zeroconf Browser";
-    extraShares.push_back(share1);
   }
   else if (m_type == "programs")
   {

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -161,15 +161,21 @@ bool CUPnPDirectory::GetResource(const CURL& path, CFileItem &item)
     CURL::Decode(object);
 
     PLT_DeviceDataReference device;
-    if(!FindDeviceWait(upnp, uuid.c_str(), device))
+    if(!FindDeviceWait(upnp, uuid.c_str(), device)) {
+        CLog::Log(LOGERROR, "CUPnPDirectory::GetResource - unable to find uuid %s", uuid.c_str());
         return false;
+    }
 
     PLT_MediaObjectListReference list;
-    if (NPT_FAILED(upnp->m_MediaBrowser->BrowseSync(device, object.c_str(), list, true)))
+    if (NPT_FAILED(upnp->m_MediaBrowser->BrowseSync(device, object.c_str(), list, true))) {
+        CLog::Log(LOGERROR, "CUPnPDirectory::GetResource - unable to find object %s", object.c_str());
         return false;
+    }
 
-    if (list.IsNull() || !list->GetItemCount())
+    if (list.IsNull() || !list->GetItemCount()) {
+      CLog::Log(LOGERROR, "CUPnPDirectory::GetResource - no items returned for object %s", object.c_str());
       return false;
+    }
 
     PLT_MediaObjectList::Iterator entry = list->GetFirstItem();
     if (entry == 0)
@@ -183,8 +189,10 @@ bool CUPnPDirectory::GetResource(const CURL& path, CFileItem &item)
                       CProtocolFinder("xbmc-get"), resource))) {
         if((*entry)->m_Resources.GetItemCount())
             resource = (*entry)->m_Resources[0];
-        else
+        else {
+            CLog::Log(LOGERROR, "CUPnPDirectory::GetResource - no resources returned for object %s", object.c_str());
             return false;
+        }
     }
 
     // store original path so we remember it

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -830,6 +830,8 @@ void CGUIBaseContainer::UpdateVisibility(const CGUIListItem *item)
   { // update our item list with our new content, but only add those items that should
     // be visible.  Save the previous item and keep it if we are adding that one.
     CGUIListItem *lastItem = m_lastItem;
+    int selected = GetSelectedItem();
+    CGUIListItem* selectedItem = (selected >= 0 && (unsigned int)selected < m_items.size()) ? m_items[selected].get() : NULL;
     Reset();
     bool updateItems = false;
     if (!m_staticUpdateTime)
@@ -849,6 +851,9 @@ void CGUIBaseContainer::UpdateVisibility(const CGUIListItem *item)
         m_items.push_back(item);
         if (item.get() == lastItem)
           m_lastItem = lastItem;
+        // if item is selected and it changed position, re-select it
+        if (item.get() == selectedItem && selected != (int)m_items.size() - 1)
+          SelectItem(m_items.size() - 1);
       }
       // update any properties
       if (updateItems)

--- a/xbmc/guilib/Key.cpp
+++ b/xbmc/guilib/Key.cpp
@@ -79,7 +79,7 @@ void CKey::Reset()
   m_rightThumbX = 0.0f;
   m_rightThumbY = 0.0f;
   m_repeat = 0.0f;
-  m_fromHttpApi = false;
+  m_fromService = false;
   m_buttonCode = KEY_INVALID;
   m_vkey = 0;
   m_unicode = 0;
@@ -98,7 +98,7 @@ const CKey& CKey::operator=(const CKey& key)
   m_rightThumbX  = key.m_rightThumbX;
   m_rightThumbY  = key.m_rightThumbY;
   m_repeat       = key.m_repeat;
-  m_fromHttpApi  = key.m_fromHttpApi;
+  m_fromService  = key.m_fromService;
   m_buttonCode   = key.m_buttonCode;
   m_vkey         = key.m_vkey;
   m_unicode     = key.m_unicode;
@@ -164,19 +164,12 @@ float CKey::GetRepeat() const
   return m_repeat;
 }
 
-bool CKey::GetFromHttpApi() const
+void CKey::SetFromService(bool fromService)
 {
-  return m_fromHttpApi;
-}
-
-void CKey::SetFromHttpApi(bool bFromHttpApi)
-{
-  if(bFromHttpApi && (m_buttonCode & KEY_ASCII) )
-  {
-      m_unicode = m_buttonCode - KEY_ASCII;      
-  }
+  if (fromService && (m_buttonCode & KEY_ASCII))
+    m_unicode = m_buttonCode - KEY_ASCII;
     
-  m_fromHttpApi = bFromHttpApi;
+  m_fromService = fromService;
 }
 
 CAction::CAction(int actionID, float amount1 /* = 1.0f */, float amount2 /* = 0.0f */, const CStdString &name /* = "" */)

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -543,8 +543,8 @@ public:
   bool FromKeyboard() const;
   bool IsAnalogButton() const;
   bool IsIRRemote() const;
-  void SetFromHttpApi(bool);
-  bool GetFromHttpApi() const;
+  void SetFromService(bool fromService);
+  bool GetFromService() const { return m_fromService; }
 
   inline uint32_t GetButtonCode() const { return m_buttonCode; }
   inline uint8_t  GetVKey() const       { return m_vkey; }
@@ -578,7 +578,7 @@ private:
   float m_rightThumbX;
   float m_rightThumbY;
   float m_repeat; // time since last keypress
-  bool m_fromHttpApi;
+  bool m_fromService;
 };
 #endif
 

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -2085,7 +2085,7 @@ int CXbmcHttp::xbmcSetKey(int numParas, CStdString paras[])
       }
     }
     CKey tempKey(buttonCode, leftTrigger, rightTrigger, fLeftThumbX, fLeftThumbY, fRightThumbX, fRightThumbY) ;
-    tempKey.SetFromHttpApi(true);
+    tempKey.SetFromService(true);
     key = tempKey;
     lastKey = key;
     return SetResponse(openTag+"OK");

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -23,8 +23,8 @@
 namespace JSONRPC
 {
   const char* const JSONRPC_SERVICE_ID          = "http://www.xbmc.org/jsonrpc/ServiceDescription.json";
-  const int         JSONRPC_SERVICE_VERSION     = 3;
-  const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON RPC API of XBMC";
+  const int         JSONRPC_SERVICE_VERSION     = 4;
+  const char* const JSONRPC_SERVICE_DESCRIPTION = "JSON-RPC API of XBMC";
 
   const char* const JSONRPC_SERVICE_TYPES[] = {  
     "\"Optional.Boolean\": {"
@@ -645,7 +645,7 @@ namespace JSONRPC
       "\"type\": \"object\","
       "\"properties\": {"
         "\"start\": { \"type\": \"integer\", \"minimum\": 0, \"default\": 0 },"
-        "\"end\": { \"type\": \"integer\", \"minimum\": 0, \"default\": -1 }"
+        "\"end\": { \"type\": \"integer\", \"minimum\": 0, \"default\": -1 \"description\": \"The number of items in the list being returned\" }"
       "},"
       "\"additionalProperties\": false"
     "}",

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -617,7 +617,7 @@
     "type": "object",
     "properties": {
       "start": { "type": "integer", "minimum": 0, "default": 0 },
-      "end": { "type": "integer", "minimum": 0, "default": -1 }
+      "end": { "type": "integer", "minimum": 0, "default": -1 "description": "The number of items in the list being returned" }
     },
     "additionalProperties": false
   },

--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -375,6 +375,13 @@ void XBPyThread::Process()
   PyThreadState_Swap(NULL);
   PyEval_ReleaseLock();
 
+  //set stopped event - this allows ::stop to run and kill remaining threads
+  //this event has to be fired without holding m_pExecuter->m_critSection
+  //before
+  //Also the GIL (PyEval_AcquireLock) must not be held
+  //if not obeyed there is still no deadlock because ::stop waits with timeout (smart one!)
+  stoppedEvent.Set();
+
   { CSingleLock lock(m_pExecuter->m_critSection);
     m_threadState = NULL;
   }
@@ -428,6 +435,17 @@ void XBPyThread::stop()
     if(!m || PyObject_SetAttrString(m, (char*)"abortRequested", PyBool_FromLong(1)))
       CLog::Log(LOGERROR, "XBPyThread::stop - failed to set abortRequested");
 
+    PyThreadState_Swap(old);
+    PyEval_ReleaseLock();
+
+    if(!stoppedEvent.WaitMSec(5000))//let the script 5 secs for shut stuff down
+    {
+      CLog::Log(LOGERROR, "XBPyThread::stop - script didn't stop in proper time - lets kill it");
+    }
+    
+    //everything which didn't exit by now gets killed
+    PyEval_AcquireLock();
+    old = PyThreadState_Swap((PyThreadState*)m_threadState);    
     for(PyThreadState* state = ((PyThreadState*)m_threadState)->interp->tstate_head; state; state = state->next)
     {
       Py_XDECREF(state->async_exc);

--- a/xbmc/interfaces/python/XBPyThread.h
+++ b/xbmc/interfaces/python/XBPyThread.h
@@ -23,6 +23,7 @@
 #define XBPYTHREAD_H_
 
 #include "threads/Thread.h"
+#include "threads/Event.h"
 #include "addons/IAddon.h"
 
 class XBPython;
@@ -42,6 +43,7 @@ public:
 
 protected:
   XBPython *m_pExecuter;
+  CEvent stoppedEvent;
   void *m_threadState;
 
   char m_type;

--- a/xbmc/interfaces/python/xbmcmodule/listitem.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/listitem.cpp
@@ -526,6 +526,8 @@ namespace PYXBMC
       {
         if (strcmpi(PyString_AsString(key), "tracknumber") == 0)
           self->item->GetMusicInfoTag()->SetTrackNumber(PyInt_AsLong(value));
+        else if (strcmpi(PyString_AsString(key), "discnumber") == 0)
+          self->item->GetMusicInfoTag()->SetPartOfSet(PyInt_AsLong(value));
         else if (strcmpi(PyString_AsString(key), "count") == 0)
           self->item->m_iprogramCount = PyInt_AsLong(value);
         else if (strcmpi(PyString_AsString(key), "size") == 0)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -62,6 +62,8 @@
 #include "utils/AutoPtrHandle.h"
 #include "interfaces/AnnouncementManager.h"
 #include "dbwrappers/dataset.h"
+#include "ThumbnailCache.h"
+#include "pictures/Picture.h"
 
 using namespace std;
 using namespace AUTOPTR;
@@ -261,7 +263,15 @@ void CMusicDatabase::AddSong(CSong& song, bool bCheck)
       idAlbumArtist = AddArtist(vecAlbumArtists[0]);
 
     int idPath = AddPath(strPath);
-    int idThumb = AddThumb(song.strThumb);
+    int idThumb; 
+    if (song.strThumb.compare(0, 4, "http") == 0) {
+      CStdString hash = CThumbnailCache::GetMusicThumbHashPath(song.strThumb.c_str(), true);
+      if (!CFile::Exists(hash)) 
+        CPicture::CreateThumbnail(song.strThumb.c_str(), hash.c_str(), true);
+      idThumb = AddThumb(hash); 
+    } else {
+            idThumb = AddThumb(song.strThumb);
+    }
     int idAlbum;
     if (idAlbumArtist > -1)  // have an album artist
       idAlbum = AddAlbum(song.strAlbum, idAlbumArtist, extraAlbumArtists, song.strAlbumArtist, idThumb, idGenre, extraGenres, song.iYear);

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -689,7 +689,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       const char* found = strstr(queryString.c_str(), "volume=");
       double volume = found ? (double)(atof(found + strlen("volume="))) : 0;
 
-      CLog::Log(LOGDEBUG, "AIRPLAY: got request %s with volume %i", uri.c_str(), volume);
+      CLog::Log(LOGDEBUG, "AIRPLAY: got request %s with volume %f", uri.c_str(), volume);
 
       if (needAuth && !checkAuthorization(authorization, method, uri))
       {

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -83,7 +83,8 @@ bool CPlayListM3U::Load(const CStdString& strFileName)
   while (file.ReadString(szLine, 1024))
   {
     strLine = szLine;
-    StringUtils::RemoveCRLF(strLine);
+    strLine.TrimRight(" \t\r\n");
+    strLine.TrimLeft(" \t");
 
     if (strLine.Left( (int)strlen(M3U_INFO_MARKER) ) == M3U_INFO_MARKER)
     {
@@ -104,6 +105,9 @@ bool CPlayListM3U::Load(const CStdString& strFileName)
     else if (strLine != M3U_START_MARKER && strLine.Left(strlen(M3U_ARTIST_MARKER)) != M3U_ARTIST_MARKER && strLine.Left(strlen(M3U_ALBUM_MARKER)) != M3U_ALBUM_MARKER )
     {
       CStdString strFileName = strLine;
+
+      if (strFileName.size() > 0 && strFileName[0] == '#')
+        continue; // assume a comment or something else we don't support
 
       // Skip self - do not load playlist recursively
       if (URIUtils::GetFileName(strFileName).Equals(m_strPlayListName))

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -663,7 +663,7 @@ CStdString CSmartPlaylistRule::GetDatabaseField(DATABASE_FIELD field, const CStd
     else if (field == FIELD_PLOTOUTLINE) result.Format("c%02d", VIDEODB_ID_PLOTOUTLINE);
     else if (field == FIELD_TAGLINE) result.Format("c%02d", VIDEODB_ID_TAGLINE);
     else if (field == FIELD_VOTES) result.Format("c%02d", VIDEODB_ID_VOTES);
-    else if (field == FIELD_RATING) result.Format("c%02d", VIDEODB_ID_RATING);
+    else if (field == FIELD_RATING) result.Format("CAST(c%02d as DECIMAL(5,3))", VIDEODB_ID_RATING);
     else if (field == FIELD_TIME) result.Format("c%02d", VIDEODB_ID_RUNTIME);
     else if (field == FIELD_WRITER) result.Format("c%02d", VIDEODB_ID_CREDITS);   // join required
     else if (field == FIELD_PLAYCOUNT) result = "playCount";

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -385,6 +385,8 @@ void CRenderSystemGL::CaptureStateBlock()
 {
   if (!m_bRenderCreated)
     return;
+  
+  glGetIntegerv(GL_VIEWPORT, m_viewPort);
 
   glMatrixMode(GL_PROJECTION);
   glPushMatrix();
@@ -405,6 +407,7 @@ void CRenderSystemGL::ApplyStateBlock()
   if (!m_bRenderCreated)
     return;
 
+  glViewport(m_viewPort[0], m_viewPort[1], m_viewPort[2], m_viewPort[3]);
   glMatrixMode(GL_PROJECTION);
   glPopMatrix();
   glMatrixMode(GL_TEXTURE);

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -99,6 +99,7 @@ void CAdvancedSettings::Initialize()
   m_DXVACheckCompatibility = false;
   m_DXVACheckCompatibilityPresent = false;
   m_DXVAForceProcessorRenderer = true;
+  m_videoFpsDetect = 1;
 
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
@@ -537,6 +538,8 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     m_DXVACheckCompatibilityPresent = XMLUtils::GetBoolean(pElement,"checkdxvacompatibility", m_DXVACheckCompatibility);
 
     XMLUtils::GetBoolean(pElement,"forcedxvarenderer", m_DXVAForceProcessorRenderer);
+    //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
+    XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);
   }
 
   pElement = pRootElement->FirstChildElement("musiclibrary");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -130,6 +130,7 @@ class CAdvancedSettings
     bool m_DXVACheckCompatibility;
     bool m_DXVACheckCompatibilityPresent;
     bool m_DXVAForceProcessorRenderer;
+    int  m_videoFpsDetect;
 
     CStdString m_videoDefaultPlayer;
     CStdString m_videoDefaultDVDPlayer;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -57,6 +57,7 @@
 #include "utils/URIUtils.h"
 #include "input/MouseStat.h"
 #include "filesystem/File.h"
+#include "filesystem/DirectoryCache.h"
 
 using namespace std;
 using namespace XFILE;
@@ -979,8 +980,8 @@ bool CSettings::LoadProfile(unsigned int index)
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_WINDOW_RESET);
     g_windowManager.SendMessage(msg);
 
-    CUtil::DeleteMusicDatabaseDirectoryCache();
-    CUtil::DeleteVideoDatabaseDirectoryCache();
+    CUtil::DeleteDirectoryCache();
+    g_directoryCache.Clear();
 
     return true;
   }

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -170,7 +170,7 @@ void CMediaManager::GetRemovableDrives(VECSOURCES &removableDrives)
   m_platformStorage->GetRemovableDrives(removableDrives);
 }
 
-void CMediaManager::GetNetworkLocations(VECSOURCES &locations)
+void CMediaManager::GetNetworkLocations(VECSOURCES &locations, bool autolocations)
 {
   // Load our xml file
   LoadSources();
@@ -180,6 +180,30 @@ void CMediaManager::GetNetworkLocations(VECSOURCES &locations)
     share.strPath = m_locations[i].path;
     CURL url(share.strPath);
     share.strName = url.GetWithoutUserDetails();
+    locations.push_back(share);
+  }
+  if (autolocations)
+  {
+    CMediaSource share;
+    share.m_ignore = true;
+#ifdef HAS_FILESYSTEM_SMB
+    share.strPath = "smb://";
+    share.strName = g_localizeStrings.Get(20171);
+    locations.push_back(share);
+#endif
+
+#ifdef HAS_FILESYSTEM_NFS
+    share.strPath = "nfs://";
+    share.strName = g_localizeStrings.Get(20259);
+    locations.push_back(share);
+#endif// HAS_FILESYSTEM_NFS
+
+    share.strPath = "upnp://";
+    share.strName = "UPnP Devices";
+    locations.push_back(share);
+
+    share.strPath = "zeroconf://";
+    share.strName = "Zeroconf Browser";
     locations.push_back(share);
   }
 }

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -55,7 +55,7 @@ public:
 
   void GetLocalDrives(VECSOURCES &localDrives, bool includeQ = true);
   void GetRemovableDrives(VECSOURCES &removableDrives);
-  void GetNetworkLocations(VECSOURCES &locations);
+  void GetNetworkLocations(VECSOURCES &locations, bool autolocations = true);
 
   bool AddNetworkLocation(const CStdString &path);
   bool HasLocation(const CStdString& path) const;

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -222,8 +222,6 @@
 
 // ARM does not support certain features... disable them here!
 #ifdef _ARMEL
-#undef HAS_AVAHI
-#undef HAS_ZEROCONF
 #undef HAS_VISUALISATION
 #undef HAS_FILESYSTEM_HTSP
 #endif

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -170,7 +170,7 @@ void CLog::MemDump(char *pData, int length)
       for (int j=0; j < 4 && i + 4*k + j < length; j++)
       {
         CStdString strFormat;
-        strFormat.Format(" %02x", *pData++);
+        strFormat.Format(" %02x", (unsigned char)*pData++);
         strLine += strFormat;
       }
       strLine += " ";

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -268,17 +268,20 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
           else
             AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 551, LABEL_MASKS("%T", "%R"));
 
-          AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%T", "%R"));  // Filename, Duration | Foldername, empty
-          AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%T", "%O"));
           AddSortMethod(SORT_METHOD_YEAR,562, LABEL_MASKS("%T", "%Y"));
         }
+        AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%T", "%R"));  // Filename, Duration | Foldername, empty
+        AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%T", "%O"));
         AddSortMethod(SORT_METHOD_VIDEO_RUNTIME,2050, LABEL_MASKS("%T", "%D"));
         AddSortMethod(SORT_METHOD_DATEADDED, 570, LABEL_MASKS("%T", "%R"));
 
         if (g_settings.GetWatchMode(items.GetContent()) == VIDEO_SHOW_ALL)
           AddSortMethod(SORT_METHOD_PLAYCOUNT, 576, LABEL_MASKS("%T", "%V"));
 
-        SetSortMethod(g_settings.m_viewStateVideoNavTitles.m_sortMethod);
+        if (params.GetSetId() > -1)
+          SetSortMethod(SORT_METHOD_YEAR);
+        else
+          SetSortMethod(g_settings.m_viewStateVideoNavTitles.m_sortMethod);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavTitles.m_viewMode);
 
@@ -364,6 +367,8 @@ void CGUIViewStateWindowVideoNav::SaveViewState()
   if (m_items.IsVideoDb())
   {
     NODE_TYPE NodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_items.GetPath());
+    CQueryParams params;
+    CVideoDatabaseDirectory::GetQueryParams(m_items.GetPath(),params);
     switch (NodeType)
     {
     case NODE_TYPE_ACTOR:
@@ -376,7 +381,7 @@ void CGUIViewStateWindowVideoNav::SaveViewState()
       SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavGenres);
       break;
     case NODE_TYPE_TITLE_MOVIES:
-      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTitles);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, params.GetSetId() > -1 ? NULL : &g_settings.m_viewStateVideoNavTitles);
       break;
     case NODE_TYPE_EPISODES:
       SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavEpisodes);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -468,7 +468,7 @@ bool CVideoDatabase::GetPaths(set<CStdString> &paths)
   return false;
 }
 
-bool CVideoDatabase::GetPathsForTvShow(int idShow, vector<int>& paths)
+bool CVideoDatabase::GetPathsForTvShow(int idShow, set<int>& paths)
 {
   CStdString strSQL;
   try
@@ -479,7 +479,7 @@ bool CVideoDatabase::GetPathsForTvShow(int idShow, vector<int>& paths)
     m_pDS->query(strSQL.c_str());
     while (!m_pDS->eof())
     {
-      paths.push_back(m_pDS->fv(0).get_asInt());
+      paths.insert(m_pDS->fv(0).get_asInt());
       m_pDS->next();
     }
     m_pDS->close();
@@ -6421,7 +6421,7 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const CStdString& strSearch, C
   }
 }
 
-void CVideoDatabase::CleanDatabase(IVideoInfoScannerObserver* pObserver, const vector<int>* paths)
+void CVideoDatabase::CleanDatabase(IVideoInfoScannerObserver* pObserver, const set<int>* paths)
 {
   CGUIDialogProgress *progress=NULL;
   try
@@ -6445,8 +6445,8 @@ void CVideoDatabase::CleanDatabase(IVideoInfoScannerObserver* pObserver, const v
       }
 
       CStdString strPaths;
-      for (unsigned int i=0;i<paths->size();++i )
-        strPaths.Format("%s,%i",strPaths.Mid(0).c_str(),paths->at(i));
+      for (std::set<int>::const_iterator i = paths->begin(); i != paths->end(); ++i)
+        strPaths.AppendFormat(",%i",*i);
       sql = PrepareSQL("select * from files,path where files.idPath=path.idPath and path.idPath in (%s)",strPaths.Mid(1).c_str());
     }
     else
@@ -6684,13 +6684,12 @@ void CVideoDatabase::CleanDatabase(IVideoInfoScannerObserver* pObserver, const v
     while (!m_pDS->eof())
     {
       if (!CDirectory::Exists(m_pDS->fv("path.strPath").get_asString()))
-        strIds.Format("%s %i,",strIds.Mid(0),m_pDS->fv("path.idPath").get_asInt()); // mid since we cannot format the same string
+        strIds.AppendFormat("%i,", m_pDS->fv("path.idPath").get_asInt());
       m_pDS->next();
     }
     m_pDS->close();
     if (!strIds.IsEmpty())
     {
-      strIds.TrimLeft(" ");
       strIds.TrimRight(",");
       sql = PrepareSQL("delete from path where idPath in (%s)",strIds.c_str());
       m_pDS->exec(sql.c_str());

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -471,7 +471,7 @@ public:
   bool SetPathHash(const CStdString &path, const CStdString &hash);
   bool GetPathHash(const CStdString &path, CStdString &hash);
   bool GetPaths(std::set<CStdString> &paths);
-  bool GetPathsForTvShow(int idShow, std::vector<int>& paths);
+  bool GetPathsForTvShow(int idShow, std::set<int>& paths);
 
   /*! \brief retrieve subpaths of a given path.  Assumes a heirarchical folder structure
    \param basepath the root path to retrieve subpaths for
@@ -548,7 +548,7 @@ public:
   bool HasContent(VIDEODB_CONTENT_TYPE type);
   bool HasSets() const;
 
-  void CleanDatabase(VIDEO::IVideoInfoScannerObserver* pObserver=NULL, const std::vector<int>* paths=NULL);
+  void CleanDatabase(VIDEO::IVideoInfoScannerObserver* pObserver=NULL, const std::set<int>* paths=NULL);
 
   /*! \brief Add a file to the database, if necessary
    If the file is already in the database, we simply return its id.

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -247,7 +247,7 @@ namespace VIDEO
           if (hash.IsEmpty() && !dbHash.IsEmpty())
           {
             CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipping dir '%s' as it's empty or doesn't exist - adding to clean list", strDirectory.c_str());
-            m_pathsToClean.push_back(m_database.GetPathId(strDirectory));
+            m_pathsToClean.insert(m_database.GetPathId(strDirectory));
           }
           else
             CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipping dir '%s' due to no change", strDirectory.c_str());
@@ -296,13 +296,13 @@ namespace VIDEO
         if (!m_bStop && (content == CONTENT_MOVIES || content == CONTENT_MUSICVIDEOS))
         {
           m_database.SetPathHash(strDirectory, hash);
-          m_pathsToClean.push_back(m_database.GetPathId(strDirectory));
+          m_pathsToClean.insert(m_database.GetPathId(strDirectory));
           CLog::Log(LOGDEBUG, "VideoInfoScanner: Finished adding information from dir %s", strDirectory.c_str());
         }
       }
       else
       {
-        m_pathsToClean.push_back(m_database.GetPathId(strDirectory));
+        m_pathsToClean.insert(m_database.GetPathId(strDirectory));
         CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir %s", strDirectory.c_str());
       }
     }
@@ -417,7 +417,7 @@ namespace VIDEO
       for (vector<int>::iterator i = libPaths.begin(); i < libPaths.end(); ++i)
       {
         if (find(seenPaths.begin(), seenPaths.end(), *i) == seenPaths.end())
-          m_pathsToClean.push_back(*i);
+          m_pathsToClean.insert(*i);
       }
     }
     if(pDlgProgress)
@@ -651,7 +651,7 @@ namespace VIDEO
         }
         return;
       }
-      m_pathsToClean.push_back(m_database.GetPathId(item->GetPath()));
+      m_pathsToClean.insert(m_database.GetPathId(item->GetPath()));
       m_database.GetPathsForTvShow(m_database.GetTvShowId(item->GetPath()), m_pathsToClean);
       item->SetProperty("hash", hash);
     }

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -252,7 +252,7 @@ namespace VIDEO
     CVideoDatabase m_database;
     std::set<CStdString> m_pathsToScan;
     std::set<CStdString> m_pathsToCount;
-    std::vector<int> m_pathsToClean;
+    std::set<int> m_pathsToClean;
     CNfoFile m_nfoReader;
   };
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -278,7 +278,7 @@ void CGUIWindowVideoBase::OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scra
     if (item.m_bIsFolder && scraper && scraper->Content() != CONTENT_TVSHOWS)
     {
       CFileItemList items;
-      CDirectory::GetDirectory(item.GetPath(), items,"",true,false,DIR_CACHE_ONCE,true,true);
+      CDirectory::GetDirectory(item.GetPath(), items, g_settings.m_videoExtensions,true,false,DIR_CACHE_ONCE,true,true);
       items.Stack();
 
       // check for media files

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1501,10 +1501,12 @@ CStdString CGUIWindowVideoNav::GetStartFolder(const CStdString &dir)
     return "videodb://3/3/";
   else if (dir.Equals("MusicVideoArtists"))
     return "videodb://3/4/";
-  else if (dir.Equals("MusicVideoDirectors"))
+  else if (dir.Equals("MusicVideoAlbums"))
     return "videodb://3/5/";
-  else if (dir.Equals("MusicVideoStudios"))
+  else if (dir.Equals("MusicVideoDirectors"))
     return "videodb://3/6/";
+  else if (dir.Equals("MusicVideoStudios"))
+    return "videodb://3/7/";
   else if (dir.Equals("MusicVideos"))
     return "videodb://3/";
   else if (dir.Equals("RecentlyAddedMovies"))


### PR DESCRIPTION
3 patchs : 
- Retrieve the discnumber when set by a music plugin (it was missing) 
- The item prefetch fail when playing a music addon item if the stored url is a plugin://
  This patch fix this by trying to resolve urls before queuing next track (perhaps it's not the good place but it works...) 
- When trying to play an item in the musicdb that was scanned from a music addon, it fails (nothing resolve the  musicdb://1/2/3/12 url).
  this patch add the musicdb urlresolv in the application.cpp probably not the good place but it works. 

Thank you !
