### PR TITLE
[fix] - fix the autoclose timeout calculation - using SystemClockMillis

### DIFF
--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -35,6 +35,8 @@ CGUIDialog::CGUIDialog(int id, const CStdString &xmlFile)
   m_wasRunning = false;
   m_renderOrder = 1;
   m_autoClosing = false;
+  m_showStartTime = 0;
+  m_showDuration = 0;
   m_enableSound = true;
 }
 
@@ -97,7 +99,7 @@ bool CGUIDialog::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_INIT:
     {
       CGUIWindow::OnMessage(message);
-      m_showStartTime = CTimeUtils::GetFrameTime();
+      m_showStartTime = 0;
       return true;
     }
   }
@@ -226,8 +228,19 @@ void CGUIDialog::Show()
 
 void CGUIDialog::FrameMove()
 {
-  if (m_autoClosing && m_showStartTime + m_showDuration < CTimeUtils::GetFrameTime() && !m_closing)
-    Close();
+  if (m_autoClosing)
+  { // check if our timer is running
+    if (!m_showStartTime)
+    {
+      if (HasRendered()) // start timer
+        m_showStartTime = CTimeUtils::GetFrameTime();
+    }
+    else
+    {
+      if (m_showStartTime + m_showDuration < CTimeUtils::GetFrameTime() && !m_closing)
+        Close();
+    }
+  }
   CGUIWindow::FrameMove();
 }
 


### PR DESCRIPTION
I got problems with the yesno dialog which is shown after resolution switching in iOS. When using the old timeout implementation based on GetFrameTime, that dialog doesn't even show up because it timed out before.

I added 2 printouts for verification of the old, wonky behaviour:

GUIDialog.cpp:L99: i logged the m_showStartTime here

GUIDialog.cpp:L229: i logged the m_showStartTime + m_showDuration < TimeUtils::GetFrameTime() here.

This is the printout:

http://pastebin.com/tmwW98YP

As you can see the timeout is 10 secs for that yesno dialog. And XBMC eats that 10 secs up in no time. Time traveling?

No sure if the switch to SystemClockMillis is the right fix here. You can't test with this special dialog because resolution/monitor switching is not in mainline yet.
