### PR TITLE
Translation: Dutch

### DIFF
--- a/language/Dutch/strings.xml
+++ b/language/Dutch/strings.xml
@@ -1003,7 +1003,7 @@
   <string id="13005">Computer uitschakelen</string>
 
   <string id="13008">Standaard afsluitmethode</string>
-  <string id="13009">XBMC afsluiten</string>
+  <string id="13009">Afsluiten</string>
   <string id="13010">Sluimerstand</string>
   <string id="13011">Slaapstand</string>
   <string id="13012">Stoppen</string>


### PR DESCRIPTION
loose the "XBMC" in front of it because the English file hasn't got this either
