### PR TITLE
[AirPlay] - fix - don't set user-agent for m3u8 urls. Demuxer can't be c...

### DIFF
--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -25,6 +25,7 @@
 #include <arpa/inet.h>
 #include "DllLibPlist.h"
 #include "utils/log.h"
+#include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 #include "threads/SingleLock.h"
 #include "filesystem/File.h"
@@ -790,7 +791,11 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
 
     if (status != AIRPLAY_STATUS_NEED_AUTH)
     {
-      CFileItem fileToPlay(location + "|User-Agent=AppleCoreMedia/1.0.0.8F455 (Apple†TV; U; CPU OS 4_3 like Mac OS X; de_de)", false);
+      CStdString userAgent="AppleCoreMedia/1.0.0.8F455 (AppleTV; U; CPU OS 4_3 like Mac OS X; de_de)";
+      CURL::Encode(userAgent);
+      location += "|User-Agent=" + userAgent;
+
+      CFileItem fileToPlay(location, false);
       fileToPlay.SetProperty("StartPercent", position*100.0f);
       g_application.getApplicationMessenger().MediaPlay(fileToPlay);
       ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_PLAYING);


### PR DESCRIPTION
...reated in this special situation. (curl problem?).

This fixes a airplay regression introduced in b2. When using AIrPlayServer app with live conversion it sends us a http url like:

http://172.22.26.3:45631/live-playback-2.4.0/index_2ead02b4-ae40-48cd-894e-633b77d40b82.m3u8

AirplayServer trys to play it in XBMC with user-agent added:

http://172.22.26.3:45631/live-playback-2.4.0/index_2ead02b4-ae40-48cd-894e-633b77d40b82.m3u8|User-Agent=AppleCoreMedia/1.0.0.8F455 (AppleTV; U; CPU OS 4_3 like Mac OS X; de_de)

Playback bumps out with:

22:39:43 T:2953850880   ERROR: OpenDemuxStream - Error creating demuxer

Without useragent it works. 

CptSpiff maybe you have any idea what might be wrong? 

I've tried with command line curl with and without set useragent - i allways got the m3u8 - i tried with the file url inside of the m3u8 and on commadnline i also allways got the movie data. Its just not working in XBMC.
