### PR TITLE
JSON-RPC notifications for python scripts

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -644,6 +644,7 @@
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\infotagvideo.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\jsonrpcclient.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\keyboard.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -663,6 +664,7 @@
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonAddon.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonJsonRpcClient.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonPlayer.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -884,6 +886,8 @@
     <ClInclude Include="..\..\xbmc\cores\paplayer\PCMCodec.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINFileSMB.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINSMBDirectory.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\jsonrpcclient.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonJsonRpcClient.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pythreadstate.h" />
     <ClInclude Include="..\..\xbmc\network\websocket\WebSocket.h" />
     <ClInclude Include="..\..\xbmc\network\websocket\WebSocketManager.h" />
@@ -1611,7 +1615,6 @@
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\listitem.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\monitor.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\player.h" />
-    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyjsonrpc.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyplaylist.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyrendercapture.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonAddon.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2642,6 +2642,12 @@
     <ClCompile Include="..\..\xbmc\MediaSource.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonJsonRpcClient.cpp">
+      <Filter>interfaces\python\xbmcmodule</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\jsonrpcclient.cpp">
+      <Filter>interfaces\python\xbmcmodule</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -4542,9 +4548,6 @@
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\player.h">
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyjsonrpc.h">
-      <Filter>interfaces\python\xbmcmodule</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyplaylist.h">
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClInclude>
@@ -5315,6 +5318,12 @@
       <Filter>cores\AudioRenderers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pythreadstate.h">
+      <Filter>interfaces\python\xbmcmodule</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonJsonRpcClient.h">
+      <Filter>interfaces\python\xbmcmodule</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\jsonrpcclient.h">
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClInclude>
   </ItemGroup>

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -38,10 +38,12 @@ typedef struct {
 
 class LibraryLoader;
 class CPythonMonitor;
+class CPythonJsonRpcClient;
 
 typedef std::vector<PyElem> PyList;
 typedef std::vector<PVOID> PlayerCallbackList;
 typedef std::vector<PVOID> MonitorCallbackList;
+typedef std::vector<PVOID> JsonRpcClientCallbackList;
 typedef std::vector<LibraryLoader*> PythonExtensionLibraries;
 
 class XBPython : 
@@ -62,6 +64,8 @@ public:
   void UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback);
   void RegisterPythonMonitorCallBack(CPythonMonitor* pCallback);
   void UnregisterPythonMonitorCallBack(CPythonMonitor* pCallback);
+  void RegisterPythonJsonRpcClientCallBack(CPythonJsonRpcClient* pCallback);
+  void UnregisterPythonJsonRpcClientCallBack(CPythonJsonRpcClient* pCallback);
   void OnSettingsChanged(const CStdString &strings);
   void OnScreensaverActivated();
   void OnScreensaverDeactivated();
@@ -130,6 +134,7 @@ private:
   PyList              m_vecPyList;
   PlayerCallbackList  m_vecPlayerCallbackList;
   MonitorCallbackList m_vecMonitorCallbackList;
+  JsonRpcClientCallbackList m_vecJsonRpcCallbackList;
   LibraryLoader*      m_pDll;
 
   // any global events that scripts should be using

--- a/xbmc/interfaces/python/xbmcmodule/Makefile.in
+++ b/xbmc/interfaces/python/xbmcmodule/Makefile.in
@@ -20,6 +20,7 @@ SRCS=action.cpp \
      GUIPythonWindowXMLDialog.cpp \
      infotagmusic.cpp \
      infotagvideo.cpp \
+     jsonrpcclient.cpp \
      keyboard.cpp \
      listitem.cpp \
      monitor.cpp \
@@ -27,6 +28,7 @@ SRCS=action.cpp \
      pyplaylist.cpp \
      pyrendercapture.cpp \
      PythonAddon.cpp \
+     PythonJsonRpcClient.cpp \
      PythonMonitor.cpp \
      PythonPlayer.cpp \
      pyutil.cpp \

