### PR TITLE
player: fix converge count in order to not lose a key frame after flush,...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -464,11 +464,13 @@ int CDVDVideoCodecFFmpeg::Decode(BYTE* pData, int iSize, double dts, double pts)
   if (!iGotPicture)
     return VC_BUFFER;
 
-  if(m_pFrame->key_frame || m_pCodecContext->codec_id == CODEC_ID_H264) /* h264 doesn't always have keyframes + won't output before first keyframe anyway */
+  if(m_pFrame->key_frame)
   {
     m_started = true;
-    m_iLastKeyframe = m_pCodecContext->has_b_frames + 1;
+    m_iLastKeyframe = m_pCodecContext->has_b_frames + 2;
   }
+  if (m_pCodecContext->codec_id == CODEC_ID_H264) /* h264 doesn't always have keyframes + won't output before first keyframe anyway */
+    m_started = true;
 
   if(m_pCodecContext->pix_fmt != PIX_FMT_YUV420P
   && m_pCodecContext->pix_fmt != PIX_FMT_YUVJ420P


### PR DESCRIPTION
Switching refresh rate causes that the first few seconds get lost on some videos. The reason is that ffmpeg needs a key frame to get started and the too small converge count does not keep the last one.
This code originally done by TheSwissKnife fixes it.
