### PR TITLE
[WIN] fix a couple dxva processor issues

### DIFF
--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -131,13 +131,14 @@ void CWinRenderer::ManageTextures()
 
 void CWinRenderer::SelectRenderMethod()
 {
+  // Set rendering to dxva before trying it, in order to open the correct processor immediately, when deinterlacing method is auto.
+
   // Force dxva renderer after dxva decoding: PS and SW renderers have performance issues after dxva decode.
   if (g_advancedSettings.m_DXVAForceProcessorRenderer && CONF_FLAGS_FORMAT_MASK(m_flags) == CONF_FLAGS_FORMAT_DXVA)
   {
     CLog::Log(LOGNOTICE, "D3D: rendering method forced to DXVA2 processor");
-    if (m_processor.Open(m_sourceWidth, m_sourceHeight, m_flags, m_format))
-        m_renderMethod = RENDER_DXVA;
-    else
+    m_renderMethod = RENDER_DXVA;
+    if (!m_processor.Open(m_sourceWidth, m_sourceHeight, m_flags, m_format))
     {
       CLog::Log(LOGNOTICE, "D3D: unable to open DXVA2 processor");
       m_processor.Close();
@@ -151,11 +152,9 @@ void CWinRenderer::SelectRenderMethod()
     switch(m_iRequestedMethod)
     {
       case RENDER_METHOD_DXVA:
+        m_renderMethod = RENDER_DXVA;
         if (m_processor.Open(m_sourceWidth, m_sourceHeight, m_flags, m_format))
-        {
-            m_renderMethod = RENDER_DXVA;
             break;
-        }
         else
         {
           CLog::Log(LOGNOTICE, "D3D: unable to open DXVA2 processor");

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -1177,6 +1177,9 @@ bool CProcessor::Open(UINT width, UINT height, unsigned int flags, unsigned int 
 
   EvaluateQuirkNoDeintProcForProg();
 
+  if (g_advancedSettings.m_DXVANoDeintProcForProgressive || m_quirk_nodeintprocforprog)
+    CLog::Log(LOGNOTICE, "DXVA: Auto deinterlacing mode workaround activated. Deinterlacing processor will be used only for interlaced frames.");
+
   if (!OpenProcessor())
     return false;
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
@@ -1151,6 +1151,9 @@ bool CProcessor::Open(UINT width, UINT height, unsigned int flags, unsigned int 
       return false;
   }
 
+  m_deinterlace_mode = g_settings.m_currentVideoSettings.m_DeinterlaceMode;
+  m_interlace_method = g_renderManager.AutoInterlaceMethod(g_settings.m_currentVideoSettings.m_InterlaceMethod);;
+
   if (!OpenProcessor())
     return false;
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.h
@@ -137,6 +137,7 @@ protected:
   bool CreateSurfaces();
   bool OpenProcessor();
   bool SelectProcessor();
+  void EvaluateQuirkNoDeintProcForProg();
 
   IDirectXVideoProcessorService* m_service;
   IDirectXVideoProcessor*        m_process;
@@ -171,6 +172,8 @@ protected:
 
   LPDIRECT3DSURFACE9* m_surfaces;
   CSurfaceContext* m_context;
+
+  bool             m_quirk_nodeintprocforprog;
 };
 
 };

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -99,6 +99,7 @@ void CAdvancedSettings::Initialize()
   m_DXVACheckCompatibility = false;
   m_DXVACheckCompatibilityPresent = false;
   m_DXVAForceProcessorRenderer = true;
+  m_DXVANoDeintProcForProgressive = false;
   m_videoFpsDetect = 1;
   m_videoDefaultLatency = 0.0;
 
@@ -539,6 +540,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     m_DXVACheckCompatibilityPresent = XMLUtils::GetBoolean(pElement,"checkdxvacompatibility", m_DXVACheckCompatibility);
 
     XMLUtils::GetBoolean(pElement,"forcedxvarenderer", m_DXVAForceProcessorRenderer);
+    XMLUtils::GetBoolean(pElement,"dxvanodeintforprogressive", m_DXVANoDeintProcForProgressive);
     //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
     XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -141,6 +141,7 @@ class CAdvancedSettings
     bool m_DXVACheckCompatibility;
     bool m_DXVACheckCompatibilityPresent;
     bool m_DXVAForceProcessorRenderer;
+    bool m_DXVANoDeintProcForProgressive;
     int  m_videoFpsDetect;
 
     CStdString m_videoDefaultPlayer;


### PR DESCRIPTION
- the incorrect processor was instantiated while the renderer is being configured. It was later replaced by the correct one, this PR goes for the correct one the first time around.
- the Ion GPU drops some frames in auto deinterlacing mode, because of the use of a deinterlacing processor for progressive frames. Initial discussion about this is in PR #752
  The solution is to use prog. processor for prog. frames and switch back and forth to a deint. processor when frame flags say so. This behavior is turned on by the detection of an Ion GPU or an advanced setting.