--- a/xbmc/interfaces/python/xbmcmodule/PythonJsonRpcClient.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/PythonJsonRpcClient.cpp
@@ -1,0 +1,121 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+
+#include "PythonJsonRpcClient.h"
+#include "pythreadstate.h"
+#include "pyutil.h"
+#include "../XBPython.h"
+#include "settings/AdvancedSettings.h"
+#include "threads/Atomics.h"
+
+using namespace std;
+using namespace ANNOUNCEMENT;
+using namespace JSONRPC;
+
+#ifdef HAS_JSONRPC
+
+struct SPyJsonRpcClient
+{
+  SPyJsonRpcClient(CPythonJsonRpcClient *client, const char *function, const std::string &arg)
+  {
+    m_client = client;
+    m_client->Acquire();
+    m_function = function;
+    m_arg = arg;
+  }
+
+  ~SPyJsonRpcClient()
+  {
+    m_client->Release();
+  }
+
+  const char* m_function;
+  std::string m_arg;
+  CPythonJsonRpcClient* m_client;
+};
+
+/*
+ * called from python library!
+ */
+static int SPyJsonRpcClient_Function(void* e)
+{
+  SPyJsonRpcClient* object = (SPyJsonRpcClient*)e;
+  PyObject* ret    = NULL;
+
+  if (object->m_client->m_callback)
+    ret = PyObject_CallMethod(object->m_client->m_callback, (char*)object->m_function, "(s)", object->m_arg.c_str());
+
+  if (ret)
+    Py_DECREF(ret);
+
+  CPyThreadState pyState;
+  delete object;
+
+  return 0;
+}
+
+CPythonJsonRpcClient::CPythonJsonRpcClient()
+  : m_callback(NULL),
+    m_state(NULL),
+    m_refs(1),
+    m_announcementFlags(ANNOUNCE_ALL)
+{
+  g_pythonParser.RegisterPythonJsonRpcClientCallBack(this);
+}
+
+CPythonJsonRpcClient::~CPythonJsonRpcClient()
+{
+  g_pythonParser.UnregisterPythonJsonRpcClientCallBack(this);
+}
+
+void CPythonJsonRpcClient::Release()
+{
+  if(AtomicDecrement(&m_refs) == 0)
+    delete this;
+}
+
+void CPythonJsonRpcClient::Acquire()
+{
+  AtomicIncrement(&m_refs);
+}
+
+void CPythonJsonRpcClient::SetCallback(PyThreadState *state, PyObject *object)
+{
+  /* python lock should be held */
+  m_callback = object;
+  m_state    = state;
+}
+
+void CPythonJsonRpcClient::Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+{
+  if (m_callback == NULL ||
+     (m_announcementFlags & flag) == 0)
+    return;
+
+  std::string strJson = AnnouncementToJSONRPC(flag, sender, message, data, g_advancedSettings.m_jsonOutputCompact);
+
+  PyXBMC_AddPendingCall(m_state, SPyJsonRpcClient_Function, new SPyJsonRpcClient(this, "onNotification", strJson));
+  g_pythonParser.PulseGlobalEvent();
+}
+
+#endif

--- a/xbmc/interfaces/python/xbmcmodule/PythonJsonRpcClient.h
+++ b/xbmc/interfaces/python/xbmcmodule/PythonJsonRpcClient.h
@@ -1,0 +1,67 @@
+#pragma once
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <Python.h>
+#include <string>
+
+#include "system.h"
+#include "interfaces/json-rpc/IJSONRPCAnnouncer.h"
+#include "interfaces/json-rpc/ITransportLayer.h"
+#include "interfaces/json-rpc/JSONRPC.h"
+
+int Py_XBMC_Event_OnNotification(void* arg);
+
+#ifdef HAS_JSONRPC
+class CPythonJsonRpcTransport : public JSONRPC::ITransportLayer
+{
+public:
+  virtual bool PrepareDownload(const char *path, CVariant &details, std::string &protocol) { return false; }
+  virtual bool Download(const char *path, CVariant &result) { return false; }
+  virtual int GetCapabilities() { return JSONRPC::Response | JSONRPC::Announcing; }
+};
+
+class CPythonJsonRpcClient : public JSONRPC::IClient, public JSONRPC::IJSONRPCAnnouncer
+{
+public:
+  CPythonJsonRpcClient();
+
+  void Acquire();
+  void Release();
+  void SetCallback(PyThreadState *state, PyObject *object);
+
+  virtual int  GetPermissionFlags() { return JSONRPC::OPERATION_PERMISSION_ALL; }
+  virtual int  GetAnnouncementFlags() { return m_announcementFlags; }
+  virtual bool SetAnnouncementFlags(int flags) { m_announcementFlags = flags; return true; }
+
+  virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
+    
+  PyObject *m_callback;
+  PyThreadState *m_state;
+
+protected:
+  virtual ~CPythonJsonRpcClient();
+  long m_refs;
+
+private:
+  int m_announcementFlags;
+};
+#endif

