### PR TITLE
ignore various na values in wu data. fixes #12740

### DIFF
--- a/addons/weather.wunderground/addon.xml
+++ b/addons/weather.wunderground/addon.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.wunderground" name="Weather Underground" version="0.0.5" provider-name="Team XBMC">
+<addon id="weather.wunderground" name="Weather Underground" version="0.0.6" provider-name="Team XBMC">
 	<requires>
 		<import addon="xbmc.python" version="2.0"/>
 		<import addon="script.module.simplejson" version="2.0.10"/>

--- a/addons/weather.wunderground/changelog.txt
+++ b/addons/weather.wunderground/changelog.txt
@@ -1,3 +1,7 @@
+v0.0.6
+- ignore various n/a values in wu data
+- use kph value for windspeed
+
 v0.0.5
 - add geoip support
 - fetch 7 day forecast

--- a/addons/weather.wunderground/default.py
+++ b/addons/weather.wunderground/default.py
@@ -68,7 +68,8 @@ def fetch(url):
     except:
         json_string = ''
     try:
-        parsed_json = simplejson.loads(json_string)
+        json_clean = json_string.replace('"-9999.00"','""').replace('"-9998"','""').replace('"NA"','""')
+        parsed_json = simplejson.loads(json_clean)
     except:
         parsed_json = ''
     return parsed_json
@@ -103,7 +104,7 @@ def properties(query):
     weathercode = WEATHER_CODES[query['current_observation']['icon_url'][31:-4]]
     set_property('Current.Condition'     , query['current_observation']['weather'])
     set_property('Current.Temperature'   , str(query['current_observation']['temp_c']))
-    set_property('Current.Wind'          , str(int(query['current_observation']['wind_mph'] * 1.609344)))
+    set_property('Current.Wind'          , str(query['current_observation']['wind_kph']))
     set_property('Current.WindDirection' , query['current_observation']['wind_dir'])
     set_property('Current.Humidity'      , query['current_observation']['relative_humidity'].rstrip('%'))
     set_property('Current.FeelsLike'     , str((int(query['hourly_forecast'][0]['feelslike']['english'])-32)*5/9))


### PR DESCRIPTION
weather underground uses -9999.00 / -9998.00 / NA values in case some weather data is unavailable.
we shouldn't pass these values as-is to xbmc, instead pass empty values.
