### PR TITLE
Handle libdl only being needed on Linux for dlopen

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -809,7 +809,9 @@ if test "$host_vendor" = "apple" ; then
     AC_DEFINE([HAVE_SDL],[1],["Define to 1 if using sdl"])
   fi
 else
-  AC_CHECK_LIB([dl],         [main],, AC_MSG_ERROR($missing_library))
+  if test "$host_os" = "linux" ; then
+    AC_CHECK_LIB([dl],         [main],, AC_MSG_ERROR($missing_library))
+  fi
   AC_CHECK_LIB([resolv],     [main],, AC_MSG_ERROR($missing_library))
   AC_CHECK_LIB([jasper],     [main],, AC_MSG_ERROR($missing_library)) # check for cximage
   AC_CHECK_LIB([rt],         [clock_gettime],, AC_MSG_ERROR($missing_library))

--- a/lib/cpluff/configure.ac
+++ b/lib/cpluff/configure.ac
@@ -165,7 +165,8 @@ dlmechanism=none
 if test "$with_dlopen" != no && test "$with_libltdl" != yes; then
   AC_CHECK_HEADER([dlfcn.h],
     AC_CHECK_LIB([dl], [dlopen],
-      [LIBS_LIBCPLUFF="-ldl $LIBS_LIBCPLUFF"; dlmechanism=dlopen]))
+      [LIBS_LIBCPLUFF="-ldl $LIBS_LIBCPLUFF"; dlmechanism=dlopen],
+	AC_CHECK_LIB([c], [dlopen], [dlmechanism=dlopen])))
 fi
 if test "$dlmechanism" = none && test "$with_libltdl" != no && test "$with_dlopen" != yes; then  
   AC_CHECK_HEADER([ltdl.h],


### PR DESCRIPTION
Should not change the behaviour of existing Linux, Apple or Windows targets
