### PR TITLE
Preparations for sourcing AirPlay out into a python addon

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		DF4485341400651B0069344B /* FilePipe.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4485301400651B0069344B /* FilePipe.cpp */; };
 		DF4485351400651B0069344B /* PipesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4485321400651B0069344B /* PipesManager.cpp */; };
 		DF4485381400654A0069344B /* AirTunesServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4485361400654A0069344B /* AirTunesServer.cpp */; };
+		DF4A2EF514E2E84800E2A981 /* pyzeroconf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4A2EF314E2E84800E2A981 /* pyzeroconf.cpp */; };
 		DF673A251443769300A5A509 /* FileUPnP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF673A231443769300A5A509 /* FileUPnP.cpp */; };
 		DF98D9A81434F4B400A6EBE1 /* SkinVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF98D9A61434F4B400A6EBE1 /* SkinVariable.cpp */; };
 		DFA6BE8713FED2A10048CC11 /* AirPlayServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFA6BE8513FED2A10048CC11 /* AirPlayServer.cpp */; };
@@ -46,6 +47,7 @@
 		DFD4D22013D7286E00A47C47 /* Implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD4D21413D7286E00A47C47 /* Implementation.cpp */; };
 		DFD4D22113D7286E00A47C47 /* README.platform in Resources */ = {isa = PBXBuildFile; fileRef = DFD4D21613D7286E00A47C47 /* README.platform */; };
 		DFD4D22213D7286E00A47C47 /* SystemClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD4D21C13D7286E00A47C47 /* SystemClock.cpp */; };
+		DFED3C2014E4843300CE6232 /* pypipesmanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFED3C1E14E4843300CE6232 /* pypipesmanager.cpp */; };
 		F54D9E8E12B71457006870F9 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F54D9E8D12B71457006870F9 /* CoreAudio.framework */; };
 		F56B15FB12CD6922009B4C96 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56B15FA12CD6922009B4C96 /* CoreVideo.framework */; };
 		F56B15FD12CD6930009B4C96 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56B15FC12CD6930009B4C96 /* AudioToolbox.framework */; };
@@ -1008,6 +1010,8 @@
 		DF4485331400651B0069344B /* PipesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PipesManager.h; sourceTree = "<group>"; };
 		DF4485361400654A0069344B /* AirTunesServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AirTunesServer.cpp; sourceTree = "<group>"; };
 		DF4485371400654A0069344B /* AirTunesServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AirTunesServer.h; sourceTree = "<group>"; };
+		DF4A2EF314E2E84800E2A981 /* pyzeroconf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pyzeroconf.cpp; sourceTree = "<group>"; };
+		DF4A2EF414E2E84800E2A981 /* pyzeroconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pyzeroconf.h; sourceTree = "<group>"; };
 		DF673A231443769300A5A509 /* FileUPnP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileUPnP.cpp; sourceTree = "<group>"; };
 		DF673A241443769300A5A509 /* FileUPnP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileUPnP.h; sourceTree = "<group>"; };
 		DF98D9A61434F4B400A6EBE1 /* SkinVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SkinVariable.cpp; sourceTree = "<group>"; };
@@ -1032,6 +1036,8 @@
 		DFD4D21713D7286E00A47C47 /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
 		DFD4D21C13D7286E00A47C47 /* SystemClock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemClock.cpp; sourceTree = "<group>"; };
 		DFD4D21D13D7286E00A47C47 /* SystemClock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemClock.h; sourceTree = "<group>"; };
+		DFED3C1E14E4843300CE6232 /* pypipesmanager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pypipesmanager.cpp; sourceTree = "<group>"; };
+		DFED3C1F14E4843300CE6232 /* pypipesmanager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pypipesmanager.h; sourceTree = "<group>"; };
 		F54D9E8D12B71457006870F9 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		F558F66813AFE7F300631E12 /* Condition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Condition.h; sourceTree = "<group>"; };
 		F558F66E13AFE81500631E12 /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
@@ -4613,6 +4619,8 @@
 				F56C758C131EC152000AD0F6 /* listitem.h */,
 				F56C758D131EC152000AD0F6 /* player.cpp */,
 				F56C758E131EC152000AD0F6 /* player.h */,
+				DFED3C1E14E4843300CE6232 /* pypipesmanager.cpp */,
+				DFED3C1F14E4843300CE6232 /* pypipesmanager.h */,
 				F56C758F131EC152000AD0F6 /* pyplaylist.cpp */,
 				F56C7590131EC152000AD0F6 /* pyplaylist.h */,
 				F5E113AC1435882400175026 /* pyrendercapture.cpp */,
@@ -4623,6 +4631,8 @@
 				F56C7592131EC152000AD0F6 /* PythonPlayer.h */,
 				F56C7593131EC152000AD0F6 /* pyutil.cpp */,
 				F56C7594131EC152000AD0F6 /* pyutil.h */,
+				DF4A2EF314E2E84800E2A981 /* pyzeroconf.cpp */,
+				DF4A2EF414E2E84800E2A981 /* pyzeroconf.h */,
 				F56C7595131EC152000AD0F6 /* window.cpp */,
 				F56C7596131EC152000AD0F6 /* window.h */,
 				F56C7597131EC152000AD0F6 /* winxml.cpp */,
@@ -6940,6 +6950,8 @@
 				DF673A251443769300A5A509 /* FileUPnP.cpp in Sources */,
 				F5BD033A148D4923001B5583 /* CryptThreading.cpp in Sources */,
 				7CCFD9AA1514952700211D82 /* PCMCodec.cpp in Sources */,
+				DF4A2EF514E2E84800E2A981 /* pyzeroconf.cpp in Sources */,
+				DFED3C2014E4843300CE6232 /* pypipesmanager.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		DFD4D1E213D725ED00A47C47 /* Implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD4D1D813D725ED00A47C47 /* Implementation.cpp */; };
 		DFD4D1E713D7263000A47C47 /* README.platform in Resources */ = {isa = PBXBuildFile; fileRef = DFD4D1E613D7263000A47C47 /* README.platform */; };
 		DFD4D1FE13D7283500A47C47 /* SystemClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFD4D1FC13D7283500A47C47 /* SystemClock.cpp */; };
+		DFDFB4C614E2E8280012E41F /* pyzeroconf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFDFB4C414E2E8280012E41F /* pyzeroconf.cpp */; };
+		DFED3C1114E4842200CE6232 /* pypipesmanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFED3C0F14E4842200CE6232 /* pypipesmanager.cpp */; };
 		F56B143412CAF279009B4C96 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56B143312CAF279009B4C96 /* CoreVideo.framework */; };
 		F56B14A512CAF523009B4C96 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56B14A412CAF523009B4C96 /* AudioToolbox.framework */; };
 		F56B15D512CD67A9009B4C96 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F56B15D412CD67A9009B4C96 /* CoreGraphics.framework */; };
