### PR TITLE
webserver: decouple different webserver capabilities into handlers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -61,6 +61,7 @@ DIRECTORY_ARCHIVES=$(DVDPLAYER_ARCHIVES) \
                    xbmc/music/tags/musictags.a \
                    xbmc/music/windows/musicwindows.a \
                    xbmc/network/libscrobbler/scrobbler.a \
+                   xbmc/network/httprequesthandler/httprequesthandlers.a \
                    xbmc/network/websocket/websocket.a \
                    xbmc/network/network.a \
                    xbmc/peripherals/bus/peripheral-bus.a \

--- a/addons/webinterface.default/js/MediaLibrary.js
+++ b/addons/webinterface.default/js/MediaLibrary.js
@@ -22,7 +22,7 @@
 var MediaLibrary = function() {
   this.init();
   return true;
-}
+};
 
 MediaLibrary.prototype = {
   playlists: { },
@@ -69,6 +69,7 @@ MediaLibrary.prototype = {
   getPlaylists: function() {
     jQuery.ajax({
       type: 'POST',
+      contentType: 'application/json',
       url: JSON_RPC + '?GetPlaylists',
       data: '{"jsonrpc": "2.0", "method": "Playlist.GetPlaylists", "id": 1}',
       timeout: 3000,
@@ -153,62 +154,190 @@ MediaLibrary.prototype = {
     //common part
     switch(keyPressed) {
       case 'cleanlib_a':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "AudioLibrary.Clean", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "AudioLibrary.Clean", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'updatelib_a':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "AudioLibrary.Scan", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "AudioLibrary.Scan", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'cleanlib_v':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "VideoLibrary.Clean", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "VideoLibrary.Clean", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'updatelib_v':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "VideoLibrary.Scan", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "VideoLibrary.Scan", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'back':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Input.Back", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "Input.Back", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'home':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Input.Home", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "Input.Home", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'mute':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Application.SetMute", "params": { "mute": "toggle" }, "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "Application.SetMute", "params": { "mute": "toggle" }, "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'power':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "System.Shutdown", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "System.Shutdown", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'volumeup':
-      jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Application.GetProperties", "params": { "properties": [ "volume" ] }, "id": 1}', function(data){
-        var volume = data.result.volume + 1;
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": { "volume": '+volume+' }, "id": 1}', function(data){
-          $('#spinner').hide();
-        }, 'json');
-       }, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "Application.GetProperties", "params": { "properties": [ "volume" ] }, "id": 1}',
+          success: jQuery.proxy(function(data) {
+            var volume = data.result.volume + 1;
+            jQuery.ajax({
+              type: 'POST',
+              contentType: 'application/json',
+              url: JSON_RPC + '?SendRemoteKey',
+              data: '{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": { "volume": '+volume+' }, "id": 1}',
+              success: jQuery.proxy(function(data) {
+                $('#spinner').hide();
+              }, this),
+              dataType: 'json'});
+          }, this),
+          dataType: 'json'});
         return;
       case 'volumedown':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Application.GetProperties", "params": { "properties": [ "volume" ] }, "id": 1}', function(data){
-          var volume = data.result.volume - 1;
-          jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": { "volume": '+volume+' }, "id": 1}', function(data){
-            $('#spinner').hide();
-          }, 'json');
-       }, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "Application.GetProperties", "params": { "properties": [ "volume" ] }, "id": 1}',
+          success: jQuery.proxy(function(data) {
+            var volume = data.result.volume - 1;
+            jQuery.ajax({
+              type: 'POST',
+              contentType: 'application/json',
+              url: JSON_RPC + '?SendRemoteKey',
+              data: '{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": { "volume": '+volume+' }, "id": 1}',
+              success: jQuery.proxy(function(data) {
+                $('#spinner').hide();
+              }, this),
+              dataType: 'json'});
+          }, this),
+          dataType: 'json'});
         return;
     }
 
     switch(keyPressed) {
       case 'up':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Input.Up", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "Input.Up", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'down':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Input.Down", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "Input.Down", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'left':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Input.Left", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "Input.Left", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'right':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Input.Right", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "Input.Right", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
       case 'ok':
-        jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Input.Select", "id": 1}', function(data){$('#spinner').hide();}, 'json');
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?SendRemoteKey',
+          data: '{"jsonrpc": "2.0", "method": "Input.Select", "id": 1}',
+          success: jQuery.proxy(function(data) {
+            $('#spinner').hide();
+          }, this),
+          dataType: 'json'});
         return;
     }
 
