### PR TITLE
Dutch translation fixes/additions

### DIFF
--- a/addons/weather.wunderground/resources/language/Dutch/strings.xml
+++ b/addons/weather.wunderground/resources/language/Dutch/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<strings>
+	<string id="30101">Plaatsen Instellen</string>
+	<string id="30111">Wijzig plaats 1</string>
+	<string id="30112">Wijzig plaats 2</string>
+	<string id="30113">Wijzig plaats 3</string>
+</strings>

--- a/language/Dutch/strings.xml
+++ b/language/Dutch/strings.xml
@@ -1975,7 +1975,7 @@
   <string id="21414">Standaard tv-serie scraper</string>
   <string id="21415">Standaard muziekvideo scraper</string>
   <string id="21416">Alternatieven toestaan op basis van originele scraper taal</string>
-  <string id="21417">- Instellingen schermbeveiliging</string>
+  <string id="21417">- Instellingen</string>
   <string id="21418">Meertalig</string>
   <string id="21419">Geen scrapers beschikbaar</string>
   <string id="21420">Waarde gelijk aan</string>


### PR DESCRIPTION
"Instellingen schermbeveiliging" was incorrectly also used for the Weather Settings dialog
