### PR TITLE
remove CSpecialProtocol::ReplaceOldPath

### DIFF
--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -236,24 +236,6 @@ CStdString CSpecialProtocol::TranslatePathConvertCase(const CStdString& path)
 #endif
 }
 
-CStdString CSpecialProtocol::ReplaceOldPath(const CStdString &oldPath, int pathVersion)
-{
-  if (pathVersion < 1)
-  {
-    if (oldPath.Left(2).CompareNoCase("P:") == 0)
-      return URIUtils::AddFileToFolder("special://profile/", oldPath.Mid(2));
-    else if (oldPath.Left(2).CompareNoCase("Q:") == 0)
-      return URIUtils::AddFileToFolder("special://xbmc/", oldPath.Mid(2));
-    else if (oldPath.Left(2).CompareNoCase("T:") == 0)
-      return URIUtils::AddFileToFolder("special://masterprofile/", oldPath.Mid(2));
-    else if (oldPath.Left(2).CompareNoCase("U:") == 0)
-      return URIUtils::AddFileToFolder("special://home/", oldPath.Mid(2));
-    else if (oldPath.Left(2).CompareNoCase("Z:") == 0)
-      return URIUtils::AddFileToFolder("special://temp/", oldPath.Mid(2));
-  }
-  return oldPath;
-}
-
 void CSpecialProtocol::LogPaths()
 {
   CLog::Log(LOGNOTICE, "special://xbmc/ is mapped to: %s", GetPath("xbmc").c_str());

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -68,7 +68,6 @@ public:
   static CStdString TranslatePath(const CStdString &path);
   static CStdString TranslatePath(const CURL &url);
   static CStdString TranslatePathConvertCase(const CStdString& path);
-  static const int path_version = 1;
 
 private:
   static void SetPath(const CStdString &key, const CStdString &path);

--- a/xbmc/filesystem/SpecialProtocol.h
+++ b/xbmc/filesystem/SpecialProtocol.h
@@ -68,7 +68,6 @@ public:
   static CStdString TranslatePath(const CStdString &path);
   static CStdString TranslatePath(const CURL &url);
   static CStdString TranslatePathConvertCase(const CStdString& path);
-  static CStdString ReplaceOldPath(const CStdString &oldPath, int pathVersion);
   static const int path_version = 1;
 
 private:

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -718,9 +718,6 @@ namespace PYXBMC
     if (!PyXBMCGetUnicodeString(strText, pObjectText, 1)) return NULL;
 
     CStdString strPath;
-    if (URIUtils::IsDOSPath(strText))
-      strText = CSpecialProtocol::ReplaceOldPath(strText, 0);
-
     strPath = CSpecialProtocol::TranslatePath(strText);
 
     return Py_BuildValue((char*)"s", strPath.c_str());

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -1258,12 +1258,6 @@ void CGUISettings::LoadFromXML(TiXmlElement *pRootElement, mapIter &it, bool adv
         CStdString strValue = pGrandChild->FirstChild() ? pGrandChild->FirstChild()->Value() : "";
         if (strValue != "-")
         { // update our item
-          if ((*it).second->GetType() == SETTINGS_TYPE_PATH)
-          { // check our path
-            int pathVersion = 0;
-            pGrandChild->Attribute("pathversion", &pathVersion);
-            strValue = CSpecialProtocol::ReplaceOldPath(strValue, pathVersion);
-          }
           (*it).second->FromString(strValue);
           if (advanced)
             (*it).second->SetAdvanced();

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -29,7 +29,6 @@
 #include "LinuxTimezone.h"
 #endif
 #include "Application.h"
-#include "filesystem/SpecialProtocol.h"
 #include "AdvancedSettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
@@ -44,6 +43,7 @@
 #include "guilib/GUIFontManager.h"
 #include "utils/Weather.h"
 #include "LangInfo.h"
+#include "utils/XMLUtils.h"
 #if defined(__APPLE__)
   #include "osx/DarwinUtils.h"
 #endif
@@ -1291,7 +1291,7 @@ void CGUISettings::SaveXML(TiXmlNode *pRootNode)
       { // successfully added (or found) our group
         TiXmlElement newElement(strSplit[1]);
         if ((*it).second->GetType() == SETTINGS_TYPE_PATH)
-          newElement.SetAttribute("pathversion", CSpecialProtocol::path_version);
+          newElement.SetAttribute("pathversion", XMLUtils::path_version);
         TiXmlNode *pNewNode = pChild->InsertEndChild(newElement);
         if (pNewNode)
         {

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -280,10 +280,7 @@ bool CSettings::GetSource(const CStdString &category, const TiXmlNode *source, C
   {
     if (pPathName->FirstChild())
     {
-      int pathVersion = 0;
-      pPathName->Attribute("pathversion", &pathVersion);
       CStdString strPath = pPathName->FirstChild()->Value();
-      strPath = CSpecialProtocol::ReplaceOldPath(strPath, pathVersion);
       // make sure there are no virtualpaths or stack paths defined in xboxmediacenter.xml
       //CLog::Log(LOGDEBUG,"    Found path: %s", strPath.c_str());
       if (!URIUtils::IsStack(strPath))

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -21,7 +21,6 @@
 
 #include "XMLUtils.h"
 #include "URL.h"
-#include "filesystem/SpecialProtocol.h"
 #include "StringUtils.h"
 #ifdef _WIN32
 #include "PlatformDefs.h" //for strcasecmp
@@ -264,7 +263,7 @@ void XMLUtils::SetHex(TiXmlNode* pRootNode, const char *strTag, uint32_t value)
 void XMLUtils::SetPath(TiXmlNode* pRootNode, const char *strTag, const CStdString& strValue)
 {
   TiXmlElement newElement(strTag);
-  newElement.SetAttribute("pathversion", CSpecialProtocol::path_version);
+  newElement.SetAttribute("pathversion", path_version);
   TiXmlNode *pNewNode = pRootNode->InsertEndChild(newElement);
   if (pNewNode)
   {

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -196,8 +196,6 @@ bool XMLUtils::GetPath(const TiXmlNode* pRootNode, const char* strTag, CStdStrin
   const TiXmlElement* pElement = pRootNode->FirstChildElement(strTag);
   if (!pElement) return false;
 
-  int pathVersion = 0;
-  pElement->Attribute("pathversion", &pathVersion);
   const char* encoded = pElement->Attribute("urlencoded");
   const TiXmlNode* pNode = pElement->FirstChild();
   if (pNode != NULL)
@@ -205,7 +203,6 @@ bool XMLUtils::GetPath(const TiXmlNode* pRootNode, const char* strTag, CStdStrin
     strStringValue = pNode->Value();
     if (encoded && strcasecmp(encoded,"yes") == 0)
       CURL::Decode(strStringValue);
-    strStringValue = CSpecialProtocol::ReplaceOldPath(strStringValue, pathVersion);
     return true;
   }
   strStringValue.Empty();

--- a/xbmc/utils/XMLUtils.h
+++ b/xbmc/utils/XMLUtils.h
@@ -66,5 +66,7 @@ public:
   static void SetHex(TiXmlNode* pRootNode, const char *strTag, uint32_t value);
   static void SetPath(TiXmlNode* pRootNode, const char *strTag, const CStdString& strValue);
   static void SetLong(TiXmlNode* pRootNode, const char *strTag, long iValue);
+
+  static const int path_version = 1;
 };
 


### PR DESCRIPTION
In regard to ticket #12237 this causes problems on windows setups with p:, q:, t:, u: or z: drive letters and should be not needed anymore.
Shouldn't harm Linux or OSX as it only replaces dos paths. Just would be nice to know if I just forgot one occurrence of ReplaceIOldPath on Linux or if everything compiles fine.
