### PR TITLE
DVDPlayer: try to find an audiostream that matches the GUI/DVD language

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1032,6 +1032,10 @@ msgstr ""
 
 #: id:285
 msgid "Preferred audio language"
+msgstr ""  
+
+#: id:286  
+msgid "Preferred subtitle language"
 msgstr ""
 
 #: id:287

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1030,7 +1030,9 @@ msgstr ""
 msgid "No results found"
 msgstr ""
 
-#empty strings from id 285 to 286
+#: id:285
+msgid "Preferred audio language"
+msgstr ""
 
 #: id:287
 msgctxt "Auto context with id 287"
@@ -1117,7 +1119,17 @@ msgstr ""
 msgid "Non-interleaved"
 msgstr ""
 
-#empty strings from id 307 to 311
+#empty string with id 307
+
+#: id:308
+msgid "Original stream's language"
+msgstr ""
+
+#: id:309 
+msgid "User Interface language"
+msgstr ""
+
+#empty strings from id 310 to 311
 
 #: id:312
 msgid "(0=auto)"

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -401,6 +401,21 @@ void CLangInfo::SetAudioLanguage(const CStdString &language)
     m_audioLanguage.clear();
 }
 
+// three char language code (not win32 specific)
+const CStdString& CLangInfo::GetSubtitleLanguage() const
+{
+  if (!m_subtitleLanguage.empty())
+    return m_subtitleLanguage;
+
+  return m_languageCodeGeneral;
+}
+
+void CLangInfo::SetSubtitleLanguage(const CStdString &language)
+{
+  if (language.empty() || !g_LangCodeExpander.ConvertToThreeCharCode(m_subtitleLanguage, language))
+    m_subtitleLanguage.clear();
+}
+
 // two character codes as defined in ISO639
 const CStdString& CLangInfo::GetDVDMenuLanguage() const
 {

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -25,9 +25,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/XBMCTinyXML.h"
-#ifdef _WIN32
 #include "utils/LangCodeExpander.h"
-#endif
 
 using namespace std;
 
@@ -226,6 +224,11 @@ bool CLangInfo::Load(const CStdString& strFileName)
     if (! g_LangCodeExpander.ConvertTwoToThreeCharCode(m_defaultRegion.m_strLangLocaleName, m_defaultRegion.m_strLangLocaleName, true))
       m_defaultRegion.m_strLangLocaleName = "";
   }
+
+  if (!g_LangCodeExpander.ConvertWindowsToGeneralCharCode(m_defaultRegion.m_strLangLocaleName, m_languageCodeGeneral))
+    m_languageCodeGeneral = "";
+#else
+  m_languageCodeGeneral = m_defaultRegion.m_strLangLocaleName;
 #endif
 
   const TiXmlNode *pCharSets = pRootElement->FirstChild("charsets");
@@ -360,6 +363,8 @@ void CLangInfo::SetDefaults()
 
   // Set the default region, we may be unable to load langinfo.xml
   m_currentRegion=&m_defaultRegion;
+  
+  m_languageCodeGeneral = "eng";
 }
 
 CStdString CLangInfo::GetGuiCharSet() const
@@ -379,6 +384,21 @@ CStdString CLangInfo::GetSubtitleCharSet() const
     strCharSet=m_currentRegion->m_strSubtitleCharSet;
 
   return strCharSet;
+}
+
+// three char language code (not win32 specific)
+const CStdString& CLangInfo::GetAudioLanguage() const
+{
+  if (!m_audioLanguage.empty())
+    return m_audioLanguage;
+
+  return m_languageCodeGeneral;
+}
+
+void CLangInfo::SetAudioLanguage(const CStdString &language)
+{
+  if (language.empty() || !g_LangCodeExpander.ConvertToThreeCharCode(m_audioLanguage, language))
+    m_audioLanguage.clear();
 }
 
 // two character codes as defined in ISO639

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -40,6 +40,12 @@ public:
   // three char language code (not win32 specific)
   const CStdString& GetLanguageCode() const { return m_languageCodeGeneral; }
 
+  const CStdString& GetAudioLanguage() const;
+  // language can either be a two char language code as defined in ISO639
+  // or a three char language code
+  // or a language name in english (as used by XBMC)
+  void SetAudioLanguage(const CStdString &language);
+
   const CStdString& GetDVDMenuLanguage() const;
   const CStdString& GetDVDAudioLanguage() const;
   const CStdString& GetDVDSubtitleLanguage() const;
@@ -144,6 +150,10 @@ protected:
   MAPREGIONS m_regions;
   CRegion* m_currentRegion; // points to the current region
   CRegion m_defaultRegion; // default, will be used if no region available via langinfo.xml
