### PR TITLE
[WIN32] play wma audio with native windows codec

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1111,6 +1111,7 @@
     <ClCompile Include="..\..\xbmc\win32\WIN32Util.cpp" />
     <ClCompile Include="..\..\xbmc\win32\WINDirectSound.cpp" />
     <ClCompile Include="..\..\xbmc\win32\WindowHelper.cpp" />
+    <ClCompile Include="..\..\xbmc\win32\XBMCistream.cpp" />
     <ClCompile Include="..\..\xbmc\win32\XBMC_PC.cpp" />
     <ClCompile Include="..\..\xbmc\cores\DummyVideoPlayer.cpp" />
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDAudio.cpp" />
@@ -1917,6 +1918,7 @@
     <ClInclude Include="..\..\xbmc\ViewState.h" />
     <ClInclude Include="..\..\xbmc\win32\pch.h" />
     <ClInclude Include="..\..\xbmc\win32\PlatformDefs.h" />
+    <ClInclude Include="..\..\xbmc\win32\XBMCistream.h" />
     <ClInclude Include="..\..\xbmc\XBDateTime.h" />
     <CustomBuild Include="..\..\xbmc\win32\PlatformInclude.h">
       <Command Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">update_git_rev.bat</Command>

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -171,7 +171,7 @@
       <IgnoreSpecificDefaultLibraries>libc;msvcrt;libcmt;msvcrtd;msvcprtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
-      <DelayLoadDLLs>dnssd.dll;dwmapi.dll;libmicrohttpd-5.dll;ssh.dll;sqlite3.dll;libsamplerate-0.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>Wmvcore.dll;dnssd.dll;dwmapi.dll;libmicrohttpd-5.dll;ssh.dll;sqlite3.dll;libsamplerate-0.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)XBMC.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
@@ -305,6 +305,7 @@
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDInputStreams\DVDInputStreamBluray.cpp" />
     <ClCompile Include="..\..\xbmc\cores\paplayer\BXAcodec.cpp" />
     <ClCompile Include="..\..\xbmc\cores\paplayer\PCMCodec.cpp" />
+    <ClCompile Include="..\..\xbmc\cores\paplayer\windows\WMAcodec.cpp" />
     <ClCompile Include="..\..\xbmc\cores\VideoRenderers\RenderCapture.cpp" />
     <ClCompile Include="..\..\xbmc\cores\VideoRenderers\VideoShaders\WinVideoFilter.cpp" />
     <ClCompile Include="..\..\xbmc\CueDocument.cpp" />
@@ -881,6 +882,7 @@
     <ClCompile Include="..\..\xbmc\threads\LockFree.cpp" />
     <ClCompile Include="..\..\xbmc\threads\platform\Implementation.cpp" />
     <ClInclude Include="..\..\xbmc\cores\AudioRenderers\IAudioRenderer.h" />
+    <ClInclude Include="..\..\xbmc\cores\paplayer\windows\WMAcodec.h" />
     <ClInclude Include="..\..\xbmc\cores\paplayer\PCMCodec.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINFileSMB.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINSMBDirectory.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -250,6 +250,9 @@
     <Filter Include="peripherals\dialogs">
       <UniqueIdentifier>{9571e2bc-891d-4496-bcba-2ec3eed45704}</UniqueIdentifier>
     </Filter>
+    <Filter Include="cores\paplayer\windows">
+      <UniqueIdentifier>{62ff8f5d-67f5-49e5-82a5-3d3ab28d055f}</UniqueIdentifier>
+    </Filter>
     <Filter Include="network\websocket">
       <UniqueIdentifier>{88e84682-dede-4bdf-9e33-a8023dd5ac78}</UniqueIdentifier>
     </Filter>
@@ -2313,6 +2316,9 @@
     <ClCompile Include="..\..\xbmc\cores\paplayer\PCMCodec.cpp">
       <Filter>cores\paplayer</Filter>
 	</ClCompile>
+    <ClCompile Include="..\..\xbmc\cores\paplayer\windows\WMAcodec.cpp">
+      <Filter>cores\paplayer\windows</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\filesystem\AFPDirectory.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
@@ -5247,6 +5253,9 @@
       <Filter>filesystem</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\AudioRenderers\IAudioRenderer.h" />
+    <ClInclude Include="..\..\xbmc\cores\paplayer\windows\WMAcodec.h">
+      <Filter>cores\paplayer\windows</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pythreadstate.h">
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClInclude>

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2319,6 +2319,9 @@
     <ClCompile Include="..\..\xbmc\cores\paplayer\windows\WMAcodec.cpp">
       <Filter>cores\paplayer\windows</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\win32\XBMCistream.cpp">
+      <Filter>win32</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\filesystem\AFPDirectory.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
@@ -5255,6 +5258,9 @@
     <ClInclude Include="..\..\xbmc\cores\AudioRenderers\IAudioRenderer.h" />
     <ClInclude Include="..\..\xbmc\cores\paplayer\windows\WMAcodec.h">
       <Filter>cores\paplayer\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\win32\XBMCistream.h">