@@ -216,22 +345,70 @@ MediaLibrary.prototype = {
     {
       switch(keyPressed) {
         case 'playpause':
-          jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Player.PlayPause", "params": { "playerid": ' + player + ' }, "id": 1}', function(data){$('#spinner').hide();}, 'json');
+          jQuery.ajax({
+            type: 'POST',
+            contentType: 'application/json',
+            url: JSON_RPC + '?SendRemoteKey',
+            data: '{"jsonrpc": "2.0", "method": "Player.PlayPause", "params": { "playerid": ' + player + ' }, "id": 1}',
+            success: jQuery.proxy(function(data) {
+              $('#spinner').hide();
+            }, this),
+            dataType: 'json'});
           return;
         case 'stop':
-          jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Player.Stop", "params": { "playerid": ' + player + ' }, "id": 1}', function(data){$('#spinner').hide();}, 'json');
+          jQuery.ajax({
+            type: 'POST',
+            contentType: 'application/json',
+            url: JSON_RPC + '?SendRemoteKey',
+            data: '{"jsonrpc": "2.0", "method": "Player.Stop", "params": { "playerid": ' + player + ' }, "id": 1}',
+            success: jQuery.proxy(function(data) {
+              $('#spinner').hide();
+            }, this),
+            dataType: 'json'});
           return;
         case 'next':
-          jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Player.GoNext", "params": { "playerid": ' + player + ' }, "id": 1}', function(data){$('#spinner').hide();}, 'json');
+          jQuery.ajax({
+            type: 'POST',
+            contentType: 'application/json',
+            url: JSON_RPC + '?SendRemoteKey',
+            data: '{"jsonrpc": "2.0", "method": "Player.GoNext", "params": { "playerid": ' + player + ' }, "id": 1}',
+            success: jQuery.proxy(function(data) {
+              $('#spinner').hide();
+            }, this),
+            dataType: 'json'});
           return;
         case 'previous':
-          jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Player.GoPrevious", "params": { "playerid": ' + player + ' }, "id": 1}', function(data){$('#spinner').hide();}, 'json');
+          jQuery.ajax({
+            type: 'POST',
+            contentType: 'application/json',
+            url: JSON_RPC + '?SendRemoteKey',
+            data: '{"jsonrpc": "2.0", "method": "Player.GoPrevious", "params": { "playerid": ' + player + ' }, "id": 1}',
+            success: jQuery.proxy(function(data) {
+              $('#spinner').hide();
+            }, this),
+            dataType: 'json'});
           return;
         case 'forward':
-          jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Player.SetSpeed", "params": { "playerid": ' + player + ', "speed": "increment" }, "id": 1}', function(data){$('#spinner').hide();}, 'json');
+          jQuery.ajax({
+            type: 'POST',
+            contentType: 'application/json',
+            url: JSON_RPC + '?SendRemoteKey',
+            data: '{"jsonrpc": "2.0", "method": "Player.SetSpeed", "params": { "playerid": ' + player + ', "speed": "increment" }, "id": 1}',
+            success: jQuery.proxy(function(data) {
+              $('#spinner').hide();
+            }, this),
+            dataType: 'json'});
           return;
         case 'rewind':
-          jQuery.post(JSON_RPC + '?SendRemoteKey', '{"jsonrpc": "2.0", "method": "Player.SetSpeed", "params": { "playerid": ' + player + ', "speed": "decrement" }, "id": 1}', function(data){$('#spinner').hide();}, 'json');
+          jQuery.ajax({
+            type: 'POST',
+            contentType: 'application/json',
+            url: JSON_RPC + '?SendRemoteKey',
+            data: '{"jsonrpc": "2.0", "method": "Player.SetSpeed", "params": { "playerid": ' + player + ', "speed": "decrement" }, "id": 1}',
+            success: jQuery.proxy(function(data) {
+              $('#spinner').hide();
+            }, this),
+            dataType: 'json'});
           return;
       }
     }
@@ -248,23 +425,29 @@ MediaLibrary.prototype = {
       libraryContainer.attr('id', 'libraryContainer')
                       .addClass('contentContainer');
       $('#content').append(libraryContainer);
-      jQuery.post(JSON_RPC + '?GetAlbums', '{"jsonrpc": "2.0", "method": "AudioLibrary.GetAlbums", "params": { "limits": { "start": 0 }, "properties": ["description", "theme", "mood", "style", "type", "albumlabel", "artist", "genre", "rating", "title", "year", "thumbnail"], "sort": { "method": "artist" } }, "id": 1}', jQuery.proxy(function(data) {
-        if (data && data.result && data.result.albums) {
-          this.albumList = data.result.albums;
-          $.each($(this.albumList), jQuery.proxy(function(i, item) {
-            var floatableAlbum = this.generateThumb('album', item.thumbnail, item.title, item.artist);
-            floatableAlbum.bind('click', { album: item }, jQuery.proxy(this.displayAlbumDetails, this));
-            libraryContainer.append(floatableAlbum);
-          }, this));
-          libraryContainer.append($('<div>').addClass('footerPadding'));
-          $('#spinner').hide();
-          libraryContainer.bind('scroll', { activeLibrary: libraryContainer }, jQuery.proxy(this.updateScrollEffects, this));
-          libraryContainer.trigger('scroll');
-          myScroll = new iScroll('libraryContainer');
-        } else {
-          libraryContainer.html('');
-        }
-      }, this), 'json');
+      jQuery.ajax({
+        type: 'POST',
+        contentType: 'application/json',
+        url: JSON_RPC + '?GetAlbums',
+        data: '{"jsonrpc": "2.0", "method": "AudioLibrary.GetAlbums", "params": { "limits": { "start": 0 }, "properties": ["description", "theme", "mood", "style", "type", "albumlabel", "artist", "genre", "rating", "title", "year", "thumbnail"], "sort": { "method": "artist" } }, "id": 1}',
+        success: jQuery.proxy(function(data) {
+          if (data && data.result && data.result.albums) {
+            this.albumList = data.result.albums;
+            $.each($(this.albumList), jQuery.proxy(function(i, item) {
+              var floatableAlbum = this.generateThumb('album', item.thumbnail, item.title, item.artist);
+              floatableAlbum.bind('click', { album: item }, jQuery.proxy(this.displayAlbumDetails, this));
+              libraryContainer.append(floatableAlbum);
+            }, this));
+            libraryContainer.append($('<div>').addClass('footerPadding'));
+            $('#spinner').hide();
+            libraryContainer.bind('scroll', { activeLibrary: libraryContainer }, jQuery.proxy(this.updateScrollEffects, this));
+            libraryContainer.trigger('scroll');
+            myScroll = new iScroll('libraryContainer');
+          } else {
+            libraryContainer.html('');
+          }
+        }, this),
+        dataType: 'json'});
     } else {
       libraryContainer.show();
       libraryContainer.trigger('scroll');
@@ -353,71 +536,77 @@ MediaLibrary.prototype = {
     $('#topScrollFade').hide();
     if (!albumDetailsContainer || albumDetailsContainer.length == 0) {
       $('#spinner').show();
-      jQuery.post(JSON_RPC + '?GetSongs', '{"jsonrpc": "2.0", "method": "AudioLibrary.GetSongs", "params": { "properties": ["title", "artist", "genre", "track", "duration", "year", "rating", "playcount"], "albumid" : ' + event.data.album.albumid + ' }, "id": 1}', jQuery.proxy(function(data) {
-        albumDetailsContainer = $('<div>');
-        albumDetailsContainer.attr('id', 'albumDetails' + event.data.album.albumid)
-                   .addClass('contentContainer')
-                   .addClass('albumContainer')
-                   .html('<table class="albumView"><thead><tr class="headerRow"><th>Artwork</th><th>&nbsp;</th><th>Name</th><th class="time">Time</th><th>Artist</th><th>Genre</th></tr></thead><tbody class="resultSet"></tbody></table>');
-        $('.contentContainer').hide();
-        $('#content').append(albumDetailsContainer);
-        var albumThumbnail = event.data.album.thumbnail;
-        var albumTitle = event.data.album.title||'Unknown Album';
-        var albumArtist = event.data.album.artist||'Unknown Artist';
-        var trackCount = data.result.limits.total;
-        $.each($(data.result.songs), jQuery.proxy(function(i, item) {
-          if (i == 0) {
-            var trackRow = $('<tr>').addClass('trackRow').addClass('tr' + i % 2);
-            trackRow.append($('<td>').attr('rowspan', ++trackCount + 1).addClass('albumThumb'));
-            for (var a = 0; a < 5; a++) {
-              trackRow.append($('<td>').html('&nbsp').attr('style', 'display: none'));
+      jQuery.ajax({
+        type: 'POST',
+        contentType: 'application/json',
+        url: JSON_RPC + '?GetSongs',
+        data: '{"jsonrpc": "2.0", "method": "AudioLibrary.GetSongs", "params": { "properties": ["title", "artist", "genre", "track", "duration", "year", "rating", "playcount"], "albumid" : ' + event.data.album.albumid + ' }, "id": 1}',
+        success: jQuery.proxy(function(data) {
+          albumDetailsContainer = $('<div>');
+          albumDetailsContainer.attr('id', 'albumDetails' + event.data.album.albumid)
+                     .addClass('contentContainer')
+                     .addClass('albumContainer')
+                     .html('<table class="albumView"><thead><tr class="headerRow"><th>Artwork</th><th>&nbsp;</th><th>Name</th><th class="time">Time</th><th>Artist</th><th>Genre</th></tr></thead><tbody class="resultSet"></tbody></table>');
+          $('.contentContainer').hide();
+          $('#content').append(albumDetailsContainer);
+          var albumThumbnail = event.data.album.thumbnail;
+          var albumTitle = event.data.album.title||'Unknown Album';
+          var albumArtist = event.data.album.artist||'Unknown Artist';
+          var trackCount = data.result.limits.total;
+          $.each($(data.result.songs), jQuery.proxy(function(i, item) {
+            if (i == 0) {
+              var trackRow = $('<tr>').addClass('trackRow').addClass('tr' + i % 2);
+              trackRow.append($('<td>').attr('rowspan', ++trackCount + 1).addClass('albumThumb'));
+              for (var a = 0; a < 5; a++) {
+                trackRow.append($('<td>').html('&nbsp').attr('style', 'display: none'));
+              }
+              $('#albumDetails' + event.data.album.albumid + ' .resultSet').append(trackRow);
+            }
+            var trackRow = $('<tr>').addClass('trackRow').addClass('tr' + i % 2).bind('click', { album: event.data.album, itmnbr: i }, jQuery.proxy(this.playTrack,this));
+            var trackNumberTD = $('<td>')
+              .html(item.track)
+
+            trackRow.append(trackNumberTD);
+            var trackTitleTD = $('<td>')
+              .html(item.title);
+
+            trackRow.append(trackTitleTD);
+            var trackDurationTD = $('<td>')
+              .addClass('time')
+              .html(durationToString(item.duration));
+
+            trackRow.append(trackDurationTD);
+            var trackArtistTD = $('<td>')
+              .html(item.artist);
+
+            trackRow.append(trackArtistTD);
+            var trackGenreTD = $('<td>')
+              .html(item.genre);
+
+            trackRow.append(trackGenreTD);
+            $('#albumDetails' + event.data.album.albumid + ' .resultSet').append(trackRow);
+          }, this));
+          if (trackCount > 0) {
+            var trackRow = $('<tr>').addClass('fillerTrackRow');
+            for (var i = 0; i < 5; i++) {
+              trackRow.append($('<td>').html('&nbsp'));
             }
             $('#albumDetails' + event.data.album.albumid + ' .resultSet').append(trackRow);
+
+            var trackRow2 = $('<tr>').addClass('fillerTrackRow2');
+            trackRow2.append($('<td>').addClass('albumBG').html('&nbsp'));
+            for (var i = 0; i < 5; i++) {
+              trackRow2.append($('<td>').html('&nbsp'));
+            }
+            $('#albumDetails' + event.data.album.albumid + ' .resultSet').append(trackRow2);
           }
-          var trackRow = $('<tr>').addClass('trackRow').addClass('tr' + i % 2).bind('click', { album: event.data.album, itmnbr: i }, jQuery.proxy(this.playTrack,this));
-          var trackNumberTD = $('<td>')
-            .html(item.track)
-
-          trackRow.append(trackNumberTD);
-          var trackTitleTD = $('<td>')
-            .html(item.title);
-
-          trackRow.append(trackTitleTD);
-          var trackDurationTD = $('<td>')
-            .addClass('time')
-            .html(durationToString(item.duration));
-
-          trackRow.append(trackDurationTD);
-          var trackArtistTD = $('<td>')
-            .html(item.artist);
-
-          trackRow.append(trackArtistTD);
-          var trackGenreTD = $('<td>')
-            .html(item.genre);
-
-          trackRow.append(trackGenreTD);
-          $('#albumDetails' + event.data.album.albumid + ' .resultSet').append(trackRow);
-        }, this));
-        if (trackCount > 0) {
-          var trackRow = $('<tr>').addClass('fillerTrackRow');
-          for (var i = 0; i < 5; i++) {
-            trackRow.append($('<td>').html('&nbsp'));
-          }
-          $('#albumDetails' + event.data.album.albumid + ' .resultSet').append(trackRow);
-
-          var trackRow2 = $('<tr>').addClass('fillerTrackRow2');
-          trackRow2.append($('<td>').addClass('albumBG').html('&nbsp'));
-          for (var i = 0; i < 5; i++) {
-            trackRow2.append($('<td>').html('&nbsp'));
-          }
-          $('#albumDetails' + event.data.album.albumid + ' .resultSet').append(trackRow2);
-        }
-        $('#albumDetails' + event.data.album.albumid + ' .albumThumb')
-          .append(this.generateThumb('album', albumThumbnail, albumTitle, albumArtist))
-          .append($('<div>').addClass('footerPadding'));
-        $('#spinner').hide();
-        myScroll = new iScroll('albumDetails' + event.data.album.albumid);
-      }, this), 'json');
+          $('#albumDetails' + event.data.album.albumid + ' .albumThumb')
+            .append(this.generateThumb('album', albumThumbnail, albumTitle, albumArtist))
+            .append($('<div>').addClass('footerPadding'));
+          $('#spinner').hide();
+          myScroll = new iScroll('albumDetails' + event.data.album.albumid);
+        }, this),
+        dataType: 'json'});
     } else {
       $('.contentContainer').hide();
       $('#albumDetails' + event.data.album.albumid).show();
@@ -463,57 +652,63 @@ MediaLibrary.prototype = {
     toggle=this.toggle.detach();
     if (!tvshowDetailsContainer || tvshowDetailsContainer.length == 0) {
       $('#spinner').show();
-      jQuery.post(JSON_RPC + '?GetTVShowSeasons', '{"jsonrpc": "2.0", "method": "VideoLibrary.GetSeasons", "params": { "properties": [ "season", "showtitle", "playcount", "episode", "thumbnail","fanart" ], "tvshowid" : ' + event.data.tvshow.tvshowid + ' }, "id": 1}', jQuery.proxy(function(data) {
-        tvshowDetailsContainer = $('<div>');
-        tvshowDetailsContainer.attr('id', 'tvShowDetails' + event.data.tvshow.tvshowid)
-                              .css('display', 'none')
-                              .addClass('contentContainer')
-                              .addClass('tvshowContainer');
-        var showThumb = this.generateThumb('tvshowseason', event.data.tvshow.thumbnail, event.data.tvshow.title);
-        if (data && data.result && data.result.seasons && data.result.seasons.length > 0) {
-          var showDetails = $('<div>').addClass('showDetails');
-          showDetails.append(toggle);
-          showDetails.append($('<p>').html(data.result.seasons[0].showtitle).addClass('showTitle'));
-          var seasonSelectionSelect = $('<select>').addClass('seasonPicker');
-          //var episodeCount = 0;
-          this.tvActiveShowContainer = tvshowDetailsContainer;
-          //var fanart;
-          $.each($(data.result.seasons), jQuery.proxy(function(i, item) {
-//              if(fanart==null && item.fanart!=null){
-//                fanart=item.fanart;
-//              }
-//              //episodeCount += item.episode;
-            var season = $('<option>').attr('value',i);
-            season.text(item.label);
-            seasonSelectionSelect.append(season);
+      jQuery.ajax({
+        type: 'POST',
+        contentType: 'application/json',
+        url: JSON_RPC + '?GetTVShowSeasons',
+        data: '{"jsonrpc": "2.0", "method": "VideoLibrary.GetSeasons", "params": { "properties": [ "season", "showtitle", "playcount", "episode", "thumbnail","fanart" ], "tvshowid" : ' + event.data.tvshow.tvshowid + ' }, "id": 1}',
+        success: jQuery.proxy(function(data) {
+          tvshowDetailsContainer = $('<div>');
+          tvshowDetailsContainer.attr('id', 'tvShowDetails' + event.data.tvshow.tvshowid)
+                                .css('display', 'none')
+                                .addClass('contentContainer')
+                                .addClass('tvshowContainer');
+          var showThumb = this.generateThumb('tvshowseason', event.data.tvshow.thumbnail, event.data.tvshow.title);
+          if (data && data.result && data.result.seasons && data.result.seasons.length > 0) {
+            var showDetails = $('<div>').addClass('showDetails');
+            showDetails.append(toggle);
+            showDetails.append($('<p>').html(data.result.seasons[0].showtitle).addClass('showTitle'));
+            var seasonSelectionSelect = $('<select>').addClass('seasonPicker');
+            //var episodeCount = 0;
+            this.tvActiveShowContainer = tvshowDetailsContainer;
+            //var fanart;
+            $.each($(data.result.seasons), jQuery.proxy(function(i, item) {
+  //              if(fanart==null && item.fanart!=null){
+  //                fanart=item.fanart;
+  //              }
+  //              //episodeCount += item.episode;
+              var season = $('<option>').attr('value',i);
+              season.text(item.label);
+              seasonSelectionSelect.append(season);
 
-          }, this));
-//            if(fanart!=null)
-//            {
-//              $('.contentContainer').css('background','url("'+this.getThumbnailPath(fanart)+'")').css('background-size','cover');
-//            }
-          seasonSelectionSelect.bind('change', {tvshow: event.data.tvshow.tvshowid, seasons: data.result.seasons, element: seasonSelectionSelect}, jQuery.proxy(this.displaySeasonListings, this));
-          //showDetails.append($('<p>').html('<span class="heading">Episodes:</span> ' + episodeCount));
-          showDetails.append(seasonSelectionSelect);
-          tvshowDetailsContainer.append(showDetails);
-          tvshowDetailsContainer.append(showThumb);
-          seasonSelectionSelect.trigger('change');
-          $('#content').append(tvshowDetailsContainer);
-          if(getCookie('TVView')!=null && getCookie('TVView')!='banner'){
-          var view=getCookie('TVView');
-          switch(view) {
-            case 'poster':
-              togglePoster.trigger('click');
-              break;
-            case 'landscape':
-              toggleLandscape.trigger('click')
-              break;
+            }, this));
+  //            if(fanart!=null)
+  //            {
+  //              $('.contentContainer').css('background','url("'+this.getThumbnailPath(fanart)+'")').css('background-size','cover');
+  //            }
+            seasonSelectionSelect.bind('change', {tvshow: event.data.tvshow.tvshowid, seasons: data.result.seasons, element: seasonSelectionSelect}, jQuery.proxy(this.displaySeasonListings, this));
+            //showDetails.append($('<p>').html('<span class="heading">Episodes:</span> ' + episodeCount));
+            showDetails.append(seasonSelectionSelect);
+            tvshowDetailsContainer.append(showDetails);
+            tvshowDetailsContainer.append(showThumb);
+            seasonSelectionSelect.trigger('change');
+            $('#content').append(tvshowDetailsContainer);
+            if(getCookie('TVView')!=null && getCookie('TVView')!='banner'){
+            var view=getCookie('TVView');
+            switch(view) {
+              case 'poster':
+                togglePoster.trigger('click');
+                break;
+              case 'landscape':
+                toggleLandscape.trigger('click')
+                break;
+            }
           }
-        }
-          tvshowDetailsContainer.fadeIn();
-        }
-        $('#spinner').hide();
-      }, this), 'json');
+            tvshowDetailsContainer.fadeIn();
+          }
+          $('#spinner').hide();
+        }, this),
+        dataType: 'json'});
     } else {
       $('.contentContainer').hide();
       $('#tvShowDetails' + event.data.tvshow.tvshowid).show();
@@ -530,24 +725,29 @@ MediaLibrary.prototype = {
     //Update ActiveSeason
     this.tvActiveSeason = selectedVal;
     //Populate new listings
-    jQuery.post(JSON_RPC + '?GetTVSeasonEpisodes', '{"jsonrpc": "2.0", "method": "VideoLibrary.GetEpisodes", "params": { "properties": [ "title", "thumbnail","episode","plot","season"], "season" : ' + seasons[selectedVal].season + ', "tvshowid" : ' + event.data.tvshow + ' }, "id": 1}', jQuery.proxy(function(data) {
-      var episodeListingsContainer = $('<div>').addClass('episodeListingsContainer');
-      var episodeTable= $('<table>').addClass('seasonView').html('<thead><tr class="headerRow"><th class="thumbHeader">N&deg;</th><th>Title</th><th class="thumbHeader">Thumb</th><th class="thumbHeader">Details</th></tr></thead><tbody class="resultSet"></tbody>');
-      $.each($(data.result.episodes), jQuery.proxy(function(i, item) {
-        var episodeRow = $('<tr>').addClass('episodeRow').addClass('tr' + i % 2);
-        var episodePictureImg = $('<img>').bind('click', { episode: item }, jQuery.proxy(this.playTVShow, this)).css('cursor','pointer');
-        episodePictureImg.attr('src', this.getThumbnailPath(item.thumbnail));
-        var episodePicture=$('<td>').addClass('episodeThumb').append(episodePictureImg).bind('click', { episode: item }, jQuery.proxy(this.playTVShow, this));
-        var episodeNumber = $('<td>').addClass('episodeNumber').html(item.episode).bind('click', { episode: item }, jQuery.proxy(this.playTVShow, this));
-        var episodeTitle = $('<td>').html(item.title).bind('click', { episode: item }, jQuery.proxy(this.playTVShow, this));
-        var episodeDetails = $('<td class="info">').html('').bind('click',{episode:item}, jQuery.proxy(this.displayEpisodeDetails, this)).css('cursor','pointer');
-        episodeRow.append(episodeNumber).append(episodeTitle).append(episodePicture).append(episodeDetails);
-        episodeTable.append(episodeRow);
-      }, this));
-      episodeListingsContainer.append(episodeTable);
-      $(this.tvActiveShowContainer).append(episodeListingsContainer);
-    }, this), 'json');
-
+    jQuery.ajax({
+      type: 'POST',
+      contentType: 'application/json',
+      url: JSON_RPC + '?GetTVSeasonEpisodes',
+      data: '{"jsonrpc": "2.0", "method": "VideoLibrary.GetEpisodes", "params": { "properties": [ "title", "thumbnail","episode","plot","season"], "season" : ' + seasons[selectedVal].season + ', "tvshowid" : ' + event.data.tvshow + ' }, "id": 1}',
+      success: jQuery.proxy(function(data) {
+        var episodeListingsContainer = $('<div>').addClass('episodeListingsContainer');
+        var episodeTable= $('<table>').addClass('seasonView').html('<thead><tr class="headerRow"><th class="thumbHeader">N&deg;</th><th>Title</th><th class="thumbHeader">Thumb</th><th class="thumbHeader">Details</th></tr></thead><tbody class="resultSet"></tbody>');
+        $.each($(data.result.episodes), jQuery.proxy(function(i, item) {
+          var episodeRow = $('<tr>').addClass('episodeRow').addClass('tr' + i % 2);
+          var episodePictureImg = $('<img>').bind('click', { episode: item }, jQuery.proxy(this.playTVShow, this)).css('cursor','pointer');
+          episodePictureImg.attr('src', this.getThumbnailPath(item.thumbnail));
+          var episodePicture=$('<td>').addClass('episodeThumb').append(episodePictureImg).bind('click', { episode: item }, jQuery.proxy(this.playTVShow, this));
+          var episodeNumber = $('<td>').addClass('episodeNumber').html(item.episode).bind('click', { episode: item }, jQuery.proxy(this.playTVShow, this));
+          var episodeTitle = $('<td>').html(item.title).bind('click', { episode: item }, jQuery.proxy(this.playTVShow, this));
+          var episodeDetails = $('<td class="info">').html('').bind('click',{episode:item}, jQuery.proxy(this.displayEpisodeDetails, this)).css('cursor','pointer');
+          episodeRow.append(episodeNumber).append(episodeTitle).append(episodePicture).append(episodeDetails);
+          episodeTable.append(episodeRow);
+        }, this));
+        episodeListingsContainer.append(episodeTable);
+        $(this.tvActiveShowContainer).append(episodeListingsContainer);
+      }, this),
+      dataType: 'json'});
   },
 
   displayEpisodeDetails: function(event) {
@@ -587,9 +787,15 @@ MediaLibrary.prototype = {
   },
 
   playTVShow: function(event) {
-    jQuery.post(JSON_RPC + '?AddTvShowToPlaylist', '{"jsonrpc": "2.0", "method": "Player.Open", "params": { "item": { "episodeid": ' + event.data.episode.episodeid + ' } }, "id": 1}', jQuery.proxy(function(data) {
-      this.hideOverlay();
-    }, this), 'json');
+    jQuery.ajax({
+      type: 'POST',
+      contentType: 'application/json',
+      url: JSON_RPC + '?AddTvShowToPlaylist',
+      data: '{"jsonrpc": "2.0", "method": "Player.Open", "params": { "item": { "episodeid": ' + event.data.episode.episodeid + ' } }, "id": 1}',
+      success: jQuery.proxy(function(data) {
+        this.hideOverlay();
+      }, this),
+      dataType: 'json'});
   },
   hideOverlay: function(event) {
     if (this.activeCover) {
@@ -620,9 +826,15 @@ MediaLibrary.prototype = {
     }
   },
   playMovie: function(event) {
-    jQuery.post(JSON_RPC + '?PlayMovie', '{"jsonrpc": "2.0", "method": "Player.Open", "params": { "item": { "movieid": ' + event.data.movie.movieid + ' } }, "id": 1}', jQuery.proxy(function(data) {
-      this.hideOverlay();
-    }, this), 'json');
+    jQuery.ajax({
+      type: 'POST',
+      contentType: 'application/json',
+      url: JSON_RPC + '?PlayMovie',
+      data: '{"jsonrpc": "2.0", "method": "Player.Open", "params": { "item": { "movieid": ' + event.data.movie.movieid + ' } }, "id": 1}',
+      success: jQuery.proxy(function(data) {
+        this.hideOverlay();
+      }, this),
+      dataType: 'json'});
   },
   displayMovieDetails: function(event) {
     var movieDetails = $('<div>').attr('id', 'movie-' + event.data.movie.movieid).addClass('moviePopoverContainer');
@@ -654,13 +866,32 @@ MediaLibrary.prototype = {
     this.updatePlayButtonLocation();
   },
   playTrack: function(event) {
-    jQuery.post(JSON_RPC + '?ClearPlaylist', '{"jsonrpc": "2.0", "method": "Playlist.Clear", "params": { "playlistid": ' + this.playlists["audio"] + ' }, "id": 1}', jQuery.proxy(function(data) {
-      //check that clear worked.
-      jQuery.post(JSON_RPC + '?AddAlbumToPlaylist', '{"jsonrpc": "2.0", "method": "Playlist.Add", "params": { "playlistid": ' + this.playlists["audio"] + ', "item": { "albumid": ' + event.data.album.albumid + ' } }, "id": 1}', jQuery.proxy(function(data) {
-        //play specific song in playlist
-        jQuery.post(JSON_RPC + '?PlaylistItemPlay', '{"jsonrpc": "2.0", "method": "Player.Open", "params": { "item": { "playlistid": ' + this.playlists["audio"] + ', "position": '+ event.data.itmnbr + ' } }, "id": 1}', function() {}, 'json');
-      }, this), 'json');
-    }, this), 'json');
+    jQuery.ajax({
+      type: 'POST',
+      contentType: 'application/json',
+      url: JSON_RPC + '?ClearPlaylist',
+      data: '{"jsonrpc": "2.0", "method": "Playlist.Clear", "params": { "playlistid": ' + this.playlists["audio"] + ' }, "id": 1}',
+      success: jQuery.proxy(function(data) {
+        //check that clear worked.
+        jQuery.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: JSON_RPC + '?AddAlbumToPlaylist',
+          data: '{"jsonrpc": "2.0", "method": "Playlist.Add", "params": { "playlistid": ' + this.playlists["audio"] + ', "item": { "albumid": ' + event.data.album.albumid + ' } }, "id": 1}',
+          success: jQuery.proxy(function(data) {
+            //play specific song in playlist
+            jQuery.ajax({
+              type: 'POST',
+              contentType: 'application/json',
+              url: JSON_RPC + '?PlaylistItemPlay',
+              data: '{"jsonrpc": "2.0", "method": "Player.Open", "params": { "item": { "playlistid": ' + this.playlists["audio"] + ', "position": '+ event.data.itmnbr + ' } }, "id": 1}',
+              success: jQuery.proxy(function(data) {
+              }, this),
+              dataType: 'json'});
+          }, this),
+          dataType: 'json'});
+      }, this),
+      dataType: 'json'});
   },
   movieLibraryOpen: function() {
     this.resetPage();
@@ -669,28 +900,34 @@ MediaLibrary.prototype = {
     var libraryContainer = $('#movieLibraryContainer');
     if (!libraryContainer || libraryContainer.length == 0) {
       $('#spinner').show();
-      jQuery.post(JSON_RPC + '?GetMovies', '{"jsonrpc": "2.0", "method": "VideoLibrary.GetMovies", "params": { "limits": { "start": 0 }, "properties": [ "genre", "director", "trailer", "tagline", "plot", "plotoutline", "title", "originaltitle", "lastplayed", "runtime", "year", "playcount", "rating", "thumbnail", "file" ], "sort": { "method": "sorttitle", "ignorearticle": true } }, "id": 1}', jQuery.proxy(function(data) {
-        if (data && data.result && data.result.movies) {
-            libraryContainer = $('<div>');
-            libraryContainer.attr('id', 'movieLibraryContainer')
-                    .addClass('contentContainer');
-            $('#content').append(libraryContainer);
-        } else {
-          libraryContainer.html('');
-        }
-        //data.result.movies.sort(jQuery.proxy(this.movieTitleSorter, this));
-        $.each($(data.result.movies), jQuery.proxy(function(i, item) {
-          var floatableMovieCover = this.generateThumb('movie', item.thumbnail, item.title);
-          floatableMovieCover.bind('click', { movie: item }, jQuery.proxy(this.displayMovieDetails, this));
-          libraryContainer.append(floatableMovieCover);
-        }, this));
-        libraryContainer.append($('<div>').addClass('footerPadding'));
-        $('#spinner').hide();
-        libraryContainer.bind('scroll', { activeLibrary: libraryContainer }, jQuery.proxy(this.updateScrollEffects, this));
-        libraryContainer.trigger('scroll');
-        //$('#libraryContainer img').lazyload();
-        myScroll = new iScroll('movieLibraryContainer');
-      }, this), 'json');
+      jQuery.ajax({
+        type: 'POST',
+        contentType: 'application/json',
+        url: JSON_RPC + '?GetMovies',
+        data: '{"jsonrpc": "2.0", "method": "VideoLibrary.GetMovies", "params": { "limits": { "start": 0 }, "properties": [ "genre", "director", "trailer", "tagline", "plot", "plotoutline", "title", "originaltitle", "lastplayed", "runtime", "year", "playcount", "rating", "thumbnail", "file" ], "sort": { "method": "sorttitle", "ignorearticle": true } }, "id": 1}',
+        success: jQuery.proxy(function(data) {
+          if (data && data.result && data.result.movies) {
+              libraryContainer = $('<div>');
+              libraryContainer.attr('id', 'movieLibraryContainer')
+                      .addClass('contentContainer');
+              $('#content').append(libraryContainer);
+          } else {
+            libraryContainer.html('');
+          }
+          //data.result.movies.sort(jQuery.proxy(this.movieTitleSorter, this));
+          $.each($(data.result.movies), jQuery.proxy(function(i, item) {
+            var floatableMovieCover = this.generateThumb('movie', item.thumbnail, item.title);
+            floatableMovieCover.bind('click', { movie: item }, jQuery.proxy(this.displayMovieDetails, this));
+            libraryContainer.append(floatableMovieCover);
+          }, this));
+          libraryContainer.append($('<div>').addClass('footerPadding'));
+          $('#spinner').hide();
+          libraryContainer.bind('scroll', { activeLibrary: libraryContainer }, jQuery.proxy(this.updateScrollEffects, this));
+          libraryContainer.trigger('scroll');
+          //$('#libraryContainer img').lazyload();
+          myScroll = new iScroll('movieLibraryContainer');
+        }, this),
+        dataType: 'json'});
     } else {
       libraryContainer.show();
       libraryContainer.trigger('scroll');
@@ -719,38 +956,44 @@ MediaLibrary.prototype = {
             .bind('click',{mode: 'landscape'},jQuery.proxy(this.togglePosterView,this));
       toggle.append(toggleBanner).append(' | ').append(togglePoster).append(' | ').append(toggleLandscape);
       this.toggle=toggle;
-      jQuery.post(JSON_RPC + '?GetTVShows', '{"jsonrpc": "2.0", "method": "VideoLibrary.GetTVShows", "params": { "properties": ["genre", "plot", "title", "lastplayed", "episode", "year", "playcount", "rating", "thumbnail", "studio", "mpaa", "premiered"] }, "id": 1}', jQuery.proxy(function(data) {
-        if (data && data.result && data.result.tvshows) {
-            libraryContainer = $('<div>');
-            libraryContainer.append(toggle);
-            libraryContainer.attr('id', 'tvshowLibraryContainer')
-                    .addClass('contentContainer');
-            $('#content').append(libraryContainer);
-        } else {
-          libraryContainer.html('');
-        }
-        $.each($(data.result.tvshows), jQuery.proxy(function(i, item) {
-          var floatableTVShowCover = this.generateThumb('tvshow', item.thumbnail, item.title);
-          floatableTVShowCover.bind('click', { tvshow: item }, jQuery.proxy(this.displayTVShowDetails, this));
-          libraryContainer.append(floatableTVShowCover);
-        }, this));
-        libraryContainer.append($('<div>').addClass('footerPadding'));
-        $('#spinner').hide();
-        libraryContainer.bind('scroll', { activeLibrary: libraryContainer }, jQuery.proxy(this.updateScrollEffects, this));
-        libraryContainer.trigger('scroll');
-        myScroll = new iScroll('tvshowLibraryContainer');
-        if(getCookie('TVView')!=null && getCookie('TVView')!='banner'){
-          var view=getCookie('TVView');
-          switch(view) {
-            case 'poster':
-              togglePoster.trigger('click');
-              break;
-            case 'landscape':
-              toggleLandscape.trigger('click')
-              break;
+      jQuery.ajax({
+        type: 'POST',
+        contentType: 'application/json',
+        url: JSON_RPC + '?GetTVShows',
+        data: '{"jsonrpc": "2.0", "method": "VideoLibrary.GetTVShows", "params": { "properties": ["genre", "plot", "title", "lastplayed", "episode", "year", "playcount", "rating", "thumbnail", "studio", "mpaa", "premiered"] }, "id": 1}',
+        success: jQuery.proxy(function(data) {
+          if (data && data.result && data.result.tvshows) {
+              libraryContainer = $('<div>');
+              libraryContainer.append(toggle);
+              libraryContainer.attr('id', 'tvshowLibraryContainer')
+                      .addClass('contentContainer');
+              $('#content').append(libraryContainer);
+          } else {
+            libraryContainer.html('');
           }
-        }
-      }, this), 'json');
+          $.each($(data.result.tvshows), jQuery.proxy(function(i, item) {
+            var floatableTVShowCover = this.generateThumb('tvshow', item.thumbnail, item.title);
+            floatableTVShowCover.bind('click', { tvshow: item }, jQuery.proxy(this.displayTVShowDetails, this));
+            libraryContainer.append(floatableTVShowCover);
+          }, this));
+          libraryContainer.append($('<div>').addClass('footerPadding'));
+          $('#spinner').hide();
+          libraryContainer.bind('scroll', { activeLibrary: libraryContainer }, jQuery.proxy(this.updateScrollEffects, this));
+          libraryContainer.trigger('scroll');
+          myScroll = new iScroll('tvshowLibraryContainer');
+          if(getCookie('TVView')!=null && getCookie('TVView')!='banner') {
+            var view=getCookie('TVView');
+            switch(view) {
+              case 'poster':
+                togglePoster.trigger('click');
+                break;
+              case 'landscape':
+                toggleLandscape.trigger('click')
+                break;
+            }
+          }
+        }, this),
+        dataType: 'json'});
     } else {
       libraryContainer.prepend($(".toggle").detach()).show();
       libraryContainer.trigger('scroll');
@@ -765,7 +1008,14 @@ MediaLibrary.prototype = {
     }
   },
   startSlideshow: function(event) {
-    jQuery.post(JSON_RPC + '?StartSlideshow', '{"jsonrpc": "2.0", "method": "Player.Open", "params": { "item": { "recursive" : "true", "random":"true", "path" : "' + this.replaceAll(event.data.directory.file, "\\", "\\\\") + '" } }, "id": 1}', null, 'json');
+    jQuery.ajax({
+      type: 'POST',
+      contentType: 'application/json',
+      url: JSON_RPC + '?StartSlideshow',
+      data: '{"jsonrpc": "2.0", "method": "Player.Open", "params": { "item": { "recursive" : "true", "random": "true", "path" : "' + this.replaceAll(event.data.directory.file, "\\", "\\\\") + '" } }, "id": 1}',
+      success: jQuery.proxy(function(data) {
+      }, this),
+      dataType: 'json'});
   },
   showDirectory: function(event) {
     var directory = event.data.directory.file;
@@ -776,53 +1026,59 @@ MediaLibrary.prototype = {
     var libraryContainer = $('#pictureLibraryDirContainer' + directory);
     if (!libraryContainer || libraryContainer.length == 0) {
       $('#spinner').show();
-      jQuery.post(JSON_RPC + '?GetDirectory', '{"jsonrpc": "2.0", "method": "Files.GetDirectory", "params": { "media" : "pictures", "directory": "' + jsonDirectory + '" }, "id": 1}', jQuery.proxy(function(data) {
-        if (data && data.result && ( data.result.directories || data.result.files )) {
-          libraryContainer = $('<div>');
-          libraryContainer.attr('id', 'pictureLibraryDirContainer' + directory)
-                  .addClass('contentContainer');
-          $('#content').append(libraryContainer);
-          var breadcrumb = $('<div>');
-          var seperator = '/';
-          var item = '';
-          var directoryArray = directory.split(seperator);
-          jQuery.each(directoryArray, function(i,v) {
-            if(v != '') {
-              item += v + seperator;
-              //tmp.bind('click', { directory: item }, jQuery.proxy(this.showDirectory, this));
-              breadcrumb.append($('<div>').text(' > ' + v).css('float','left').addClass('breadcrumb'));
+      jQuery.ajax({
+        type: 'POST',
+        contentType: 'application/json',
+        url: JSON_RPC + '?GetDirectory',
+        data: '{"jsonrpc": "2.0", "method": "Files.GetDirectory", "params": { "media" : "pictures", "directory": "' + jsonDirectory + '" }, "id": 1}',
+        success: jQuery.proxy(function(data) {
+          if (data && data.result && ( data.result.directories || data.result.files )) {
+            libraryContainer = $('<div>');
+            libraryContainer.attr('id', 'pictureLibraryDirContainer' + directory)
+                    .addClass('contentContainer');
+            $('#content').append(libraryContainer);
+            var breadcrumb = $('<div>');
+            var seperator = '/';
+            var item = '';
+            var directoryArray = directory.split(seperator);
+            jQuery.each(directoryArray, function(i,v) {
+              if(v != '') {
+                item += v + seperator;
+                //tmp.bind('click', { directory: item }, jQuery.proxy(this.showDirectory, this));
+                breadcrumb.append($('<div>').text(' > ' + v).css('float','left').addClass('breadcrumb'));
+              }
+            });
+            libraryContainer.append(breadcrumb);
+            libraryContainer.append($('<div>').css('clear','both'));
+            if (data.result.files) {
+              $.each($(data.result.files), jQuery.proxy(function(i, item) {
+                if (item.filetype == "file")
+                {
+                  var floatableImage = this.generateThumb('image', item.file, item.label);
+                  libraryContainer.append(floatableImage);
+                }
+                else if (item.filetype == "directory")
+                {
+                  var floatableShare = this.generateThumb('directory', item.thumbnail, item.label);
+                  floatableShare.bind('click', { directory: item }, jQuery.proxy(this.showDirectory, this));
+                  //var slideshow = $('<div">');
+                  //slideshow.html('<div>Slideshow</div>');
+                  //slideshow.bind('click', { directory: item }, jQuery.proxy(this.startSlideshow, this));
+                  //floatableShare.append(slideshow);
+                  libraryContainer.append(floatableShare);
+                }
+              }, this));
             }
-          });
-          libraryContainer.append(breadcrumb);
-          libraryContainer.append($('<div>').css('clear','both'));
-          if (data.result.files) {
-            $.each($(data.result.files), jQuery.proxy(function(i, item) {
-              if (item.filetype == "file")
-              {
-                var floatableImage = this.generateThumb('image', item.file, item.label);
-                libraryContainer.append(floatableImage);
-              }
-              else if (item.filetype == "directory")
-              {
-                var floatableShare = this.generateThumb('directory', item.thumbnail, item.label);
-                floatableShare.bind('click', { directory: item }, jQuery.proxy(this.showDirectory, this));
-                //var slideshow = $('<div">');
-                //slideshow.html('<div>Slideshow</div>');
-                //slideshow.bind('click', { directory: item }, jQuery.proxy(this.startSlideshow, this));
-                //floatableShare.append(slideshow);
-                libraryContainer.append(floatableShare);
-              }
-            }, this));
+            libraryContainer.append($('<div>').addClass('footerPadding'));
+          } else {
+            libraryContainer.html('');
           }
-          libraryContainer.append($('<div>').addClass('footerPadding'));
-        } else {
-          libraryContainer.html('');
-        }
-        $('#spinner').hide();
-        libraryContainer.bind('scroll', { activeLibrary: libraryContainer }, jQuery.proxy(this.updateScrollEffects, this));
-        libraryContainer.trigger('scroll');
-        myScroll = new iScroll('#pictureLibraryDirContainer' + directory);
-      }, this), 'json');
+          $('#spinner').hide();
+          libraryContainer.bind('scroll', { activeLibrary: libraryContainer }, jQuery.proxy(this.updateScrollEffects, this));
+          libraryContainer.trigger('scroll');
+          myScroll = new iScroll('#pictureLibraryDirContainer' + directory);
+        }, this),
+        dataType: 'json'});
     } else {
       libraryContainer.show();
       libraryContainer.trigger('scroll');
@@ -835,26 +1091,32 @@ MediaLibrary.prototype = {
     var libraryContainer = $('#pictureLibraryContainer');
     if (!libraryContainer || libraryContainer.length == 0) {
       $('#spinner').show();
-      jQuery.post(JSON_RPC + '?GetSources', '{"jsonrpc": "2.0", "method": "Files.GetSources", "params": { "media" : "pictures" }, "id": 1}', jQuery.proxy(function(data) {
-        if (data && data.result && data.result.shares) {
-          libraryContainer = $('<div>');
-          libraryContainer.attr('id', 'pictureLibraryContainer')
-                          .addClass('contentContainer');
-          $('#content').append(libraryContainer);
-        } else {
-          libraryContainer.html('');
-        }
-        $.each($(data.result.shares), jQuery.proxy(function(i, item) {
-          var floatableShare = this.generateThumb('directory', item.thumbnail, item.label);
-          floatableShare.bind('click', { directory: item }, jQuery.proxy(this.showDirectory, this));
-          libraryContainer.append(floatableShare);
-        }, this));
-        libraryContainer.append($('<div>').addClass('footerPadding'));
-        $('#spinner').hide();
-        libraryContainer.bind('scroll', { activeLibrary: libraryContainer }, jQuery.proxy(this.updateScrollEffects, this));
-        libraryContainer.trigger('scroll');
-        myScroll = new iScroll('#pictureLibraryContainer');
-      }, this), 'json');
+      jQuery.ajax({
+        type: 'POST',
+        contentType: 'application/json',
+        url: JSON_RPC + '?GetSources',
+        data: '{"jsonrpc": "2.0", "method": "Files.GetSources", "params": { "media" : "pictures" }, "id": 1}',
+        success: jQuery.proxy(function(data) {
+          if (data && data.result && data.result.shares) {
+            libraryContainer = $('<div>');
+            libraryContainer.attr('id', 'pictureLibraryContainer')
+                            .addClass('contentContainer');
+            $('#content').append(libraryContainer);
+          } else {
+            libraryContainer.html('');
+          }
+          $.each($(data.result.shares), jQuery.proxy(function(i, item) {
+            var floatableShare = this.generateThumb('directory', item.thumbnail, item.label);
+            floatableShare.bind('click', { directory: item }, jQuery.proxy(this.showDirectory, this));
+            libraryContainer.append(floatableShare);
+          }, this));
+          libraryContainer.append($('<div>').addClass('footerPadding'));
+          $('#spinner').hide();
+          libraryContainer.bind('scroll', { activeLibrary: libraryContainer }, jQuery.proxy(this.updateScrollEffects, this));
+          libraryContainer.trigger('scroll');
+          myScroll = new iScroll('#pictureLibraryContainer');
+        }, this),
+        dataType: 'json'});
     } else {
       libraryContainer.show();
       libraryContainer.trigger('scroll');

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -685,6 +685,8 @@
     <ClCompile Include="..\..\xbmc\network\EventServer.cpp" />
     <ClCompile Include="..\..\xbmc\network\GUIDialogAccessPoints.cpp" />
     <ClCompile Include="..\..\xbmc\network\GUIDialogNetworkSetup.cpp" />
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.cpp" />
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\lastfmscrobbler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\librefmscrobbler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\scrobbler.cpp" />
@@ -799,6 +801,8 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\IJSONRPCAnnouncer.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\JSONRPCUtils.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\GUIOperations.h" />
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.h" />
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\IHTTPRequestHandler.h" />
     <ClInclude Include="..\..\xbmc\threads\platform\win\Implementation.cpp" />
     <ClCompile Include="..\..\xbmc\threads\SystemClock.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -690,6 +690,7 @@
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.cpp" />
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\IHTTPRequestHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\lastfmscrobbler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\librefmscrobbler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\scrobbler.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -687,6 +687,7 @@
     <ClCompile Include="..\..\xbmc\network\GUIDialogNetworkSetup.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.cpp" />
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\lastfmscrobbler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\librefmscrobbler.cpp" />
@@ -804,6 +805,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\GUIOperations.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.h" />
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\IHTTPRequestHandler.h" />
     <ClInclude Include="..\..\xbmc\threads\platform\win\Implementation.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -686,6 +686,7 @@
     <ClCompile Include="..\..\xbmc\network\GUIDialogAccessPoints.cpp" />
     <ClCompile Include="..\..\xbmc\network\GUIDialogNetworkSetup.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.cpp" />
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.cpp" />
@@ -804,6 +805,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\JSONRPCUtils.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\GUIOperations.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.h" />
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.h" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -687,6 +687,7 @@
     <ClCompile Include="..\..\xbmc\network\GUIDialogNetworkSetup.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.cpp" />
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\lastfmscrobbler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\librefmscrobbler.cpp" />
     <ClCompile Include="..\..\xbmc\network\libscrobbler\scrobbler.cpp" />
@@ -803,6 +804,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\GUIOperations.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.h" />
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\IHTTPRequestHandler.h" />
     <ClInclude Include="..\..\xbmc\threads\platform\win\Implementation.cpp" />
     <ClCompile Include="..\..\xbmc\threads\SystemClock.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -799,6 +799,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\IJSONRPCAnnouncer.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\JSONRPCUtils.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\GUIOperations.h" />
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\IHTTPRequestHandler.h" />
     <ClInclude Include="..\..\xbmc\threads\platform\win\Implementation.cpp" />
     <ClCompile Include="..\..\xbmc\threads\SystemClock.cpp" />
     <ClCompile Include="..\..\xbmc\threads\Thread.cpp" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2607,6 +2607,9 @@
     <ClCompile Include="..\..\xbmc\utils\Mime.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.cpp">
+      <Filter>network\httprequesthandler</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5236,6 +5239,9 @@
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.h">
+      <Filter>network\httprequesthandler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.h">
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
   </ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2571,6 +2571,12 @@
     <ClCompile Include="..\..\xbmc\cores\paplayer\PCMCodec.cpp">
       <Filter>cores\paplayer</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.cpp">
+      <Filter>network\httprequesthandler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.cpp">
+      <Filter>network\httprequesthandler</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\utils\Base64.cpp">
       <Filter>utils</Filter>
     </ClCompile>
@@ -5224,6 +5230,12 @@
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\IHTTPRequestHandler.h">
+      <Filter>network\httprequesthandler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.h">
+      <Filter>network\httprequesthandler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.h">
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
   </ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2613,6 +2613,9 @@
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.cpp">
       <Filter>network\httprequesthandler</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.cpp">
+      <Filter>network\httprequesthandler</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5248,6 +5251,9 @@
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.h">
+      <Filter>network\httprequesthandler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.h">
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
   </ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2616,6 +2616,9 @@
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.cpp">
       <Filter>network\httprequesthandler</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\IHTTPRequestHandler.cpp">
+      <Filter>network\httprequesthandler</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -256,6 +256,9 @@
     <Filter Include="filesystem\windows">
       <UniqueIdentifier>{1cc693eb-11ad-4f53-8640-198d5ab9bcc8}</UniqueIdentifier>
     </Filter>
+    <Filter Include="network\httprequesthandler">
+      <UniqueIdentifier>{9029e610-aa5a-4414-9e96-1d69f03b3bd8}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\xbmc\win32\pch.cpp">
@@ -5219,6 +5222,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\Mime.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\IHTTPRequestHandler.h">
+      <Filter>network\httprequesthandler</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2610,6 +2610,9 @@
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.cpp">
       <Filter>network\httprequesthandler</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.cpp">
+      <Filter>network\httprequesthandler</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5242,6 +5245,9 @@
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceHandler.h">
+      <Filter>network\httprequesthandler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.h">
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
   </ItemGroup>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -42,6 +42,7 @@
 #endif
 #ifdef HAS_WEB_INTERFACE
 #include "network/httprequesthandler/HTTPWebinterfaceHandler.h"
+#include "network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h"
 #endif
 #endif
 #ifdef HAS_LCD
@@ -348,6 +349,7 @@ CApplication::CApplication(void)
 #endif
 #ifdef HAS_WEB_INTERFACE
   , m_httpWebinterfaceHandler(*new CHTTPWebinterfaceHandler)
+  , m_httpWebinterfaceAddonsHandler(*new CHTTPWebinterfaceAddonsHandler)
 #endif
 #endif
   , m_itemCurrentFile(new CFileItem)
@@ -404,6 +406,7 @@ CApplication::~CApplication(void)
 #endif
 #ifdef HAS_WEB_INTERFACE
   delete &m_httpWebinterfaceHandler;
+  delete &m_httpWebinterfaceAddonsHandler;
 #endif
 #endif
   delete &m_progressTrackingVideoResumeBookmark;
@@ -1095,6 +1098,7 @@ bool CApplication::Initialize()
   CWebServer::RegisterRequestHandler(&m_httpApiHandler);
 #endif
 #ifdef HAS_WEB_INTERFACE
+  CWebServer::RegisterRequestHandler(&m_httpWebinterfaceAddonsHandler);
   // Must always be registered as the last HTTP handler as it is the default handler
   CWebServer::RegisterRequestHandler(&m_httpWebinterfaceHandler);
 #endif
@@ -3366,6 +3370,7 @@ void CApplication::Stop(int exitCode)
   CWebServer::UnregisterRequestHandler(&m_httpApiHandler);
 #endif
 #ifdef HAS_WEB_INTERFACE
+  CWebServer::UnregisterRequestHandler(&m_httpWebinterfaceAddonsHandler);
   CWebServer::UnregisterRequestHandler(&m_httpWebinterfaceHandler);
 #endif
 #endif

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1111,7 +1111,6 @@ bool CApplication::Initialize()
 #endif
 #ifdef HAS_WEB_INTERFACE
   CWebServer::RegisterRequestHandler(&m_httpWebinterfaceAddonsHandler);
-  // Must always be registered as the last HTTP handler as it is the default handler
   CWebServer::RegisterRequestHandler(&m_httpWebinterfaceHandler);
 #endif
 #endif

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -40,6 +40,9 @@
 #ifdef HAS_HTTPAPI
 #include "network/httprequesthandler/HTTPApiHandler.h"
 #endif
+#ifdef HAS_JSONRPC
+#include "network/httprequesthandler/HTTPJsonRpcHandler.h"
+#endif
 #ifdef HAS_WEB_INTERFACE
 #include "network/httprequesthandler/HTTPWebinterfaceHandler.h"
 #include "network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h"
@@ -347,6 +350,9 @@ CApplication::CApplication(void)
 #ifdef HAS_HTTPAPI
   , m_httpApiHandler(*new CHTTPApiHandler)
 #endif
+#ifdef HAS_JSONRPC
+  , m_httpJsonRpcHandler(*new CHTTPJsonRpcHandler)
+#endif
 #ifdef HAS_WEB_INTERFACE
   , m_httpWebinterfaceHandler(*new CHTTPWebinterfaceHandler)
   , m_httpWebinterfaceAddonsHandler(*new CHTTPWebinterfaceAddonsHandler)
@@ -403,6 +409,9 @@ CApplication::~CApplication(void)
   delete &m_httpVfsHandler;
 #ifdef HAS_HTTPAPI
   delete &m_httpApiHandler;
+#endif
+#ifdef HAS_JSONRPC
+  delete &m_httpJsonRpcHandler;
 #endif
 #ifdef HAS_WEB_INTERFACE
   delete &m_httpWebinterfaceHandler;
@@ -1094,6 +1103,9 @@ bool CApplication::Initialize()
 
 #ifdef HAS_WEB_SERVER
   CWebServer::RegisterRequestHandler(&m_httpVfsHandler);
+#ifdef HAS_JSONRPC
+  CWebServer::RegisterRequestHandler(&m_httpJsonRpcHandler);
+#endif
 #ifdef HAS_HTTPAPI
   CWebServer::RegisterRequestHandler(&m_httpApiHandler);
 #endif
@@ -3366,6 +3378,9 @@ void CApplication::Stop(int exitCode)
 
 #ifdef HAS_WEB_SERVER
   CWebServer::UnregisterRequestHandler(&m_httpVfsHandler);
+#ifdef HAS_JSONRPC
+  CWebServer::UnregisterRequestHandler(&m_httpJsonRpcHandler);
+#endif
 #ifdef HAS_HTTPAPI
   CWebServer::UnregisterRequestHandler(&m_httpApiHandler);
 #endif

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -40,6 +40,9 @@
 #ifdef HAS_HTTPAPI
 #include "network/httprequesthandler/HTTPApiHandler.h"
 #endif
+#ifdef HAS_WEB_INTERFACE
+#include "network/httprequesthandler/HTTPWebinterfaceHandler.h"
+#endif
 #endif
 #ifdef HAS_LCD
 #include "utils/LCDFactory.h"
@@ -343,6 +346,9 @@ CApplication::CApplication(void)
 #ifdef HAS_HTTPAPI
   , m_httpApiHandler(*new CHTTPApiHandler)
 #endif
+#ifdef HAS_WEB_INTERFACE
+  , m_httpWebinterfaceHandler(*new CHTTPWebinterfaceHandler)
+#endif
 #endif
   , m_itemCurrentFile(new CFileItem)
   , m_progressTrackingVideoResumeBookmark(*new CBookmark)
@@ -395,6 +401,9 @@ CApplication::~CApplication(void)
   delete &m_httpVfsHandler;
 #ifdef HAS_HTTPAPI
   delete &m_httpApiHandler;
+#endif
+#ifdef HAS_WEB_INTERFACE
+  delete &m_httpWebinterfaceHandler;
 #endif
 #endif
   delete &m_progressTrackingVideoResumeBookmark;
@@ -1084,6 +1093,10 @@ bool CApplication::Initialize()
   CWebServer::RegisterRequestHandler(&m_httpVfsHandler);
 #ifdef HAS_HTTPAPI
   CWebServer::RegisterRequestHandler(&m_httpApiHandler);
+#endif
+#ifdef HAS_WEB_INTERFACE
+  // Must always be registered as the last HTTP handler as it is the default handler
+  CWebServer::RegisterRequestHandler(&m_httpWebinterfaceHandler);
 #endif
 #endif
 
@@ -3351,6 +3364,9 @@ void CApplication::Stop(int exitCode)
   CWebServer::UnregisterRequestHandler(&m_httpVfsHandler);
 #ifdef HAS_HTTPAPI
   CWebServer::UnregisterRequestHandler(&m_httpApiHandler);
+#endif
+#ifdef HAS_WEB_INTERFACE
+  CWebServer::UnregisterRequestHandler(&m_httpWebinterfaceHandler);
 #endif
 #endif
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -36,6 +36,10 @@
 #include "video/Bookmark.h"
 #ifdef HAS_WEB_SERVER
 #include "network/WebServer.h"
+#include "network/httprequesthandler/HTTPVfsHandler.h"
+#ifdef HAS_HTTPAPI
+#include "network/httprequesthandler/HTTPApiHandler.h"
+#endif
 #endif
 #ifdef HAS_LCD
 #include "utils/LCDFactory.h"
@@ -335,6 +339,10 @@ CApplication::CApplication(void)
   : m_pPlayer(NULL)
 #ifdef HAS_WEB_SERVER
   , m_WebServer(*new CWebServer)
+  , m_httpVfsHandler(*new CHTTPVfsHandler)
+#ifdef HAS_HTTPAPI
+  , m_httpApiHandler(*new CHTTPApiHandler)
+#endif
 #endif
   , m_itemCurrentFile(new CFileItem)
   , m_progressTrackingVideoResumeBookmark(*new CBookmark)
@@ -384,6 +392,10 @@ CApplication::~CApplication(void)
 {
 #ifdef HAS_WEB_SERVER
   delete &m_WebServer;
+  delete &m_httpVfsHandler;
+#ifdef HAS_HTTPAPI
+  delete &m_httpApiHandler;
+#endif
 #endif
   delete &m_progressTrackingVideoResumeBookmark;
 #ifdef HAS_DVD_DRIVE
@@ -1067,6 +1079,13 @@ bool CApplication::Initialize()
   //  uses these other libraries."
   g_curlInterface.Load();
   g_curlInterface.Unload();
+
+#ifdef HAS_WEB_SERVER
+  CWebServer::RegisterRequestHandler(&m_httpVfsHandler);
+#ifdef HAS_HTTPAPI
+  CWebServer::RegisterRequestHandler(&m_httpApiHandler);
+#endif
+#endif
 
   StartServices();
 
@@ -3327,6 +3346,13 @@ void CApplication::Stop(int exitCode)
 
     StopServices();
     //Sleep(5000);
+
+#ifdef HAS_WEB_SERVER
+  CWebServer::UnregisterRequestHandler(&m_httpVfsHandler);
+#ifdef HAS_HTTPAPI
+  CWebServer::UnregisterRequestHandler(&m_httpApiHandler);
+#endif
+#endif
 
 #if defined(__APPLE__) && !defined(__arm__)
     XBMCHelper::GetInstance().ReleaseAllInput();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -72,6 +72,9 @@ class CWebServer;
 #ifdef HAS_WEB_SERVER
 class CWebServer;
 class CHTTPVfsHandler;
+#ifdef HAS_JSONRPC
+class CHTTPJsonRpcHandler;
+#endif
 #ifdef HAS_HTTPAPI
 class CHTTPApiHandler;
 #endif
@@ -237,6 +240,9 @@ public:
 #ifdef HAS_WEB_SERVER
   CWebServer& m_WebServer;
   CHTTPVfsHandler& m_httpVfsHandler;
+#ifdef HAS_JSONRPC
+  CHTTPJsonRpcHandler& m_httpJsonRpcHandler;
+#endif
 #ifdef HAS_HTTPAPI
   CHTTPApiHandler& m_httpApiHandler;
 #endif

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -77,6 +77,7 @@ class CHTTPApiHandler;
 #endif
 #ifdef HAS_WEB_INTERFACE
 class CHTTPWebinterfaceHandler;
+class CHTTPWebinterfaceAddonsHandler;
 #endif
 #endif
 
@@ -241,6 +242,7 @@ public:
 #endif
 #ifdef HAS_WEB_INTERFACE
   CHTTPWebinterfaceHandler& m_httpWebinterfaceHandler;
+  CHTTPWebinterfaceAddonsHandler& m_httpWebinterfaceAddonsHandler;
 #endif
 #endif
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -75,6 +75,9 @@ class CHTTPVfsHandler;
 #ifdef HAS_HTTPAPI
 class CHTTPApiHandler;
 #endif
+#ifdef HAS_WEB_INTERFACE
+class CHTTPWebinterfaceHandler;
+#endif
 #endif
 
 class CBackgroundPlayer : public CThread
@@ -235,6 +238,9 @@ public:
   CHTTPVfsHandler& m_httpVfsHandler;
 #ifdef HAS_HTTPAPI
   CHTTPApiHandler& m_httpApiHandler;
+#endif
+#ifdef HAS_WEB_INTERFACE
+  CHTTPWebinterfaceHandler& m_httpWebinterfaceHandler;
 #endif
 #endif
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -69,6 +69,13 @@ class DPMSSupport;
 class CSplash;
 class CBookmark;
 class CWebServer;
+#ifdef HAS_WEB_SERVER
+class CWebServer;
+class CHTTPVfsHandler;
+#ifdef HAS_HTTPAPI
+class CHTTPApiHandler;
+#endif
+#endif
 
 class CBackgroundPlayer : public CThread
 {
@@ -225,6 +232,10 @@ public:
 
 #ifdef HAS_WEB_SERVER
   CWebServer& m_WebServer;
+  CHTTPVfsHandler& m_httpVfsHandler;
+#ifdef HAS_HTTPAPI
+  CHTTPApiHandler& m_httpApiHandler;
+#endif
 #endif
 
   inline bool IsInScreenSaver() { return m_bScreenSave; };

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -120,7 +120,7 @@ int CWebServer::AnswerToConnection(void *cls, struct MHD_Connection *connection,
     IHTTPRequestHandler *handler = *it;
     if (handler->CheckHTTPRequest(connection, url, methodType, version))
     {
-      int ret = handler->HandleHTTPRequest(connection, url, methodType, version, upload_data, upload_data_size, con_cls);
+      int ret = handler->HandleHTTPRequest(server, connection, url, methodType, version, upload_data, upload_data_size, con_cls);
       if (ret != MHD_YES)
         return SendErrorResponse(connection, MHD_HTTP_INTERNAL_SERVER_ERROR, methodType);
 

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -430,10 +430,16 @@ void CWebServer::RegisterRequestHandler(IHTTPRequestHandler *handler)
   if (handler == NULL)
     return;
 
-  for (vector<IHTTPRequestHandler *>::const_iterator it = m_requestHandlers.begin(); it != m_requestHandlers.end(); it++)
+  for (vector<IHTTPRequestHandler *>::iterator it = m_requestHandlers.begin(); it != m_requestHandlers.end(); it++)
   {
     if (*it == handler)
       return;
+
+    if ((*it)->GetPriority() < handler->GetPriority())
+    {
+      m_requestHandlers.insert(it, handler);
+      return;
+    }
   }
 
   m_requestHandlers.push_back(handler);

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -52,6 +52,7 @@ public:
 
   static std::string GetRequestHeaderValue(struct MHD_Connection *connection, enum MHD_ValueKind kind, const std::string &key);
   static int GetRequestHeaderValues(struct MHD_Connection *connection, enum MHD_ValueKind kind, std::map<std::string, std::string> &headerValues);
+  static int GetRequestHeaderValues(struct MHD_Connection *connection, enum MHD_ValueKind kind, std::multimap<std::string, std::string> &headerValues);
 private:
   struct MHD_Daemon* StartMHD(unsigned int flags, int port);
   static int AskForAuthentication (struct MHD_Connection *connection);
@@ -96,6 +97,7 @@ private:
   
   static HTTPMethod GetMethod(const char *method);
   static int FillArgumentMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
+  static int FillArgumentMultiMap(void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
 
   static const char *CreateMimeTypeFromExtension(const char *ext);
 

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -81,7 +81,6 @@ private:
   static int CreateFileDownloadResponse(struct MHD_Connection *connection, const std::string &strURL, HTTPMethod methodType, struct MHD_Response *&response);
   static int CreateErrorResponse(struct MHD_Connection *connection, int responseType, HTTPMethod method, struct MHD_Response *&response);
   static int CreateMemoryDownloadResponse(struct MHD_Connection *connection, void *data, size_t size, bool free, bool copy, struct MHD_Response *&response);
-  static int CreateAddonsListResponse(struct MHD_Connection *connection);
 
   static int SendErrorResponse(struct MHD_Connection *connection, int errorType, HTTPMethod method);
 

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <vector>
 #include "interfaces/json-rpc/ITransportLayer.h"
 #include "threads/CriticalSection.h"
 #include "httprequesthandler/IHTTPRequestHandler.h"
@@ -37,6 +38,7 @@ class CWebServer : public JSONRPC::ITransportLayer
 {
 public:
   CWebServer();
+  virtual ~CWebServer() { }
 
   bool Start(int port, const std::string &username, const std::string &password);
   bool Stop();
@@ -85,8 +87,7 @@ private:
                              const char *transfer_encoding, const char *data, uint64_t off,
                              unsigned int size);
 #endif
-  static int HandleRequest(IHTTPRequestHandler *handler, CWebServer *webserver, struct MHD_Connection *connection,
-                           const std::string &url, HTTPMethod method, const std::string &version);
+  static int HandleRequest(IHTTPRequestHandler *handler, const HTTPRequest &request);
   static void ContentReaderFreeCallback (void *cls);
   static int CreateRedirect(struct MHD_Connection *connection, const std::string &strURL, struct MHD_Response *&response);
   static int CreateFileDownloadResponse(struct MHD_Connection *connection, const std::string &strURL, HTTPMethod methodType, struct MHD_Response *&response);

--- a/xbmc/network/httprequesthandler/HTTPApiHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPApiHandler.cpp
@@ -27,19 +27,15 @@
 
 using namespace std;
 
-bool CHTTPApiHandler::CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
+bool CHTTPApiHandler::CheckHTTPRequest(const HTTPRequest &request)
 {
-  return ((method == GET || method == POST) && url.find("/xbmcCmds/xbmcHttp") == 0);
+  return ((request.method == GET || request.method == POST) && request.url.find("/xbmcCmds/xbmcHttp") == 0);
 }
 
-#if (MHD_VERSION >= 0x00040001)
-int CHTTPApiHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
-#else
-int CHTTPApiHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
-#endif
+int CHTTPApiHandler::HandleHTTPRequest(const HTTPRequest &request)
 {
   map<string, string> arguments;
-  if (CWebServer::GetRequestHeaderValues(connection, MHD_GET_ARGUMENT_KIND, arguments) > 0)
+  if (CWebServer::GetRequestHeaderValues(request.connection, MHD_GET_ARGUMENT_KIND, arguments) > 0)
   {
     m_responseCode = MHD_HTTP_OK;
     m_responseType = HTTPMemoryDownloadNoFreeCopy;

--- a/xbmc/network/httprequesthandler/HTTPApiHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPApiHandler.cpp
@@ -33,10 +33,10 @@ bool CHTTPApiHandler::CheckHTTPRequest(struct MHD_Connection *connection, const 
 }
 
 #if (MHD_VERSION >= 0x00040001)
-int CHTTPApiHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+int CHTTPApiHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                             const char *upload_data, size_t *upload_data_size, void **con_cls)
 #else
-int CHTTPApiHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+int CHTTPApiHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                             const char *upload_data, unsigned int *upload_data_size, void **con_cls)
 #endif
 {

--- a/xbmc/network/httprequesthandler/HTTPApiHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPApiHandler.cpp
@@ -39,7 +39,9 @@ int CHTTPApiHandler::HandleHTTPRequest(const HTTPRequest &request)
   {
     m_responseCode = MHD_HTTP_OK;
     m_responseType = HTTPMemoryDownloadNoFreeCopy;
-    m_response = CHttpApi::WebMethodCall(CStdString(arguments["command"]), CStdString(arguments["parameter"]));
+    CStdString command = arguments["command"];
+    CStdString parameter = arguments["parameter"];
+    m_response = CHttpApi::WebMethodCall(command, parameter);
 
     return MHD_YES;
   }

--- a/xbmc/network/httprequesthandler/HTTPApiHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPApiHandler.cpp
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <map>
+
+#include "HTTPApiHandler.h"
+#include "interfaces/http-api/HttpApi.h"
+#include "network/WebServer.h"
+
+using namespace std;
+
+bool CHTTPApiHandler::CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
+{
+  return ((method == GET || method == POST) && url.find("/xbmcCmds/xbmcHttp") == 0);
+}
+
+#if (MHD_VERSION >= 0x00040001)
+int CHTTPApiHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                            const char *upload_data, size_t *upload_data_size, void **con_cls)
+#else
+int CHTTPApiHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                            const char *upload_data, unsigned int *upload_data_size, void **con_cls)
+#endif
+{
+  map<string, string> arguments;
+  if (CWebServer::GetRequestHeaderValues(connection, MHD_GET_ARGUMENT_KIND, arguments) > 0)
+  {
+    m_responseCode = MHD_HTTP_OK;
+    m_responseType = HTTPMemoryDownloadNoFreeCopy;
+    m_response = CHttpApi::WebMethodCall(CStdString(arguments["command"]), CStdString(arguments["parameter"]));
+
+    return MHD_YES;
+  }
+
+  return MHD_NO;
+}

--- a/xbmc/network/httprequesthandler/HTTPApiHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPApiHandler.cpp
@@ -33,11 +33,9 @@ bool CHTTPApiHandler::CheckHTTPRequest(struct MHD_Connection *connection, const 
 }
 
 #if (MHD_VERSION >= 0x00040001)
-int CHTTPApiHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                            const char *upload_data, size_t *upload_data_size, void **con_cls)
+int CHTTPApiHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
 #else
-int CHTTPApiHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                            const char *upload_data, unsigned int *upload_data_size, void **con_cls)
+int CHTTPApiHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
 #endif
 {
   map<string, string> arguments;

--- a/xbmc/network/httprequesthandler/HTTPApiHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPApiHandler.h
@@ -40,6 +40,8 @@ public:
   virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
   virtual size_t GetHTTPResonseDataLength() const { return m_response.size(); }
 
+  virtual int GetPriority() const { return 2; }
+
 private:
   std::string m_response;
 };

--- a/xbmc/network/httprequesthandler/HTTPApiHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPApiHandler.h
@@ -30,10 +30,10 @@ public:
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                                 const char *upload_data, size_t *upload_data_size, void **con_cls);
 #else
-  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                                 const char *upload_data, unsigned int *upload_data_size, void **con_cls);
 #endif
 

--- a/xbmc/network/httprequesthandler/HTTPApiHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPApiHandler.h
@@ -27,6 +27,7 @@ class CHTTPApiHandler : public IHTTPRequestHandler
 public:
   CHTTPApiHandler() { };
 
+  virtual IHTTPRequestHandler* GetInstance() { return new CHTTPApiHandler(); }
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)

--- a/xbmc/network/httprequesthandler/HTTPApiHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPApiHandler.h
@@ -1,0 +1,45 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "IHTTPRequestHandler.h"
+
+class CHTTPApiHandler : public IHTTPRequestHandler
+{
+public:
+  CHTTPApiHandler() { };
+
+  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
+
+#if (MHD_VERSION >= 0x00040001)
+  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, size_t *upload_data_size, void **con_cls);
+#else
+  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, unsigned int *upload_data_size, void **con_cls);
+#endif
+
+  virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
+  virtual size_t GetHTTPResonseDataLength() const { return m_response.size(); }
+
+private:
+  std::string m_response;
+};

--- a/xbmc/network/httprequesthandler/HTTPApiHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPApiHandler.h
@@ -28,13 +28,8 @@ public:
   CHTTPApiHandler() { };
 
   virtual IHTTPRequestHandler* GetInstance() { return new CHTTPApiHandler(); }
-  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-
-#if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-#else
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-#endif
+  virtual bool CheckHTTPRequest(const HTTPRequest &request);
+  virtual int HandleHTTPRequest(const HTTPRequest &request);
 
   virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
   virtual size_t GetHTTPResonseDataLength() const { return m_response.size(); }

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -1,0 +1,110 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "HTTPJsonRpcHandler.h"
+#include "network/WebServer.h"
+#include "utils/log.h"
+#include "interfaces/json-rpc/JSONRPC.h"
+#include "interfaces/json-rpc/JSONUtils.h"
+
+#define MAX_STRING_POST_SIZE 20000
+#define PAGE_JSONRPC_INFO   "<html><head><title>JSONRPC</title></head><body>JSONRPC active and working</body></html>"
+
+using namespace std;
+using namespace JSONRPC;
+
+bool CHTTPJsonRpcHandler::CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
+{
+  return (url.find("/jsonrpc") == url.size() - 8);
+}
+
+#if (MHD_VERSION >= 0x00040001)
+int CHTTPJsonRpcHandler::HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                            const char *upload_data, size_t *upload_data_size, void **con_cls)
+#else
+int CHTTPJsonRpcHandler::HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                            const char *upload_data, unsigned int *upload_data_size, void **con_cls)
+#endif
+{
+  if (method == POST)
+  {
+    m_responseType = HTTPNone;
+
+    if ((*con_cls) == NULL)
+    {
+      *con_cls = new string();
+
+      return MHD_YES;
+    }
+    if (*upload_data_size) 
+    {
+      string *post = (string *)(*con_cls);
+      if (*upload_data_size + post->size() > MAX_STRING_POST_SIZE)
+      {
+        CLog::Log(LOGERROR, "WebServer: Stopped uploading post since it exceeded size limitations");
+        return MHD_NO;
+      }
+      else
+      {
+        post->append(upload_data, *upload_data_size);
+        *upload_data_size = 0;
+        return MHD_YES;
+      }
+    }
+    else
+    {
+      string *jsoncall = (string *)(*con_cls);
+
+      CHTTPClient client;
+      m_response = CJSONRPC::MethodCall(*jsoncall, server, &client);
+
+      m_responseHeaderFields["Content-Type"] = "application/json";
+      m_responseType = HTTPMemoryDownloadNoFreeCopy;
+
+      delete jsoncall;
+    }
+  }
+  else
+  {
+    m_response = PAGE_JSONRPC_INFO;
+    m_responseType = HTTPMemoryDownloadNoFreeNoCopy;
+  }
+
+  m_responseCode = MHD_HTTP_OK;
+
+  return MHD_YES;
+}
+
+int CHTTPJsonRpcHandler::CHTTPClient::GetPermissionFlags()
+{
+  return OPERATION_PERMISSION_ALL;
+}
+
+int CHTTPJsonRpcHandler::CHTTPClient::GetAnnouncementFlags()
+{
+  // Does not support broadcast
+  return 0;
+}
+
+bool CHTTPJsonRpcHandler::CHTTPClient::SetAnnouncementFlags(int flags)
+{
+  return false;
+}

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -55,7 +55,7 @@ int CHTTPJsonRpcHandler::HandleHTTPRequest(CWebServer *server, struct MHD_Connec
     CHTTPClient client;
     m_response = CJSONRPC::MethodCall(m_request, server, &client);
 
-    m_responseHeaderFields["Content-Type"] = "application/json";
+    m_responseHeaderFields.insert(pair<string, string>("Content-Type", "application/json"));
 
     m_request.clear();
   }

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -31,21 +31,17 @@
 using namespace std;
 using namespace JSONRPC;
 
-bool CHTTPJsonRpcHandler::CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
+bool CHTTPJsonRpcHandler::CheckHTTPRequest(const HTTPRequest &request)
 {
-  return (url.compare("/jsonrpc") == 0);
+  return (request.url.compare("/jsonrpc") == 0);
 }
 
-#if (MHD_VERSION >= 0x00040001)
-int CHTTPJsonRpcHandler::HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
-#else
-int CHTTPJsonRpcHandler::HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
-#endif
+int CHTTPJsonRpcHandler::HandleHTTPRequest(const HTTPRequest &request)
 {
-  if (method == POST)
+  if (request.method == POST)
   {
     // The content-type of the request must be application/json
-    if (CWebServer::GetRequestHeaderValue(connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_CONTENT_TYPE).compare("application/json") != 0)
+    if (CWebServer::GetRequestHeaderValue(request.connection, MHD_HEADER_KIND, MHD_HTTP_HEADER_CONTENT_TYPE).compare("application/json") != 0)
     {
       m_responseType = HTTPError;
       m_responseCode = MHD_HTTP_UNSUPPORTED_MEDIA_TYPE;
@@ -53,7 +49,7 @@ int CHTTPJsonRpcHandler::HandleHTTPRequest(CWebServer *server, struct MHD_Connec
     }
 
     CHTTPClient client;
-    m_response = CJSONRPC::MethodCall(m_request, server, &client);
+    m_response = CJSONRPC::MethodCall(m_request, request.webserver, &client);
 
     m_responseHeaderFields.insert(pair<string, string>("Content-Type", "application/json"));
 

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
@@ -29,13 +29,8 @@ public:
   CHTTPJsonRpcHandler() { };
   
   virtual IHTTPRequestHandler* GetInstance() { return new CHTTPJsonRpcHandler(); }
-  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-
-#if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-#else
-  virtual int HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-#endif
+  virtual bool CheckHTTPRequest(const HTTPRequest &request);
+  virtual int HandleHTTPRequest(const HTTPRequest &request);
 
   virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
   virtual size_t GetHTTPResonseDataLength() const { return m_response.size(); }

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
@@ -1,0 +1,54 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "IHTTPRequestHandler.h"
+#include "interfaces/json-rpc/IClient.h"
+
+class CHTTPJsonRpcHandler : public IHTTPRequestHandler
+{
+public:
+  CHTTPJsonRpcHandler() { };
+
+  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
+
+#if (MHD_VERSION >= 0x00040001)
+  virtual int HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, size_t *upload_data_size, void **con_cls);
+#else
+  virtual int HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, unsigned int *upload_data_size, void **con_cls);
+#endif
+
+  virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
+  virtual size_t GetHTTPResonseDataLength() const { return m_response.size(); }
+
+private:
+  std::string m_response;
+
+  class CHTTPClient : public JSONRPC::IClient
+  {
+  public:
+    virtual int  GetPermissionFlags();
+    virtual int  GetAnnouncementFlags();
+    virtual bool SetAnnouncementFlags(int flags);
+  };
+};

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
@@ -32,11 +32,9 @@ public:
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                                const char *upload_data, size_t *upload_data_size, void **con_cls);
+  virtual int HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 #else
-  virtual int HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                                const char *upload_data, unsigned int *upload_data_size, void **con_cls);
+  virtual int HandleHTTPRequest(CWebServer *server, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 #endif
 
   virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
@@ -44,7 +42,15 @@ public:
 
   virtual int GetPriority() const { return 2; }
 
+protected:
+#if (MHD_VERSION >= 0x00040001)
+  virtual bool appendPostData(const char *data, size_t size);
+#else
+  virtual bool appendPostData(const char *data, unsigned int size);
+#endif
+
 private:
+  std::string m_request;
   std::string m_response;
 
   class CHTTPClient : public JSONRPC::IClient

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
@@ -41,6 +41,8 @@ public:
   virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
   virtual size_t GetHTTPResonseDataLength() const { return m_response.size(); }
 
+  virtual int GetPriority() const { return 2; }
+
 private:
   std::string m_response;
 

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.h
@@ -27,7 +27,8 @@ class CHTTPJsonRpcHandler : public IHTTPRequestHandler
 {
 public:
   CHTTPJsonRpcHandler() { };
-
+  
+  virtual IHTTPRequestHandler* GetInstance() { return new CHTTPJsonRpcHandler(); }
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -32,11 +32,9 @@ bool CHTTPVfsHandler::CheckHTTPRequest(struct MHD_Connection *connection, const 
 }
 
 #if (MHD_VERSION >= 0x00040001)
-int CHTTPVfsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                            const char *upload_data, size_t *upload_data_size, void **con_cls)
+int CHTTPVfsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
 #else
-int CHTTPVfsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                            const char *upload_data, unsigned int *upload_data_size, void **con_cls)
+int CHTTPVfsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
 #endif
 {
   bool ok = false;

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -26,21 +26,17 @@
 
 using namespace std;
 
-bool CHTTPVfsHandler::CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
+bool CHTTPVfsHandler::CheckHTTPRequest(const HTTPRequest &request)
 {
-  return (url.find("/vfs") == 0);
+  return (request.url.find("/vfs") == 0);
 }
 
-#if (MHD_VERSION >= 0x00040001)
-int CHTTPVfsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
-#else
-int CHTTPVfsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
-#endif
+int CHTTPVfsHandler::HandleHTTPRequest(const HTTPRequest &request)
 {
   bool ok = false;
-  if (url.size() > 5)
+  if (request.url.size() > 5)
   {
-    m_path = url.substr(5);
+    m_path = request.url.substr(5);
 
     if (XFILE::CFile::Exists(m_path))
     {

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -1,0 +1,64 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "HTTPVfsHandler.h"
+#include "URL.h"
+#include "filesystem/File.h"
+
+using namespace std;
+
+bool CHTTPVfsHandler::CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
+{
+  return (url.find("/vfs") == 0);
+}
+
+#if (MHD_VERSION >= 0x00040001)
+int CHTTPVfsHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                            const char *upload_data, size_t *upload_data_size, void **con_cls)
+#else
+int CHTTPVfsHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                            const char *upload_data, unsigned int *upload_data_size, void **con_cls)
+#endif
+{
+  bool ok = false;
+  if (url.size() > 5)
+  {
+    m_path = url.substr(5);
+
+    if (XFILE::CFile::Exists(m_path))
+    {
+      m_responseCode = MHD_HTTP_OK;
+      m_responseType = HTTPFileDownload;
+    }
+    else
+    {
+      m_responseCode = MHD_HTTP_NOT_FOUND;
+      m_responseType = HTTPError;
+    }
+  }
+  else
+  {
+    m_responseCode = MHD_HTTP_BAD_REQUEST;
+    m_responseType = HTTPError;
+  }
+
+  return MHD_YES;
+}

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -33,7 +33,6 @@ bool CHTTPVfsHandler::CheckHTTPRequest(const HTTPRequest &request)
 
 int CHTTPVfsHandler::HandleHTTPRequest(const HTTPRequest &request)
 {
-  bool ok = false;
   if (request.url.size() > 5)
   {
     m_path = request.url.substr(5);

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "HTTPVfsHandler.h"
+#include "network/WebServer.h"
 #include "URL.h"
 #include "filesystem/File.h"
 
@@ -31,10 +32,10 @@ bool CHTTPVfsHandler::CheckHTTPRequest(struct MHD_Connection *connection, const 
 }
 
 #if (MHD_VERSION >= 0x00040001)
-int CHTTPVfsHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+int CHTTPVfsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                             const char *upload_data, size_t *upload_data_size, void **con_cls)
 #else
-int CHTTPVfsHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+int CHTTPVfsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                             const char *upload_data, unsigned int *upload_data_size, void **con_cls)
 #endif
 {

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.h
@@ -41,6 +41,8 @@ public:
 
   virtual std::string GetHTTPResponseFile() const { return m_path; }
 
+  virtual int GetPriority() const { return 2; }
+
 private:
   CStdString m_path;
 };

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.h
@@ -28,7 +28,8 @@ class CHTTPVfsHandler : public IHTTPRequestHandler
 {
 public:
   CHTTPVfsHandler() { };
-
+  
+  virtual IHTTPRequestHandler* GetInstance() { return new CHTTPVfsHandler(); }
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.h
@@ -30,13 +30,8 @@ public:
   CHTTPVfsHandler() { };
   
   virtual IHTTPRequestHandler* GetInstance() { return new CHTTPVfsHandler(); }
-  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-
-#if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-#else
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-#endif
+  virtual bool CheckHTTPRequest(const HTTPRequest &request);
+  virtual int HandleHTTPRequest(const HTTPRequest &request);
 
   virtual std::string GetHTTPResponseFile() const { return m_path; }
 

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.h
@@ -1,0 +1,46 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "IHTTPRequestHandler.h"
+
+#include "utils/StdString.h"
+
+class CHTTPVfsHandler : public IHTTPRequestHandler
+{
+public:
+  CHTTPVfsHandler() { };
+
+  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
+
+#if (MHD_VERSION >= 0x00040001)
+  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, size_t *upload_data_size, void **con_cls);
+#else
+  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, unsigned int *upload_data_size, void **con_cls);
+#endif
+
+  virtual std::string GetHTTPResponseFile() const { return m_path; }
+
+private:
+  CStdString m_path;
+};

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.h
@@ -33,11 +33,9 @@ public:
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                                const char *upload_data, size_t *upload_data_size, void **con_cls);
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 #else
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                                const char *upload_data, unsigned int *upload_data_size, void **con_cls);
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 #endif
 
   virtual std::string GetHTTPResponseFile() const { return m_path; }

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.h
@@ -32,10 +32,10 @@ public:
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                                 const char *upload_data, size_t *upload_data_size, void **con_cls);
 #else
-  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                                 const char *upload_data, unsigned int *upload_data_size, void **con_cls);
 #endif
 

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
@@ -1,0 +1,58 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "HTTPWebinterfaceAddonsHandler.h"
+#include "addons/AddonManager.h"
+
+#define ADDON_HEADER      "<html><head><title>Add-on List</title></head><body>\n<h1>Available web interfaces:</h1>\n<ul>\n"
+
+using namespace std;
+using namespace ADDON;
+
+bool CHTTPWebinterfaceAddonsHandler::CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
+{
+  return (url.compare("/addons") == 0 || url.compare("/addons/") == 0);
+}
+
+#if (MHD_VERSION >= 0x00040001)
+int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                            const char *upload_data, size_t *upload_data_size, void **con_cls)
+#else
+int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                            const char *upload_data, unsigned int *upload_data_size, void **con_cls)
+#endif
+{
+  m_response = ADDON_HEADER;
+  VECADDONS addons;
+  CAddonMgr::Get().GetAddons(ADDON_WEB_INTERFACE, addons);
+  IVECADDONS addons_it;
+  for (addons_it=addons.begin(); addons_it!=addons.end(); addons_it++)
+    m_response += "<li><a href=/addons/"+ (*addons_it)->ID() + "/>" + (*addons_it)->Name() + "</a></li>\n";
+
+  m_response += "</ul>\n</body></html>";
+
+  m_responseType = HTTPMemoryDownloadNoFreeCopy;
+  m_responseCode = MHD_HTTP_OK;
+
+  return MHD_YES;
+}
+
+

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
@@ -34,11 +34,9 @@ bool CHTTPWebinterfaceAddonsHandler::CheckHTTPRequest(struct MHD_Connection *con
 }
 
 #if (MHD_VERSION >= 0x00040001)
-int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                            const char *upload_data, size_t *upload_data_size, void **con_cls)
+int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
 #else
-int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                            const char *upload_data, unsigned int *upload_data_size, void **con_cls)
+int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
 #endif
 {
   m_response = ADDON_HEADER;

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
@@ -28,16 +28,12 @@
 using namespace std;
 using namespace ADDON;
 
-bool CHTTPWebinterfaceAddonsHandler::CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
+bool CHTTPWebinterfaceAddonsHandler::CheckHTTPRequest(const HTTPRequest &request)
 {
-  return (url.compare("/addons") == 0 || url.compare("/addons/") == 0);
+  return (request.url.compare("/addons") == 0 || request.url.compare("/addons/") == 0);
 }
 
-#if (MHD_VERSION >= 0x00040001)
-int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
-#else
-int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
-#endif
+int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(const HTTPRequest &request)
 {
   m_response = ADDON_HEADER;
   VECADDONS addons;

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "HTTPWebinterfaceAddonsHandler.h"
+#include "network/WebServer.h"
 #include "addons/AddonManager.h"
 
 #define ADDON_HEADER      "<html><head><title>Add-on List</title></head><body>\n<h1>Available web interfaces:</h1>\n<ul>\n"
@@ -33,10 +34,10 @@ bool CHTTPWebinterfaceAddonsHandler::CheckHTTPRequest(struct MHD_Connection *con
 }
 
 #if (MHD_VERSION >= 0x00040001)
-int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                             const char *upload_data, size_t *upload_data_size, void **con_cls)
 #else
-int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+int CHTTPWebinterfaceAddonsHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                             const char *upload_data, unsigned int *upload_data_size, void **con_cls)
 #endif
 {

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
@@ -31,11 +31,9 @@ public:
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                                const char *upload_data, size_t *upload_data_size, void **con_cls);
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 #else
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                                const char *upload_data, unsigned int *upload_data_size, void **con_cls);
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 #endif
 
   virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
@@ -30,10 +30,10 @@ public:
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                                 const char *upload_data, size_t *upload_data_size, void **con_cls);
 #else
-  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                                 const char *upload_data, unsigned int *upload_data_size, void **con_cls);
 #endif
 

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
@@ -26,7 +26,8 @@ class CHTTPWebinterfaceAddonsHandler : public IHTTPRequestHandler
 {
 public:
   CHTTPWebinterfaceAddonsHandler() { };
-
+  
+  virtual IHTTPRequestHandler* GetInstance() { return new CHTTPWebinterfaceAddonsHandler(); }
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
@@ -28,13 +28,8 @@ public:
   CHTTPWebinterfaceAddonsHandler() { };
   
   virtual IHTTPRequestHandler* GetInstance() { return new CHTTPWebinterfaceAddonsHandler(); }
-  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-
-#if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-#else
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-#endif
+  virtual bool CheckHTTPRequest(const HTTPRequest &request);
+  virtual int HandleHTTPRequest(const HTTPRequest &request);
 
   virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
   virtual size_t GetHTTPResonseDataLength() const { return m_response.size(); }

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
@@ -1,0 +1,45 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "IHTTPRequestHandler.h"
+
+class CHTTPWebinterfaceAddonsHandler : public IHTTPRequestHandler
+{
+public:
+  CHTTPWebinterfaceAddonsHandler() { };
+
+  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
+
+#if (MHD_VERSION >= 0x00040001)
+  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, size_t *upload_data_size, void **con_cls);
+#else
+  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, unsigned int *upload_data_size, void **con_cls);
+#endif
+
+  virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
+  virtual size_t GetHTTPResonseDataLength() const { return m_response.size(); }
+
+private:
+  std::string m_response;
+};

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceAddonsHandler.h
@@ -40,6 +40,8 @@ public:
   virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
   virtual size_t GetHTTPResonseDataLength() const { return m_response.size(); }
 
+  virtual int GetPriority() const { return 1; }
+
 private:
   std::string m_response;
 };

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -38,11 +38,9 @@ bool CHTTPWebinterfaceHandler::CheckHTTPRequest(struct MHD_Connection *connectio
 }
 
 #if (MHD_VERSION >= 0x00040001)
-int CHTTPWebinterfaceHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                            const char *upload_data, size_t *upload_data_size, void **con_cls)
+int CHTTPWebinterfaceHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
 #else
-int CHTTPWebinterfaceHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                            const char *upload_data, unsigned int *upload_data_size, void **con_cls)
+int CHTTPWebinterfaceHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
 #endif
 {
   m_responseCode = ResolveUrl(url, m_url);

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "HTTPWebinterfaceHandler.h"
+#include "network/WebServer.h"
 #include "addons/AddonManager.h"
 #include "utils/URIUtils.h"
 #include "filesystem/Directory.h"
@@ -37,10 +38,10 @@ bool CHTTPWebinterfaceHandler::CheckHTTPRequest(struct MHD_Connection *connectio
 }
 
 #if (MHD_VERSION >= 0x00040001)
-int CHTTPWebinterfaceHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+int CHTTPWebinterfaceHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                             const char *upload_data, size_t *upload_data_size, void **con_cls)
 #else
-int CHTTPWebinterfaceHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+int CHTTPWebinterfaceHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                             const char *upload_data, unsigned int *upload_data_size, void **con_cls)
 #endif
 {

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -1,0 +1,132 @@
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "HTTPWebinterfaceHandler.h"
+#include "addons/AddonManager.h"
+#include "utils/URIUtils.h"
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
+
+#define DEFAULT_PAGE        "index.html"
+
+using namespace std;
+using namespace ADDON;
+using namespace XFILE;
+
+bool CHTTPWebinterfaceHandler::CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
+{
+  return true;
+}
+
+#if (MHD_VERSION >= 0x00040001)
+int CHTTPWebinterfaceHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                            const char *upload_data, size_t *upload_data_size, void **con_cls)
+#else
+int CHTTPWebinterfaceHandler::HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                            const char *upload_data, unsigned int *upload_data_size, void **con_cls)
+#endif
+{
+  m_responseCode = ResolveUrl(url, m_url);
+  if (m_responseCode != MHD_HTTP_OK)
+  {
+    if (m_responseCode == MHD_HTTP_FOUND)
+      m_responseType = HTTPRedirect;
+    else
+      m_responseType = HTTPError;
+
+    return MHD_YES;
+  }
+
+  m_responseType = HTTPFileDownload;
+
+  return MHD_YES;
+}
+
+int CHTTPWebinterfaceHandler::ResolveUrl(const std::string &url, std::string &path)
+{
+  AddonPtr dummyAddon;
+  return ResolveUrl(url, path, dummyAddon);
+}
+
+int CHTTPWebinterfaceHandler::ResolveUrl(const std::string &url, std::string &path, AddonPtr &addon)
+{
+  string addonPath;
+  bool useDefaultWebInterface = true;
+
+  path = url;
+  if (url.find("/addons/") == 0 && url.size() > 8)
+  {
+    CStdStringArray components;
+    CUtil::Tokenize(path, components, "/");
+    if (components.size() > 1)
+    {
+      CAddonMgr::Get().GetAddon(components.at(1), addon);
+      if (addon)
+      {
+        size_t pos;
+        pos = path.find('/', 8); // /addons/ = 8 characters +1 to start behind the last slash
+        if (pos != string::npos)
+          path = path.substr(pos);
+        else // missing trailing slash
+        {
+          path = url + "/";
+          return MHD_HTTP_FOUND;
+        }
+
+        useDefaultWebInterface = false;
+        addonPath = addon->Path();
+        if (addon->Type() != ADDON_WEB_INTERFACE) // No need to append /htdocs for web interfaces
+          addonPath = URIUtils::AddFileToFolder(addonPath, "/htdocs/");
+      }
+    }
+    else
+      return MHD_HTTP_NOT_FOUND;
+  }
+
+  if (path.compare("/") == 0)
+    path.append(DEFAULT_PAGE);
+
+  if (useDefaultWebInterface)
+  {
+    CAddonMgr::Get().GetDefault(ADDON_WEB_INTERFACE, addon);
+    if (addon)
+      addonPath = addon->Path();
+  }
+
+  if (addon)
+    path = URIUtils::AddFileToFolder(addon->Path(), path);
+  
+  if (CDirectory::Exists(path))
+  {
+    if (path.at(path.size() -1) == '/')
+      path.append(DEFAULT_PAGE);
+    else
+    {
+      path = url + "/";
+      return MHD_HTTP_FOUND;
+    }
+  }
+
+  if (!CFile::Exists(path))
+    return MHD_HTTP_NOT_FOUND;
+
+  return MHD_HTTP_OK;
+}

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -32,18 +32,14 @@ using namespace std;
 using namespace ADDON;
 using namespace XFILE;
 
