### PR TITLE
fixed: don't load non-matching archived subtitles (fixes #12719)

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2459,7 +2459,12 @@ int CUtil::ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStd
     ScanArchiveForSubtitles(strRarInRar,strMovieFileNameNoExt,vecSubtitles);
    }
    // done checking if this is a rar-in-rar
-   
+
+   // check that the found filename matches the movie filename
+   int fnl = strMovieFileNameNoExt.size();
+   if (!URIUtils::GetFileName(strPathInRar).Left(fnl).Equals(strMovieFileNameNoExt))
+     continue;
+
    int iPos=0;
     while (sub_exts[iPos])
     {


### PR DESCRIPTION
Commit ea87f7e8574430 ("removed subtitle caching as it was only needed
on xbox, partialy takes care of #9736.") mistakenly removed the filename
check for subtitles in zip or rar archives, causing any subtitle file
inside archives to be loaded.

Fix that by re-adding a filename check into
CUtil::ScanArchiveForSubtitles().

Seems rather straight-forward, but I'm making this a pull request just in case as we are so close to a release.This fixes the regression where XBMC would load any randomly named subtitle from any randomly named rar in the video directory, instead of only restricting to matching subtitles like previously.

Any objections?
