### PR TITLE
[GUI] - fix possible deadlock when calling send message

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -74,6 +74,7 @@ bool CGUIWindowManager::SendMessage(CGUIMessage& message)
 
     if (pMsgTarget)
     {
+      CSingleExit exit(g_graphicsContext);
       if (pMsgTarget->OnMessage( message )) handled = true;
     }
   }


### PR DESCRIPTION
We have to release the graphicslock when sending messages to none window targets. This deadlock is present in the current AE branch and isn't exposed on mainline yet.

Here is the stacktrace for it.

Thx to jm for finding out :)

deadlock between thread1 and thread26 (using the code from AE branch of gnif)

http://pastebin.com/s6enHXgS

To trigger just play an mp3 with fullscreen viz and stop the playback...

This PR has to be merged with the AE merge at the latest...
