### PR TITLE
Fix conditional navigation in grouplist

### DIFF
--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -32,6 +32,12 @@ CGUIAction::CGUIAction()
   m_sendThreadMessages = false;
 }
 
+CGUIAction::CGUIAction(int controlID)
+{
+  m_sendThreadMessages = false;
+  SetNavigation(controlID);
+}
+
 bool CGUIAction::Execute(int controlID, int parentID, int direction /*= 0*/) const
 {
   if (m_actions.size() == 0) return false;

--- a/xbmc/guilib/GUIAction.h
+++ b/xbmc/guilib/GUIAction.h
@@ -32,6 +32,7 @@ class CGUIAction
 {
 public:
   CGUIAction();
+  CGUIAction(int controlID);
 
   /**
    * Execute actions, if action is paired with condition - evaluate condition first

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -478,6 +478,33 @@ void CGUIControl::SetNavigationActions(const CGUIAction &up, const CGUIAction &d
   if (!m_actionBack.HasAnyActions()  || replace) m_actionBack  = back;
 }
 
+void CGUIControl::SetNavigationAction(int direction, const CGUIAction &action, bool replace /*= true*/)
+{
+  switch (direction)
+  {
+  case ACTION_MOVE_UP:
+    if (!m_actionUp.HasAnyActions() || replace)
+      m_actionUp = action;
+    break;
+  case ACTION_MOVE_DOWN:
+    if (!m_actionDown.HasAnyActions() || replace)
+      m_actionDown = action;
+    break;
+  case ACTION_MOVE_LEFT:
+    if (!m_actionLeft.HasAnyActions() || replace)
+      m_actionLeft = action;
+    break;
+  case ACTION_MOVE_RIGHT:
+    if (!m_actionRight.HasAnyActions() || replace)
+      m_actionRight = action;
+    break;
+  case ACTION_NAV_BACK:
+    if (!m_actionBack.HasAnyActions() || replace)
+      m_actionBack = action;
+    break;
+  }
+}
+
 void CGUIControl::SetWidth(float width)
 {
   if (m_width != width)

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -193,6 +193,7 @@ public:
   virtual void SetNavigationActions(const CGUIAction &up, const CGUIAction &down,
                                     const CGUIAction &left, const CGUIAction &right,
                                     const CGUIAction &back, bool replace = true);
+  void SetNavigationAction(int direction, const CGUIAction &action, bool replace = true);
   int GetControlIdUp() const { return m_actionUp.GetNavigation(); };
   int GetControlIdDown() const { return  m_actionDown.GetNavigation(); };
   int GetControlIdLeft() const { return m_actionLeft.GetNavigation(); };

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -721,12 +721,12 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   hitRect.SetRect(posX, posY, posX + width, posY + height);
   GetHitRect(pControlNode, hitRect);
 
-  if (!GetActions(pControlNode, "onup",    upActions))    upActions.SetNavigation(id);
-  if (!GetActions(pControlNode, "ondown",  downActions))  downActions.SetNavigation(id);
-  if (!GetActions(pControlNode, "onleft",  leftActions))  leftActions.SetNavigation(id);
-  if (!GetActions(pControlNode, "onright", rightActions)) rightActions.SetNavigation(id);
-  if (!GetActions(pControlNode, "onnext",  nextActions))  nextActions.SetNavigation(id);
-  if (!GetActions(pControlNode, "onprev",  prevActions))  prevActions.SetNavigation(id);
+  GetActions(pControlNode, "onup",    upActions);
+  GetActions(pControlNode, "ondown",  downActions);
+  GetActions(pControlNode, "onleft",  leftActions);
+  GetActions(pControlNode, "onright", rightActions);
+  GetActions(pControlNode, "onnext",  nextActions);
+  GetActions(pControlNode, "onprev",  prevActions);
   GetActions(pControlNode, "onback",  backActions);
 
   if (XMLUtils::GetInt(pControlNode, "defaultcontrol", defaultControl))

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -262,30 +262,37 @@ void CGUIControlGroupList::AddControl(CGUIControl *control, int position /*= -1*
       if (m_orientation == VERTICAL)
       {
         if (before) // update the DOWN action to point to us
-          before->SetNavigation(before->GetControlIdUp(), control->GetID(), GetControlIdLeft(), GetControlIdRight(), GetControlIdBack());
+          before->SetNavigationAction(ACTION_MOVE_DOWN, CGUIAction(control->GetID()));
         if (after) // update the UP action to point to us
-          after->SetNavigation(control->GetID(), after->GetControlIdDown(), GetControlIdLeft(), GetControlIdRight(), GetControlIdBack());
+          after->SetNavigationAction(ACTION_MOVE_UP, CGUIAction(control->GetID()));
       }
       else
       {
         if (before) // update the RIGHT action to point to us
-          before->SetNavigation(GetControlIdUp(), GetControlIdDown(), before->GetControlIdLeft(), control->GetID(), GetControlIdBack());
+          before->SetNavigationAction(ACTION_MOVE_RIGHT, CGUIAction(control->GetID()));
         if (after) // update the LEFT action to point to us
-          after->SetNavigation(GetControlIdUp(), GetControlIdDown(), control->GetID(), after->GetControlIdRight(), GetControlIdBack());
+          after->SetNavigationAction(ACTION_MOVE_LEFT, CGUIAction(control->GetID()));
       }
     }
     // now the control's nav
-    CGUIAction empty;
+    // set navigation path on orientation axis
+    // and try to apply other nav actions from grouplist
+    // don't override them if child have already defined actions
     if (m_orientation == VERTICAL)
     {
-      control->SetNavigation(beforeID, afterID, GetControlIdLeft(), GetControlIdRight(), GetControlIdBack());
-      control->SetNavigationActions(empty, empty, m_actionLeft, m_actionRight, empty, false);
+      control->SetNavigationAction(ACTION_MOVE_UP, CGUIAction(beforeID));
+      control->SetNavigationAction(ACTION_MOVE_DOWN, CGUIAction(afterID));
+      control->SetNavigationAction(ACTION_MOVE_LEFT, m_actionLeft, false);
+      control->SetNavigationAction(ACTION_MOVE_RIGHT, m_actionRight, false);
     }
     else
     {
-      control->SetNavigation(GetControlIdUp(), GetControlIdDown(), beforeID, afterID, GetControlIdBack());
-      control->SetNavigationActions(m_actionUp, m_actionDown, empty, empty, empty, false);
+      control->SetNavigationAction(ACTION_MOVE_LEFT, CGUIAction(beforeID));
+      control->SetNavigationAction(ACTION_MOVE_RIGHT, CGUIAction(afterID));
+      control->SetNavigationAction(ACTION_MOVE_UP, m_actionUp, false);
+      control->SetNavigationAction(ACTION_MOVE_DOWN, m_actionDown, false);
     }
+    control->SetNavigationAction(ACTION_NAV_BACK, m_actionBack, false);
 
     if (!m_useControlPositions)
       control->SetPosition(0,0);


### PR DESCRIPTION
This should be pretty straight forward.
My only concern are changes in CGUIControlFactory - is it safe to not set fallback navigation there? We won't do anything if action list is empty. This change is needed to set navigation using replace=false flag (we can't set actions because list isn't empty - fallback navigation is there)
