### PR TITLE
[WIN] close/reopen the wasapi audio device when lost

### DIFF
--- a/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
@@ -250,6 +250,10 @@ bool CWin32WASAPI::Initialize()
 
   if(!m_pDevice)
   {
+    if (m_bIsAllocated)
+      // no fallback to default device when recovering from device loss
+      goto failed;
+
     CLog::Log(LOGDEBUG, __FUNCTION__": Could not locate the device named \"%s\" in the list of WASAPI endpoint devices.  Trying the default device...", m_device.c_str());
     hr = pEnumerator->GetDefaultAudioEndpoint(eRender, eConsole, &m_pDevice);
     EXIT_ON_FAILURE(hr, __FUNCTION__": Could not retrieve the default WASAPI audio endpoint.")

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
@@ -338,19 +338,19 @@ bool CWin32WASAPI::Deinitialize()
 //***********************************************************************************************
 bool CWin32WASAPI::Close()
 {
-    m_pAudioClient->Stop();
+  m_pAudioClient->Stop();
 
-    SAFE_RELEASE(m_pRenderClient);
-    SAFE_RELEASE(m_pAudioClient);
-    SAFE_RELEASE(m_pDevice);
+  SAFE_RELEASE(m_pRenderClient);
+  SAFE_RELEASE(m_pAudioClient);
+  SAFE_RELEASE(m_pDevice);
 
-    m_CacheLen = 0;
-    m_uiChunkSize = 0;
-    m_uiBufferLen = 0;
+  m_CacheLen = 0;
+  m_uiChunkSize = 0;
+  m_uiBufferLen = 0;
 
-    m_Initialized = false;
+  m_Initialized = false;
 
-    return true;
+  return true;
 }
 
 //***********************************************************************************************

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
@@ -550,8 +550,6 @@ bool CWin32WASAPI::UpdateCacheStatus()
   {
     CLog::Log(LOGERROR, __FUNCTION__": GetCurrentPadding failed (%i)", hr);
     CLOSE_ON_INVALID(hr,)
-    // On error pretend the buffer is full.
-    m_CacheLen = m_uiBufferLen;
     return false;
   }
   else

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
@@ -64,7 +64,7 @@ const enum PCMChannels wasapi_channel_order[] = {PCM_FRONT_LEFT, PCM_FRONT_RIGHT
 #define WASAPI_TOTAL_CHANNELS 11
 
 #define EXIT_ON_FAILURE(hr, reason, ...) if(FAILED(hr)) {CLog::Log(LOGERROR, reason, __VA_ARGS__); goto failed;}
-#define CLOSE_ON_INVALID(hr, action) if (hr == AUDCLNT_E_DEVICE_INVALIDATED) { Close(); action; }
+#define CLOSE_ON_INVALID(hr, action) if (hr == AUDCLNT_E_DEVICE_INVALIDATED) { CLog::Log(LOGERROR, __FUNCTION__": lost device."); Close() ; action; }
 
 //This needs to be static since only one exclusive stream can exist at one time.
 bool CWin32WASAPI::m_bIsAllocated = false;

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
@@ -199,7 +199,8 @@ bool CWin32WASAPI::Initialize()
   IMMDeviceCollection* pEnumDevices = NULL;
 
   //Shut down Directsound.
-  g_audioContext.SetActiveDevice(CAudioContext::NONE);
+  if (!m_bIsAllocated)
+    g_audioContext.SetActiveDevice(CAudioContext::NONE);
 
   HRESULT hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, IID_IMMDeviceEnumerator, (void**)&pEnumerator);
   EXIT_ON_FAILURE(hr, __FUNCTION__": Could not allocate WASAPI device enumerator. CoCreateInstance error code: %i", hr)
@@ -312,7 +313,8 @@ failed:
   SAFE_RELEASE(m_pDevice);
 
   //Restart Directsound
-  g_audioContext.SetActiveDevice(CAudioContext::DEFAULT_DEVICE);
+  if (!m_bIsAllocated)
+    g_audioContext.SetActiveDevice(CAudioContext::DEFAULT_DEVICE);
 
   return false;
 }

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.cpp
@@ -518,22 +518,19 @@ unsigned int CWin32WASAPI::AddPackets(const void* data, unsigned int len)
     if (FAILED(hr=m_pRenderClient->ReleaseBuffer(uiBytesToWrite/m_uiBytesPerFrame, dwFlags)))
     {
       CLog::Log(LOGERROR, __FUNCTION__": ReleaseBuffer failed (%i)", hr);
-      CLOSE_ON_INVALID(hr, goto failed)
+      CLOSE_ON_INVALID(hr, return 0)
     }
   }
   else
   {
     CLog::Log(LOGERROR, __FUNCTION__": GetBuffer failed (%i)", hr);
-    CLOSE_ON_INVALID(hr, goto failed)
+    CLOSE_ON_INVALID(hr, return 0)
   }
   m_CacheLen += uiBytesToWrite;
 
   CheckPlayStatus();
 
   return uiSrcBytesToWrite; // Bytes used