+
+  CStdString m_audioLanguage;
+  // this is the general (not win32-specific) three char language code
+  CStdString m_languageCodeGeneral;
 };
 
 

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -37,6 +37,9 @@ public:
   CStdString GetGuiCharSet() const;
   CStdString GetSubtitleCharSet() const;
 
+  // three char language code (not win32 specific)
+  const CStdString& GetLanguageCode() const { return m_languageCodeGeneral; }
+
   const CStdString& GetDVDMenuLanguage() const;
   const CStdString& GetDVDAudioLanguage() const;
   const CStdString& GetDVDSubtitleLanguage() const;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -45,6 +45,13 @@ public:
   // or a three char language code
   // or a language name in english (as used by XBMC)
   void SetAudioLanguage(const CStdString &language);
+  
+  // three char language code (not win32 specific)
+  const CStdString& GetSubtitleLanguage() const;
+  // language can either be a two char language code as defined in ISO639
+  // or a three char language code
+  // or a language name in english (as used by XBMC)
+  void SetSubtitleLanguage(const CStdString &language);
 
   const CStdString& GetDVDMenuLanguage() const;
   const CStdString& GetDVDAudioLanguage() const;
@@ -152,6 +159,7 @@ protected:
   CRegion m_defaultRegion; // default, will be used if no region available via langinfo.xml
 
   CStdString m_audioLanguage;
+  CStdString m_subtitleLanguage;
   // this is the general (not win32-specific) three char language code
   CStdString m_languageCodeGeneral;
 };

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -116,6 +116,68 @@ SelectionStream& CSelectionStreams::Get(StreamType type, int index)
   return m_invalid;
 }
 
+std::vector<SelectionStream> CSelectionStreams::Get(StreamType type)
+{
+  std::vector<SelectionStream> streams;
+  int count = Count(type);
+  for(int index = 0; index < count; ++index){
+    streams.push_back(Get(type, index));
+  }
+  return streams;
+}
+
+#define PREDICATE_RETURN(lh, rh) \
+  do { \
+    if((lh) != (rh)) \
+      return (lh) > (rh); \
+  } while(0)
+
+static bool PredicateAudioPriority(const SelectionStream& lh, const SelectionStream& rh)
+{
+  PREDICATE_RETURN(lh.type_index == g_settings.m_currentVideoSettings.m_AudioStream
+                 , rh.type_index == g_settings.m_currentVideoSettings.m_AudioStream);
+
+  PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT
+                 , rh.flags & CDemuxStream::FLAG_DEFAULT);
+
+  PREDICATE_RETURN(lh.channels
+                 , rh.channels);
+
+  PREDICATE_RETURN(StreamUtils::GetCodecPriority(lh.codec)
+                 , StreamUtils::GetCodecPriority(rh.codec));
+  return false;
+}
+
+static bool PredicateSubtitlePriority(const SelectionStream& lh, const SelectionStream& rh)
+{
+  if(!g_settings.m_currentVideoSettings.m_SubtitleOn)
+  {
+    PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_FORCED
+                   , rh.flags & CDemuxStream::FLAG_FORCED);
+  }
+
+  PREDICATE_RETURN(lh.type_index == g_settings.m_currentVideoSettings.m_SubtitleStream
+                 , rh.type_index == g_settings.m_currentVideoSettings.m_SubtitleStream);
+
+  PREDICATE_RETURN(lh.source == STREAM_SOURCE_DEMUX_SUB
+                 , rh.source == STREAM_SOURCE_DEMUX_SUB);
+
+  PREDICATE_RETURN(lh.source == STREAM_SOURCE_TEXT
+                 , rh.source == STREAM_SOURCE_TEXT);
+
+  PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT
+                 , rh.flags & CDemuxStream::FLAG_DEFAULT);
+
+  return false;
+}
+
+static bool PredicateVideoPriority(const SelectionStream& lh, const SelectionStream& rh)
+{
+  PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT
+                 , rh.flags & CDemuxStream::FLAG_DEFAULT);
+  return false;
+}
+
 bool CSelectionStreams::Get(StreamType type, CDemuxStream::EFlags flag, SelectionStream& out)
 {
   CSingleLock lock(m_section);
@@ -204,9 +266,16 @@ void CSelectionStreams::Update(SelectionStream& s)
   CSingleLock lock(m_section);
   int index = IndexOf(s.type, s.source, s.id);
   if(index >= 0)
-    Get(s.type, index) = s;
+  {
+    SelectionStream& o = Get(s.type, index);
+    s.type_index = o.type_index;
+    o = s;
+  }
   else
+  {
+    s.type_index = Count(s.type);
     m_Streams.push_back(s);
+  }
 }
 
 void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
