### PR TITLE
Add defaultseason attribute to TV Show regex

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -964,6 +964,7 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
     if (pRegExp->FirstChild())
     {
       bool bByDate = false;
+      int iDefaultSeason = 1;
       if (pRegExp->ToElement())
       {
         CStdString byDate = pRegExp->ToElement()->Attribute("bydate");
@@ -971,13 +972,18 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
         {
           bByDate = true;
         }
+        CStdString defaultSeason = pRegExp->ToElement()->Attribute("defaultseason");
+        if(!defaultSeason.empty())
+        {
+          iDefaultSeason = atoi(defaultSeason.c_str());
+        }
       }
       CStdString regExp = pRegExp->FirstChild()->Value();
       regExp.MakeLower();
       if (iAction == 2)
-        settings.insert(settings.begin() + i++, 1, TVShowRegexp(bByDate,regExp));
+        settings.insert(settings.begin() + i++, 1, TVShowRegexp(bByDate,regExp,iDefaultSeason));
       else
-        settings.push_back(TVShowRegexp(bByDate,regExp));
+        settings.push_back(TVShowRegexp(bByDate,regExp,iDefaultSeason));
     }
     pRegExp = pRegExp->NextSibling("regexp");
   }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -41,10 +41,12 @@ struct TVShowRegexp
 {
   bool byDate;
   CStdString regexp;
-  TVShowRegexp(bool d, const CStdString& r)
+  int defaultSeason;
+  TVShowRegexp(bool d, const CStdString& r, int s = 1)
   {
     byDate = d;
     regexp = r;
+    defaultSeason = s;
   }
 };
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -856,6 +856,7 @@ namespace VIDEO
       episode.isFolder = false;
 
       bool byDate = expression[i].byDate ? true : false;
+      int defaultSeason = expression[i].defaultSeason;
 
       if (byDate)
       {
@@ -867,7 +868,7 @@ namespace VIDEO
       }
       else
       {
-        if (!GetEpisodeAndSeasonFromRegExp(reg, episode))
+        if (!GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason))
           continue;
 
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Found episode match %s (s%ie%i) [%s]", strLabel.c_str(),
@@ -898,7 +899,7 @@ namespace VIDEO
         }
         else
         {
-          GetEpisodeAndSeasonFromRegExp(reg, parent);
+          GetEpisodeAndSeasonFromRegExp(reg, parent, defaultSeason);
           if (episode.iSeason == parent.iSeason && episode.iEpisode == parent.iEpisode)
             episode.isFolder = true;
         }
@@ -919,7 +920,7 @@ namespace VIDEO
           if (((regexppos <= regexp2pos) && regexppos != -1) ||
              (regexppos >= 0 && regexp2pos == -1))
           {
-            GetEpisodeAndSeasonFromRegExp(reg, episode);
+            GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason);
 
             CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new season %u, multipart episode %u [%s]",
                       episode.iSeason, episode.iEpisode,
@@ -949,7 +950,7 @@ namespace VIDEO
     return false;
   }
 
-  bool CVideoInfoScanner::GetEpisodeAndSeasonFromRegExp(CRegExp &reg, SEpisode &episodeInfo)
+  bool CVideoInfoScanner::GetEpisodeAndSeasonFromRegExp(CRegExp &reg, SEpisode &episodeInfo, int defaultSeason)
   {
     char* season = reg.GetReplaceString("\\1");
     char* episode = reg.GetReplaceString("\\2");
@@ -957,14 +958,14 @@ namespace VIDEO
     if (season && episode)
     {
       if (strlen(season) == 0 && strlen(episode) > 0)
-      { // no season specified -> assume season 1
-        episodeInfo.iSeason = 1;
+      { // no season specified -> assume defaultSeason
+        episodeInfo.iSeason = defaultSeason;
         if ((episodeInfo.iEpisode = CUtil::TranslateRomanNumeral(episode)) == -1)
           episodeInfo.iEpisode = atoi(episode);
       }
       else if (strlen(season) > 0 && strlen(episode) == 0)
-      { // no episode specification -> assume season 1
-        episodeInfo.iSeason = 1;
+      { // no episode specification -> assume defaultSeason
+        episodeInfo.iSeason = defaultSeason;
         if ((episodeInfo.iEpisode = CUtil::TranslateRomanNumeral(season)) == -1)
           episodeInfo.iEpisode = atoi(season);
       }

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -174,9 +174,10 @@ namespace VIDEO
     /*! \brief Extract episode and season numbers from a processed regexp
      \param reg Regular expression object with at least 2 matches
      \param episodeInfo Episode information to fill in.
+     \param defaultSeason Season to use if not found in reg.
      \return true on success (2 matches), false on failure (fewer than 2 matches)
      */
-    bool GetEpisodeAndSeasonFromRegExp(CRegExp &reg, SEpisode &episodeInfo);
+    bool GetEpisodeAndSeasonFromRegExp(CRegExp &reg, SEpisode &episodeInfo, int defaultSeason);
 
     /*! \brief Extract episode air-date from a processed regexp
      \param reg Regular expression object with at least 3 matches


### PR DESCRIPTION
This is a pull request to replace the one found <a href="https://github.com/xbmc/xbmc/pull/649">here</a>.

Allow the default season to be set for TV shows. This will be used when
no season is found in the filename. If no default is set, use 1 as the
default season for the sake of both backwards compatibility and to
conform with the assumption that season 1 is the standard season, as
opposed to season 0 (usually used for special episodes).

Use of this feature is through the advancedsettings.xml configuration
file, under the tvshowmatching tag. An example is as follows.

<pre>&lt;tvshowmatching action="append"&gt;
   &lt;regexp defaultseason="0"&gt;[\._ \-]()S([0-9]{1,3})([^\\/]*)-&lt;/regexp&gt;
   &lt;regexp defaultseason="1"&gt;[\._ \-]()E([0-9]{1,3})([^\\/]*)-&lt;/regexp&gt;
   &lt;regexp&gt;[\._ \-]()X([0-9]{1,3})([^\\/]*)-&lt;/regexp&gt;
&lt;/tvshowmatching&gt;</pre>


Here are some sample filenames run through these settings.

<table>
   <tr>
      <td><h4 style="text-align:center">Filename</h1></td><td><h4 style="text-align:center">XBMC Result</h1></td><td><h4 style="text-align:center">Comment</h1></td>
   </tr>
   <tr>
      <td>Foo - S001 - Title.avi</td><td>Foo - 0x1 - Title</td><td>Season forced to 0</td>
   </tr>
   <tr>
      <td>Foo - E001 - Title.avi</td><td>Foo - 1x1 - Title</td><td>Season forced to 1 (not needed)</td>
   </tr>
   <tr>
      <td>Foo - X001 - Title.avi</td><td>Foo - 1x1 - Title</td><td>Season defaulted to 1</td>
   </tr>
</table> 