-
-failed:
-  return 0;
 }
 
 void CWin32WASAPI::UpdateCacheStatus()

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.h
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.h
@@ -70,7 +70,7 @@ private:
   bool Initialize();
   bool Close();
   void AddDataToBuffer(unsigned char* pData, unsigned int len, unsigned char* pOut);
-  void UpdateCacheStatus();
+  bool UpdateCacheStatus();
   void CheckPlayStatus();
   void BuildChannelMapping(int channels, enum PCMChannels* map);
 

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.h
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.h
@@ -107,6 +107,7 @@ private:
 
   // Initialization parameters
   bool              m_Initialized;
+  unsigned int      m_LastInitializationAttempt;
   IAudioCallback*   m_pCallback;
   CStdString        m_device;
   int               m_iChannels;

--- a/xbmc/cores/AudioRenderers/Win32WASAPI.h
+++ b/xbmc/cores/AudioRenderers/Win32WASAPI.h
@@ -67,6 +67,8 @@ public:
   static void EnumerateAudioSinks(AudioSinkList& vAudioSinks, bool passthrough);
 
 private:
+  bool Initialize();
+  bool Close();
   void AddDataToBuffer(unsigned char* pData, unsigned int len, unsigned char* pOut);
   void UpdateCacheStatus();
   void CheckPlayStatus();
@@ -75,8 +77,6 @@ private:
   IMMDevice* m_pDevice;
   IAudioClient* m_pAudioClient;
   IAudioRenderClient* m_pRenderClient;
-
-  IAudioCallback* m_pCallback;
 
   long m_nCurrentVolume;
   long m_drc;
@@ -87,7 +87,6 @@ private:
   unsigned int m_uiBufferLen;
   unsigned int m_uiBytesPerFrame;
   unsigned int m_uiBytesPerSrcFrame;
-  unsigned int m_uiBitsPerSample;
   unsigned int m_uiChannels;
   unsigned int m_uiAvgBytesPerSec;
   unsigned int m_uiSpeakerMask;
@@ -105,6 +104,20 @@ private:
 
   CPCMAmplifier m_pcmAmplifier;
   CCriticalSection m_critSection;
+
+  // Initialization parameters
+  bool              m_Initialized;
+  IAudioCallback*   m_pCallback;
+  CStdString        m_device;
+  int               m_iChannels;
+  enum PCMChannels *m_channelMap;
+  unsigned int      m_uiSamplesPerSec;
+  unsigned int      m_uiBitsPerSample;
+  bool              m_bResample;
+  bool              m_bIsMusic;
+  EEncoded          m_bAudioPassthrough;
+
+
 };
 
 #endif //__WIN32WASAPI_H__


### PR DESCRIPTION
This is an attempt to fix http://forum.xbmc.org/showthread.php?t=121689

The error code returned by WASAPI is clear, so chances are pretty good this fix works (ie release the device interfaces and recreate them later)

Unfortunately I am unable to repro the issue, and don't receive the error code when unplugging outputs or changing device parameters while paused.
