### PR TITLE
Fix CrystalHD for Windows

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.cpp
@@ -1240,6 +1240,9 @@ bool CCrystalHD::OpenDecoder(CRYSTALHD_CODEC_TYPE codec_type, CDVDStreamInfo &hi
   {
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, "CrystalHD", g_localizeStrings.Get(2101));
     CLog::Log(LOGWARNING, "CrystalHD drivers too old, please upgrade to 3.6.9 or later.");
+
+    if (codec_type == CRYSTALHD_CODEC_ID_AVC1)
+      return false;
   }
 #endif
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.h
@@ -99,6 +99,46 @@ enum _CRYSTALHD_CODEC_TYPES
 };
 
 typedef uint32_t CRYSTALHD_CODEC_TYPE;
+
+#if (HAVE_LIBCRYSTALHD == 2)
+
+  typedef struct _BC_INFO_CRYSTAL_ {
+	  uint8_t device;
+	  union {
+		  struct {
+			  uint32_t dilRelease:8;
+			  uint32_t dilMajor:8;
+			  uint32_t dilMinor:16;
+		  };
+		  uint32_t version;
+	  } dilVersion;
+
+	  union {
+		  struct {
+			  uint32_t drvRelease:4;
+			  uint32_t drvMajor:8;
+			  uint32_t drvMinor:12;
+			  uint32_t drvBuild:8;
+		  };
+		  uint32_t version;
+	  } drvVersion;
+
+	  union {
+		  struct {
+			  uint32_t fwRelease:4;
+			  uint32_t fwMajor:8;
+			  uint32_t fwMinor:12;
+			  uint32_t fwBuild:8;
+		  };
+		  uint32_t version;
+	  } fwVersion;
+
+	  uint32_t Reserved1; // For future expansion
+	  uint32_t Reserved2; // For future expansion
+  } BC_INFO_CRYSTAL, *PBC_INFO_CRYSTAL;
+
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////////////////
 
 #define CRYSTALHD_FIELD_FULL        0x00
@@ -163,6 +203,9 @@ protected:
 
   CMPCOutputThread *m_pOutputThread;
   CSyncPtrQueue<CPictureBuffer> m_BusyList;
+#if (HAVE_LIBCRYSTALHD == 2)
+  BC_INFO_CRYSTAL m_bc_info_crystal;
+#endif
 
 private:
   CCrystalHD();


### PR DESCRIPTION
XBMC CHD code requires windows driver version 3.6.9 or better for AVC1 material. On IRC the agreed solution is to nag the user to update the driver, instead of working around the situation and engaging the bitstream conversion.

This PR displays a toast at the beginning of playback of all video + adds a line to the log. It's a bit obnoxious and could be restricted to pop up only for AVC1 videos.

Since bc_dts_defs.h is not included in CrystalHD.h, I had to do a silly copy/paste for the CHD version structure.

@davilla, I'm especially looking for your feedback.