+      <Filter>win32</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pythreadstate.h">
       <Filter>interfaces\python\xbmcmodule</Filter>

--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -142,7 +142,11 @@ ICodec* CodecFactory::CreateCodecDemux(const CStdString& strFile, const CStdStri
     return pCodec;
   }
   else if( strContent.Equals("audio/x-ms-wma") )
+#ifdef TARGET_WINDOWS
+    return new WMAcodec();
+#else
     return new DVDPlayerCodec();
+#endif
   else if( strContent.Equals("application/ogg") || strContent.Equals("audio/ogg"))
     return CreateOGGCodec(strFile,filecache);
   else if (strContent.Equals("audio/x-xbmc-pcm"))

--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -101,10 +101,11 @@ ICodec* CodecFactory::CreateCodec(const CStdString& strFileType)
     return new YMCodec();
   else if (strFileType.Equals("wma"))
 #ifdef TARGET_WINDOWS
-    return new WMAcodec();
-#else
-    return new DVDPlayerCodec();
+    if(WMAcodec::IsWMAavailable())
+      return new WMAcodec();
+    else
 #endif
+    return new DVDPlayerCodec();
   else if (strFileType.Equals("aiff") || strFileType.Equals("aif"))
     return new DVDPlayerCodec();
   else if (strFileType.Equals("xwav"))
@@ -143,10 +144,11 @@ ICodec* CodecFactory::CreateCodecDemux(const CStdString& strFile, const CStdStri
   }
   else if( strContent.Equals("audio/x-ms-wma") )
 #ifdef TARGET_WINDOWS
-    return new WMAcodec();
-#else
-    return new DVDPlayerCodec();
+    if(WMAcodec::IsWMAavailable())
+      return new WMAcodec();
+    else
 #endif
+    return new DVDPlayerCodec();
   else if( strContent.Equals("application/ogg") || strContent.Equals("audio/ogg"))
     return CreateOGGCodec(strFile,filecache);
   else if (strContent.Equals("audio/x-xbmc-pcm"))

--- a/xbmc/cores/paplayer/CodecFactory.cpp
+++ b/xbmc/cores/paplayer/CodecFactory.cpp
@@ -41,7 +41,10 @@
 #endif
 #include "URL.h"
 #include "DVDPlayerCodec.h"
-#include "BXAcodec.h" 
+#include "BXAcodec.h"
+#ifdef TARGET_WINDOWS
+#include "windows/WMAcodec.h"
+#endif
 #include "PCMCodec.h"
 
 ICodec* CodecFactory::CreateCodec(const CStdString& strFileType)
@@ -97,7 +100,11 @@ ICodec* CodecFactory::CreateCodec(const CStdString& strFileType)
   else if (strFileType.Equals("ym"))
     return new YMCodec();
   else if (strFileType.Equals("wma"))
+#ifdef TARGET_WINDOWS
+    return new WMAcodec();
+#else
     return new DVDPlayerCodec();
+#endif
   else if (strFileType.Equals("aiff") || strFileType.Equals("aif"))
     return new DVDPlayerCodec();
   else if (strFileType.Equals("xwav"))

--- a/xbmc/cores/paplayer/windows/WMAcodec.cpp
+++ b/xbmc/cores/paplayer/windows/WMAcodec.cpp
@@ -36,7 +36,7 @@ WMAcodec::WMAcodec()
   m_Bitrate = 0;
   m_CodecName = "WMA";
   m_bnomoresamples = false;
-  m_uimaxwritebuffer = 0;
+  m_dmaxwritebuffer = 0;
   m_pStream   = NULL;
   
   ::CoInitializeEx(NULL, COINIT_MULTITHREADED);
@@ -92,6 +92,8 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
     CLog::Log(LOGERROR,"WMAcodec: error opening file %s!",strFile.c_str());
     return false;
   }
+
+  m_ISyncReader->GetMaxOutputSampleSize(dwStreams, &m_dmaxwritebuffer);
 
   m_ISyncReader->QueryInterface(&wmHeaderInfo);
   wmHeaderInfo->GetAttributeByName(&wmStreamNum, L"Duration", &wmAttrDataType, (BYTE*)&durationInNano, &lengthDataType ) ;
@@ -223,7 +225,7 @@ int WMAcodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
   WORD wStreamNum;
   DWORD dwBufferLength;
 
