### PR TITLE
[ios] - Allow repeated keypresses with remote on atv2

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3083,7 +3083,7 @@ bool CApplication::ProcessEventServer(float frameTime)
   return false;
 }
 
-bool CApplication::ProcessJoystickEvent(const std::string& joystickName, int wKeyID, bool isAxis, float fAmount)
+bool CApplication::ProcessJoystickEvent(const std::string& joystickName, int wKeyID, bool isAxis, float fAmount, unsigned int holdTime /*=0*/)
 {
 #if defined(HAS_EVENT_SERVER)
   m_idleTimer.StartZero();
@@ -3119,7 +3119,7 @@ bool CApplication::ProcessJoystickEvent(const std::string& joystickName, int wKe
    // Translate using regular joystick translator.
    if (CButtonTranslator::GetInstance().TranslateJoystickString(iWin, joystickName.c_str(), wKeyID, isAxis ? JACTIVE_AXIS : JACTIVE_BUTTON, actionID, actionName, fullRange))
    {
-     CAction action(actionID, fAmount, 0.0f, actionName);
+     CAction action(actionID, fAmount, 0.0f, actionName, holdTime);
      g_audioManager.PlayActionSound(action);
      return OnAction(action);
    }
@@ -5508,3 +5508,4 @@ CPerformanceStats &CApplication::GetPerformanceStats()
   return m_perfStats;
 }
 #endif
+

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -363,7 +363,7 @@ protected:
   bool ProcessPeripherals(float frameTime);
   bool ProcessHTTPApiButtons();
   bool ProcessJsonRpcButtons();
-  bool ProcessJoystickEvent(const std::string& joystickName, int button, bool isAxis, float fAmount);
+  bool ProcessJoystickEvent(const std::string& joystickName, int button, bool isAxis, float fAmount, unsigned int holdTime = 0);
 
   float NavigationIdleTime();
   static bool AlwaysProcess(const CAction& action);

--- a/xbmc/guilib/Key.cpp
+++ b/xbmc/guilib/Key.cpp
@@ -172,7 +172,7 @@ void CKey::SetFromService(bool fromService)
   m_fromService = fromService;
 }
 