@@ -572,178 +641,59 @@ bool CDVDPlayer::OpenDemuxStream()
 
 void CDVDPlayer::OpenDefaultStreams()
 {
-  int  count;
+  SelectionStreams streams;
   bool valid;
-  bool force = false;
-  SelectionStream st;
 
   // open video stream
-  count = m_SelectionStreams.Count(STREAM_VIDEO);
-  valid = false;
-
-  if(!valid
-  && m_SelectionStreams.Get(STREAM_VIDEO, CDemuxStream::FLAG_DEFAULT, st))
+  streams = m_SelectionStreams.Get(STREAM_VIDEO, PredicateVideoPriority);
+  valid   = false;
+  for(SelectionStreams::iterator it = streams.begin(); it != streams.end() && !valid; ++it)
   {
-    if(OpenVideoStream(st.id, st.source))
-      valid = true;
-    else
-      CLog::Log(LOGWARNING, "%s - failed to open default stream (%d)", __FUNCTION__, st.id);
-  }
-
-  for(int i = 0;i<count && !valid;i++)
-  {
-    SelectionStream& s = m_SelectionStreams.Get(STREAM_VIDEO, i);
-    if(OpenVideoStream(s.id, s.source))
-      valid = true;
+    if(OpenVideoStream(it->id, it->source))
+      valid = true;;
   }
   if(!valid)
     CloseVideoStream(true);
 
-  if(!m_PlayerOptions.video_only)
+  // open audio stream
+  if(m_PlayerOptions.video_only)
+    streams.clear();
+  else
+    streams = m_SelectionStreams.Get(STREAM_AUDIO, PredicateAudioPriority);
+  valid   = false;
+
+  for(SelectionStreams::iterator it = streams.begin(); it != streams.end() && !valid; ++it)
   {
-    // open audio stream
-    count = m_SelectionStreams.Count(STREAM_AUDIO);
-    valid = false;
-    if(g_settings.m_currentVideoSettings.m_AudioStream >= 0
-    && g_settings.m_currentVideoSettings.m_AudioStream < count)
-    {
-      SelectionStream& s = m_SelectionStreams.Get(STREAM_AUDIO, g_settings.m_currentVideoSettings.m_AudioStream);
-      if(OpenAudioStream(s.id, s.source))
-        valid = true;
-      else
-        CLog::Log(LOGWARNING, "%s - failed to restore selected audio stream (%d)", __FUNCTION__, g_settings.m_currentVideoSettings.m_AudioStream);
-    }
-
-    if(!valid
-    && m_SelectionStreams.Get(STREAM_AUDIO, CDemuxStream::FLAG_DEFAULT, st))
-    {
-      if(OpenAudioStream(st.id, st.source))
-        valid = true;
-      else
-        CLog::Log(LOGWARNING, "%s - failed to open default stream (%d)", __FUNCTION__, st.id);
-    }
-
-    if(!valid
-    && count > 1)
-    {
-      /*
-       * If there is more than one audio stream and a valid one is not chosen yet, select the one
-       * with the maximum number of channels or the best codec if the same number of channels.
-       */
-      int max_channels = -1;
-      int max_codec_priority = -1;
-      CStdString max_codec;
-      int max_stream_id = -1;
-      for(int i = 0; i < count; i++)
-      {
-        SelectionStream& s = m_SelectionStreams.Get(STREAM_AUDIO, i);
-        if(s.source == STREAM_SOURCE_DEMUX) // Only demux streams
-        {
-          int codec_priority = StreamUtils::GetCodecPriority(s.codec);
-          if(s.channels > max_channels
-          ||(s.channels == max_channels && codec_priority > max_codec_priority))
-          {
-            max_channels = s.channels;
-            max_codec_priority = codec_priority;
-            max_codec = s.codec;
-            max_stream_id = i;
-          }
-        }
-      }
-      if(max_stream_id >= 0)
-      {
-        SelectionStream& s = m_SelectionStreams.Get(STREAM_AUDIO, max_stream_id);
-        if(OpenAudioStream(s.id, s.source))
-        {
-          valid = true;
-          CLog::Log(LOGDEBUG, "%s - using automatically selected audio stream (%d) based on codec '%s' and maximum number of channels '%d'",
-                    __FUNCTION__, s.id, max_codec.c_str(), max_channels);
-        }
-        else
-          CLog::Log(LOGWARNING, "%s - failed to open automatically selected audio stream (%d)", __FUNCTION__, s.id);
-      }
-    }
-
-    for(int i = 0; i<count && !valid; i++)
-    {
-      SelectionStream& s = m_SelectionStreams.Get(STREAM_AUDIO, i);
-      if(OpenAudioStream(s.id, s.source))
-        valid = true;
-    }
-    if(!valid)
-      CloseAudioStream(true);
-  }
-
-  // open subtitle stream
-  count = m_SelectionStreams.Count(STREAM_SUBTITLE);
-  valid = false;
-
-  // if subs are disabled, check for forced
-  if(!valid && !g_settings.m_currentVideoSettings.m_SubtitleOn 
-  && m_SelectionStreams.Get(STREAM_SUBTITLE, CDemuxStream::FLAG_FORCED, st))
-  {
-    if(OpenSubtitleStream(st.id, st.source))
-    {
-      valid = true;
-      force = true;
-    }
-    else
-      CLog::Log(LOGWARNING, "%s - failed to open default/forced stream (%d)", __FUNCTION__, st.id);
-  }
-
-  // restore selected
-  if(!valid
-  && g_settings.m_currentVideoSettings.m_SubtitleStream >= 0
-  && g_settings.m_currentVideoSettings.m_SubtitleStream < count)
-  {
-    SelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, g_settings.m_currentVideoSettings.m_SubtitleStream);
-    if(OpenSubtitleStream(s.id, s.source))
-      valid = true;
-    else
-      CLog::Log(LOGWARNING, "%s - failed to restore selected subtitle stream (%d)", __FUNCTION__, g_settings.m_currentVideoSettings.m_SubtitleStream);
-  }
-
-  // check if there are external subtitles available
-  for(int i = 0;i<count && !valid; i++)
-  {
-    SelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, i);
-    if ((s.source == STREAM_SOURCE_DEMUX_SUB || s.source == STREAM_SOURCE_TEXT)
-    && OpenSubtitleStream(s.id, s.source))
-      valid = true;
-  }
-
-  // select default
-  if(!valid
-  && m_SelectionStreams.Get(STREAM_SUBTITLE, CDemuxStream::FLAG_DEFAULT, st))
-  {
-    if(OpenSubtitleStream(st.id, st.source))
-      valid = true;
-    else
-      CLog::Log(LOGWARNING, "%s - failed to open default/forced stream (%d)", __FUNCTION__, st.id);
-  }
-
-  // select first
-  for(int i = 0;i<count && !valid; i++)
-  {
-    SelectionStream& s = m_SelectionStreams.Get(STREAM_SUBTITLE, i);
-    if(OpenSubtitleStream(s.id, s.source))
+    if(OpenAudioStream(it->id, it->source))
       valid = true;
   }
   if(!valid)
