### PR TITLE
fix movie stacking when additional files are present in a directory

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2250,11 +2250,11 @@ void CFileItemList::StackFiles()
               break;
             }
           }
-          else // No match 2, next expression
+          else // No match 2, next item
           {
             offset = 0;
-            expr++;
-            break;
+            j++;
+            continue;
           }
           j++;
         }


### PR DESCRIPTION
If I'm reading the code correctly, the stacking algorithm is: for every file in this CFileItemList, check whether it matches any stacking regexp; if it does, check if other files in this CFileItemList match the same regexp this file does, starting with the next object in this CFileItemList. Yet, lines 2256-2257 cause the algorithm to skip checking the remaining list items if the file following _file1_ is not stackable with _file1_ (e.g. subtitles). This is somewhat challenging to explain, so let me give an example. Imagine a file list containing 4 items:

1: Movie.CD1.avi
2: Movie.CD1.srt
3: Movie.CD2.avi
4: Movie.CD2.srt

Now let's assume the user has set a stacking regexp that only matches AVI files (like in my case), e.g.:

> ^(.*?)(\.CD[1-4])(.*?)(\.avi)$

The first item matches this regexp. The algorithm should check (starting with item 2) whether the remaining items also match this regexp and whether or not they are stackable (matching title, ignore, extension; mismatching volume) with item 1. Yet, because item 2 does not match the stacking regexp, lines 2256-2257 will restart the algorithm for item 1 with a different regexp instead of giving the algorithm a chance to find other files matching the regexp and stackable with item 1 (namely item 3) in the rest of the list. I believe the wrong iterator is incremented at line 2256 and that line 2257 should not read _break_ but rather _continue_ instead. If I'm right about the above, I believe the other _expr++/break_ combos also need to be changed.

I've come across this issue when some of my movies failed to stack properly only when subtitles were present in the same directory. This patch hasn't broken anything in my XBMC installation, yet obviously it needs to be reviewed by someone with better insight into XBMC's inner workings. Maybe I am missing something here.