@@ -1032,6 +1034,10 @@
 		DFD4D1E613D7263000A47C47 /* README.platform */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.platform; sourceTree = "<group>"; };
 		DFD4D1FC13D7283500A47C47 /* SystemClock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemClock.cpp; sourceTree = "<group>"; };
 		DFD4D1FD13D7283500A47C47 /* SystemClock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemClock.h; sourceTree = "<group>"; };
+		DFDFB4C414E2E8280012E41F /* pyzeroconf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pyzeroconf.cpp; sourceTree = "<group>"; };
+		DFDFB4C514E2E8280012E41F /* pyzeroconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pyzeroconf.h; sourceTree = "<group>"; };
+		DFED3C0F14E4842200CE6232 /* pypipesmanager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pypipesmanager.cpp; sourceTree = "<group>"; };
+		DFED3C1014E4842200CE6232 /* pypipesmanager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pypipesmanager.h; sourceTree = "<group>"; };
 		F558F60613AFDC1700631E12 /* Condition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Condition.h; sourceTree = "<group>"; };
 		F558F61013AFDC3000631E12 /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
 		F56B143312CAF279009B4C96 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
@@ -4972,6 +4978,8 @@
 				F56C856F131F42EA000AD0F6 /* listitem.h */,
 				F56C8570131F42EA000AD0F6 /* player.cpp */,
 				F56C8571131F42EA000AD0F6 /* player.h */,
+				DFED3C0F14E4842200CE6232 /* pypipesmanager.cpp */,
+				DFED3C1014E4842200CE6232 /* pypipesmanager.h */,
 				F56C8572131F42EA000AD0F6 /* pyplaylist.cpp */,
 				F56C8573131F42EA000AD0F6 /* pyplaylist.h */,
 				F5E1127A14356C4600175026 /* pyrendercapture.cpp */,
@@ -4982,6 +4990,8 @@
 				F56C8575131F42EA000AD0F6 /* PythonPlayer.h */,
 				F56C8576131F42EA000AD0F6 /* pyutil.cpp */,
 				F56C8577131F42EA000AD0F6 /* pyutil.h */,
+				DFDFB4C414E2E8280012E41F /* pyzeroconf.cpp */,
+				DFDFB4C514E2E8280012E41F /* pyzeroconf.h */,
 				F56C8578131F42EA000AD0F6 /* window.cpp */,
 				F56C8579131F42EA000AD0F6 /* window.h */,
 				F56C857A131F42EA000AD0F6 /* winxml.cpp */,
@@ -6955,6 +6965,8 @@
 				DF6739E21443765F00A5A509 /* FileUPnP.cpp in Sources */,
 				F5BD034F148D496A001B5583 /* CryptThreading.cpp in Sources */,
 				7CCFD9991514950700211D82 /* PCMCodec.cpp in Sources */,
+				DFDFB4C614E2E8280012E41F /* pyzeroconf.cpp in Sources */,
+				DFED3C1114E4842200CE6232 /* pypipesmanager.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -637,6 +637,8 @@
 		DF448460140048C80069344B /* PipesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF44845B140048C80069344B /* PipesManager.cpp */; };
 		DF4484EE140054530069344B /* BXAcodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4484EC140054530069344B /* BXAcodec.cpp */; };
 		DF4484EF140054530069344B /* BXAcodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4484EC140054530069344B /* BXAcodec.cpp */; };
+		DF4B7B2614E1908D000E8004 /* pyzeroconf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4B7B2414E1908D000E8004 /* pyzeroconf.cpp */; };
+		DF4B7B2714E1908D000E8004 /* pyzeroconf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4B7B2414E1908D000E8004 /* pyzeroconf.cpp */; };
 		DF673AA51443819600A5A509 /* AddonManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FF41152BFA5001AF8A6 /* AddonManager.cpp */; };
 		DF85BAB51443669A000686BE /* FileUPnP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF85BAB41443669A000686BE /* FileUPnP.cpp */; };
 		DF85BAB61443669A000686BE /* FileUPnP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF85BAB41443669A000686BE /* FileUPnP.cpp */; };
@@ -644,6 +646,8 @@
 		DF98D98D1434F47D00A6EBE1 /* SkinVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF98D98A1434F47D00A6EBE1 /* SkinVariable.cpp */; };
 		DFAB049813F8376700B70BFB /* InertialScrollingHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB049613F8376700B70BFB /* InertialScrollingHandler.cpp */; };
 		DFAB049913F8376700B70BFB /* InertialScrollingHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB049613F8376700B70BFB /* InertialScrollingHandler.cpp */; };
+		DFED3A1B14E436D400CE6232 /* pypipesmanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFED3A1914E436D400CE6232 /* pypipesmanager.cpp */; };
+		DFED3A1C14E436D400CE6232 /* pypipesmanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFED3A1914E436D400CE6232 /* pypipesmanager.cpp */; };
 		E306D12E0DDF7B590052C2AD /* XBMCHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E306D12C0DDF7B590052C2AD /* XBMCHelper.cpp */; };
 		E33206380D5070AA00435CE3 /* DVDDemuxVobsub.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33206370D5070AA00435CE3 /* DVDDemuxVobsub.cpp */; };
 		E33466A60D2E5103005A65EC /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33466A50D2E5103005A65EC /* IOKit.framework */; };
@@ -2613,12 +2617,16 @@
 		DF44845C140048C80069344B /* PipesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PipesManager.h; sourceTree = "<group>"; };
 		DF4484EC140054530069344B /* BXAcodec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BXAcodec.cpp; sourceTree = "<group>"; };
 		DF4484ED140054530069344B /* BXAcodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BXAcodec.h; sourceTree = "<group>"; };
+		DF4B7B2414E1908D000E8004 /* pyzeroconf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pyzeroconf.cpp; sourceTree = "<group>"; };
+		DF4B7B2514E1908D000E8004 /* pyzeroconf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pyzeroconf.h; sourceTree = "<group>"; };
 		DF85BAB31443669A000686BE /* FileUPnP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileUPnP.h; sourceTree = "<group>"; };
 		DF85BAB41443669A000686BE /* FileUPnP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileUPnP.cpp; sourceTree = "<group>"; };
 		DF98D98A1434F47D00A6EBE1 /* SkinVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SkinVariable.cpp; sourceTree = "<group>"; };
 		DF98D98B1434F47D00A6EBE1 /* SkinVariable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SkinVariable.h; sourceTree = "<group>"; };
 		DFAB049613F8376700B70BFB /* InertialScrollingHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InertialScrollingHandler.cpp; sourceTree = "<group>"; };
 		DFAB049713F8376700B70BFB /* InertialScrollingHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InertialScrollingHandler.h; sourceTree = "<group>"; };
+		DFED3A1914E436D400CE6232 /* pypipesmanager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pypipesmanager.cpp; sourceTree = "<group>"; };
+		DFED3A1A14E436D400CE6232 /* pypipesmanager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pypipesmanager.h; sourceTree = "<group>"; };
 		E306D12C0DDF7B590052C2AD /* XBMCHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XBMCHelper.cpp; sourceTree = "<group>"; };
 		E306D12D0DDF7B590052C2AD /* XBMCHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XBMCHelper.h; sourceTree = "<group>"; };
 		E33206370D5070AA00435CE3 /* DVDDemuxVobsub.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDDemuxVobsub.cpp; sourceTree = "<group>"; };
@@ -6048,6 +6056,8 @@
 				E38E19FA0D25F9FB00618676 /* listitem.h */,
 				E38E25930D263CE000618676 /* player.cpp */,
 				E38E19FE0D25F9FB00618676 /* player.h */,