-    CloseSubtitleStream(false);
+    CloseAudioStream(true);
 
-  if(valid && (g_settings.m_currentVideoSettings.m_SubtitleOn || force) && !m_PlayerOptions.video_only)
-    m_dvdPlayerVideo.EnableSubtitle(true);
-  else
-    m_dvdPlayerVideo.EnableSubtitle(false);
+  // enable subtitles
+  m_dvdPlayerVideo.EnableSubtitle(g_settings.m_currentVideoSettings.m_SubtitleOn);
 
-  // open teletext data stream
-  count = m_SelectionStreams.Count(STREAM_TELETEXT);
-  valid = false;
-  for(int i = 0;i<count && !valid;i++)
+  // open subtitle stream
+  streams = m_SelectionStreams.Get(STREAM_SUBTITLE, PredicateSubtitlePriority);
+  valid   = false;
+  for(SelectionStreams::iterator it = streams.begin(); it != streams.end() && !valid; ++it)
   {
-    SelectionStream& s = m_SelectionStreams.Get(STREAM_TELETEXT, i);
-    if(OpenTeletextStream(s.id, s.source))
+    if(OpenSubtitleStream(it->id, it->source))
+    {
+      valid = true;
+      if(it->flags & CDemuxStream::FLAG_FORCED)
+        m_dvdPlayerVideo.EnableSubtitle(true);
+    }
+  }
+  if(!valid)
+    CloseSubtitleStream(true);
+
+  // open teletext stream
+  streams = m_SelectionStreams.Get(STREAM_TELETEXT);
+  valid   = false;
+  for(SelectionStreams::iterator it = streams.begin(); it != streams.end() && !valid; ++it)
+  {
+    if(OpenTeletextStream(it->id, it->source))
       valid = true;
   }
   if(!valid)

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -167,11 +167,24 @@ static bool PredicateSubtitlePriority(const SelectionStream& lh, const Selection
   PREDICATE_RETURN(lh.type_index == g_settings.m_currentVideoSettings.m_SubtitleStream
                  , rh.type_index == g_settings.m_currentVideoSettings.m_SubtitleStream);
 
+  CStdString subtitle_language = g_langInfo.GetSubtitleLanguage();
+  if(!g_guiSettings.GetString("locale.subtitlelanguage").Equals("original"))
+  {
+    PREDICATE_RETURN((lh.source == STREAM_SOURCE_DEMUX_SUB || lh.source == STREAM_SOURCE_TEXT) && subtitle_language.Equals(lh.language.c_str())
+                   , (rh.source == STREAM_SOURCE_DEMUX_SUB || rh.source == STREAM_SOURCE_TEXT) && subtitle_language.Equals(rh.language.c_str()));
+  }
+
   PREDICATE_RETURN(lh.source == STREAM_SOURCE_DEMUX_SUB
                  , rh.source == STREAM_SOURCE_DEMUX_SUB);
 
   PREDICATE_RETURN(lh.source == STREAM_SOURCE_TEXT
                  , rh.source == STREAM_SOURCE_TEXT);
+
+  if(!g_guiSettings.GetString("locale.subtitlelanguage").Equals("original"))
+  {
+    PREDICATE_RETURN(subtitle_language.Equals(lh.language.c_str())
+                   , subtitle_language.Equals(rh.language.c_str()));
+  }
 
   PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT
                  , rh.flags & CDemuxStream::FLAG_DEFAULT);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -74,6 +74,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "utils/StringUtils.h"
 #include "Util.h"
