### PR TITLE
[ios] - release mouse exclusive mode on ACTION_GESTURE_BEGIN - this fixe...

### DIFF
--- a/xbmc/input/InertialScrollingHandler.cpp
+++ b/xbmc/input/InertialScrollingHandler.cpp
@@ -75,6 +75,11 @@ bool CInertialScrollingHandler::CheckForInertialScrolling(const CAction* action)
   //on begin/tap stop all inertial scrolling
   if ( action->GetID() == ACTION_GESTURE_BEGIN )
   {
+    //release any former exclusive mouse mode
+    //for making switching between multiple lists
+    //possible
+    CGUIMessage message(GUI_MSG_EXCLUSIVE_MOUSE, 0, 0);
+    g_windowManager.SendMessage(message);     
     m_bScrolling = false;
     //wakeup screensaver on pan begin
     g_application.ResetScreenSaver();    


### PR DESCRIPTION
...s usage of multiple lists. When inertial scrolling was running the focus was fixed on the scrolling control because of mouse exclusive mode release happend after inertial scrolling end and not on new pan begin.

jmarshallnz any comments? (testbuild sent to JezzX)