+				DFED3A1914E436D400CE6232 /* pypipesmanager.cpp */,
+				DFED3A1A14E436D400CE6232 /* pypipesmanager.h */,
 				E38E25940D263CE000618676 /* pyplaylist.cpp */,
 				E38E1A000D25F9FB00618676 /* pyplaylist.h */,
 				F5E1125C14356B2400175026 /* pyrendercapture.cpp */,
@@ -6058,6 +6068,8 @@
 				E38E1A020D25F9FB00618676 /* PythonPlayer.h */,
 				E38E25960D263CE000618676 /* pyutil.cpp */,
 				E38E1A040D25F9FB00618676 /* pyutil.h */,
+				DF4B7B2414E1908D000E8004 /* pyzeroconf.cpp */,
+				DF4B7B2514E1908D000E8004 /* pyzeroconf.h */,
 				E38E25970D263CE000618676 /* window.cpp */,
 				E38E1A060D25F9FB00618676 /* window.h */,
 				E38E25980D263CE000618676 /* winxml.cpp */,
@@ -8050,6 +8062,8 @@
 				DF673AA51443819600A5A509 /* AddonManager.cpp in Sources */,
 				F5BD02F6148D3A7E001B5583 /* CryptThreading.cpp in Sources */,
 				7CCFD98D151494E100211D82 /* PCMCodec.cpp in Sources */,
+				DF4B7B2614E1908D000E8004 /* pyzeroconf.cpp in Sources */,
+				DFED3A1B14E436D400CE6232 /* pypipesmanager.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8971,6 +8985,8 @@
 				DF85BAB61443669A000686BE /* FileUPnP.cpp in Sources */,
 				F5BD02F7148D3A7E001B5583 /* CryptThreading.cpp in Sources */,
 				7CCFD98C151494E100211D82 /* PCMCodec.cpp in Sources */,
