### PR TITLE
Wraplist focus animation with static content, part 1

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -51,7 +51,6 @@ CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, fl
   m_pageControl = 0;
   m_orientation = orientation;
   m_analogScrollCount = 0;
-  m_lastItem = NULL;
   m_staticContent = false;
   m_staticUpdateTime = 0;
   m_staticDefaultItem = -1;
@@ -119,9 +118,9 @@ void CGUIBaseContainer::Process(unsigned int currentTime, CDirtyRegionList &dirt
       CGUIListItemPtr item = m_items[itemNo];
       // render our item
       if (m_orientation == VERTICAL)
-        ProcessItem(origin.x, pos, item.get(), focused, currentTime, dirtyregions);
+        ProcessItem(origin.x, pos, item, focused, currentTime, dirtyregions);
       else
-        ProcessItem(pos, origin.y, item.get(), focused, currentTime, dirtyregions);
+        ProcessItem(pos, origin.y, item, focused, currentTime, dirtyregions);
     }
     // increment our position
     pos += focused ? m_focusedLayout->Size(m_orientation) : m_layout->Size(m_orientation);
@@ -133,7 +132,7 @@ void CGUIBaseContainer::Process(unsigned int currentTime, CDirtyRegionList &dirt
   CGUIControl::Process(currentTime, dirtyregions);
 }
 
-void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItem *item, bool focused, unsigned int currentTime, CDirtyRegionList &dirtyregions)
+void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItemPtr& item, bool focused, unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   if (!m_focusedLayout || !m_layout) return;
 
@@ -163,7 +162,7 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItem *item, 
           subItem = m_lastItem->GetFocusedLayout()->GetFocusedItem();
         item->GetFocusedLayout()->SetFocusedItem(subItem ? subItem : 1);
       }
-      item->GetFocusedLayout()->Process(item, m_parentID, currentTime, dirtyregions);
+      item->GetFocusedLayout()->Process(item.get(), m_parentID, currentTime, dirtyregions);
     }
     m_lastItem = item;
   }
@@ -177,9 +176,9 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItem *item, 
       item->SetLayout(layout);
     }
     if (item->GetFocusedLayout())
-      item->GetFocusedLayout()->Process(item, m_parentID, currentTime, dirtyregions);
+      item->GetFocusedLayout()->Process(item.get(), m_parentID, currentTime, dirtyregions);
     if (item->GetLayout())
-      item->GetLayout()->Process(item, m_parentID, currentTime, dirtyregions);
+      item->GetLayout()->Process(item.get(), m_parentID, currentTime, dirtyregions);
   }
 
   g_graphicsContext.RestoreOrigin();
@@ -735,7 +734,7 @@ void CGUIBaseContainer::SetFocus(bool bOnOff)
   if (bOnOff != HasFocus())
   {
     SetInvalid();
-    m_lastItem = NULL;
+    m_lastItem.reset();
   }
   CGUIControl::SetFocus(bOnOff);
 }
@@ -830,7 +829,6 @@ void CGUIBaseContainer::UpdateVisibility(const CGUIListItem *item)
   if (m_staticContent)
   { // update our item list with our new content, but only add those items that should
     // be visible.  Save the previous item and keep it if we are adding that one.
-    CGUIListItem *lastItem = m_lastItem;
     int selected = GetSelectedItem();
     CGUIListItem* selectedItem = (selected >= 0 && (unsigned int)selected < m_items.size()) ? m_items[selected].get() : NULL;
     Reset();
@@ -850,8 +848,6 @@ void CGUIBaseContainer::UpdateVisibility(const CGUIListItem *item)
       if (staticItem->IsVisible())
       {
         m_items.push_back(staticItem);
-        if (staticItem.get() == lastItem)
-          m_lastItem = lastItem;
         // if item is selected and it changed position, re-select it
         if (staticItem.get() == selectedItem && selected != (int)m_items.size() - 1)
           SelectItem(m_items.size() - 1);
@@ -975,7 +971,6 @@ void CGUIBaseContainer::Reset()
 {
   m_wasReset = true;
   m_items.clear();
-  m_lastItem = NULL;
 }
 
 void CGUIBaseContainer::LoadLayout(TiXmlElement *layout)

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -866,6 +866,7 @@ void CGUIBaseContainer::UpdateStaticItems(bool refreshItems)
     {
       Reset();
       m_items = items;
+      SetPageControlRange();
       if (reselect >= 0 && reselect < (int)m_items.size())
         SelectItem(reselect);
       MarkDirtyRegion();

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -101,7 +101,7 @@ protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   bool OnClick(int actionID);
 
-  virtual void ProcessItem(float posX, float posY, CGUIListItem *item, bool focused, unsigned int currentTime, CDirtyRegionList &dirtyregions);
+  virtual void ProcessItem(float posX, float posY, CGUIListItemPtr& item, bool focused, unsigned int currentTime, CDirtyRegionList &dirtyregions);
 
   virtual void Render();
   virtual void RenderItem(float posX, float posY, CGUIListItem *item, bool focused);
@@ -142,7 +142,7 @@ protected:
 
   std::vector< CGUIListItemPtr > m_items;
   typedef std::vector<CGUIListItemPtr> ::iterator iItems;
-  CGUIListItem *m_lastItem;
+  CGUIListItemPtr m_lastItem;
 
   int m_pageControl;
 

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -124,6 +124,7 @@ protected:
   virtual int GetCurrentPage() const;
   bool InsideLayout(const CGUIListItemLayout *layout, const CPoint &point) const;
   virtual void OnFocus();
+  void UpdateStaticItems(bool refreshItems = false);
 
   int ScrollCorrectionRange() const;
   inline float Size() const;

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -75,9 +75,9 @@ void CGUIPanelContainer::Process(unsigned int currentTime, CDirtyRegionList &dir
       bool focused = (current == GetOffset() * m_itemsPerRow + GetCursor()) && m_bHasFocus;
 
       if (m_orientation == VERTICAL)
-        ProcessItem(origin.x + col * m_layout->Size(HORIZONTAL), pos, item.get(), focused, currentTime, dirtyregions);
+        ProcessItem(origin.x + col * m_layout->Size(HORIZONTAL), pos, item, focused, currentTime, dirtyregions);
       else
-        ProcessItem(pos, origin.y + col * m_layout->Size(VERTICAL), item.get(), focused, currentTime, dirtyregions);
+        ProcessItem(pos, origin.y + col * m_layout->Size(VERTICAL), item, focused, currentTime, dirtyregions);
     }
     // increment our position
     if (col < m_itemsPerRow - 1)


### PR DESCRIPTION
This PR is limiting exposure to [Ticket 12773](http://trac.xbmc.org/ticket/12773). It's done by doing smarter static items processing - let's not reset and set items every frame as it is now (and thus create new extraitems instances in wraplist every frame) - rather do it only if items have changed (visibility of any item have changed).

Next (real) part of fixing bug will need some kind of m_lastItem shuffling and animation transfer (whole animation including current states) from extraitem (that will be removed) to corresponding "normal" item in wraplist. Posted just 1st part because I don't think I will have time to work on it soon and this is hiding this bug in most cases (visiblity conditions used for static content don't change to often)

I'd like it to be included in eden if in general this is good approach and it will pass review.
