### PR TITLE
[fix] - let the scripts react on the abortRequested flag before killing them

### DIFF
--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -375,6 +375,13 @@ void XBPyThread::Process()
   PyThreadState_Swap(NULL);
   PyEval_ReleaseLock();
 
+  //set stopped event - this allows ::stop to run and kill remaining threads
+  //this event has to be fired without holding m_pExecuter->m_critSection
+  //before
+  //Also the GIL (PyEval_AcquireLock) must not be held
+  //if not obeyed there is still no deadlock because ::stop waits with timeout (smart one!)
+  stoppedEvent.Set();
+
   { CSingleLock lock(m_pExecuter->m_critSection);
     m_threadState = NULL;
   }
@@ -428,6 +435,17 @@ void XBPyThread::stop()
     if(!m || PyObject_SetAttrString(m, (char*)"abortRequested", PyBool_FromLong(1)))
       CLog::Log(LOGERROR, "XBPyThread::stop - failed to set abortRequested");
 
+    PyThreadState_Swap(old);
+    PyEval_ReleaseLock();
+
+    if(!stoppedEvent.WaitMSec(5000))//let the script 5 secs for shut stuff down
+    {
+      CLog::Log(LOGERROR, "XBPyThread::stop - script didn't stop in proper time - lets kill it");
+    }
+    
+    //everything which didn't exit by now gets killed
+    PyEval_AcquireLock();
+    old = PyThreadState_Swap((PyThreadState*)m_threadState);    
     for(PyThreadState* state = ((PyThreadState*)m_threadState)->interp->tstate_head; state; state = state->next)
     {
       Py_XDECREF(state->async_exc);

--- a/xbmc/interfaces/python/XBPyThread.h
+++ b/xbmc/interfaces/python/XBPyThread.h
@@ -23,6 +23,7 @@
 #define XBPYTHREAD_H_
 
 #include "threads/Thread.h"
+#include "threads/Event.h"
 #include "addons/IAddon.h"
 
 class XBPython;
@@ -42,6 +43,7 @@ public:
 
 protected:
   XBPython *m_pExecuter;
+  CEvent stoppedEvent;
   void *m_threadState;
 
   char m_type;


### PR DESCRIPTION
This fixes the shutdown of python scripts.

Until now we set abortRequested true and then raised the SystemExit exception on each running python thread in a running python script. There was no chance for the script to react on the abortRequested flag because we didn't even release the Global Interpreter Lock.

This is an example script which didn't shutdown properly: http://pastebin.com/dyUcb4sA

This PR realises the following shutdown flow:
1. When script gets stopped - set the abortRequested flag to the scripts module
2. Release the GIL and wait for stoppedEvent to get set for up to 5 secs (thats the time where the script and its threads can react on the abortRequested flag)
3. Meanwhile - the script can shutdown and the PyThread should go out of his Process() handler
4. When Process() is nearly finished set the stoppedEvent and wait on the m_pExecuter->m_critSection which is entered by the ::stop method at that time
5. ::stop gets signaled and locks the GIL again
6. ::stop function now kills all remaining threads in that script by raising the SystemExit exception
7. ::stop leaves the m_pExecuter->m_critSection
8. ::Process handler is able to enter it now and shuts down the interpreter for that script. And done we are.

This allows a really clean shutdown. But would be nice if jimfcarroll or anyone else could have a look.

Thx to cptspiff for the open ear :)

PS: i would like this to be eden code ...
