### PR TITLE
Fix: DVD aspect ratio requested by navigator was not correctly set in hints

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2740,7 +2740,10 @@ bool CDVDPlayer::OpenVideoStream(int iStream, int source)
     /* set aspect ratio as requested by navigator for dvd's */
     float aspect = static_cast<CDVDInputStreamNavigator*>(m_pInputStream)->GetVideoAspectRatio();
     if(aspect != 0.0)
+    {
       hint.aspect = aspect;
+      hint.forced_aspect = true;
+    }
     hint.software = true;
     hint.stills   = static_cast<CDVDInputStreamNavigator*>(m_pInputStream)->IsInMenu();
   }


### PR DESCRIPTION
Some DVD structures contain 4:3 streams that are overridden to 16:9 at the DVD container level (e.g. Sony DVD handycams, some DVD TV recorders etc.).

Since commit dd28e1aca2fb8c657c8da9052aa18785f544b897 the DVDPlayerVideo code checks hint.forced_aspect flag, but unfortunately there was an oversight in coding this, as it isn't set properly when the DVDNavigator wants to set the aspect ratio. 

This commit fixes the issue.
