### PR TITLE
linux: disable gui sounds before starting player

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3804,7 +3804,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
 
   // Workaround for bug/quirk in SDL_Mixer on OSX.
   // TODO: Remove after GUI Sounds redux
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(_LINUX)
   g_audioManager.Enable(false);
 #endif
 
@@ -3868,7 +3868,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
     }
 #endif
 
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(_LINUX)
     g_audioManager.Enable(false);
 #endif
   }


### PR DESCRIPTION
fixes audio pass through problems like "device busy" on Linux.

@elupus
newphreak has tested this and it resolves his issues. To be honest, I don't know exactly what has been the problem, just tried the same solution which has been done for Apple. Seems to work.