-  if(!m_bnomoresamples && m_pcmBuffer.getMaxWriteSize() > m_uimaxwritebuffer)
+  if(!m_bnomoresamples && m_pcmBuffer.getMaxWriteSize() > m_dmaxwritebuffer)
   {
     hr = m_ISyncReader->GetNextSample(0,
 		  									&m_pINSSBuffer,
@@ -235,9 +237,6 @@ int WMAcodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
 
     if(hr== NS_E_NO_MORE_SAMPLES)
 		  m_bnomoresamples = true;
-
-    if(m_uimaxwritebuffer == 0)
-      m_pINSSBuffer->GetMaxLength(&m_uimaxwritebuffer);
 
     if(SUCCEEDED(hr))
 	  {

--- a/xbmc/cores/paplayer/windows/WMAcodec.cpp
+++ b/xbmc/cores/paplayer/windows/WMAcodec.cpp
@@ -75,12 +75,16 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
 
   m_pStream = new XBMCistream();
   if(m_pStream == NULL)
+  {
+    DeInit();
     return false;
+  }
 
   hr = m_pStream->Open(strFile);
   if(hr!=S_OK)
   {
     CLog::Log(LOGERROR,"WMAcodec: error opening file %s!",strFile.c_str());
+    DeInit();
     return false;
   }
 
@@ -88,6 +92,7 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
   if(hr!=S_OK)
   {
     CLog::Log(LOGERROR,"WMAcodec: error opening stream.");
+    DeInit();
     return false;
   }
 
@@ -104,6 +109,7 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
   {
     CLog::Log(LOGERROR,"WMAcodec: GetStreamCount failed (hr=0x%08x).", hr );
     SAFE_RELEASE(wmProfile);
+    SAFE_RELEASE(wmHeaderInfo);
     return false;
   }
 
@@ -114,6 +120,7 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
     {
       CLog::Log(LOGERROR,"WMAcodec: GetStream failed (hr=0x%08x).", hr );
       SAFE_RELEASE(wmProfile);
+      SAFE_RELEASE(wmHeaderInfo);
       return false;
     }
 
@@ -121,16 +128,18 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
     if(hr!=S_OK)
     {
       CLog::Log(LOGERROR,"WMAcodec: GetStreamNumber failed (hr=0x%08x).", hr );
-      SAFE_RELEASE(wmProfile);
       SAFE_RELEASE(wmStreamConfig);
+      SAFE_RELEASE(wmProfile);
+      SAFE_RELEASE(wmHeaderInfo);
       return false;
     }
     hr = wmStreamConfig->GetStreamType( &pguidStreamType );
     if(hr!=S_OK)
     {
       CLog::Log(LOGERROR,"WMAcodec: GetStreamNumber failed (hr=0x%08x).", hr );
-      SAFE_RELEASE(wmProfile);
       SAFE_RELEASE(wmStreamConfig);
+      SAFE_RELEASE(wmProfile);
+      SAFE_RELEASE(wmHeaderInfo);
       return false;
     }
     if( WMMEDIATYPE_Audio == pguidStreamType )
@@ -143,7 +152,9 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
 
   if(wAudioStreamNum == -1)
   {
+    SAFE_RELEASE(wmStreamConfig);
     SAFE_RELEASE(wmProfile);
+    SAFE_RELEASE(wmHeaderInfo);
     return false;
   }
 

--- a/xbmc/cores/paplayer/windows/WMAcodec.cpp
+++ b/xbmc/cores/paplayer/windows/WMAcodec.cpp
@@ -38,9 +38,9 @@ WMAcodec::WMAcodec()
   m_bnomoresamples = false;
   m_dmaxwritebuffer = 0;
   m_pStream   = NULL;
-  
+
   ::CoInitializeEx(NULL, COINIT_MULTITHREADED);
-	m_ISyncReader = NULL;
+  m_ISyncReader = NULL;
 }
 
 WMAcodec::~WMAcodec()
@@ -62,13 +62,13 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
   WORD wAudioStreamNum = -1;
   DWORD sizeMediaType;
   DWORD dwStreams = 0;
-  WMT_STREAM_SELECTION	wmtSS = WMT_ON;
+  WMT_STREAM_SELECTION    wmtSS = WMT_ON;
   GUID pguidStreamType;
   WORD wmStreamNum = 0;
 
   hr  = WMCreateSyncReader(NULL, WMT_RIGHT_PLAYBACK, &m_ISyncReader);
-	if(hr!=S_OK)
-	{
+  if(hr!=S_OK)
+  {
     CLog::Log(LOGERROR,"WMAcodec: error creating WMCreateSyncReader");
     return false;
   }
@@ -88,7 +88,7 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
 
   hr = m_ISyncReader->OpenStream(m_pStream);
   if(hr!=S_OK)
-	{
+  {
     CLog::Log(LOGERROR,"WMAcodec: error opening file %s!",strFile.c_str());
     return false;
   }
@@ -96,14 +96,14 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
   m_ISyncReader->GetMaxOutputSampleSize(dwStreams, &m_dmaxwritebuffer);
 
   m_ISyncReader->QueryInterface(&wmHeaderInfo);
-  wmHeaderInfo->GetAttributeByName(&wmStreamNum, L"Duration", &wmAttrDataType, (BYTE*)&durationInNano, &lengthDataType ) ;
+  wmHeaderInfo->GetAttributeByName(&wmStreamNum, L"Duration", &wmAttrDataType, (BYTE*)&durationInNano, &lengthDataType );
   m_TotalTime = (long long)(durationInNano/10000);
 
   m_ISyncReader->QueryInterface(&wmProfile);
 
   hr = wmProfile->GetStreamCount(&dwStreams);
   if(hr!=S_OK)
-	{
+  {
     CLog::Log(LOGERROR,"WMAcodec: GetStreamCount failed (hr=0x%08x).", hr );
     SAFE_RELEASE(wmProfile);
     return false;
@@ -113,7 +113,7 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
   {
     hr = wmProfile->GetStream(i, &wmStreamConfig);
     if(hr!=S_OK)
-	  {
+    {
       CLog::Log(LOGERROR,"WMAcodec: GetStream failed (hr=0x%08x).", hr );
       SAFE_RELEASE(wmProfile);
       return false;
@@ -121,7 +121,7 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
 
     hr = wmStreamConfig->GetStreamNumber( &wmStreamNum );
     if(hr!=S_OK)
-	  {
+    {
       CLog::Log(LOGERROR,"WMAcodec: GetStreamNumber failed (hr=0x%08x).", hr );
       SAFE_RELEASE(wmProfile);
       SAFE_RELEASE(wmStreamConfig);
@@ -129,7 +129,7 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
     }
     hr = wmStreamConfig->GetStreamType( &pguidStreamType );
     if(hr!=S_OK)
-	  {
+    {
       CLog::Log(LOGERROR,"WMAcodec: GetStreamNumber failed (hr=0x%08x).", hr );
       SAFE_RELEASE(wmProfile);
       SAFE_RELEASE(wmStreamConfig);
@@ -152,7 +152,7 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
   m_ISyncReader->SetStreamsSelected(1, &wAudioStreamNum, &wmtSS);
   m_ISyncReader->SetReadStreamSamples(wAudioStreamNum, false);
 
-  
+
   wmStreamConfig->QueryInterface(&wmMediaProperties);
   wmMediaProperties->GetMediaType(NULL, &sizeMediaType);
 
@@ -219,8 +219,8 @@ int WMAcodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
 {
   HRESULT hr;
   QWORD cnsSampleTime = 0;
-	QWORD cnsSampleDuration = 0;
-	DWORD dwFlags = 0;
+  QWORD cnsSampleDuration = 0;
+  DWORD dwFlags = 0;
   DWORD dwOutputNum;
   WORD wStreamNum;
   DWORD dwBufferLength;
@@ -228,30 +228,30 @@ int WMAcodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
   if(!m_bnomoresamples && m_pcmBuffer.getMaxWriteSize() > m_dmaxwritebuffer)
   {
     hr = m_ISyncReader->GetNextSample(0,
-		  									&m_pINSSBuffer,
-			  								&cnsSampleTime,
-				  							&cnsSampleDuration,
-					  						&dwFlags,
-						  					&dwOutputNum,
-							  				&wStreamNum);
+                                      &m_pINSSBuffer,
+                                      &cnsSampleTime,
+                                      &cnsSampleDuration,
+                                      &dwFlags,
+                                      &dwOutputNum,
+                                      &wStreamNum);
 
     if(hr== NS_E_NO_MORE_SAMPLES)
-		  m_bnomoresamples = true;
+      m_bnomoresamples = true;
 
     if(SUCCEEDED(hr))
-	  {
-	    unsigned char *buffer;
-		  m_pINSSBuffer->GetBufferAndLength(&buffer,&dwBufferLength);
+    {
+      unsigned char *buffer;
+      m_pINSSBuffer->GetBufferAndLength(&buffer,&dwBufferLength);
 
       m_pcmBuffer.WriteData((char *)buffer, dwBufferLength);
 
-		  //cleaning up before reading next sample
-		  SAFE_RELEASE(m_pINSSBuffer);
-	  }
+      //cleaning up before reading next sample
+      SAFE_RELEASE(m_pINSSBuffer);
+    }
   }
 
   if ((unsigned int)size < m_pcmBuffer.getMaxReadSize())
-  { 
+  {
     m_pcmBuffer.ReadData((char *)pBuffer, size);
     *actualsize=size;
   }

--- a/xbmc/cores/paplayer/windows/WMAcodec.cpp
+++ b/xbmc/cores/paplayer/windows/WMAcodec.cpp
@@ -1,0 +1,265 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "WMAcodec.h"
+#include "utils/log.h"
+#include "utils/CharsetConverter.h"
+#include "system.h"
+
+#pragma comment(lib, "wmvcore.lib")
+
+#define BUFFER_MAX_WRITE 20000
+#define BUFFER_SIZE 882000 //4*44100*5
+
+WMAcodec::WMAcodec()
+{
+  m_SampleRate = 0;
+  m_Channels = 0;
+  m_BitsPerSample = 0;
+  m_TotalTime=0;
+  m_Bitrate = 0;
+  m_CodecName = "WMA";
+  m_bnomoresamples = false;
+  m_uimaxwritebuffer = 0;
+  
+  ::CoInitializeEx(NULL, COINIT_MULTITHREADED);
+	m_ISyncReader = NULL;
+}
+
+WMAcodec::~WMAcodec()
+{
+  DeInit();
+  ::CoUninitialize();
+}
+
+bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
+{
+  hr  = WMCreateSyncReader(NULL,0,&m_ISyncReader);
+	if(hr!=S_OK)
+	{
+    CLog::Log(LOGERROR,"WMAcodec: error creating WMCreateSyncReader");
+    return false;
+  }
+
+  CStdStringW strWFile;
+  g_charsetConverter.utf8ToW(strFile, strWFile, false);
+
+  hr = m_ISyncReader->Open(strWFile.c_str());
+  if(hr!=S_OK)
+	{
+    CLog::Log(LOGERROR,"WMAcodec: error opening file %s!",strFile.c_str());
+    return false;
+  }
+
+  IWMHeaderInfo* wmHeaderInfo;
+  IWMProfile* wmProfile;
+  IWMStreamConfig* wmStreamConfig;
+  IWMMediaProps* wmMediaProperties;
+  WMT_ATTR_DATATYPE wmAttrDataType;
+  QWORD durationInNano;
+  WORD lengthDataType = sizeof(QWORD);
+  WORD wAudioStreamNum = -1;
+  DWORD sizeMediaType;
+  DWORD dwStreams = 0;
+  WMT_STREAM_SELECTION	wmtSS = WMT_ON;
+  GUID pguidStreamType;
+  WORD wmStreamNum = 0;
+
+  m_ISyncReader->QueryInterface(&wmHeaderInfo);
+  wmHeaderInfo->GetAttributeByName(&wmStreamNum, L"Duration", &wmAttrDataType, (BYTE*)&durationInNano, &lengthDataType ) ;
+  m_TotalTime = (long long)(durationInNano/10000);
+
+  m_ISyncReader->QueryInterface(&wmProfile);
+
+  hr = wmProfile->GetStreamCount(&dwStreams);
+  if(hr!=S_OK)
+	{
+    CLog::Log(LOGERROR,"WMAcodec: GetStreamCount failed (hr=0x%08x).", hr );
+    SAFE_RELEASE(wmProfile);
+    return false;
+  }
+
+  for ( DWORD i = 0; i < dwStreams; i++ )
+  {
+    hr = wmProfile->GetStream(i, &wmStreamConfig);
+    if(hr!=S_OK)
+	  {
+      CLog::Log(LOGERROR,"WMAcodec: GetStream failed (hr=0x%08x).", hr );
+      SAFE_RELEASE(wmProfile);
+      return false;
+    }
+
+    hr = wmStreamConfig->GetStreamNumber( &wmStreamNum );
+    if(hr!=S_OK)
+	  {
+      CLog::Log(LOGERROR,"WMAcodec: GetStreamNumber failed (hr=0x%08x).", hr );
+      SAFE_RELEASE(wmProfile);
+      SAFE_RELEASE(wmStreamConfig);
+      return false;
+    }
+    hr = wmStreamConfig->GetStreamType( &pguidStreamType );
+    if(hr!=S_OK)
+	  {
+      CLog::Log(LOGERROR,"WMAcodec: GetStreamNumber failed (hr=0x%08x).", hr );
+      SAFE_RELEASE(wmProfile);
+      SAFE_RELEASE(wmStreamConfig);
+      return false;
+    }
+    if( WMMEDIATYPE_Audio == pguidStreamType )
+    {
+      wAudioStreamNum = wmStreamNum;
+      break;
+    }
+  }
+
+  if(wAudioStreamNum == -1)
+  {
+    SAFE_RELEASE(wmProfile);
+    SAFE_RELEASE(wmStreamConfig);
+    return false;
+  }
+  
+  wmStreamConfig->QueryInterface(&wmMediaProperties);
+  wmMediaProperties->GetMediaType(NULL, &sizeMediaType);
+
+  WM_MEDIA_TYPE* mediaType = (WM_MEDIA_TYPE*)LocalAlloc(LPTR,sizeMediaType);
+  wmMediaProperties->GetMediaType(mediaType, &sizeMediaType);
+
+  WAVEFORMATEX* inputFormat = (WAVEFORMATEX*)mediaType->pbFormat;
+
+  switch(inputFormat->wFormatTag)
+  {
+  case WAVE_FORMAT_WMAUDIO2:
+    m_CodecName = "WMA2";
+    break;
+  case WAVE_FORMAT_WMAUDIO3:
+    m_CodecName = "WMA3";
+    break;
+  case WAVE_FORMAT_WMAUDIO_LOSSLESS:
+    m_CodecName = "WMA Lossless";
+    break;
+  }
+
+  m_Channels = 2;       //inputFormat->nChannels;
+  m_SampleRate = 44100; //inputFormat->nSamplesPerSec;
+  m_BitsPerSample = 16; //inputFormat->wBitsPerSample;
+
+  if(!m_pcmBuffer.Create(BUFFER_SIZE))
+    return false;
+
+  SAFE_RELEASE(wmMediaProperties);
+  SAFE_RELEASE(wmStreamConfig);
+  SAFE_RELEASE(wmProfile);
+  SAFE_RELEASE(wmHeaderInfo);
+
+  LocalFree(mediaType);
+
+  m_ISyncReader->SetStreamsSelected(1, &wAudioStreamNum, &wmtSS);
+  m_ISyncReader->SetReadStreamSamples(wAudioStreamNum, false);
+
+  return true;
+}
+
+void WMAcodec::DeInit()
+{
+  if(m_ISyncReader != NULL)
+    m_ISyncReader->Close();
+
+  SAFE_RELEASE(m_ISyncReader);
+  m_pcmBuffer.Destroy();
+  m_bnomoresamples = false;
+}
+
+__int64 WMAcodec::Seek(__int64 iSeekTime)
+{
+  m_pcmBuffer.Clear();
+  m_bnomoresamples = false;
+  if(m_ISyncReader->SetRange(iSeekTime*10000,0) == S_OK)
+    return iSeekTime;
+  return 0;
+}
+
+int WMAcodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)
+{
+  QWORD cnsSampleTime = 0;
+	QWORD cnsSampleDuration = 0;
+	DWORD dwFlags = 0;
+  DWORD dwOutputNum;
+  WORD wStreamNum;
+  DWORD dwBufferLength;
+
+
+  if(!m_bnomoresamples && m_pcmBuffer.getMaxWriteSize() > m_uimaxwritebuffer)
+  {
+    hr = m_ISyncReader->GetNextSample(0,
+		  									&m_pINSSBuffer,
+			  								&cnsSampleTime,
+				  							&cnsSampleDuration,
+					  						&dwFlags,
+						  					&dwOutputNum,
+							  				&wStreamNum);
+
+    if(hr== NS_E_NO_MORE_SAMPLES)
+		  m_bnomoresamples = true;
+
+    if(m_uimaxwritebuffer == 0)
+      m_pINSSBuffer->GetMaxLength(&m_uimaxwritebuffer);
+
+    if(SUCCEEDED(hr))
+	  {
+	    unsigned char *buffer;
+		  m_pINSSBuffer->GetBufferAndLength(&buffer,&dwBufferLength);
+
+      m_pcmBuffer.WriteData((char *)buffer, dwBufferLength);
+
+		  //cleaning up before reading next sample
+		  SAFE_RELEASE(m_pINSSBuffer);
+	  }
+  }
+
+  if ((unsigned int)size < m_pcmBuffer.getMaxReadSize())
+  { 
+    m_pcmBuffer.ReadData((char *)pBuffer, size);
+    *actualsize=size;
+  }
+  else
+  {
+    m_pcmBuffer.ReadData((char *)pBuffer, m_pcmBuffer.getMaxReadSize());
+    *actualsize=m_pcmBuffer.getMaxReadSize();
+    if(m_bnomoresamples)
+      return READ_EOF;
+  }
+
+  return READ_SUCCESS;
+}
+
+int WMAcodec::ReadSamples(float *pBuffer, int numsamples, int *actualsamples)
+{
+  int result = ReadPCM((BYTE *)pBuffer, numsamples * sizeof(float), actualsamples);
+  *actualsamples /= sizeof(float);
+  return result;
+}
+
+bool WMAcodec::CanInit()
+{
+  return true;
+}
+

--- a/xbmc/cores/paplayer/windows/WMAcodec.cpp
+++ b/xbmc/cores/paplayer/windows/WMAcodec.cpp
@@ -276,6 +276,6 @@ int WMAcodec::ReadSamples(float *pBuffer, int numsamples, int *actualsamples)
 
 bool WMAcodec::CanInit()
 {
-  return true;
+  return (LoadLibrary("WMVcore.dll") != NULL);
 }
 

--- a/xbmc/cores/paplayer/windows/WMAcodec.cpp
+++ b/xbmc/cores/paplayer/windows/WMAcodec.cpp
@@ -89,7 +89,7 @@ bool WMAcodec::Init(const CStdString &strFile, unsigned int filecache)
   hr = m_ISyncReader->OpenStream(m_pStream);
   if(hr!=S_OK)
   {
-    CLog::Log(LOGERROR,"WMAcodec: error opening file %s!",strFile.c_str());
+    CLog::Log(LOGERROR,"WMAcodec: error opening stream.");
     return false;
   }
 
@@ -274,6 +274,11 @@ int WMAcodec::ReadSamples(float *pBuffer, int numsamples, int *actualsamples)
 }
 
 bool WMAcodec::CanInit()
+{
+  return (LoadLibrary("WMVcore.dll") != NULL);
+}
+
+bool WMAcodec::IsWMAavailable()
 {
   return (LoadLibrary("WMVcore.dll") != NULL);
 }

--- a/xbmc/cores/paplayer/windows/WMAcodec.h
+++ b/xbmc/cores/paplayer/windows/WMAcodec.h
@@ -40,7 +40,6 @@ public:
   virtual bool CanInit();
 
 private:
-  HRESULT hr;
   IWMSyncReader* m_ISyncReader;
   INSSBuffer* m_pINSSBuffer;
   CRingBuffer m_pcmBuffer;

--- a/xbmc/cores/paplayer/windows/WMAcodec.h
+++ b/xbmc/cores/paplayer/windows/WMAcodec.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- *      Copyright (C) 2005-2012 Team XBMC
+ *      Copyright (C) 2012 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -42,7 +42,6 @@ public:
 
 private:
   IWMSyncReader* m_ISyncReader;
-  INSSBuffer* m_pINSSBuffer;
   CRingBuffer m_pcmBuffer;
   bool m_bnomoresamples;
   DWORD m_dmaxwritebuffer;

--- a/xbmc/cores/paplayer/windows/WMAcodec.h
+++ b/xbmc/cores/paplayer/windows/WMAcodec.h
@@ -38,6 +38,7 @@ public:
   virtual int ReadPCM(BYTE *pBuffer, int size, int *actualsize);
   virtual int ReadSamples(float *pBuffer, int numsamples, int *actualsamples);
   virtual bool CanInit();
+  static bool IsWMAavailable();
 
 private:
   IWMSyncReader* m_ISyncReader;

--- a/xbmc/cores/paplayer/windows/WMAcodec.h
+++ b/xbmc/cores/paplayer/windows/WMAcodec.h
@@ -1,0 +1,49 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "../CachingCodec.h"
+#include <wmsdk.h>
+#include "utils/RingBuffer.h"
+
+class WMAcodec : public CachingCodec
+{
+public:
+  WMAcodec();
+  virtual ~WMAcodec();
+
+  virtual bool Init(const CStdString &strFile, unsigned int filecache);
+  virtual void DeInit();
+  virtual __int64 Seek(__int64 iSeekTime);
+  virtual int ReadPCM(BYTE *pBuffer, int size, int *actualsize);
+  virtual int ReadSamples(float *pBuffer, int numsamples, int *actualsamples);
+  virtual bool CanInit();
+
+private:
+  HRESULT hr;
+  IWMSyncReader* m_ISyncReader;
+  INSSBuffer* m_pINSSBuffer;
+  CRingBuffer m_pcmBuffer;
+  bool m_bnomoresamples;
+  DWORD m_uimaxwritebuffer;
+  __int64 m_iDataPos;
+};

--- a/xbmc/cores/paplayer/windows/WMAcodec.h
+++ b/xbmc/cores/paplayer/windows/WMAcodec.h
@@ -24,6 +24,7 @@
 #include "../CachingCodec.h"
 #include <wmsdk.h>
 #include "utils/RingBuffer.h"
+#include "win32/XBMCistream.h"
 
 class WMAcodec : public CachingCodec
 {
@@ -46,4 +47,5 @@ private:
   bool m_bnomoresamples;
   DWORD m_uimaxwritebuffer;
   __int64 m_iDataPos;
+  XBMCistream* m_pStream;
 };

--- a/xbmc/cores/paplayer/windows/WMAcodec.h
+++ b/xbmc/cores/paplayer/windows/WMAcodec.h
@@ -44,7 +44,7 @@ private:
   INSSBuffer* m_pINSSBuffer;
   CRingBuffer m_pcmBuffer;
   bool m_bnomoresamples;
-  DWORD m_uimaxwritebuffer;
+  DWORD m_dmaxwritebuffer;
   __int64 m_iDataPos;
   XBMCistream* m_pStream;
 };

--- a/xbmc/win32/XBMCistream.cpp
+++ b/xbmc/win32/XBMCistream.cpp
@@ -1,0 +1,137 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+#include "XBMCistream.h"
+
+
+XBMCistream::XBMCistream() :
+  m_cRef( 1 )
+{
+}
+
+XBMCistream::~XBMCistream()
+{
+  m_file.Close();
+}
+
+HRESULT STDMETHODCALLTYPE XBMCistream::QueryInterface( REFIID riid, void __RPC_FAR *__RPC_FAR *ppvObject ) 
+{
+  if( ( IID_IStream == riid ) || ( IID_IUnknown == riid ) )
+  {
+    *ppvObject = static_cast< IStream* >( this );
+    AddRef();
+    return( S_OK );
+  }
+
+  *ppvObject = NULL;
+  return( E_NOINTERFACE );
+}
+
+ULONG STDMETHODCALLTYPE XBMCistream::AddRef()
+{
+  return( InterlockedIncrement( &m_cRef ) );
+}
+
+ULONG STDMETHODCALLTYPE XBMCistream::Release()
+{
+  if( 0 == InterlockedDecrement( &m_cRef ) )
+  {
+    delete this;
+    return( 0 );
+  }
+
+  return( m_cRef );
+}
+
+
+HRESULT XBMCistream::Open( LPCTSTR ptszURL )
+{
+  if (!m_file.Open(ptszURL))
+    return E_FAIL;
+
+  return S_OK;
+}
+
+
+HRESULT XBMCistream::Read( void *pv, ULONG cb, ULONG *pcbRead )
+{
+
+  *pcbRead = (ULONG) m_file.Read(pv, cb);
+
+  if(pcbRead <= 0)
+    return E_FAIL;
+
+  return S_OK;
+}
+
+HRESULT XBMCistream::Seek( LARGE_INTEGER dlibMove,
+                         DWORD dwOrigin,
+                         ULARGE_INTEGER *plibNewPosition )
+{
+  int iWhence = 0;
+
+  switch( dwOrigin )
+  {
+      case STREAM_SEEK_SET:
+          iWhence = SEEK_SET;
+          break;
+
+      case STREAM_SEEK_CUR:
+          iWhence = SEEK_CUR;
+          break;
+
+      case STREAM_SEEK_END:
+          iWhence = SEEK_END;
+          break;
+
+      default:
+          return( E_INVALIDARG );
+  };
+
+  int64_t ipos = m_file.Seek(dlibMove.QuadPart, iWhence);
+
+  if(ipos < 0)
+    return E_FAIL;
+
+  if( NULL != plibNewPosition )
+    plibNewPosition->QuadPart = ipos;
+
+  return S_OK;
+}
+
+HRESULT XBMCistream::Stat( STATSTG *pstatstg, DWORD grfStatFlag )
+{
+  if( ( NULL == pstatstg ) || ( STATFLAG_NONAME != grfStatFlag ) )
+  {
+    return( E_INVALIDARG );
+  }
+
+  struct __stat64 buffer;
+
+  if(m_file.Stat(&buffer) == -1)
+    return E_FAIL;
+
+  memset( pstatstg, 0, sizeof( STATSTG ) );
+
+  pstatstg->type = STGTY_STREAM;
+  pstatstg->cbSize.QuadPart = buffer.st_size;
+
+  return S_OK;
+}

--- a/xbmc/win32/XBMCistream.h
+++ b/xbmc/win32/XBMCistream.h
@@ -1,0 +1,95 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+
+#include <objidl.h>
+#include "filesystem/File.h"
+
+class XBMCistream : public IStream
+{
+public:
+
+    XBMCistream();
+    ~XBMCistream();
+
+    //
+    // IUnknown methods
+    //
+    HRESULT STDMETHODCALLTYPE QueryInterface( /* [in] */  REFIID riid,
+                                              /* [out] */ void **ppvObject );
+    ULONG STDMETHODCALLTYPE AddRef();
+    ULONG STDMETHODCALLTYPE Release();
+
+    //
+    // Methods of IStream
+    //
+    HRESULT STDMETHODCALLTYPE Read( void *pv, ULONG cb, ULONG *pcbRead );
+    HRESULT STDMETHODCALLTYPE Seek( LARGE_INTEGER dlibMove, DWORD dwOrigin, ULARGE_INTEGER *plibNewPosition );
+    HRESULT STDMETHODCALLTYPE Stat( STATSTG *pstatstg, DWORD grfStatFlag );
+
+    //
+    // Non-implemented methods of IStream
+    //
+    HRESULT STDMETHODCALLTYPE Write( void const *pv, ULONG cb, ULONG *pcbWritten )
+    {
+        return( E_NOTIMPL );
+    }
+    HRESULT STDMETHODCALLTYPE SetSize( ULARGE_INTEGER libNewSize )
+    {
+        return( E_NOTIMPL );
+    }
+    HRESULT STDMETHODCALLTYPE CopyTo( IStream *pstm, ULARGE_INTEGER cb, ULARGE_INTEGER *pcbRead, ULARGE_INTEGER *pcbWritten )
+    {
+        return( E_NOTIMPL );
+    }
+    HRESULT STDMETHODCALLTYPE Commit( DWORD grfCommitFlags )
+    {
+        return( E_NOTIMPL );
+    }
+    HRESULT STDMETHODCALLTYPE Revert()
+    {
+        return( E_NOTIMPL );
+    }
+    HRESULT STDMETHODCALLTYPE LockRegion( ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, DWORD dwLockType )
+    {
+        return( E_NOTIMPL );
+    }
+    HRESULT STDMETHODCALLTYPE UnlockRegion( ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, DWORD dwLockType )
+    {
+        return( E_NOTIMPL );
+    }
+    HRESULT STDMETHODCALLTYPE Clone( IStream **ppstm )
+    {
+        return( E_NOTIMPL );
+    }
+
+    //
+    // CROStream method
+    //
+    HRESULT Open( /* [in] */ LPCTSTR ptszURL );
+
+protected:
+
+    XFILE::CFile m_file;
+    LONG    m_cRef;
+};


### PR DESCRIPTION
this pull request implements a paplayer codec to play wma audio instead with our dvdplayer (ffmpeg) with the native windows codec. This adds support for wma lossless which doesn't work in the current implementation.

I did this primary for learning reasons as a native wmv codec for dvdplayer would make more sense but I guess it could be a nice addition.

One thing I don't understand is that regardless which file I present to paplayer (16 or 24 bit, 44100Hz vs 48000Hz) I need to supply always 16 bit and 44100Hz in the parameters. Either the isyncreader interface just delivers only this format or I'm doing something wrong for paplayer.