+#include "LangInfo.h"
 
 using namespace std;
 
@@ -136,6 +137,13 @@ static bool PredicateAudioPriority(const SelectionStream& lh, const SelectionStr
 {
   PREDICATE_RETURN(lh.type_index == g_settings.m_currentVideoSettings.m_AudioStream
                  , rh.type_index == g_settings.m_currentVideoSettings.m_AudioStream);
+
+  if(!g_guiSettings.GetString("locale.audiolanguage").Equals("original"))
+  {
+    CStdString audio_language = g_langInfo.GetAudioLanguage();
+    PREDICATE_RETURN(audio_language.Equals(lh.language.c_str())
+                   , audio_language.Equals(rh.language.c_str()));
+  }
 
   PREDICATE_RETURN(lh.flags & CDemuxStream::FLAG_DEFAULT
                  , rh.flags & CDemuxStream::FLAG_DEFAULT);

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -108,6 +108,7 @@ public:
 typedef struct
 {
   StreamType   type;
+  int          type_index;
   std::string  filename;
   std::string  filename2;  // for vobsub subtitles, 2 files are necessary (idx/sub) 
   std::string  language;
@@ -118,6 +119,8 @@ typedef struct
   std::string  codec;
   int          channels;
 } SelectionStream;
+
+typedef std::vector<SelectionStream> SelectionStreams;
 
 class CSelectionStreams
 {
@@ -137,6 +140,14 @@ public:
   int              Count   (StreamType type) const { return IndexOf(type, STREAM_SOURCE_NONE, -1) + 1; }
   SelectionStream& Get     (StreamType type, int index);
   bool             Get     (StreamType type, CDemuxStream::EFlags flag, SelectionStream& out);
+
+  SelectionStreams Get(StreamType type);
+  template<typename Compare> SelectionStreams Get(StreamType type, Compare compare)
+  {
+    SelectionStreams streams = Get(type);
+    std::stable_sort(streams.begin(), streams.end(), compare);
+    return streams;
+  }
 
   void             Clear   (StreamType type, StreamSource source);
   int              Source  (StreamSource source, std::string filename);

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -847,6 +847,7 @@ void CGUISettings::Initialize()
 #endif
   AddSeparator(loc, "locale.sep3");
   AddString(loc, "locale.audiolanguage", 285, "original", SPIN_CONTROL_TEXT);
+  AddString(loc, "locale.subtitlelanguage", 286, "original", SPIN_CONTROL_TEXT);
 
   CSettingsCategory* fl = AddCategory(7, "filelists", 14081);
   AddBool(fl, "filelists.showparentdiritems", 13306, true);
@@ -1271,6 +1272,12 @@ void CGUISettings::LoadXML(TiXmlElement *pRootElement, bool hideSettings /* = fa
     g_langInfo.SetAudioLanguage(streamLanguage);
   else
     g_langInfo.SetAudioLanguage("");
+
+  streamLanguage = GetString("locale.subtitlelanguage");
+  if (!streamLanguage.Equals("original") && !streamLanguage.Equals("default"))
+    g_langInfo.SetSubtitleLanguage(streamLanguage);
+  else
+    g_langInfo.SetSubtitleLanguage("");
 }
 
 void CGUISettings::LoadFromXML(TiXmlElement *pRootElement, mapIter &it, bool advanced /* = false */)

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -845,6 +845,8 @@ void CGUISettings::Initialize()
   AddBool(loc, "locale.timeserver", 168, false);
   AddString(loc, "locale.timeserveraddress", 731, "pool.ntp.org", EDIT_CONTROL_INPUT);
 #endif
+  AddSeparator(loc, "locale.sep3");
+  AddString(loc, "locale.audiolanguage", 285, "original", SPIN_CONTROL_TEXT);
 
   CSettingsCategory* fl = AddCategory(7, "filelists", 14081);
   AddBool(fl, "filelists.showparentdiritems", 13306, true);
@@ -1263,6 +1265,12 @@ void CGUISettings::LoadXML(TiXmlElement *pRootElement, bool hideSettings /* = fa
     g_timezone.SetTimezone(timezone);	
   }
 #endif
+
+  CStdString streamLanguage = GetString("locale.audiolanguage");
+  if (!streamLanguage.Equals("original") && !streamLanguage.Equals("default"))
+    g_langInfo.SetAudioLanguage(streamLanguage);
+  else
+    g_langInfo.SetAudioLanguage("");
 }
 
 void CGUISettings::LoadFromXML(TiXmlElement *pRootElement, mapIter &it, bool advanced /* = false */)

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -440,7 +440,7 @@ void CGUIWindowSettingsCategory::CreateSettings()
       FillInLanguages(pSetting);
       continue;
     }
-    else if (strSetting.Equals("locale.audiolanguage"))
+    else if (strSetting.Equals("locale.audiolanguage") || strSetting.Equals("locale.subtitlelanguage"))
     {
       AddSetting(pSetting, group->GetWidth(), iControlID);
       vector<CStdString> languages;
@@ -1480,6 +1480,29 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
       {
         g_guiSettings.SetString(strSetting, strLanguage);
         g_langInfo.SetAudioLanguage(strLanguage);
+      }
+    }
+  }
+  else if (strSetting.Equals("locale.subtitlelanguage"))
+  { // new subtitle language chosen...
+    CSettingString *pSettingString = (CSettingString *)pSettingControl->GetSetting();
+    CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(pSettingControl->GetID());
+    int iLanguage = pControl->GetValue();
+    if (iLanguage < 2)
+    {
+      if (iLanguage < 1)
+        g_guiSettings.SetString(strSetting, "original");
+      else
+        g_guiSettings.SetString(strSetting, "default");
+      g_langInfo.SetSubtitleLanguage("");
+    }
+    else
+    {
+      CStdString strLanguage = pControl->GetCurrentLabel();
+      if (strLanguage != pSettingString->GetData())
+      {
+        g_guiSettings.SetString(strSetting, strLanguage);
+        g_langInfo.SetSubtitleLanguage(strLanguage);
       }
     }
   }

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -436,7 +436,20 @@ void CGUIWindowSettingsCategory::CreateSettings()
     else if (strSetting.Equals("locale.language"))
     {
       AddSetting(pSetting, group->GetWidth(), iControlID);
+      GetSetting(pSetting->GetSetting())->SetDelayed();
       FillInLanguages(pSetting);
+      continue;
+    }
+    else if (strSetting.Equals("locale.audiolanguage"))
+    {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
+      vector<CStdString> languages;
+      languages.push_back(g_localizeStrings.Get(308));
+      languages.push_back(g_localizeStrings.Get(309));
+      vector<CStdString> languageKeys;
+      languageKeys.push_back("original");
+      languageKeys.push_back("default");
+      FillInLanguages(pSetting, languages, languageKeys);
       continue;
     }
 #ifdef _LINUX
@@ -1447,6 +1460,29 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
     if (g_graphicsContext.IsFullScreenRoot())
       g_graphicsContext.SetVideoResolution(g_graphicsContext.GetVideoResolution(), true);
   }
