### PR TITLE
Fix deinterlacing occurring when renderer really just wants progressive ...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -951,6 +951,9 @@ CProcessor::CProcessor()
   m_context = NULL;
   m_index = 0;
   m_progressive = true;
+
+  m_deinterlace_mode = VS_DEINTERLACEMODE_OFF;
+  m_interlace_method = VS_INTERLACEMETHOD_NONE;
 }
 
 CProcessor::~CProcessor()
@@ -1409,12 +1412,17 @@ bool CProcessor::Render(CRect src, CRect dst, IDirect3DSurface9* target, REFEREN
 {
   CSingleLock lock(m_section);
 
+  // get the current renderer-determined deinterlace mode
+  EDEINTERLACEMODE mode = g_settings.m_currentVideoSettings.m_DeinterlaceMode;
+  if (!g_advancedSettings.m_DXVADeinterlaceProcessorAlwaysOnForAutoMode)
+    mode = (flags & RENDER_FLAG_FIELD0 || flags & RENDER_FLAG_FIELD1) ? VS_DEINTERLACEMODE_FORCE : VS_DEINTERLACEMODE_OFF;
+
   EINTERLACEMETHOD method = g_renderManager.AutoInterlaceMethod(g_settings.m_currentVideoSettings.m_InterlaceMethod);
   if(m_interlace_method != method
-  || m_deinterlace_mode != g_settings.m_currentVideoSettings.m_DeinterlaceMode
+  || m_deinterlace_mode != mode
   || !m_process)
   {
-    m_deinterlace_mode = g_settings.m_currentVideoSettings.m_DeinterlaceMode;
+    m_deinterlace_mode = mode;
     m_interlace_method = method;
 
     if (!OpenProcessor())

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -99,6 +99,7 @@ void CAdvancedSettings::Initialize()
   m_DXVACheckCompatibility = false;
   m_DXVACheckCompatibilityPresent = false;
   m_DXVAForceProcessorRenderer = true;
+  m_DXVADeinterlaceProcessorAlwaysOnForAutoMode = true;
   m_videoFpsDetect = 1;
   m_videoDefaultLatency = 0.0;
 
@@ -539,6 +540,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     m_DXVACheckCompatibilityPresent = XMLUtils::GetBoolean(pElement,"checkdxvacompatibility", m_DXVACheckCompatibility);
 
     XMLUtils::GetBoolean(pElement,"forcedxvarenderer", m_DXVAForceProcessorRenderer);
+    XMLUtils::GetBoolean(pElement,"dxvadeinterlaceprocessoralwaysonforautomode", m_DXVADeinterlaceProcessorAlwaysOnForAutoMode);
     //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
     XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -141,6 +141,7 @@ class CAdvancedSettings
     bool m_DXVACheckCompatibility;
     bool m_DXVACheckCompatibilityPresent;
     bool m_DXVAForceProcessorRenderer;
+    bool m_DXVADeinterlaceProcessorAlwaysOnForAutoMode;
     int  m_videoFpsDetect;
 
     CStdString m_videoDefaultPlayer;


### PR DESCRIPTION
...outputFix deinterlacing occurring when renderer really just wants progressive output

This is an attempt at fixing http://trac.xbmc.org/ticket/12726

The problem: DXVA deinterlacing happens all the time when deinterlace mode is Auto. Even if the rendermanager correctly decides to output "progressively", DXVA processor still goes for Bob. This can cause bad presentation performance on some GPUs (ticket reported AMD E350 / Radeon).

The solution: correctly interpret Auto as either ON or OFF, based on what the RenderManager is driving.
The logic is that if the RenderManager is outputting "PresentBob", the deinterlace mode should be considered "ON" while in any other case it should be considered "OFF". 

This immediately helps with the fact that at the DXVA processor level we don't really know what "auto" means for the deinterlace mode. Since the rendermanager knows, we just ask the rendermanager.
