### PR TITLE
Add the option the eject the CD after ripping is down(full disc only)

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1357,6 +1357,7 @@
   <string id="14093">Security</string>
   <string id="14094">Input devices</string>
   <string id="14095">Power saving</string>
+  <string id="14099">Eject disc when CD ripping is complete</string>
 
   <string id="15015">Remove</string>
   <string id="15016">Games</string>

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -332,6 +332,11 @@ bool CCDDARipper::RipCD()
   }
 
   CLog::Log(LOGINFO, "Ripped CD succesfull");
+  if (g_guiSettings.GetBool("audiocds.ejectonrip"))
+  {
+    CLog::Log(LOGINFO, "Ejecting CD");
+    CIoSupport::EjectTray();
+  }
   return true;
 }
 

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -338,6 +338,7 @@ void CGUISettings::Initialize()
   AddInt(acd, "audiocds.quality", 622, CDDARIP_QUALITY_CBR, qualities, SPIN_CONTROL_TEXT);
   AddInt(acd, "audiocds.bitrate", 623, 192, 128, 32, 320, SPIN_CONTROL_INT_PLUS, MASK_KBPS);
   AddInt(acd, "audiocds.compressionlevel", 665, 5, 0, 1, 8, SPIN_CONTROL_INT_PLUS);
+  AddBool(acd, "audiocds.ejectonrip", 14099, true);
 
 #ifdef HAS_KARAOKE
   CSettingsCategory* kar = AddCategory(3, "karaoke", 13327);


### PR DESCRIPTION
This PR adds the option to automatically Eject the CD when a full disc rip has completed.

Used to be part of my other PR(auto rip) but I figured that since it is a separate feature I should split them up.