-CAction::CAction(int actionID, float amount1 /* = 1.0f */, float amount2 /* = 0.0f */, const CStdString &name /* = "" */)
+CAction::CAction(int actionID, float amount1 /* = 1.0f */, float amount2 /* = 0.0f */, const CStdString &name /* = "" */, unsigned int holdTime /*= 0*/)
 {
   m_id = actionID;
   m_amount[0] = amount1;
@@ -183,7 +183,7 @@ CAction::CAction(int actionID, float amount1 /* = 1.0f */, float amount2 /* = 0.
   m_repeat = 0;
   m_buttonCode = 0;
   m_unicode = 0;
-  m_holdTime = 0;
+  m_holdTime = holdTime;
 }
 
 CAction::CAction(int actionID, unsigned int state, float posX, float posY, float offsetX, float offsetY, const CStdString &name)

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -436,7 +436,7 @@ class CKey;
 class CAction
 {
 public:
-  CAction(int actionID, float amount1 = 1.0f, float amount2 = 0.0f, const CStdString &name = "");
+  CAction(int actionID, float amount1 = 1.0f, float amount2 = 0.0f, const CStdString &name = "", unsigned int holdTime = 0);
   CAction(int actionID, wchar_t unicode);
   CAction(int actionID, unsigned int state, float posX, float posY, float offsetX, float offsetY, const CStdString &name = "");
   CAction(int actionID, const CStdString &name, const CKey &key);

--- a/xbmc/osx/atv2/XBMCController.mm
+++ b/xbmc/osx/atv2/XBMCController.mm
@@ -35,24 +35,23 @@
 #import "XBMCEAGLView.h"
 #import "XBMCDebugHelpers.h"
 
+//start repeating after 0.5s
+#define REPEATED_KEYPRESS_DELAY_S     0.5
+//pause 0.01s (10ms) between keypresses
+#define REPEATED_KEYPRESS_PAUSE_S 0.01
+
 typedef enum {
 
   ATV_BUTTON_UP                 = 1,
-  ATV_BUTTON_UP_RELEASE         = 1,
   ATV_BUTTON_DOWN               = 2,
-  ATV_BUTTON_DOWN_RELEASE       = 2,
   ATV_BUTTON_LEFT               = 3,
-  ATV_BUTTON_LEFT_RELEASE       = 3,
   ATV_BUTTON_RIGHT              = 4,
-  ATV_BUTTON_RIGHT_RELEASE      = 4,
   ATV_BUTTON_PLAY               = 5,
   ATV_BUTTON_MENU               = 6,
   ATV_BUTTON_PLAY_H             = 7,
   ATV_BUTTON_MENU_H             = 8,
   ATV_BUTTON_LEFT_H             = 9,
-  ATV_BUTTON_LEFT_H_RELEASE     = 9,
   ATV_BUTTON_RIGHT_H            = 10,
-  ATV_BUTTON_RIGHT_H_RELEASE    = 10,
 
   //new aluminium remote buttons
   ATV_ALUMINIUM_PLAY            = 12,
@@ -194,10 +193,15 @@ extern NSString* kBRScreenSaverDismissed;
 @interface XBMCController (PrivateMethods)
 UIWindow      *m_window;
 XBMCEAGLView  *m_glView;
+NSTimer       *m_keyTimer;
 int           m_screensaverTimeout;
 int           m_systemsleepTimeout;
 
 - (void) observeDefaultCenterStuff: (NSNotification *) notification;
+- (void) keyPressTimerCallback: (NSTimer*)theTimer;
+- (void) startKeyPressTimer: (int) keyId;
+- (void) stopKeyPressTimer;
+- (void) setUserEvent:(int) id withHoldTime:(unsigned int) holdTime;
 @end
 //
 //
@@ -337,39 +341,40 @@ int           m_systemsleepTimeout;
   return YES;
 }
 
-- (eATVClientEvent) ATVClientEventFromBREvent:(BREvent*) f_event
+- (eATVClientEvent) ATVClientEventFromBREvent:(BREvent*) f_event 
+                    Repeatable:(bool &) isRepeatable
+                    ButtonState:(bool &) isPressed
 {
   int remoteAction = [f_event remoteAction];
   CLog::Log(LOGDEBUG,"XBMCPureController: Button press remoteAction = %i", remoteAction);
+  isRepeatable = false;
+  isPressed = false;
 
   switch (remoteAction)
   {
     // tap up
     case kBREventRemoteActionUp:
     case 65676:
+      isRepeatable = true;
       if([f_event value] == 1)
-        return ATV_BUTTON_UP;
-      else
-        return ATV_INVALID_BUTTON;
-        //return ATV_BUTTON_UP_RELEASE;
+        isPressed = true;
+      return ATV_BUTTON_UP;
 
     // tap down
     case kBREventRemoteActionDown:
     case 65677:
+      isRepeatable = true;
       if([f_event value] == 1)
-        return ATV_BUTTON_DOWN;
-      else
-        return ATV_INVALID_BUTTON;
-        //return ATV_BUTTON_DOWN_RELEASE;
+        isPressed = true;
+      return ATV_BUTTON_DOWN;
 
     // tap left
     case kBREventRemoteActionLeft:
     case 65675:
+      isRepeatable = true;
       if([f_event value] == 1)
-        return ATV_BUTTON_LEFT;
-      else
-        return ATV_INVALID_BUTTON;
-        //return ATV_BUTTON_LEFT_RELEASE;
+        isPressed = true;
+      return ATV_BUTTON_LEFT;
 
     // hold left
     case 786612:
@@ -377,16 +382,14 @@ int           m_systemsleepTimeout;
         return ATV_LEARNED_REWIND;
       else
         return ATV_INVALID_BUTTON;
-        //return ATV_LEARNED_REWIND_RELEASE;
 
     // tap right
     case kBREventRemoteActionRight:
     case 65674:
+      isRepeatable = true;
       if ([f_event value] == 1)
-        return ATV_BUTTON_RIGHT;
-      else
-        return ATV_INVALID_BUTTON;
-        //return ATV_BUTTON_RIGHT_RELEASE;
+        isPressed = true;
+      return ATV_BUTTON_RIGHT;
 
     // hold right
     case 786611:
@@ -394,7 +397,6 @@ int           m_systemsleepTimeout;
         return ATV_LEARNED_FORWARD;
       else
         return ATV_INVALID_BUTTON;
-        //return ATV_LEARNED_FORWARD_RELEASE;
 
     // tap play
     case kBREventRemoteActionPlay:
@@ -457,69 +459,66 @@ int           m_systemsleepTimeout;
 
     // PageUp
     case kBREventRemoteActionPageUp:
+      isRepeatable = true;
       if ([f_event value] == 1)
-        return ATV_BUTTON_PAGEUP;
-      else
-        return ATV_INVALID_BUTTON;
+        isPressed = true;
+      return ATV_BUTTON_PAGEUP;
 
     // PageDown
     case kBREventRemoteActionPageDown:
+      isRepeatable = true;
       if ([f_event value] == 1)
-        return ATV_BUTTON_PAGEDOWN;
-      else
-        return ATV_INVALID_BUTTON;
+        isPressed = true;
+      return ATV_BUTTON_PAGEDOWN;
 
     // Pause
     case kBREventRemoteActionPause:
+      isRepeatable = true;
       if ([f_event value] == 1)
-        return ATV_BUTTON_PAUSE;
-      else
-        return ATV_INVALID_BUTTON;
+        isPressed = true;
+      return ATV_BUTTON_PAUSE;
 
     // Play2
     case kBREventRemoteActionPlay2:
+      isRepeatable = true;
       if ([f_event value] == 1)
-        return ATV_BUTTON_PLAY2;
-      else
-        return ATV_INVALID_BUTTON;
+        isPressed = true;
+      return ATV_BUTTON_PLAY2;
 
     // Stop
     case kBREventRemoteActionStop:
+      isRepeatable = true;
       if ([f_event value] == 1)
-        return ATV_BUTTON_STOP;
-      else
-        return ATV_INVALID_BUTTON;
-        //return ATV_BUTTON_STOP_RELEASE;
+        isPressed = true;
+      return ATV_BUTTON_STOP;
 
     // Fast Forward
     case kBREventRemoteActionFastFwd:
+      isRepeatable = true;
       if ([f_event value] == 1)
-        return ATV_BUTTON_FASTFWD;
-      else
-        return ATV_INVALID_BUTTON;
-        //return ATV_BUTTON_FASTFWD_RELEASE;
+        isPressed = true;
+      return ATV_BUTTON_FASTFWD;
 
     // Rewind
     case kBREventRemoteActionRewind:
+      isRepeatable = true;
       if ([f_event value] == 1)
-        return ATV_BUTTON_REWIND;
-      else
-        return ATV_INVALID_BUTTON;
-        //return ATV_BUTTON_REWIND_RELEASE;
+        isPressed = true;
+      return ATV_BUTTON_REWIND;
 
     // Skip Forward
     case kBREventRemoteActionSkipFwd:
+      isRepeatable = true;
       if ([f_event value] == 1)
-        return ATV_BUTTON_SKIPFWD;
-      else
-        return ATV_INVALID_BUTTON;
+        isPressed = true;
+      return ATV_BUTTON_SKIPFWD;
 
     // Skip Back
     case kBREventRemoteActionSkipBack:
+      isRepeatable = true;
       if ([f_event value] == 1)
-        return ATV_BUTTON_SKIPBACK;
-      else
-        return ATV_INVALID_BUTTON;
+        isPressed = true;
+      return ATV_BUTTON_SKIPBACK;
 
     // Gesture Swipe Left
     case kBREventRemoteActionSwipeLeft:
@@ -585,6 +584,17 @@ int           m_systemsleepTimeout;
   }
 }
 
+- (void)setUserEvent:(int) id withHoldTime:(unsigned int) holdTime
+{
+  XBMC_Event newEvent;
+  memset(&newEvent, 0, sizeof(newEvent));
+
+  newEvent.type = XBMC_USEREVENT;
+  newEvent.jbutton.which = id;
+  newEvent.jbutton.holdTime = holdTime;
+  CWinEventsIOS::MessagePush(&newEvent);
+}
+
 - (BOOL)brEventAction:(BREvent*)event
 {
   //NSLog(@"%s", __PRETTY_FUNCTION__);
@@ -592,15 +602,19 @@ int           m_systemsleepTimeout;
 	if ([m_glView isAnimating])
   {
     BOOL is_handled = NO;
-    eATVClientEvent xbmc_ir_key = [self ATVClientEventFromBREvent:event];
+    bool isRepeatable = false;
+    bool isPressed = false;
+    eATVClientEvent xbmc_ir_key = [self ATVClientEventFromBREvent:event 
+                                        Repeatable:isRepeatable
+                                        ButtonState:isPressed];
     
     if ( xbmc_ir_key != ATV_INVALID_BUTTON )
     {
-      XBMC_Event newEvent;
-      memset(&newEvent, 0, sizeof(newEvent));
-
       if (xbmc_ir_key == ATV_BTKEYPRESS && [event value] == 1)
       {
+        XBMC_Event newEvent;
+        memset(&newEvent, 0, sizeof(newEvent));
+
         NSDictionary *dict = [event eventDictionary];
         NSString *key_nsstring = [dict objectForKey:@"kBRKeyEventCharactersKey"];
         
@@ -636,9 +650,23 @@ int           m_systemsleepTimeout;
       }
       else
       {
-        newEvent.type = XBMC_USEREVENT;
-        newEvent.user.code = xbmc_ir_key;
-        CWinEventsIOS::MessagePush(&newEvent);
+        if(isRepeatable)
+        {
+          if(isPressed)
+          {
+            [self setUserEvent:xbmc_ir_key withHoldTime:0]; //fire event
+            [self startKeyPressTimer:xbmc_ir_key];//start repeat timer
+          }
+          else
+          {
+            //stop the timer
+            [self stopKeyPressTimer];
+          }
+        }
+        else
+        {
+          [self setUserEvent:xbmc_ir_key  withHoldTime:0];
+        }
         is_handled = TRUE;
       }
     }
@@ -652,6 +680,54 @@ int           m_systemsleepTimeout;
 
 #pragma mark -
 #pragma mark private helper methods
+- (void)startKeyPressTimer: (int) keyId
+{ 
+  NSNumber *number = [NSNumber numberWithInt:keyId]; 
+  NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:[NSDate date], @"StartDate", 
+                                                                  number, @"keyId", nil];
+  
+  NSDate *fireDate = [NSDate dateWithTimeIntervalSinceNow:REPEATED_KEYPRESS_DELAY_S]; 
+
+  [self stopKeyPressTimer];
+
+  //schedule repeated timer which starts after REPEATED_KEYPRESS_DELAY_S and fires
+  //every REPEATED_KEYPRESS_PAUSE_S
+  m_keyTimer       = [[NSTimer alloc] initWithFireDate:fireDate 
+                                      interval:REPEATED_KEYPRESS_PAUSE_S 
+                                      target:self 
+                                      selector:@selector(keyPressTimerCallback:) 
+                                      userInfo:dict 
+                                      repeats:YES]; 
+  //schedule the timer to the runloop
+  NSRunLoop *runLoop = [NSRunLoop currentRunLoop]; 
+  [runLoop addTimer:m_keyTimer forMode:NSDefaultRunLoopMode]; 
+} 
+
+- (void)stopKeyPressTimer
+{
+  if(m_keyTimer != nil)
+  {
+    [m_keyTimer invalidate];
+    [m_keyTimer release];
+    m_keyTimer = nil;
+  }
+}
+
+- (void)keyPressTimerCallback:(NSTimer*)theTimer 
+{ 
+  //if queue is empty - skip this timer event
+  //for letting it process
+  if(CWinEventsIOS::GetQueueSize())
+    return;
+  NSDate *startDate = [[theTimer userInfo] objectForKey:@"StartDate"];
+  int keyId = [[[theTimer userInfo] objectForKey:@"keyId"] intValue];
+  //calc the holdTime - timeIntervalSinceNow gives the
+  //passed time since startDate in seconds as negative number
+  //so multiply with -1000 for getting the positive ms
+  NSTimeInterval holdTime = [startDate timeIntervalSinceNow] * -1000.0f;
+  [self setUserEvent:keyId withHoldTime:(unsigned int)holdTime];
+} 
+
 //
 - (void)observeDefaultCenterStuff: (NSNotification *) notification
 {
@@ -993,3 +1069,4 @@ int           m_systemsleepTimeout;
 }
 
 @end
+

--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -128,6 +128,7 @@ typedef struct XBMC_JoyButtonEvent {
 	unsigned char which;	/* The joystick device index */
 	unsigned char button;	/* The joystick button index */
 	unsigned char state;	/* XBMC_PRESSED or XBMC_RELEASED */
+  uint32_t      holdTime; /*holdTime of the pressed button*/
 } XBMC_JoyButtonEvent;
 
 /* The "window resized" event

--- a/xbmc/windowing/osx/WinEventsIOS.h
+++ b/xbmc/windowing/osx/WinEventsIOS.h
@@ -1,5 +1,5 @@
 /*
-*      Copyright (C) 2010 Team XBMC
+*      Copyright (C) 2012 Team XBMC
 *      http://www.xbmc.org
 *
 *  This Program is free software; you can redistribute it and/or modify
@@ -33,8 +33,10 @@ public:
   static void DeInit();
   static void MessagePush(XBMC_Event *newEvent);
   static bool MessagePump();
+  static int  GetQueueSize();
 
 protected:
 };
 
 #endif // WINDOW_EVENTS_IOS_H
+

--- a/xbmc/windowing/osx/WinEventsIOS.mm
+++ b/xbmc/windowing/osx/WinEventsIOS.mm
@@ -1,5 +1,5 @@
 /*
-*      Copyright (C) 2010 Team XBMC
+*      Copyright (C) 2012 Team XBMC
 *      http://www.xbmc.org
 *
 *  This Program is free software; you can redistribute it and/or modify
@@ -70,18 +70,26 @@ bool CWinEventsIOS::MessagePump()
     if (pumpEvent.type == XBMC_USEREVENT)
     {
       // On ATV2, we push in events as a XBMC_USEREVENT,
-      // the user.code will be the keyID to translate using joystick.AppleRemote.xml
+      // the jbutton.which will be the keyID to translate using joystick.AppleRemote.xml
+      // jbutton.holdTime is the time the button is hold in ms (for repeated keypresses)
       std::string joystickName = "AppleRemote";
       bool isAxis = false;
       float fAmount = 1.0;
-      unsigned short wKeyID = pumpEvent.user.code;
+      unsigned char wKeyID = pumpEvent.jbutton.which;
+      unsigned int holdTime = pumpEvent.jbutton.holdTime;
 
       CLog::Log(LOGDEBUG,"CWinEventsIOS: Button press keyID = %i", wKeyID);
-      ret |= g_application.ProcessJoystickEvent(joystickName, wKeyID, isAxis, fAmount);
+      ret |= g_application.ProcessJoystickEvent(joystickName, wKeyID, isAxis, fAmount, holdTime);
     }
     else
       ret |= g_application.OnEvent(pumpEvent);
   }
 
   return ret;
+}
+
+int CWinEventsIOS::GetQueueSize()
+{
+  CSingleLock lock(g_inputCond);
+  return events.size();
 }


### PR DESCRIPTION
Well topic says it all. This allows repeated keypresses when using a ir remote with atv2.

So holding a button on the remote will execute the action as long as its hold (with a threshhold of 500ms before it starts).

This works for all buttons where iOS reports the keyPressed state (cursor + some custom learned ones i think).