--- a/xbmc/interfaces/python/xbmcmodule/jsonrpcclient.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/jsonrpcclient.cpp
@@ -1,0 +1,140 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "jsonrpcclient.h"
+#include "pythreadstate.h"
+#include "pyutil.h"
+
+using namespace std;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace PYXBMC
+{
+  /* JsonRpcClient Fucntions */
+
+  PyObject* JsonRpcClient_New(PyTypeObject *type, PyObject *args, PyObject *kwds)
+  {
+    JsonRpcClient *self = (JsonRpcClient*)type->tp_alloc(type, 0);
+    if (!self) 
+      return NULL;
+    
+    self->pClient = new CPythonJsonRpcClient();
+    if (self->pClient == NULL)
+    {
+      PyErr_SetString((PyObject*)self, "Unable to create JSON-RPC client");
+      return NULL;
+    }
+
+    self->pClient->SetCallback(PyThreadState_Get(), (PyObject*)self);
+
+    return (PyObject*)self;
+  }
+
+  void JsonRpcClient_Dealloc(JsonRpcClient* self)
+  {
+    if (self == NULL)
+      return;
+
+    if (self->pClient)
+    {
+      self->pClient->SetCallback(NULL, NULL);
+      CPyThreadState pyState;
+      self->pClient->Release();
+      pyState.Restore();
+      
+      self->pClient = NULL;
+    }
+
+    self->ob_type->tp_free((PyObject*)self);
+  }
+
+  PyDoc_STRVAR(execute__doc__,
+    "execute(jsonrpccommand) -- Execute a JSON-RPC command.\n"
+    "\n"
+    "jsonrpccommand    : string - JSON-RPC command to execute.\n"
+    "\n"
+    "List of commands - \n"
+    "\n"
+    "example:\n"
+    "  - response = xbmc.executeJSONRPC('{ \"jsonrpc\": \"2.0\", \"method\": \"JSONRPC.Introspect\", \"id\": 1 }')\n");
+
+  PyObject* JsonRpcClient_execute(JsonRpcClient *self, PyObject *args)
+  {
+    if (self == NULL || self->pClient == NULL)
+      return NULL;
+
+    PyObject *requestObj = NULL;
+    if (!PyArg_ParseTuple(args, (char*)"O", &requestObj))
+      return NULL;
+
+    CStdString request;
+    if (requestObj == NULL || !PyXBMCGetUnicodeString(request, requestObj, 1))
+      return NULL;
+
+    CPythonJsonRpcTransport transport;
+    return PyString_FromString(JSONRPC::CJSONRPC::MethodCall(request, &transport, self->pClient).c_str());
+  }
+
+  PyDoc_STRVAR(onnotification__doc__,
+    "onNotification(json) -- callback function for JSON-RPC notifications.\n");
+
+  PyObject* JsonRpcClient_onNotification(JsonRpcClient *self, PyObject *args)
+  {
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+
+  PyMethodDef JsonRpcClient_methods[] = {
+    {(char*)"execute", (PyCFunction)JsonRpcClient_execute, METH_VARARGS, execute__doc__},
+    {(char*)"onNotification", (PyCFunction)JsonRpcClient_onNotification, METH_VARARGS, onnotification__doc__},
+    {NULL, NULL, 0, NULL}
+  };
+
+  PyDoc_STRVAR(jsonrpcclient__doc__,
+    "JsonRpcClient class.\n"
+    "\n"
+    "Derive from this class and overwrite onNotification() to receive notifications.");
+
+// Restore code and data sections to normal.
+
+  PyTypeObject JsonRpcClient_Type;
+
+  void initJsonRpcClient_Type()
+  {
+    PyXBMCInitializeTypeObject(&JsonRpcClient_Type);
+
+    JsonRpcClient_Type.tp_name = (char*)"xbmc.JsonRpcClient";
+    JsonRpcClient_Type.tp_basicsize = sizeof(JsonRpcClient);
+    JsonRpcClient_Type.tp_dealloc = (destructor)JsonRpcClient_Dealloc;
+    JsonRpcClient_Type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
+    JsonRpcClient_Type.tp_doc = jsonrpcclient__doc__;
+    JsonRpcClient_Type.tp_methods = JsonRpcClient_methods;
+    JsonRpcClient_Type.tp_base = 0;
+    JsonRpcClient_Type.tp_new = JsonRpcClient_New;
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/xbmc/interfaces/python/xbmcmodule/jsonrpcclient.h
+++ b/xbmc/interfaces/python/xbmcmodule/jsonrpcclient.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2010 Team XBMC
+ *      Copyright (C) 2012 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,24 +19,33 @@
  *  http://www.gnu.org/copyleft/gpl.html
  *
  */
-#include "system.h"
-#include "interfaces/json-rpc/ITransportLayer.h"
-#include "interfaces/json-rpc/JSONRPC.h"
 
-#ifdef HAS_JSONRPC
-class CPythonTransport : public JSONRPC::ITransportLayer
+#include <Python.h>
+
+#include "PythonJsonRpcClient.h"
+
+#define JsonRpcClient_Check(op) PyObject_TypeCheck(op, &JsonRpcClient_Type)
+#define JsonRpcClient_CheckExact(op) ((op)->ob_type == &JsonRpcClient_Type)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace PYXBMC
 {
-public:
-  virtual bool PrepareDownload(const char *path, CVariant &details, std::string &protocol) { return false; }
-  virtual bool Download(const char *path, CVariant &result) { return false; }
-  virtual int GetCapabilities() { return JSONRPC::Response; }
+  extern PyTypeObject JsonRpcClient_Type;
 
-  class CPythonClient : public JSONRPC::IClient
-  {
-  public:
-    virtual int  GetPermissionFlags() { return JSONRPC::OPERATION_PERMISSION_ALL; }
-    virtual int  GetAnnouncementFlags() { return 0; }
-    virtual bool SetAnnouncementFlags(int flags) { return true; }
-  };
-};
+  typedef struct {
+    PyObject_HEAD
+    CPythonJsonRpcClient* pClient;
+  } JsonRpcClient;
+
+  void initJsonRpcClient_Type();
+
+  PyObject* JsonRpcClient_New(PyTypeObject *type, PyObject *args, PyObject *kwds);
+  PyObject* JsonRpcClient_execute(JsonRpcClient *self, PyObject *args);
+}
+
+#ifdef __cplusplus
+}
 #endif


### PR DESCRIPTION
Currently the only way for python scripts using JSON-RPC to receive JSON-RPC notifications is to open a TCP socket to localhost:9090 and parse the notifications coming through the socket. This has two major drawbacks:
1. This only works if the user enabled "Allow programs on this system to control XBMC" in Settings -> Network -> Services
2. The TCP port (default 9090) is configurable through advancedsettings.xml so an addon using this method needs to add a configuration option to allow changing the port for users who changed that port through AS.xml

This implementation adds a new python class xbmc.JSONRPCClient which can be used as a base class in a python script. By overriding the onNotification() method it is possible to receive JSON-RPC notifications in that method (similar to how the player callbacks (OnPlaybackStarted etc) work). Furthermore the whole logic from xbmc.executeJSONRPC has been moved to xbmc.JSONRPCClient.execute().

As I'm not very familiar with the python callback stuff I mainly copied from the player callback implementation and made the necessary adjustments. So I'd be grateful if someone could take a closer look at that part of the changes to make sure I didn't screw something up. I tested this (on win32) by modifying a python script of an existing addon and it worked fine for me.
