### PR TITLE
add bd="true" test to playercorefactory

### DIFF
--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -48,6 +48,7 @@ void CPlayerSelectionRule::Initialize(TiXmlElement* pRule)
   m_tAudio = GetTristate(pRule->Attribute("audio"));
   m_tVideo = GetTristate(pRule->Attribute("video"));
 
+  m_tBD = GetTristate(pRule->Attribute("bd"));
   m_tDVD = GetTristate(pRule->Attribute("dvd"));
   m_tDVDFile = GetTristate(pRule->Attribute("dvdfile"));
   m_tDVDImage = GetTristate(pRule->Attribute("dvdimage"));
@@ -111,6 +112,7 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, VECPLAYERCORES &vec
   if (m_tVideo >= 0 && (m_tVideo > 0) != item.IsVideo()) return;
   if (m_tInternetStream >= 0 && (m_tInternetStream > 0) != item.IsInternetStream()) return;
 
+  if (m_tBD >= 0 && (m_tBD > 0) != (item.IsBDFile() && item.IsOnDVD())) return;
   if (m_tDVD >= 0 && (m_tDVD > 0) != item.IsDVD()) return;
   if (m_tDVDFile >= 0 && (m_tDVDFile > 0) != item.IsDVDFile()) return;
   if (m_tDVDImage >= 0 && (m_tDVDImage > 0) != item.IsDVDImage()) return;

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.h
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.h
@@ -49,6 +49,7 @@ private:
   int m_tVideo;
   int m_tInternetStream;
 
+  int m_tBD;
   int m_tDVD;
   int m_tDVDFile;
   int m_tDVDImage;


### PR DESCRIPTION
This PR allows the user to use bd="true" as an attribute in rules in their playercorefactory.xml to match against Blu-ray discs.  
In Dharma it was possible to use protocols="bd", but after changes to Autorun.cpp, that no longer works, despite people in the forums still propagating the idea that it does (and worse besides).  
It's fairly easy to come up with a rule that does work, but using this means that the user wouldn't have to make further changes to their playercorefactory.xml if the way blu-ray discs are handled changes, since those changes can just be incorporated internally into the URIUtils::IsBD function.