+  else if (strSetting.Equals("locale.audiolanguage"))
+  { // new audio language chosen...
+    CSettingString *pSettingString = (CSettingString *)pSettingControl->GetSetting();
+    CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(pSettingControl->GetID());
+    int iLanguage = pControl->GetValue();
+    if (iLanguage < 2)
+    {
+      if (iLanguage < 1)
+        g_guiSettings.SetString(strSetting, "original");
+      else
+        g_guiSettings.SetString(strSetting, "default");
+      g_langInfo.SetAudioLanguage("");
+    }
+    else
+    {
+      CStdString strLanguage = pControl->GetCurrentLabel();
+      if (strLanguage != pSettingString->GetData())
+      {
+        g_guiSettings.SetString(strSetting, strLanguage);
+        g_langInfo.SetAudioLanguage(strLanguage);
+      }
+    }
+  }
   else if (strSetting.Equals("locale.language"))
   { // new language chosen...
     CSettingString *pSettingString = (CSettingString *)pSettingControl->GetSetting();
@@ -2348,12 +2384,11 @@ void CGUIWindowSettingsCategory::OnRefreshRateChanged(RESOLUTION nextRes)
   }
 }
 
-void CGUIWindowSettingsCategory::FillInLanguages(CSetting *pSetting)
+void CGUIWindowSettingsCategory::FillInLanguages(CSetting *pSetting, const std::vector<CStdString> &languages /* = std::vector<CStdString>() */, const std::vector<CStdString> &languageKeys /* = std::vector<CStdString>() */)
 {
   CSettingString *pSettingString = (CSettingString *)pSetting;
   CBaseSettingControl *setting = GetSetting(pSetting->GetSetting());
   CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(setting->GetID());
-  setting->SetDelayed();
   pControl->Clear();
 
   //find languages...
@@ -2361,7 +2396,6 @@ void CGUIWindowSettingsCategory::FillInLanguages(CSetting *pSetting)
   CDirectory::GetDirectory("special://xbmc/language/", items);
 
   int iCurrentLang = 0;
-  int iLanguage = 0;
   vector<CStdString> vecLanguage;
   for (int i = 0; i < items.Size(); ++i)
   {
@@ -2376,12 +2410,16 @@ void CGUIWindowSettingsCategory::FillInLanguages(CSetting *pSetting)
   }
 
   sort(vecLanguage.begin(), vecLanguage.end(), sortstringbyname());
+  // Add language options passed by parameter at the beginning
+  if (languages.size() > 0)
+    vecLanguage.insert(vecLanguage.begin(), languages.begin(), languages.begin() + languages.size());
   for (unsigned int i = 0; i < vecLanguage.size(); ++i)
   {
     CStdString strLanguage = vecLanguage[i];
-    if (strcmpi(strLanguage.c_str(), pSettingString->GetData().c_str()) == 0)
-      iCurrentLang = iLanguage;
-    pControl->AddLabel(strLanguage, iLanguage++);
+    if ((i < languageKeys.size() && strcmpi(languageKeys[i].c_str(), pSettingString->GetData().c_str()) == 0) ||
+        strcmpi(strLanguage.c_str(), pSettingString->GetData().c_str()) == 0)
+      iCurrentLang = i;
+    pControl->AddLabel(strLanguage, i);
   }
 
   pControl->SetValue(iCurrentLang);

--- a/xbmc/settings/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/GUIWindowSettingsCategory.h
@@ -48,7 +48,7 @@ protected:
   void FillInCharSets(CSetting *pSetting);
   void FillInSkinFonts(CSetting *pSetting);
   void FillInSoundSkins(CSetting *pSetting);
-  void FillInLanguages(CSetting *pSetting);
+  void FillInLanguages(CSetting *pSetting, const std::vector<CStdString> &languages = std::vector<CStdString>(), const std::vector<CStdString> &languageKeys = std::vector<CStdString>());
   DisplayMode FillInScreens(CStdString strSetting, RESOLUTION res);
   void FillInResolutions(CStdString strSetting, DisplayMode mode, RESOLUTION res, bool UserChange);
   void FillInRefreshRates(CStdString strSetting, RESOLUTION res, bool UserChange);

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -21,6 +21,7 @@
 
 #include "LangCodeExpander.h"
 #include "utils/XBMCTinyXML.h"
+#include "LangInfo.h"
 #include "utils/log.h" 
 
 #define MAKECODE(a, b, c, d)  ((((long)(a))<<24) | (((long)(b))<<16) | (((long)(c))<<8) | (long)(d))
@@ -141,7 +142,7 @@ bool CLangCodeExpander::Lookup(CStdString& desc, const int code)
   return Lookup(desc, lang);
 }
 
