### PR TITLE
changed: Save (video) file state on shutdown

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3326,6 +3326,8 @@ void CApplication::Stop(int exitCode)
     CVariant vExitCode(exitCode);
     CAnnouncementManager::Announce(System, "xbmc", "OnQuit", vExitCode);
 
+    SaveFileState(true);
+
     // cancel any jobs from the jobmanager
     CJobManager::GetInstance().CancelJobs();
 
@@ -4234,14 +4236,27 @@ bool CApplication::IsFullScreen()
          g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW;
 }
 
-void CApplication::SaveFileState()
+void CApplication::SaveFileState(bool bForeground /* = false */)
 {
   if (!g_settings.GetCurrentProfile().canWriteDatabases())
     return;
-  CJob* job = new CSaveFileStateJob(*m_progressTrackingItem,
-      m_progressTrackingVideoResumeBookmark,
-      m_progressTrackingPlayCountUpdate);
-  CJobManager::GetInstance().AddJob(job, NULL);
+
+  if (bForeground)
+  {
+    CSaveFileStateJob job(*m_progressTrackingItem,
+    m_progressTrackingVideoResumeBookmark,
+    m_progressTrackingPlayCountUpdate);
+
+    // Run job in the foreground to make sure it finishes
+    job.DoWork();
+  }
+  else
+  {
+    CJob* job = new CSaveFileStateJob(*m_progressTrackingItem,
+        m_progressTrackingVideoResumeBookmark,
+        m_progressTrackingPlayCountUpdate);
+    CJobManager::GetInstance().AddJob(job, NULL);
+  }
 }
 
 void CApplication::UpdateFileState()

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -151,7 +151,7 @@ public:
   bool PlayMediaSync(const CFileItem& item, int iPlaylist = PLAYLIST_MUSIC);
   bool ProcessAndStartPlaylist(const CStdString& strPlayList, PLAYLIST::CPlayList& playlist, int iPlaylist, int track=0);
   bool PlayFile(const CFileItem& item, bool bRestart = false);
-  void SaveFileState();
+  void SaveFileState(bool bForeground = false);
   void UpdateFileState();
   void StopPlaying();
   void Restart(bool bSamePosition = true);

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -193,6 +193,7 @@ void CPowerManager::OnSleep()
   CBuiltins::Execute("LIRC.Stop");
 #endif
 
+  g_application.SaveFileState(true);
   g_application.StopPlaying();
   g_application.StopShutdownTimer();
   g_application.StopScreenSaverTimer();


### PR DESCRIPTION
Currently the (video) file state is not saved when one shuts down XBMC. This is unfortunate when you forgot something was eg. paused and you already turned off your TV. This fixes it. With this change we could also consider re-enabling timer shutdown for paused videos (?)
