### PR TITLE
[windows] Aero + fake fullscreen + adjust refresh rate: display popup on possible video playback stutter

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1359,6 +1359,12 @@
   <string id="14095">Power saving</string>
   <string id="14099">Eject disc when CD ripping is complete</string>
 
+  <string id="14100">Disable adjust display refresh rate?</string>
+  <string id="14101">Enable true fullscreen mode?</string>
+  <string id="14102">Adjust display refresh rate to match video in</string>
+  <string id="14103">fullscreen window mode can result in stuttering</string>
+  <string id="14104">video playback.</string>
+
   <string id="15015">Remove</string>
   <string id="15016">Games</string>
 

--- a/language/Hungarian/strings.xml
+++ b/language/Hungarian/strings.xml
@@ -1383,6 +1383,12 @@
   <string id="14094">Beviteli-eszközök</string>
   <string id="14095">Energiakezelés</string>
 
+  <string id="14100">Képfrissítés igazítás kikapcsolása?</string>
+  <string id="14101">Teljesképernyős-mód engedélyezése?</string>
+  <string id="14102">A képfrissítésfrekvencia igazítása a film-képkocka-</string>
+  <string id="14103">sebességhez opció használata maximált ablak</string>
+  <string id="14104">módban akadozó filmlejátszást okozhat.</string>
+
   <string id="15015">Törlés</string>
   <string id="15016">Játékok</string>
 

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -97,6 +97,7 @@
 #ifdef _WIN32
 #include "WIN32Util.h"
 #include "cores/AudioRenderers/AudioRendererFactory.h"
+#include "utils/SystemInfo.h"
 #endif
 #include <map>
 #include "Settings.h"
@@ -1446,7 +1447,29 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
   {
     if (g_graphicsContext.IsFullScreenRoot())
       g_graphicsContext.SetVideoResolution(g_graphicsContext.GetVideoResolution(), true);
+#ifdef _WIN32
+    // aero with fake fullscreen and adjust refresh rate is know to cause stutter for a lot of users; offer to disable auto refresh rate
+    if (g_guiSettings.GetBool("videoscreen.fakefullscreen") && g_guiSettings.GetBool("videoplayer.adjustrefreshrate") && !(g_sysinfo.IsAeroDisabled()))
+    {
+      if (CGUIDialogYesNo::ShowAndGetInput(14100, 14102, 14103, 14104))
+        g_guiSettings.SetBool("videoplayer.adjustrefreshrate", false);
+    }
+#endif
   }
+#ifdef _WIN32
+  else if (strSetting.Equals("videoplayer.adjustrefreshrate"))
+  {
+    if (g_guiSettings.GetBool("videoscreen.fakefullscreen") && g_guiSettings.GetBool("videoplayer.adjustrefreshrate") && !(g_sysinfo.IsAeroDisabled()))
+    {
+      if (CGUIDialogYesNo::ShowAndGetInput(14101, 14102, 14103, 14104))
+      {
+        g_guiSettings.SetBool("videoscreen.fakefullscreen", false);
+        if (g_graphicsContext.IsFullScreenRoot())
+          g_graphicsContext.SetVideoResolution(g_graphicsContext.GetVideoResolution(), true);
+      }
+    }
+  }
+#endif
   else if (strSetting.Equals("locale.language"))
   { // new language chosen...
     CSettingString *pSettingString = (CSettingString *)pSettingControl->GetSetting();


### PR DESCRIPTION
Not for Eden. :)

This PR is a small usability addition. Combining fake fullscreen and adjust refresh rate is known to cause video playback stutter with Aero enabled and the only reliable solution at hand is to use true fullscreen mode.

The PR adds a popup about the issue and offers the user to change the conflicting option comfortably. The combination of aero and adjust refresh rate stutter is a common reappearing problem in the Windows forum section.
