### PR TITLE
UnrarXLIB messed with endianess on APPLE platform

### DIFF
--- a/lib/UnrarXLib/os.hpp
+++ b/lib/UnrarXLib/os.hpp
@@ -200,15 +200,6 @@
 
 #define _stdfunction 
 
-#ifdef _APPLE
-  #ifndef BIG_ENDIAN
-    #define BIG_ENDIAN
-  #endif
-  #ifdef LITTLE_ENDIAN
-    #undef LITTLE_ENDIAN
-  #endif
-#endif
-
 #if defined(__sparc) || defined(sparc) || defined(__hpux)
   #ifndef BIG_ENDIAN
      #define BIG_ENDIAN


### PR DESCRIPTION
UnrarXlib forced BIG_ENDIAN on apple. This should be removed. 

On OSX the endian.h sys header should automagically define everything right.

This fixes #12684. (extraction of password protected rar files)

awaiting ok from beenje who has a ppc and can test if it still works on ppc with this.

I tested on osx intel and ios and the issue is fixed by this change there.
