### PR TITLE
Support for scanning a specific library directory via the API.

### DIFF
--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -238,7 +238,9 @@ JSON_STATUS CAudioLibrary::GetGenres(const CStdString &method, ITransportLayer *
 
 JSON_STATUS CAudioLibrary::Scan(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  g_application.getApplicationMessenger().ExecBuiltIn("updatelibrary(music)");
+  CStdString cmd;
+  cmd.Format("updatelibrary(music, %s)", parameterObject["path"].asString());
+  g_application.getApplicationMessenger().ExecBuiltIn(cmd);
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -1525,7 +1525,9 @@ namespace JSONRPC
       "\"description\": \"Scans the audio sources for new library items\","
       "\"transport\": \"Response\","
       "\"permission\": \"UpdateData\","
-      "\"params\": [],"
+      "\"params\": ["
+        "{ \"name\": \"path\", \"type\": \"string\", \"required\": false }"
+      "],"
       "\"returns\": \"string\""
     "}",
     "\"AudioLibrary.Export\": {"
@@ -1844,7 +1846,9 @@ namespace JSONRPC
       "\"description\": \"Scans the video sources for new library items\","
       "\"transport\": \"Response\","
       "\"permission\": \"UpdateData\","
-      "\"params\": [],"
+      "\"params\": ["
+        "{ \"name\": \"path\", \"type\": \"string\", \"required\": false }"
+      "],"
       "\"returns\": \"string\""
     "}",
     "\"VideoLibrary.Export\": {"

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -351,7 +351,9 @@ JSON_STATUS CVideoLibrary::GetGenres(const CStdString &method, ITransportLayer *
 
 JSON_STATUS CVideoLibrary::Scan(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  g_application.getApplicationMessenger().ExecBuiltIn("updatelibrary(video)");
+  CStdString cmd;
+  cmd.Format("updatelibrary(video, %s)", parameterObject["path"].asString());
+  g_application.getApplicationMessenger().ExecBuiltIn(cmd);
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/methods.json
+++ b/xbmc/interfaces/json-rpc/methods.json
@@ -748,7 +748,9 @@
     "description": "Scans the audio sources for new library items",
     "transport": "Response",
     "permission": "UpdateData",
-    "params": [],
+    "params": [
+      { "name": "path", "type": "string", "required": false }
+    ],
     "returns": "string"
   },
   "AudioLibrary.Export": {
@@ -1067,7 +1069,9 @@
     "description": "Scans the video sources for new library items",
     "transport": "Response",
     "permission": "UpdateData",
-    "params": [],
+    "params": [
+      { "name": "path", "type": "string", "required": false }
+    ],
     "returns": "string"
   },
   "VideoLibrary.Export": {


### PR DESCRIPTION
This patch makes it possible to pass a param name path to VideoLibrary.Scan and AudioLibrary.Scan containing a directory path. I personally use this to auto scan newly downloaded movies and episodes.
