### PR TITLE
add support for adding or removing a list of controls from python

### DIFF
--- a/xbmc/interfaces/python/xbmcmodule/window.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/window.cpp
@@ -721,9 +721,12 @@ namespace PYXBMC
     Control *pControl = (Control *)object;
 
     {
-      GilSafeSingleLock lock(g_graphicsContext);
+      CPyThreadState state;
+      CSingleLock lock(g_graphicsContext);
       if(!self->pWindow->GetControl(pControl->iControlId))
       {
+        lock.Leave();
+        state.Restore();
         PyErr_SetString(PyExc_RuntimeError, "Control does not exist in window");
         return false;
       }

--- a/xbmc/interfaces/python/xbmcmodule/window.h
+++ b/xbmc/interfaces/python/xbmcmodule/window.h
@@ -70,6 +70,8 @@ namespace PYXBMC
   void initWindow_Type();
 
   bool Window_CreateNewWindow(Window* pWindow, bool bAsDialog);
+  bool Window_AddSingleControl(Window* self, PyObject *object, bool wait = true);
+  bool Window_RemoveSingleControl(Window* self, PyObject *object, bool wait = true);
   void Window_Dealloc(Window* self);
   PyObject* Window_Close(Window *self, PyObject *args);
 }


### PR DESCRIPTION
This add PyList support to the existing functions addControl/removeControl.

Without this python has to wait on a threadmessage between each control addition which is not aesthetically pleasing.

@jimfcarroll: would appreciate comments on whether it's sane to do so via the existing functions, or whether new functions would be preferred.
