### PR TITLE
Add dates to files and directories listed from an HTTP source

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1286,3 +1286,15 @@ CStdString CDateTime::GetAsRFC1123DateTime() const
   result.Format("%s, %02i %s %04i %02i:%02i:%02i GMT", DAY_NAMES[time.GetDayOfWeek()], time.GetDay(), MONTH_NAMES[time.GetMonth()-1], time.GetYear(), time.GetHour(), time.GetMinute(), time.GetSecond());
   return result;
 }
+
+int CDateTime::MonthStringToMonthNum(const CStdString& month)
+{
+  const char* months[] = {"january","february","march","april","may","june","july","august","september","october","november","december"};
+  const char* abr_months[] = {"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"};
+
+  int i = 0;
+  for (; i < 12 && month.CompareNoCase(months[i]) != 0 && month.CompareNoCase(abr_months[i]) != 0; i++);
+  i++;
+
+  return i;
+}

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -99,6 +99,7 @@ public:
 
   static CDateTime GetCurrentDateTime();
   static CDateTime GetUTCDateTime();
+  static int MonthStringToMonthNum(const CStdString& month);
 
   const CDateTime& operator =(const SYSTEMTIME& right);
   const CDateTime& operator =(const FILETIME& right);


### PR DESCRIPTION
This commit adds dates to directories and files listed from an HTTP
source and thus enables the user to sort them by date. It has been made
with Apache and Nginx autoindex modules in mind. There's also a small
change that enables XBMC to read the filesize from Nginx as well.