-#ifdef _WIN32
+#ifdef TARGET_WINDOWS
 bool CLangCodeExpander::ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool localeHack /*= false*/)
 #else
 bool CLangCodeExpander::ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode)
@@ -175,6 +176,50 @@ bool CLangCodeExpander::ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, 
   return false;
 }
 
+#ifdef TARGET_WINDOWS
+bool CLangCodeExpander::ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool localeHack /*= false*/)
+#else
+bool CLangCodeExpander::ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode)
+#endif
+{
+  if (strCharCode.size() == 2)
+#ifdef TARGET_WINDOWS
+    return g_LangCodeExpander.ConvertTwoToThreeCharCode(strThreeCharCode, strCharCode, localeHack);
+#else
+    return g_LangCodeExpander.ConvertTwoToThreeCharCode(strThreeCharCode, strCharCode);
+#endif
+  else if (strCharCode.size() == 3)
+  {
+    for (unsigned int index = 0; index < sizeof(CharCode2To3) / sizeof(CharCode2To3[0]); ++index)
+    {
+#ifdef TARGET_WINDOWS
+      if (strCharCode.Equals(CharCode2To3[index].id) ||
+         (localeHack && CharCode2To3[index].win_id != NULL && strCharCode.Equals(CharCode2To3[index].win_id)))
+#else
+      if (strCharCode.Equals(CharCode2To3[index].id))
+#endif
+      {
+        strThreeCharCode = strCharCode;
+        return true;
+      }
+    }
+  }
+  else if (strCharCode.size() > 3)
+  {
+    CStdString strLangInfoPath;
+    strLangInfoPath.Format("special://xbmc/language/%s/langinfo.xml", strCharCode.c_str());
+    CLangInfo langInfo;
+    if (!langInfo.Load(strLangInfoPath))
+      return false;
+
+    strThreeCharCode = langInfo.GetLanguageCode();
+    return true;
+  }
+
+  return false;
+}
+
+#ifdef TARGET_WINDOWS
 bool CLangCodeExpander::ConvertLinuxToWindowsRegionCodes(const CStdString& strTwoCharCode, CStdString& strThreeCharCode)
 {
   if (strTwoCharCode.length() != 2)
@@ -195,6 +240,27 @@ bool CLangCodeExpander::ConvertLinuxToWindowsRegionCodes(const CStdString& strTw
 
   return true;
 }
+
+bool CLangCodeExpander::ConvertWindowsToGeneralCharCode(const CStdString& strWindowsCharCode, CStdString& strThreeCharCode)
+{
+  if (strWindowsCharCode.length() != 3)
+    return false;
+
+  CStdString strLower(strWindowsCharCode);
+  strLower.MakeLower();
+  for (unsigned int index = 0; index < sizeof(CharCode2To3) / sizeof(CharCode2To3[0]); ++index)
+  {
+    if ((CharCode2To3[index].win_id && strLower.Equals(CharCode2To3[index].win_id)) ||
+         strLower.Equals(CharCode2To3[index].id))
+    {
+      strThreeCharCode = CharCode2To3[index].id;
+      return true;
+    }
+  }
+
+  return true;
+}
+#endif
 
 bool CLangCodeExpander::LookupInMap(CStdString& desc, const CStdString& code)
 {

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -34,12 +34,18 @@ public:
 
   bool Lookup(CStdString& desc, const CStdString& code);
   bool Lookup(CStdString& desc, const int code);
-#ifdef _WIN32
+#ifdef TARGET_WINDOWS
   bool ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode, bool localeHack = false);
+  bool ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode, bool localeHack = false);
 #else
   bool ConvertTwoToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strTwoCharCode);