-bool CHTTPWebinterfaceHandler::CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
+bool CHTTPWebinterfaceHandler::CheckHTTPRequest(const HTTPRequest &request)
 {
   return true;
 }
 
-#if (MHD_VERSION >= 0x00040001)
-int CHTTPWebinterfaceHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
-#else
-int CHTTPWebinterfaceHandler::HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version)
-#endif
+int CHTTPWebinterfaceHandler::HandleHTTPRequest(const HTTPRequest &request)
 {
-  m_responseCode = ResolveUrl(url, m_url);
+  m_responseCode = ResolveUrl(request.url, m_url);
   if (m_responseCode != MHD_HTTP_OK)
   {
     if (m_responseCode == MHD_HTTP_FOUND)

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
@@ -27,7 +27,8 @@ class CHTTPWebinterfaceHandler : public IHTTPRequestHandler
 {
 public:
   CHTTPWebinterfaceHandler() { };
-
+  
+  virtual IHTTPRequestHandler* GetInstance() { return new CHTTPWebinterfaceHandler(); }
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
@@ -31,10 +31,10 @@ public:
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                                 const char *upload_data, size_t *upload_data_size, void **con_cls);
 #else
-  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                                 const char *upload_data, unsigned int *upload_data_size, void **con_cls);
 #endif
 

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
@@ -1,0 +1,49 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "IHTTPRequestHandler.h"
+#include "addons/IAddon.h"
+
+class CHTTPWebinterfaceHandler : public IHTTPRequestHandler
+{
+public:
+  CHTTPWebinterfaceHandler() { };
+
+  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
+
+#if (MHD_VERSION >= 0x00040001)
+  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, size_t *upload_data_size, void **con_cls);
+#else
+  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, unsigned int *upload_data_size, void **con_cls);
+#endif
+
+  virtual std::string GetHTTPRedirectUrl() const { return m_url; }
+  virtual std::string GetHTTPResponseFile() const { return m_url; }
+  
+  static int ResolveUrl(const std::string &url, std::string &path);
+  static int ResolveUrl(const std::string &url, std::string &path, ADDON::AddonPtr &addon);
+
+private:
+  std::string m_url;
+};

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
@@ -32,11 +32,9 @@ public:
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                                const char *upload_data, size_t *upload_data_size, void **con_cls);
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 #else
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                                const char *upload_data, unsigned int *upload_data_size, void **con_cls);
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
 #endif
 
   virtual std::string GetHTTPRedirectUrl() const { return m_url; }

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.h
@@ -29,13 +29,8 @@ public:
   CHTTPWebinterfaceHandler() { };
   
   virtual IHTTPRequestHandler* GetInstance() { return new CHTTPWebinterfaceHandler(); }