+				DF4B7B2714E1908D000E8004 /* pyzeroconf.cpp in Sources */,
+				DFED3A1C14E436D400CE6232 /* pypipesmanager.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/configure.in
+++ b/configure.in
@@ -900,6 +900,7 @@ else
 fi
 
 # avahi
+USE_AVAHI=0
 if test "$host_vendor" = "apple" ; then
   use_avahi="no"
   AC_MSG_RESULT($avahi_disabled)
@@ -911,6 +912,9 @@ else
       #either both libs or none
       AC_CHECK_LIB([avahi-client], [main],,
         use_avahi=no;AC_MSG_RESULT($avahi_not_found))
+    fi
+    if test "$use_avahi" = "yes"; then
+      USE_AVAHI=1
     fi
   else
     AC_MSG_RESULT($avahi_disabled)
@@ -1959,7 +1963,7 @@ AC_SUBST(USE_AIRTUNES)
 AC_SUBST(USE_LIBUDEV)
 AC_SUBST(USE_LIBUSB)
 AC_SUBST(USE_LIBCEC)
-
+AC_SUBST(USE_AVAHI)
 
 # pushd and popd are not available in other shells besides bash, so implement
 # our own pushd/popd functions

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -551,6 +551,7 @@
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\player.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\pypipesmanager.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\pyplaylist.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -564,6 +565,7 @@
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\pyutil.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\pyzeroconf.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\window.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -759,6 +761,8 @@
     <ClInclude Include="..\..\xbmc\cores\paplayer\PCMCodec.h" />
     <ClInclude Include="..\..\xbmc\filesystem\FileUPnP.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pythreadstate.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pypipesmanager.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyzeroconf.h" />
     <ClInclude Include="..\..\xbmc\threads\platform\win\Implementation.cpp" />
     <ClCompile Include="..\..\xbmc\threads\SystemClock.cpp" />
     <ClCompile Include="..\..\xbmc\threads\Thread.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2567,6 +2567,11 @@
     </ClCompile>
     <ClCompile Include="..\..\xbmc\cores\paplayer\PCMCodec.cpp">
       <Filter>cores\paplayer</Filter>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\pyzeroconf.cpp">
+      <Filter>interfaces\python\xbmcmodule</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\pypipesmanager.cpp">
+      <Filter>interfaces\python\xbmcmodule</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -5159,6 +5164,11 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\paplayer\PCMCodec.h">
       <Filter>cores\paplayer</Filter>
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pypipesmanager.h">
+      <Filter>interfaces\python\xbmcmodule</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyzeroconf.h">
+      <Filter>interfaces\python\xbmcmodule</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1132,10 +1132,13 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
     if(g_application.IsPlaying() && g_application.m_pPlayer)
       g_application.m_pPlayer->GetChapterName(strLabel);
     break;
+  case PLAYER_PROGRESS:
+  case PLAYER_PROGRESS_CACHE:
+  case PLAYER_SEEKBAR:
   case PLAYER_CACHELEVEL:
     {
       int iLevel = 0;
-      if(g_application.IsPlaying() && GetInt(iLevel, PLAYER_CACHELEVEL) && iLevel >= 0)
+      if(g_application.IsPlaying() && GetInt(iLevel, info) && iLevel >= 0)
         strLabel.Format("%i", iLevel);
     }
     break;

--- a/xbmc/filesystem/PipesManager.cpp
+++ b/xbmc/filesystem/PipesManager.cpp
@@ -30,7 +30,7 @@
 using namespace XFILE;
 
 
-Pipe::Pipe(const CStdString &name, int nMaxSize)
+Pipe::Pipe(const std::string &name, int nMaxSize)
 {
   m_buffer.Create(nMaxSize);
   m_nRefCount = 1;
@@ -52,7 +52,7 @@ void Pipe::SetOpenThreashold(int threashold)
   m_nOpenThreashold = threashold;
 }
 
-const CStdString &Pipe::GetName() 
+const std::string &Pipe::GetName() 
 {
   return m_strPipeName;
 }
@@ -281,7 +281,7 @@ PipesManager &PipesManager::GetInstance()
   return instance;
 }
 
-CStdString   PipesManager::GetUniquePipeName()
+std::string   PipesManager::GetUniquePipeName()
 {
   CSingleLock lock(m_lock);
   CStdString id;
@@ -289,10 +289,10 @@ CStdString   PipesManager::GetUniquePipeName()
   return id;
 }
 
-XFILE::Pipe *PipesManager::CreatePipe(const CStdString &name, int nMaxPipeSize)
+XFILE::Pipe *PipesManager::CreatePipe(const std::string &name, int nMaxPipeSize)
 {
-  CStdString pName = name;
-  if (pName.IsEmpty())
+  std::string pName = name;
+  if (pName.empty())
     pName = GetUniquePipeName();
   
   CSingleLock lock(m_lock);
@@ -304,7 +304,7 @@ XFILE::Pipe *PipesManager::CreatePipe(const CStdString &name, int nMaxPipeSize)
   return p;
 }
 
-bool         PipesManager::OpenPipeForWrite(const CStdString &name)
+bool         PipesManager::OpenPipeForWrite(const std::string &name)
 {
   bool ret = true;
   CSingleLock lock(m_lock);
@@ -314,38 +314,42 @@ bool         PipesManager::OpenPipeForWrite(const CStdString &name)
   return ret;
 }
 
-bool         PipesManager::Write(const CStdString &name, const char *buf, int nSize)
+bool         PipesManager::Write(const std::string &name, const char *buf, int nSize)
 {
   CSingleLock lock(m_lock);
-  if (m_pipes.find(name) == m_pipes.end())
+  std::map<std::string, XFILE::Pipe *>::iterator i = m_pipes.find(name);
+  if (i == m_pipes.end())
     return false;
-  return m_pipes[name]->Write(buf,nSize, INFINITE);
+  return i->second->Write(buf,nSize, INFINITE);
 }
 
-bool         PipesManager::Read(const CStdString &name, char *buf, int nSize)
+bool         PipesManager::Read(const std::string &name, char *buf, int nSize)
 {
   CSingleLock lock(m_lock);
-  if (m_pipes.find(name) == m_pipes.end())
+  std::map<std::string, XFILE::Pipe *>::iterator i = m_pipes.find(name);
+  if (i == m_pipes.end())
     return false;
-  return m_pipes[name]->Read(buf,nSize, INFINITE);
+  return i->second->Read(buf,nSize, INFINITE);
 }
 
-XFILE::Pipe *PipesManager::OpenPipe(const CStdString &name)
+XFILE::Pipe *PipesManager::OpenPipe(const std::string &name)
 {
   CSingleLock lock(m_lock);
-  if (m_pipes.find(name) == m_pipes.end())
+  std::map<std::string, XFILE::Pipe *>::iterator i = m_pipes.find(name);
+  if (i == m_pipes.end())
     return NULL;
-  m_pipes[name]->AddRef();
-  return m_pipes[name];
+  i->second->AddRef();
+  return i->second;
 }
 
-void         PipesManager::ClosePipe(const CStdString &name)
+void         PipesManager::ClosePipe(const std::string &name)
 {
   CSingleLock lock(m_lock);
-  if (m_pipes.find(name) == m_pipes.end())
+  std::map<std::string, XFILE::Pipe *>::iterator i = m_pipes.find(name);
+  if (i == m_pipes.end())
     return;
   lock.Leave();
-  ClosePipe(m_pipes[name]);
+  ClosePipe(i->second);
 }
 
 void         PipesManager::ClosePipe(XFILE::Pipe *pipe)
@@ -363,32 +367,35 @@ void         PipesManager::ClosePipe(XFILE::Pipe *pipe)
   }
 }
 
-bool         PipesManager::Exists(const CStdString &name)
+bool         PipesManager::Exists(const std::string &name)
 {
   CSingleLock lock(m_lock);
   return (m_pipes.find(name) != m_pipes.end());
 }
 
-void         PipesManager::SetOpenThreashold(const CStdString &name, int threashold)
+void         PipesManager::SetOpenThreashold(const std::string &name, int threashold)
 {
   CSingleLock lock(m_lock);
-  if (m_pipes.find(name) == m_pipes.end())
+  std::map<std::string, XFILE::Pipe *>::iterator i = m_pipes.find(name);
+  if (i == m_pipes.end())
     return;
-  m_pipes[name]->SetOpenThreashold(threashold);
+  i->second->SetOpenThreashold(threashold);
 }
 
-void         PipesManager::SetEof(const CStdString &name)
+void         PipesManager::SetEof(const std::string &name)
 {
   CSingleLock lock(m_lock);
-  if (m_pipes.find(name) == m_pipes.end())
+  std::map<std::string, XFILE::Pipe *>::iterator i = m_pipes.find(name);
+  if (i == m_pipes.end())
     return;
-  m_pipes[name]->SetEof();
+  i->second->SetEof();
 }
 
-void         PipesManager::Flush(const CStdString &name)
+void         PipesManager::Flush(const std::string &name)
 {
   CSingleLock lock(m_lock);
-  if (m_pipes.find(name) == m_pipes.end())
+  std::map<std::string, XFILE::Pipe *>::iterator i = m_pipes.find(name);  
+  if (i == m_pipes.end())
     return;
-  m_pipes[name]->Flush();
+  i->second->Flush();
 }

--- a/xbmc/filesystem/PipesManager.h
+++ b/xbmc/filesystem/PipesManager.h
@@ -27,7 +27,7 @@
 
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
-#include "utils/StdString.h"
+#include <string>
 #include "utils/RingBuffer.h"
 
 #include <map>
@@ -48,9 +48,9 @@ public:
 class Pipe
   {
   public:
-    Pipe(const CStdString &name, int nMaxSize = PIPE_DEFAULT_MAX_SIZE ); 
+    Pipe(const std::string &name, int nMaxSize = PIPE_DEFAULT_MAX_SIZE ); 
     virtual ~Pipe();
-    const CStdString &GetName();
+    const std::string &GetName();
     
     void AddRef();
     void DecRef();   // a pipe does NOT delete itself with ref-count 0. 
@@ -81,7 +81,7 @@ class Pipe
 
     bool        m_bEof;
     CRingBuffer m_buffer;
-    CStdString  m_strPipeName;  
+    std::string  m_strPipeName;  
     int         m_nRefCount;
     int         m_nOpenThreashold;
 
@@ -100,23 +100,23 @@ public:
   virtual ~PipesManager();
   static PipesManager &GetInstance();
 
-  CStdString   GetUniquePipeName();
-  XFILE::Pipe *CreatePipe(const CStdString &name="", int nMaxPipeSize = PIPE_DEFAULT_MAX_SIZE);
-  XFILE::Pipe *OpenPipe(const CStdString &name);
-  bool         OpenPipeForWrite(const CStdString &name);
-  bool         Write(const CStdString &name, const char *buf, int nSize);
-  bool         Read(const CStdString &name, char *buf, int nSize);
+  std::string   GetUniquePipeName();
+  XFILE::Pipe *CreatePipe(const std::string &name="", int nMaxPipeSize = PIPE_DEFAULT_MAX_SIZE);
+  XFILE::Pipe *OpenPipe(const std::string &name);
+  bool         OpenPipeForWrite(const std::string &name);
+  bool         Write(const std::string &name, const char *buf, int nSize);
+  bool         Read(const std::string &name, char *buf, int nSize);
   void         ClosePipe(XFILE::Pipe *pipe);
-  void         ClosePipe(const CStdString &name);
-  bool         Exists(const CStdString &name);
-  void         SetOpenThreashold(const CStdString &name, int threashold);
-  void         SetEof(const CStdString &name);
-  void         Flush(const CStdString &name);
+  void         ClosePipe(const std::string &name);
+  bool         Exists(const std::string &name);
+  void         SetOpenThreashold(const std::string &name, int threashold);
+  void         SetEof(const std::string &name);
+  void         Flush(const std::string &name);
   
 protected:
   PipesManager();
   int    m_nGenIdHelper;
-  std::map<CStdString, XFILE::Pipe *> m_pipes;  
+  std::map<std::string, XFILE::Pipe *> m_pipes;  
   
   CCriticalSection m_lock;
 };

--- a/xbmc/filesystem/PipesManager.h
+++ b/xbmc/filesystem/PipesManager.h
@@ -103,8 +103,15 @@ public:
   CStdString   GetUniquePipeName();
   XFILE::Pipe *CreatePipe(const CStdString &name="", int nMaxPipeSize = PIPE_DEFAULT_MAX_SIZE);
   XFILE::Pipe *OpenPipe(const CStdString &name);
+  bool         OpenPipeForWrite(const CStdString &name);
+  bool         Write(const CStdString &name, const char *buf, int nSize);
+  bool         Read(const CStdString &name, char *buf, int nSize);
   void         ClosePipe(XFILE::Pipe *pipe);
+  void         ClosePipe(const CStdString &name);
   bool         Exists(const CStdString &name);
+  void         SetOpenThreashold(const CStdString &name, int threashold);
+  void         SetEof(const CStdString &name);
+  void         Flush(const CStdString &name);
   
 protected:
   PipesManager();
@@ -117,4 +124,5 @@ protected:
 }
 
 #endif
+
 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -128,6 +128,7 @@ const BUILT_IN commands[] = {
   { "PlayMedia",                  true,   "Play the specified media file (or playlist)" },
   { "SlideShow",                  true,   "Run a slideshow from the specified directory" },
   { "RecursiveSlideShow",         true,   "Run a slideshow from the specified directory, including all subdirs" },
+  { "ShowPicture",                true,   "Show the picture from the specified path" },
   { "ReloadSkin",                 false,  "Reload XBMC's skin" },
   { "UnloadSkin",                 false,  "Unload XBMC's skin" },
   { "RefreshRSS",                 false,  "Reload RSS feeds from RSSFeeds.xml"},
@@ -590,6 +591,15 @@ int CBuiltins::Execute(const CStdString& execString)
     msg.SetStringParam(params[0]);
     CGUIWindow *pWindow = g_windowManager.GetWindow(WINDOW_SLIDESHOW);
     if (pWindow) pWindow->OnMessage(msg);
+  }
+  else if (execute.Equals("ShowPicture"))
+  {
+    if (!params.size())
+    {
+      CLog::Log(LOGERROR, "XBMC.ShowPicture called with empty parameter");
+      return -2;
+    }
+    g_application.getApplicationMessenger().PictureShow(params[0]);
   }
   else if (execute.Equals("reloadskin"))
   {

--- a/xbmc/interfaces/python/xbmcmodule/Makefile.in
+++ b/xbmc/interfaces/python/xbmcmodule/Makefile.in
@@ -25,6 +25,7 @@ SRCS=action.cpp \
      player.cpp \
      pyplaylist.cpp \
      pyrendercapture.cpp \
+     pypipesmanager.cpp \
      PythonAddon.cpp \
      PythonPlayer.cpp \
      pyutil.cpp \
@@ -36,6 +37,11 @@ SRCS=action.cpp \
      xbmcmodule.cpp \
      xbmcplugin.cpp \
      xbmcvfsmodule.cpp \
+
+ifeq (@USE_AVAHI@, 1)
+SRCS+=pyzeroconf.cpp
+endif
+
 
 LIB=xbmcmodule.a
 

--- a/xbmc/interfaces/python/xbmcmodule/pypipesmanager.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/pypipesmanager.cpp
@@ -1,0 +1,202 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "pypipesmanager.h"
+#include "system.h"
+
+#include "pyutil.h"
+#include "pythreadstate.h"
+#include "filesystem/PipesManager.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace PYXBMC
+{
+  PyObject* PipesManager_New(PyTypeObject *type, PyObject *args, PyObject *kwds)
+  {
+    PipesManager *self = (PipesManager*)type->tp_alloc(type, 0);
+    if (!self)
+      return NULL;
+
+    return (PyObject*)self;
+  }
+
+  void PipesManager_Dealloc(PipesManager* self)
+  {
+    self->ob_type->tp_free((PyObject*)self);
+  }
+  
+  // PipesManager_OpenPipeForWrite
+  PyDoc_STRVAR(openPipeForWrite__doc__,
+    "openPipeForWrite(name) -- creates and opens a pipe with the given name/url - name has to be in form pipe://pipename/\n"
+    "return true on success");
+
+  PyObject* PipesManager_OpenPipeForWrite(PipesManager *self, PyObject *args)
+  {   
+    char *name = NULL;
+    bool ret = false;
+    if (PyArg_ParseTuple(args, (char*)"s", &name))
+    {
+      ret = XFILE::PipesManager::GetInstance().OpenPipeForWrite(CStdString(name));
+    }  
+    return Py_BuildValue((char*)"b", ret);
+  }
+
+  // PipesManager_Write
+  PyDoc_STRVAR(write__doc__,
+    "write(name, buff) -- write buff in pipe name. returns true on success\n");
+
+  PyObject* PipesManager_Write(PipesManager *self, PyObject *args)
+  {
+    bool ret = false;
+    char *name = NULL;
+    char *buff = NULL;
+    int nSize = 0;
+
+    if (PyArg_ParseTuple(args, (char*)"ss#", &name, &buff, &nSize))
+    {
+      ret = XFILE::PipesManager::GetInstance().Write(CStdString(name), buff, nSize);
+    }
+    return Py_BuildValue((char*)"b", ret);
+  }
+
+  // PipesManager_ClosePipe
+  PyDoc_STRVAR(closePipe__doc__,
+    "closePipe(name), close the given pipe\n");
+
+  PyObject* PipesManager_ClosePipe(PipesManager *self, PyObject *args)
+  {
+    char *name = NULL;
+    
+    if (PyArg_ParseTuple(args, (char*)"s", &name))
+    {
+      XFILE::PipesManager::GetInstance().ClosePipe(CStdString(name));
+    }
+    Py_INCREF(Py_None);
+    return Py_None;
+  }  
+  
+  // PipesManager_SetOpenThreshold
+  PyDoc_STRVAR(setOpenThreshold__doc__,
+    "setOpenThreshold(name, thre), close the given pipe\n");
+
+  PyObject* PipesManager_SetOpenThreshold(PipesManager *self, PyObject *args)
+  {
+    char *name = NULL;
+    int thresh = 0;
+    
+    if (PyArg_ParseTuple(args, (char*)"si", &name, &thresh))
+    {
+      XFILE::PipesManager::GetInstance().SetOpenThreashold(CStdString(name),thresh);
+    }
+    Py_INCREF(Py_None);
+    return Py_None;
+  }  
+  
+   // PipesManager_SetEof
+  PyDoc_STRVAR(setEof__doc__,
+    "setEof(name), sets eof on the given pipe\n");
+
+  PyObject* PipesManager_SetEof(PipesManager *self, PyObject *args)
+  {
+    char *name = NULL;
+    
+    if (PyArg_ParseTuple(args, (char*)"s", &name))
+    {
+      XFILE::PipesManager::GetInstance().SetEof(CStdString(name));
+    }
+    Py_INCREF(Py_None);
+    return Py_None;
+  }  
+  
+  // PipesManager_Flush
+  PyDoc_STRVAR(flush__doc__,
+    "flush(name), flush the given pipe\n");
+
+  PyObject* PipesManager_Flush(PipesManager *self, PyObject *args)
+  {
+    char *name = NULL;
+    
+    if (PyArg_ParseTuple(args, (char*)"s", &name))
+    {
+      XFILE::PipesManager::GetInstance().Flush(CStdString(name));
+    }
+    Py_INCREF(Py_None);
+    return Py_None;
+  }  
+  
+  // PipesManager_Exists
+  PyDoc_STRVAR(exists__doc__,
+    "exists(name), returns true if given pipe exists\n");
+
+  PyObject* PipesManager_Exists(PipesManager *self, PyObject *args)
+  {
+    char *name = NULL;
+    bool ret = false;
+    
+    if (PyArg_ParseTuple(args, (char*)"s", &name))
+    {
+      ret = XFILE::PipesManager::GetInstance().Exists(CStdString(name));
+    }
+    return Py_BuildValue((char*)"b", ret);;
+  }  
+  
+  PyMethodDef PipesManager_methods[] = {
+    {(char*)"openPipeForWrite",   (PyCFunction)PipesManager_OpenPipeForWrite,   METH_VARARGS, openPipeForWrite__doc__   },
+    {(char*)"write",              (PyCFunction)PipesManager_Write,              METH_VARARGS, write__doc__              },
+    {(char*)"closePipe",          (PyCFunction)PipesManager_ClosePipe,          METH_VARARGS, closePipe__doc__          },
+    {(char*)"setOpenThreshold",   (PyCFunction)PipesManager_SetOpenThreshold,   METH_VARARGS, setOpenThreshold__doc__   },
+    {(char*)"setEof",             (PyCFunction)PipesManager_SetEof,             METH_VARARGS, setEof__doc__             },
+    {(char*)"flush",              (PyCFunction)PipesManager_Flush,              METH_VARARGS, flush__doc__              },
+    {(char*)"exists",             (PyCFunction)PipesManager_Exists,             METH_VARARGS, exists__doc__             },
+    {NULL,                        NULL,                                         0,            NULL                      }
+  };
+  
+  PyDoc_STRVAR(PipesManager__doc__,
+    "PipesManager class.\n"
+    "\n"
+    "Access pipes via our PipesManager instance.\n");
+
+// Restore code and data sections to normal.
+
+  PyTypeObject PipesManager_Type;
+
+  void initPipesManager_Type()
+  {
+    PyXBMCInitializeTypeObject(&PipesManager_Type);
+
+    PipesManager_Type.tp_name      = (char*)"xbmc.PipesManager";
+    PipesManager_Type.tp_basicsize = sizeof(PipesManager);
+    PipesManager_Type.tp_dealloc   = (destructor)PipesManager_Dealloc;
+    PipesManager_Type.tp_flags     = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
+    PipesManager_Type.tp_doc       = PipesManager__doc__;
+    PipesManager_Type.tp_methods   = PipesManager_methods;
+    PipesManager_Type.tp_base      = 0;
+    PipesManager_Type.tp_new       = PipesManager_New;
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/xbmc/interfaces/python/xbmcmodule/pypipesmanager.h
+++ b/xbmc/interfaces/python/xbmcmodule/pypipesmanager.h
@@ -1,0 +1,53 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#pragma once
+
+#include <Python.h>
+#include <map>
+#include <string>
+
+//PyByteArray_FromStringAndSize is only available in python 2.6 and up
+#if PY_VERSION_HEX >= 0x02060000 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+class PipesManager;
+
+namespace PYXBMC
+{
+  typedef struct {
+    PyObject_HEAD
+  } PipesManager;
+
+  extern PyTypeObject PipesManager_Type;
+  void initPipesManager_Type();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //PY_VERSION_HEX >= 0x02060000
+
+

--- a/xbmc/interfaces/python/xbmcmodule/pypipesmanager.h
+++ b/xbmc/interfaces/python/xbmcmodule/pypipesmanager.h
@@ -25,9 +25,6 @@
 #include <map>
 #include <string>
 
-//PyByteArray_FromStringAndSize is only available in python 2.6 and up
-#if PY_VERSION_HEX >= 0x02060000 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,7 +44,3 @@ namespace PYXBMC
 #ifdef __cplusplus
 }
 #endif
-
-#endif //PY_VERSION_HEX >= 0x02060000
-
-

--- a/xbmc/interfaces/python/xbmcmodule/pyzeroconf.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/pyzeroconf.cpp
@@ -41,12 +41,6 @@ namespace PYXBMC
     if (!self)
       return NULL;
 
-    self->zeroconf = CZeroconf::GetInstance();
-    if (!self->zeroconf)
-    {
-        return PyErr_NoMemory();    //we will never hit this imho
-    }
-    
     self->txt_records = new std::map<std::string, std::string>();
 
     return (PyObject*)self;
@@ -81,7 +75,7 @@ namespace PYXBMC
 
     if (PyArg_ParseTuple(args, (char*)"ss", &key, &value))
     {
-      self->txt_records->insert(std::make_pair(CStdString(key), CStdString(value)));
+      self->txt_records->insert(std::make_pair(std::string(key), std::string(value)));
     }
     Py_INCREF(Py_None);
     return Py_None;
@@ -93,8 +87,7 @@ namespace PYXBMC
 
   PyObject* Zeroconf_IsEnabled(Zeroconf *self, PyObject *args)
   {
-    bool ret = false;
-    ret = g_guiSettings.GetBool("services.zeroconf");
+    bool ret = g_guiSettings.GetBool("services.zeroconf");
     return Py_BuildValue((char*)"b", ret);
   }
 
@@ -109,7 +102,7 @@ namespace PYXBMC
     
     if (PyArg_ParseTuple(args, (char*)"s", &fcr_identifier))
     {
-      ret = self->zeroconf->RemoveService(fcr_identifier);
+      ret = CZeroconf::GetInstance()->RemoveService(fcr_identifier);
     }
     return Py_BuildValue((char*)"b", ret);
   }
@@ -135,7 +128,7 @@ namespace PYXBMC
     
     if (PyArg_ParseTuple(args, (char*)"sssi", &fcr_identifier, &fcr_type, &fcr_name, &f_port))
     {
-      ret = self->zeroconf->PublishService(fcr_identifier, fcr_type, fcr_name, f_port, *self->txt_records);
+      ret = CZeroconf::GetInstance()->PublishService(fcr_identifier, fcr_type, fcr_name, f_port, *self->txt_records);
       self->txt_records->clear();
     }
     return Py_BuildValue((char*)"b", ret);

--- a/xbmc/interfaces/python/xbmcmodule/pyzeroconf.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/pyzeroconf.cpp
@@ -1,0 +1,183 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "pyzeroconf.h"
+#include "system.h"
+
+#ifdef HAS_ZEROCONF
+
+#include "pyutil.h"
+#include "pythreadstate.h"
+#include "network/Zeroconf.h"
+#include "settings/GUISettings.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace PYXBMC
+{
+  PyObject* Zeroconf_New(PyTypeObject *type, PyObject *args, PyObject *kwds)
+  {
+    Zeroconf *self = (Zeroconf*)type->tp_alloc(type, 0);
+    if (!self)
+      return NULL;
+
+    self->zeroconf = CZeroconf::GetInstance();
+    if (!self->zeroconf)
+    {
+        return PyErr_NoMemory();    //we will never hit this imho
+    }
+    
+    self->txt_records = new std::map<std::string, std::string>();
+
+    return (PyObject*)self;
+  }
+
+  void Zeroconf_Dealloc(Zeroconf* self)
+  {
+    self->txt_records->clear();
+    delete self->txt_records;
+    self->ob_type->tp_free((PyObject*)self);
+  }
+  
+  // Zeroconf_ClearTxtRecords
+  PyDoc_STRVAR(clearTxtRecords__doc__,
+    "clearTxtRecords() -- clears self->txt_records\n");
+
+  PyObject* Zeroconf_ClearTxtRecords(Zeroconf *self, PyObject *args)
+  {   
+    self->txt_records->clear();
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+  
+  // Zeroconf_AddTxtRecord
+  PyDoc_STRVAR(addTxtRecord__doc__,
+    "addTxtRecords(key, value) -- add a txt record to self->txt_records\n");
+
+  PyObject* Zeroconf_AddTxtRecord(Zeroconf *self, PyObject *args)
+  { 
+    char *key = NULL;
+    char *value = NULL;
+
+    if (PyArg_ParseTuple(args, (char*)"ss", &key, &value))
+    {
+      self->txt_records->insert(std::make_pair(CStdString(key), CStdString(value)));
+    }
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+
+  // Zeroconf_IsEnabled
+  PyDoc_STRVAR(isEnabled__doc__,
+    "isEnabled() -- returns false if zeroconf is disabled in settings, else true\n");
+
+  PyObject* Zeroconf_IsEnabled(Zeroconf *self, PyObject *args)
+  {
+    bool ret = false;
+    ret = g_guiSettings.GetBool("services.zeroconf");
+    return Py_BuildValue((char*)"b", ret);
+  }
+
+  // Zeroconf_RemoveService
+  PyDoc_STRVAR(removeSerice__doc__,
+    "removeService(fcr_identifier) -- returns false if fcr_identifier does not exist\n");
+
+  PyObject* Zeroconf_RemoveService(Zeroconf *self, PyObject *args)
+  {
+    bool ret = false;
+    char *fcr_identifier = NULL;
+    
+    if (PyArg_ParseTuple(args, (char*)"s", &fcr_identifier))
+    {
+      ret = self->zeroconf->RemoveService(fcr_identifier);
+    }
+    return Py_BuildValue((char*)"b", ret);
+  }
+
+  // Zeroconf_PublishService
+  PyDoc_STRVAR(publishService__doc__,
+    "removeService(fcr_identifier, fcr_type, fcr_name, f_port) -- Announce a service via zeroconf\n"
+    "fcr_identifier         : can be used to stop this service later - so its a unique identifier for this service\n"
+    "fcr_type               : is the zeroconf service type to publish (e.g. _http._tcp for webserver)\n"
+    "fcr_name               : is the name of the service to publish (human readable). The hostname is currently automatically appended\n"
+    "and used for name collisions. e.g. XBMC would get published as fcr_name@Martn or, after collision fcr_name@Martn-2\n"
+    "f_port                 : port of the service to publish\n"
+    "if txt-records where added via addTxtRecord these will be published aswell\n"
+    "returns                : false if fcr_identifier was already present\n");
+
+  PyObject* Zeroconf_PublishService(Zeroconf *self, PyObject *args)
+  {
+    bool ret = false;
+    char *fcr_identifier = NULL;
+    char *fcr_type = NULL;
+    char *fcr_name = NULL;
+    unsigned int f_port = 0;
+    
+    if (PyArg_ParseTuple(args, (char*)"sssi", &fcr_identifier, &fcr_type, &fcr_name, &f_port))
+    {
+      ret = self->zeroconf->PublishService(fcr_identifier, fcr_type, fcr_name, f_port, *self->txt_records);
+      self->txt_records->clear();
+    }
+    return Py_BuildValue((char*)"b", ret);
+  }  
+  
+  PyMethodDef Zeroconf_methods[] = {
+    {(char*)"removeService",    (PyCFunction)Zeroconf_RemoveService,    METH_VARARGS, removeSerice__doc__     },
+    {(char*)"publishService",   (PyCFunction)Zeroconf_PublishService,   METH_VARARGS, publishService__doc__   },
+    {(char*)"clearTxtRecords",  (PyCFunction)Zeroconf_ClearTxtRecords,  METH_VARARGS, clearTxtRecords__doc__  },
+    {(char*)"addTxtRecord",     (PyCFunction)Zeroconf_AddTxtRecord,     METH_VARARGS, addTxtRecord__doc__     },
+    {(char*)"isEnabled",        (PyCFunction)Zeroconf_IsEnabled,        METH_VARARGS, isEnabled__doc__        },
+    {NULL,                      NULL,                                   0,            NULL                    }
+  };
+
+  PyDoc_STRVAR(Zeroconf__doc__,
+    "Zeroconf class.\n"
+    "\n"
+    "Announce a service via zeroconf.\n");
+
+// Restore code and data sections to normal.
+
+  PyTypeObject Zeroconf_Type;
+
+  void initZeroconf_Type()
+  {
+    PyXBMCInitializeTypeObject(&Zeroconf_Type);
+
+    Zeroconf_Type.tp_name      = (char*)"xbmc.Zeroconf";
+    Zeroconf_Type.tp_basicsize = sizeof(Zeroconf);
+    Zeroconf_Type.tp_dealloc   = (destructor)Zeroconf_Dealloc;
+    Zeroconf_Type.tp_flags     = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
+    Zeroconf_Type.tp_doc       = Zeroconf__doc__;
+    Zeroconf_Type.tp_methods   = Zeroconf_methods;
+    Zeroconf_Type.tp_base      = 0;
+    Zeroconf_Type.tp_new       = Zeroconf_New;
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //HAS_PYZEROCONF
+
+

--- a/xbmc/interfaces/python/xbmcmodule/pyzeroconf.h
+++ b/xbmc/interfaces/python/xbmcmodule/pyzeroconf.h
@@ -35,7 +35,6 @@ namespace PYXBMC
 {
   typedef struct {
     PyObject_HEAD
-    CZeroconf* zeroconf;
     std::map<std::string, std::string> *txt_records;
   } Zeroconf;
 

--- a/xbmc/interfaces/python/xbmcmodule/pyzeroconf.h
+++ b/xbmc/interfaces/python/xbmcmodule/pyzeroconf.h
@@ -1,0 +1,48 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#pragma once
+
+#include <Python.h>
+#include <map>
+#include <string>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+class CZeroconf;
+
+namespace PYXBMC
+{
+  typedef struct {
+    PyObject_HEAD
+    CZeroconf* zeroconf;
+    std::map<std::string, std::string> *txt_records;
+  } Zeroconf;
+
+  extern PyTypeObject Zeroconf_Type;
+  void initZeroconf_Type();
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -54,6 +54,10 @@
 #include "pythreadstate.h"
 #include "utils/log.h"
 #include "pyrendercapture.h"
+#include "pypipesmanager.h"
+#ifdef HAS_ZEROCONF
+#include "pyzeroconf.h"
+#endif//HAS_ZEROCONF
 
 // include for constants
 #include "pyutil.h"
@@ -1025,6 +1029,11 @@ namespace PYXBMC
     initPlayListItem_Type();
     initInfoTagMusic_Type();
     initInfoTagVideo_Type();
+    initPipesManager_Type();
+ 
+ #ifdef HAS_ZEROCONF
+    initZeroconf_Type();
+ #endif//HAS_ZEROCONF
 
 #ifdef HAS_PYRENDERCAPTURE
     initRenderCapture_Type();
@@ -1035,8 +1044,14 @@ namespace PYXBMC
         PyType_Ready(&PlayList_Type) < 0 ||
         PyType_Ready(&PlayListItem_Type) < 0 ||
         PyType_Ready(&InfoTagMusic_Type) < 0 ||
-        PyType_Ready(&InfoTagVideo_Type) < 0) return;
+        PyType_Ready(&InfoTagVideo_Type) < 0 ||
+        PyType_Ready(&PipesManager_Type) < 0) return;
 
+#ifdef HAS_ZEROCONF
+    if (PyType_Ready(&Zeroconf_Type) < 0)
+      return;
+#endif//HAS_ZEROCONF
+        
 #ifdef HAS_PYRENDERCAPTURE
     if (PyType_Ready(&RenderCapture_Type) < 0)
       return;
@@ -1062,6 +1077,11 @@ namespace PYXBMC
     Py_INCREF(&PlayListItem_Type);
     Py_INCREF(&InfoTagMusic_Type);
     Py_INCREF(&InfoTagVideo_Type);
+    Py_INCREF(&PipesManager_Type);
+    
+#ifdef HAS_ZEROCONF
+    Py_INCREF(&Zeroconf_Type);
+#endif//HAS_ZEROCONF
 
 #ifdef HAS_PYRENDERCAPTURE
     Py_INCREF(&RenderCapture_Type);
@@ -1076,6 +1096,11 @@ namespace PYXBMC
     PyModule_AddObject(pXbmcModule, (char*)"PlayListItem", (PyObject*)&PlayListItem_Type);
     PyModule_AddObject(pXbmcModule, (char*)"InfoTagMusic", (PyObject*)&InfoTagMusic_Type);
     PyModule_AddObject(pXbmcModule, (char*)"InfoTagVideo", (PyObject*)&InfoTagVideo_Type);
+    PyModule_AddObject(pXbmcModule, (char*)"PipesManager", (PyObject*)&PipesManager_Type);
+    
+#ifdef HAS_ZEROCONF
+    PyModule_AddObject(pXbmcModule, (char*)"Zeroconf", (PyObject*)&Zeroconf_Type);
+#endif//HAS_ZEROCONF
 
     // constants
     PyModule_AddStringConstant(pXbmcModule, (char*)"__author__", (char*)PY_XBMC_AUTHOR);
@@ -1131,3 +1156,4 @@ namespace PYXBMC
 #ifdef __cplusplus
 }
 #endif
+

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -95,7 +95,7 @@ ao_device* CAirTunesServer::AudioOutputFunctions::ao_open_live(int driver_id, ao
   ao_device_xbmc* device = new ao_device_xbmc();
 
   device->pipe = new XFILE::CFilePipe;
-  device->pipe->OpenForWrite(XFILE::PipesManager::GetInstance().GetUniquePipeName());
+  device->pipe->OpenForWrite(CStdString(XFILE::PipesManager::GetInstance().GetUniquePipeName()));
   device->pipe->SetOpenThreashold(300);
 
   BXA_FmtHeader header;


### PR DESCRIPTION
This PR is a preparation for factoring the whole AirPlay/AirTunes stuff out into a python addon.

What this PR does:
1. Extend the PipesManager to add some sort of plain C interface for using it from Python. PipesManager allows to create a pipe and read or write from/to it. The pipe can be feed into our player with using the pipe:// protocol (this is already used for internal AirTunes).
2. Expose the PipesManager API via our python interface (getting the object into python by accessing xbmc.PipesManager).
3. Expose our Zeroconf API via our python interface (allowing addons to announce or deannounce services) - accessible via xbmc.Zeroconf. This is build only when avahi is there on linux. (at least thats what i wanted to accomplish with the buildsys adaptions here haha).
4. Add the InfoLabels "seekbar, progress, progresscache" which where there already but only hooked up in the GetInt method not in the GetLabel method.
5. Additions to our Builtin functions:
   a. Add "ShowPicture" for showing a single picture given by an URL - its just a wrapper for g_application.getApplicationMessenger().PictureShow(url) which wasn't there before (only slideshow builtins with a folder as argument as of now)
   
   b. New params for the PlayMedia builtin:
       \* startpercentage= <- for telling the player to start the media at a given percentage (wrapper for the SetProperty of the item)
       \* mimytype= <- wrapper for item.SetMimeType("audio/blubblibb");
       \* isradio <- when set - SetProperty("isradio",true) on item
       \* isfile <- when set - item.m_bIsFolder = false; (opposite of isdir)
       \* no-skip <- when set - SetProperty("no-skip",true) on item
       \* no-pause <- when set - SetProperty("no-pause,true) on item

Sounds like much but imho its not very intrusive all in all. I have the python addon ready too. It still depends on libshairport for AirTunes (and will download it after addon installation - same like with boblight). It has identical features like the internal version as of now - but since we are still missing the python ctypes module on iOS - AirTunes is not available. We can get rid of the libplist dependency when finally removing the internal implementation.

Well i think its something we want for the future. It makes it easier to adapt protocol changes or new findings via addon. Also it might be interesting for 3rd party companys who having doubt about legality or something.

No Eden food.
