### PR TITLE
Nvidia settings fix

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -191,11 +191,9 @@ bool CDVDPlayerVideo::OpenStream( CDVDStreamInfo &hint )
     return false;
   }
 
-  if(g_guiSettings.GetBool("videoplayer.usedisplayasclock") && g_VideoReferenceClock.ThreadHandle() == NULL)
+  if(g_guiSettings.GetBool("videoplayer.usedisplayasclock"))
   {
-    g_VideoReferenceClock.Create();
-    //we have to wait for the clock to start otherwise alsa can cause trouble
-    if (!g_VideoReferenceClock.WaitStarted(2000))
+    if (!g_VideoReferenceClock.Start())
       CLog::Log(LOGDEBUG, "g_VideoReferenceClock didn't start in time");
   }
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -157,7 +157,9 @@ CDVDPlayerVideo::~CDVDPlayerVideo()
 {
   StopThread();
   g_dvdPerformanceCounter.DisableVideoQueue();
-  g_VideoReferenceClock.StopThread();
+
+  //don't wait on g_VideoReferenceClock to stop, since it might be waiting on the application messenger
+  g_VideoReferenceClock.StopThread(false);
 }
 
 double CDVDPlayerVideo::GetOutputDelay()

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -442,7 +442,7 @@ bool CVideoReferenceClock::ParseNvSettings(int& RefreshRate)
 
   now = CurrentHostCounter();
   buffpos = 0;
-  while (CurrentHostCounter() - now < CurrentHostFrequency() * 5)
+  while (CurrentHostCounter() - now < CurrentHostFrequency() * 30)
   {
     fd_set set;
     FD_ZERO(&set);

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -123,6 +123,21 @@ CVideoReferenceClock::CVideoReferenceClock()
 #endif
 }
 
+bool CVideoReferenceClock::Start()
+{
+  if (ThreadHandle() && m_bStop)
+    StopThread(); //thread is busy stopping, wait for it to stop
+
+  if (ThreadHandle() == NULL)
+  {
+    Create();
+    //not waiting here can cause issues with alsa
+    return m_Started.WaitMSec(2000);
+  }
+  
+  return true;
+}
+
 void CVideoReferenceClock::Process()
 {
   bool SetupSuccess = false;
@@ -204,12 +219,6 @@ void CVideoReferenceClock::Process()
 #if defined(_WIN32) && defined(HAS_DX)
   g_Windowing.Unregister(&m_D3dCallback);
 #endif
-}
-
-bool CVideoReferenceClock::WaitStarted(int MSecs)
-{
-  //not waiting here can cause issues with alsa
-  return m_Started.WaitMSec(MSecs);
 }
 
 #if defined(HAS_GLX) && defined(HAS_XRANDR)

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -109,6 +109,7 @@ class CVideoReferenceClock : public CThread
     bool SetupGLX();
     void RunGLX();
     void CleanupGLX();
+    static void NvSettingsCallback(void* ptr);
     bool ParseNvSettings(int& RefreshRate);
     int  GetRandRRate();
 

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -60,13 +60,14 @@ class CVideoReferenceClock : public CThread
   public:
     CVideoReferenceClock();
 
+    bool    Start();
+
     int64_t GetTime(bool interpolated = true);
     int64_t GetFrequency();
     void    SetSpeed(double Speed);
     double  GetSpeed();
     int     GetRefreshRate(double* interval = NULL);
     int64_t Wait(int64_t Target);
-    bool    WaitStarted(int MSecs);
     bool    GetClockInfo(int& MissedVblanks, double& ClockSpeed, int& RefreshRate);
     void    SetFineAdjust(double fineadjust);
     void    RefreshChanged() { m_RefreshChanged = 1; }


### PR DESCRIPTION
In the 295 series drivers, Nvidia has introduced a bug in their libGL where if you call popen(), the child process may hang.
This patch works around that by opening nvidia-settings from the main thread.

I'm wondering if we should put this in master, or if we should wait for nvidia to fix their libGL.
