### PR TITLE
fix import error loading weather underground on Windows with with non/extended-ascii profile paths

### DIFF
--- a/addons/weather.wunderground/addon.xml
+++ b/addons/weather.wunderground/addon.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="weather.wunderground" name="Weather Underground" version="0.0.6" provider-name="Team XBMC">
+<addon id="weather.wunderground" name="Weather Underground" version="0.0.7" provider-name="Team XBMC">
 	<requires>
 		<import addon="xbmc.python" version="2.0"/>
 		<import addon="script.module.simplejson" version="2.0.10"/>

--- a/addons/weather.wunderground/changelog.txt
+++ b/addons/weather.wunderground/changelog.txt
@@ -1,3 +1,6 @@
+v0.0.7
+- fix: import error on Windows with non/extended-ascii profile paths
+
 v0.0.6
 - ignore various n/a values in wu data
 - use kph value for windspeed

--- a/addons/weather.wunderground/default.py
+++ b/addons/weather.wunderground/default.py
@@ -20,7 +20,7 @@ import xbmcgui, xbmcaddon
 __addon__      = xbmcaddon.Addon()
 __provider__   = __addon__.getAddonInfo('name')
 __cwd__        = __addon__.getAddonInfo('path')
-__resource__   = xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib'))
+__resource__   = xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib')).decode("utf-8")
 
 sys.path.append (__resource__)
 


### PR DESCRIPTION
fixed: import error loading weather underground on windows with non/extended-ascii profile paths like G:\XBMC\íö Decode utf-8 returnvalue of translatePath to internal encoding before appending it to the system path.