+  bool ConvertToThreeCharCode(CStdString& strThreeCharCode, const CStdString& strCharCode);
 #endif
+
+#ifdef TARGET_WINDOWS
   bool ConvertLinuxToWindowsRegionCodes(const CStdString& strTwoCharCode, CStdString& strThreeCharCode);
+  bool ConvertWindowsToGeneralCharCode(const CStdString& strWindowsCharCode, CStdString& strThreeCharCode);
+#endif
 
   void LoadUserCodes(const TiXmlElement* pRootElement);
   void Clear();


### PR DESCRIPTION
This commit changes the way CDVDPlayer chooses the default audio stream. Up until now we choose the audio stream with the default flag and if there's no default flag we try the one with the most channels/best codec and if that fails we choose the first one available.

With these changes the behaviour will be like this:
1. Sort all available audio streams by number of channels and codec with the "best" being first and the "worst" being last.
2. Go through the sorted streams and check if there's one stream matching the GUI/DVD language of the current XBMC installation. Try all the ones with a matching language starting with the "best" until we find one that works.
3. If there's no matching/working audio stream based on the language we look for the default stream. If there is one use it.
4. If there is no default stream start with the "best" stream and work your way down towards the worst until we find a stream that works.

So all in all we have two improvements (at least for me those are improvements):
- If possible we use the audio stream with the appropriate language
- If there's no default stream we use the "best" working audio stream. The way it is now we only try the best and if that doesn't work out we don't use the second best, instead we use the first stream. So if there are three audio streams, one with DTS-HD, one with DD5.1 and one with MP3 we currently choose the best one (DTS-HD) but if that fails we try the first one, which might be MP3. With these changes we first try DTS-HD, then DD5.1 and then at last MP3.
