### PR TITLE
Windows: fix a couple device notifications issues

### DIFF
--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -383,6 +383,8 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     case WM_CLOSE:
     case WM_QUIT:
     case WM_DESTROY:
+      if (hDeviceNotify)
+        UnregisterDeviceNotification(hDeviceNotify);
       newEvent.type = XBMC_QUIT;
       m_pEventFunc(newEvent);
       break;

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -678,6 +678,8 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       break;
     case WM_DEVICECHANGE:
       {
+        if (((_DEV_BROADCAST_HEADER*) lParam)->dbcd_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+        {
         PDEV_BROADCAST_DEVICEINTERFACE b = (PDEV_BROADCAST_DEVICEINTERFACE) lParam;
         switch (wParam)
         {
@@ -686,6 +688,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           case DBT_DEVNODES_CHANGED:
             g_peripherals.TriggerDeviceScan(PERIPHERAL_BUS_USB);
             break;
+        }
         }
         break;
       }

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -680,15 +680,15 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       {
         if (((_DEV_BROADCAST_HEADER*) lParam)->dbcd_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
         {
-        PDEV_BROADCAST_DEVICEINTERFACE b = (PDEV_BROADCAST_DEVICEINTERFACE) lParam;
-        switch (wParam)
-        {
-          case DBT_DEVICEARRIVAL:
-          case DBT_DEVICEREMOVECOMPLETE:
-          case DBT_DEVNODES_CHANGED:
-            g_peripherals.TriggerDeviceScan(PERIPHERAL_BUS_USB);
-            break;
-        }
+          PDEV_BROADCAST_DEVICEINTERFACE b = (PDEV_BROADCAST_DEVICEINTERFACE) lParam;
+          switch (wParam)
+          {
+            case DBT_DEVICEARRIVAL:
+            case DBT_DEVICEREMOVECOMPLETE:
+            case DBT_DEVNODES_CHANGED:
+              g_peripherals.TriggerDeviceScan(PERIPHERAL_BUS_USB);
+              break;
+          }
         }
         break;
       }


### PR DESCRIPTION
- unregister when exiting
- react only to actual device insertion/removal, ie do not reenumerate the USB bus to find a CEC adapter when a CD is inserted...

I don't see any risk here, but doing a PR since we're close to release.
