### PR TITLE
Disable Yadif activated by mistake for first frame decode

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -709,6 +709,12 @@ int CDVDVideoCodecFFmpeg::FilterOpen(const CStdString& filters)
   if (filters.IsEmpty())
     return 0;
 
+  if (m_pHardware)
+  {
+    CLog::Log(LOGWARNING, "CDVDVideoCodecFFmpeg::FilterOpen - skipped opening filters on hardware decode");
+    return 0;
+  }
+
   if (!(m_pFilterGraph = m_dllAvFilter.avfilter_graph_alloc()))
   {
     CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::FilterOpen - unable to alloc filter graph");


### PR DESCRIPTION
Corrects stutter when starting video with hardware decoders.
