### PR TITLE
Sorting inside sets should default to year

### DIFF
--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -268,10 +268,10 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
           else
             AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 551, LABEL_MASKS("%T", "%R"));
 
-          AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%T", "%R"));  // Filename, Duration | Foldername, empty
-          AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%T", "%O"));
           AddSortMethod(SORT_METHOD_YEAR,562, LABEL_MASKS("%T", "%Y"));
         }
+        AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%T", "%R"));  // Filename, Duration | Foldername, empty
+        AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%T", "%O"));
         AddSortMethod(SORT_METHOD_VIDEO_RUNTIME,2050, LABEL_MASKS("%T", "%D"));
         AddSortMethod(SORT_METHOD_DATEADDED, 570, LABEL_MASKS("%T", "%R"));
 

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -278,7 +278,10 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
         if (g_settings.GetWatchMode(items.GetContent()) == VIDEO_SHOW_ALL)
           AddSortMethod(SORT_METHOD_PLAYCOUNT, 576, LABEL_MASKS("%T", "%V"));
 
-        SetSortMethod(g_settings.m_viewStateVideoNavTitles.m_sortMethod);
+        if (params.GetSetId() > -1)
+          SetSortMethod(SORT_METHOD_YEAR);
+        else
+          SetSortMethod(g_settings.m_viewStateVideoNavTitles.m_sortMethod);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavTitles.m_viewMode);
 
@@ -364,6 +367,8 @@ void CGUIViewStateWindowVideoNav::SaveViewState()
   if (m_items.IsVideoDb())
   {
     NODE_TYPE NodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_items.GetPath());
+    CQueryParams params;
+    CVideoDatabaseDirectory::GetQueryParams(m_items.GetPath(),params);
     switch (NodeType)
     {
     case NODE_TYPE_ACTOR:
@@ -376,7 +381,7 @@ void CGUIViewStateWindowVideoNav::SaveViewState()
       SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavGenres);
       break;
     case NODE_TYPE_TITLE_MOVIES:
-      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTitles);
+      SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, params.GetSetId() > -1 ? NULL : &g_settings.m_viewStateVideoNavTitles);
       break;
     case NODE_TYPE_EPISODES:
       SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavEpisodes);


### PR DESCRIPTION
Currently the set sorting does default to year, but this is then overriden by the default sort by sorttitle of the main movie title node.

This changes things so that the sort mode always defaults to sort by year, and if changed by the user, this is no longer saved into the default sort modes for title nodes.  It is still saved for the actual set that's changed.

The alternative to this would be to have a set-specific default sorting/view structure, so that if the user changes the view/sort mode/direction in one set it's automatically changed in all other sets (not previously changed by the user).  Not sure if that's better or not - typically sort by year would be correct in almost all cases, but there may be cases where the user wants a default view type for listings inside sets that is different than movie title listings??  Personally I don't see the use case.