-  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-
-#if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-#else
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
-#endif
+  virtual bool CheckHTTPRequest(const HTTPRequest &request);
+  virtual int HandleHTTPRequest(const HTTPRequest &request);
 
   virtual std::string GetHTTPRedirectUrl() const { return m_url; }
   virtual std::string GetHTTPResponseFile() const { return m_url; }

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.cpp
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.cpp
@@ -1,4 +1,3 @@
-#pragma once
 /*
  *      Copyright (C) 2011 Team XBMC
  *      http://www.xbmc.org
@@ -22,25 +21,26 @@
 
 #include "IHTTPRequestHandler.h"
 
-class CHTTPApiHandler : public IHTTPRequestHandler
+void IHTTPRequestHandler::AddPostField(const std::string &key, const std::string &value)
 {
-public:
-  CHTTPApiHandler() { };
+  if (key.empty())
+    return;
 
-  virtual IHTTPRequestHandler* GetInstance() { return new CHTTPApiHandler(); }
-  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
+  std::map<std::string, std::string>::iterator field = m_postFields.find(key);
+  if (field == m_postFields.end())
+    m_postFields[key] = value;
+  else
+    m_postFields[key].append(value);
+}
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
+bool IHTTPRequestHandler::AddPostData(const char *data, size_t size)
 #else
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version);
+bool IHTTPRequestHandler::AddPostData(const char *data, unsigned int size)
 #endif
-
-  virtual void* GetHTTPResponseData() const { return (void *)m_response.c_str(); };
-  virtual size_t GetHTTPResonseDataLength() const { return m_response.size(); }
-
-  virtual int GetPriority() const { return 2; }
-
-private:
-  std::string m_response;
-};
+{
+  if (size > 0)
+    return appendPostData(data, size);
+  
+  return true;
+}

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -29,6 +29,8 @@
 #include <microhttpd.h>
 #endif
 
+class CWebServer;
+
 enum HTTPMethod
 {
   UNKNOWN,
@@ -57,10 +59,10 @@ public:
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version) = 0;
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                                 const char *upload_data, size_t *upload_data_size, void **con_cls) = 0;
 #else
-  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
                                 const char *upload_data, unsigned int *upload_data_size, void **con_cls) = 0;
 #endif
   

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -60,11 +60,9 @@ public:
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version) = 0;
 
 #if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                                const char *upload_data, size_t *upload_data_size, void **con_cls) = 0;
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version) = 0;
 #else
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
-                                const char *upload_data, unsigned int *upload_data_size, void **con_cls) = 0;
+  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version) = 0;
 #endif
   
   virtual void* GetHTTPResponseData() const { return NULL; };
@@ -75,12 +73,28 @@ public:
   // The higher the more important
   virtual int GetPriority() const { return 0; }
 
+  void AddPostField(const std::string &key, const std::string &value);
+#if (MHD_VERSION >= 0x00040001)
+  bool AddPostData(const char *data, size_t size);
+#else
+  bool AddPostData(const char *data, unsigned int size);
+#endif
+
   int GetHTTPResonseCode() const { return m_responseCode; }
   HTTPResponseType GetHTTPResponseType() const { return m_responseType; }
   const std::map<std::string, std::string>& GetHTTPResponseHeaderFields() const { return m_responseHeaderFields; };
 
 protected:
+#if (MHD_VERSION >= 0x00040001)
+  virtual bool appendPostData(const char *data, size_t size)
+#else
+  virtual bool appendPostData(const char *data, unsigned int size)
+#endif
+  { return true; }
+
   int m_responseCode;
   HTTPResponseType m_responseType;
   std::map<std::string, std::string> m_responseHeaderFields;
+
+  std::map<std::string, std::string> m_postFields;
 };

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -71,6 +71,9 @@ public:
   virtual std::string GetHTTPRedirectUrl() const { return ""; }
   virtual std::string GetHTTPResponseFile() const { return ""; }
 
+  // The higher the more important
+  virtual int GetPriority() const { return 0; }
+
   int GetHTTPResonseCode() const { return m_responseCode; }
   HTTPResponseType GetHTTPResponseType() const { return m_responseType; }
   const std::map<std::string, std::string>& GetHTTPResponseHeaderFields() const { return m_responseHeaderFields; };

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -56,6 +56,7 @@ class IHTTPRequestHandler
 public:
   virtual ~IHTTPRequestHandler() { }
 
+  virtual IHTTPRequestHandler* GetInstance() = 0;
   virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version) = 0;
 
 #if (MHD_VERSION >= 0x00040001)

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -51,19 +51,23 @@ enum HTTPResponseType
   HTTPMemoryDownloadFreeCopy
 };
 
+typedef struct HTTPRequest
+{
+  struct MHD_Connection *connection;
+  std::string url;
+  HTTPMethod method;
+  std::string version;
+  CWebServer *webserver;
+} HTTPRequest;
+
 class IHTTPRequestHandler
 {
 public:
   virtual ~IHTTPRequestHandler() { }
 
   virtual IHTTPRequestHandler* GetInstance() = 0;
-  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version) = 0;
-
-#if (MHD_VERSION >= 0x00040001)
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version) = 0;
-#else
-  virtual int HandleHTTPRequest(CWebServer *webserver, struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version) = 0;
-#endif
+  virtual bool CheckHTTPRequest(const HTTPRequest &request) = 0;
+  virtual int HandleHTTPRequest(const HTTPRequest &request) = 0;
   
   virtual void* GetHTTPResponseData() const { return NULL; };
   virtual size_t GetHTTPResonseDataLength() const { return 0; }

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -82,7 +82,7 @@ public:
 
   int GetHTTPResonseCode() const { return m_responseCode; }
   HTTPResponseType GetHTTPResponseType() const { return m_responseType; }
-  const std::map<std::string, std::string>& GetHTTPResponseHeaderFields() const { return m_responseHeaderFields; };
+  const std::multimap<std::string, std::string>& GetHTTPResponseHeaderFields() const { return m_responseHeaderFields; };
 
 protected:
 #if (MHD_VERSION >= 0x00040001)
@@ -94,7 +94,7 @@ protected:
 
   int m_responseCode;
   HTTPResponseType m_responseType;
-  std::map<std::string, std::string> m_responseHeaderFields;
+  std::multimap<std::string, std::string> m_responseHeaderFields;
 
   std::map<std::string, std::string> m_postFields;
 };

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -1,0 +1,80 @@
+#pragma once
+/*
+ *      Copyright (C) 2011 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+#include <map>
+#include <sys/socket.h>
+#ifdef __APPLE__
+#include "lib/libmicrohttpd/src/include/microhttpd.h"
+#else
+#include <microhttpd.h>
+#endif
+
+enum HTTPMethod
+{
+  UNKNOWN,
+  POST,
+  GET,
+  HEAD
+};
+
+enum HTTPResponseType
+{
+  HTTPNone,
+  HTTPError,
+  HTTPRedirect,
+  HTTPFileDownload,
+  HTTPMemoryDownloadNoFreeNoCopy,
+  HTTPMemoryDownloadNoFreeCopy,
+  HTTPMemoryDownloadFreeNoCopy,
+  HTTPMemoryDownloadFreeCopy
+};
+
+class IHTTPRequestHandler
+{
+public:
+  virtual ~IHTTPRequestHandler() { }
+
+  virtual bool CheckHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version) = 0;
+
+#if (MHD_VERSION >= 0x00040001)
+  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, size_t *upload_data_size, void **con_cls) = 0;
+#else
+  virtual int HandleHTTPRequest(struct MHD_Connection *connection, const std::string &url, HTTPMethod method, const std::string &version,
+                                const char *upload_data, unsigned int *upload_data_size, void **con_cls) = 0;
+#endif
+  
+  virtual void* GetHTTPResponseData() const { return NULL; };
+  virtual size_t GetHTTPResonseDataLength() const { return 0; }
+  virtual std::string GetHTTPRedirectUrl() const { return ""; }
+  virtual std::string GetHTTPResponseFile() const { return ""; }
+
+  int GetHTTPResonseCode() const { return m_responseCode; }
+  HTTPResponseType GetHTTPResponseType() const { return m_responseType; }
+  const std::map<std::string, std::string>& GetHTTPResponseHeaderFields() const { return m_responseHeaderFields; };
+
+protected:
+  int m_responseCode;
+  HTTPResponseType m_responseType;
+  std::map<std::string, std::string> m_responseHeaderFields;
+};

--- a/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
+++ b/xbmc/network/httprequesthandler/IHTTPRequestHandler.h
@@ -22,7 +22,14 @@
 
 #include <string>
 #include <map>
+
+#include <sys/types.h>
+#include <sys/select.h>
 #include <sys/socket.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
 #ifdef __APPLE__
 #include "lib/libmicrohttpd/src/include/microhttpd.h"
 #else

--- a/xbmc/network/httprequesthandler/Makefile
+++ b/xbmc/network/httprequesthandler/Makefile
@@ -1,0 +1,11 @@
+SRCS=HTTPApiHandler.cpp \
+     HTTPJsonRpcHandler.cpp \
+     HTTPVfsHandler.cpp \
+     HTTPWebinterfaceAddonsHandler.cpp \
+     HTTPWebinterfaceHandler.cpp \
+     IHTTPRequestHandler.cpp \
+
+LIB=httprequesthandlers.a
+
+include ../../../Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))


### PR DESCRIPTION
These changes decouple different capabilities we built into our webserver (like HTTP API, JSON-RPC, VFS access etc) which are currently all handled in CWebServer::AnswerToConnection(), into different classes called handlers which all implement the same interface IHTTPRequestHandler. This makes it a lot easier to maintain those different handlers without having to fear that changing something in one of them affects the behaviour of one of the other handlers (which is currently possible). Most webservers (like Apache HTTPd etc) use handlers to allow to extend them without having to mess around with the webserver implementation itself.

The whole handler-system is based on registering the existing handlers (with a priority) in the CWebserver instance. Then everytime a new HTTP request comes through libmicrohttpd the webserver works through the list of the registered handlers and calls IHTTPRequestHandler::CheckHTTPRequest() which will return whether this handler wants/is able to handle the current request. If that's the case a new instance of that specific handler is requested (because HTTP requests are handled in different and possibly concurrent threads) and then the webserver lets the handler do with the request whatever he wants by calling IHTTPRequestHandler::HandleHTTPRequest(). It then waits for that method to finish and then retrieves the HTTP response code and the data of the response from the instance before destroying it and sending the HTTP response to the requester.

IMO this will also make it easier to add new functionality (e.g. the image resizing posted in PR #92). Based on this work I have also started implementing a handler which will be able to execute python scripts through our webserver (which would allow more powerful webinterfaces for XBMC).

I have tested these changes on win32 and linux (ubuntu) but it's not tested on osx and requires changes to osx/ios project files.
