### PR TITLE
Cleanup and TextureCache changes

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		7C0A7FC813A9E75400AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC413A9E75400AFC2BD /* DirtyRegionSolvers.cpp */; };
 		7C0A7FC913A9E75400AFC2BD /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC613A9E75400AFC2BD /* DirtyRegionTracker.cpp */; };
 		7C0A7FCC13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FCA13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp */; };
+		7C1A89BB152671FB00C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A89B9152671FB00C63311 /* TextureCacheJob.cpp */; };
 		7C89627013B702F3003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89626E13B702F3003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C99B7AA134072CD00FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */; };
 		7CCFD9AA1514952700211D82 /* PCMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCFD9A81514952700211D82 /* PCMCodec.cpp */; };
@@ -996,6 +997,8 @@
 		7C0A7FC713A9E75400AFC2BD /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
 		7C0A7FCA13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowDebugInfo.cpp; sourceTree = "<group>"; };
 		7C0A7FCB13A9E76E00AFC2BD /* GUIWindowDebugInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowDebugInfo.h; sourceTree = "<group>"; };
+		7C1A89B9152671FB00C63311 /* TextureCacheJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureCacheJob.cpp; sourceTree = "<group>"; };
+		7C1A89BA152671FB00C63311 /* TextureCacheJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureCacheJob.h; sourceTree = "<group>"; };
 		7C89626E13B702F3003631FE /* GUIWindowScreensaverDim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowScreensaverDim.cpp; sourceTree = "<group>"; };
 		7C89626F13B702F3003631FE /* GUIWindowScreensaverDim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowScreensaverDim.h; sourceTree = "<group>"; };
 		7C99B7A8134072CD00FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -3458,6 +3461,8 @@
 				F56C77FF131EC154000AD0F6 /* Temperature.h */,
 				F56C7800131EC154000AD0F6 /* TextureCache.cpp */,
 				F56C7801131EC154000AD0F6 /* TextureCache.h */,
+				7C1A89B9152671FB00C63311 /* TextureCacheJob.cpp */,
+				7C1A89BA152671FB00C63311 /* TextureCacheJob.h */,
 				F56C7802131EC154000AD0F6 /* TextureDatabase.cpp */,
 				F56C7803131EC154000AD0F6 /* TextureDatabase.h */,
 				F56C7804131EC154000AD0F6 /* ThumbLoader.cpp */,
@@ -7056,6 +7061,7 @@
 				DFDB004A1516408F005079A4 /* DirectoryCache.cpp in Sources */,
 				DFDB004B1516408F005079A4 /* FileCache.cpp in Sources */,
 				DFDB004C1516408F005079A4 /* MemBufferCache.cpp in Sources */,
+				7C1A89BB152671FB00C63311 /* TextureCacheJob.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		7C0A7F9D13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7F9B13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp */; };
 		7C0A7FB213A9E72E00AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FAE13A9E72E00AFC2BD /* DirtyRegionSolvers.cpp */; };
 		7C0A7FB313A9E72E00AFC2BD /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FB013A9E72E00AFC2BD /* DirtyRegionTracker.cpp */; };
+		7C1A89CE1526722200C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A89CC1526722200C63311 /* TextureCacheJob.cpp */; };
 		7C89628013B7031E003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89627E13B7031E003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C99B7BE1340730000FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */; };
 		7CCFD9991514950700211D82 /* PCMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCFD9971514950700211D82 /* PCMCodec.cpp */; };
@@ -997,6 +998,8 @@
 		7C0A7FAF13A9E72E00AFC2BD /* DirtyRegionSolvers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionSolvers.h; sourceTree = "<group>"; };
 		7C0A7FB013A9E72E00AFC2BD /* DirtyRegionTracker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirtyRegionTracker.cpp; sourceTree = "<group>"; };
 		7C0A7FB113A9E72E00AFC2BD /* DirtyRegionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirtyRegionTracker.h; sourceTree = "<group>"; };
+		7C1A89CC1526722200C63311 /* TextureCacheJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureCacheJob.cpp; sourceTree = "<group>"; };
+		7C1A89CD1526722200C63311 /* TextureCacheJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureCacheJob.h; sourceTree = "<group>"; };
 		7C89627E13B7031E003631FE /* GUIWindowScreensaverDim.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIWindowScreensaverDim.cpp; sourceTree = "<group>"; };
 		7C89627F13B7031E003631FE /* GUIWindowScreensaverDim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GUIWindowScreensaverDim.h; sourceTree = "<group>"; };
 		7C99B7BC1340730000FC2B16 /* GUIDialogPlayEject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GUIDialogPlayEject.cpp; sourceTree = "<group>"; };
@@ -3817,6 +3820,8 @@
 				F56C87EC131F42ED000AD0F6 /* Temperature.h */,
 				F56C87ED131F42ED000AD0F6 /* TextureCache.cpp */,
 				F56C87EE131F42ED000AD0F6 /* TextureCache.h */,
+				7C1A89CC1526722200C63311 /* TextureCacheJob.cpp */,
+				7C1A89CD1526722200C63311 /* TextureCacheJob.h */,
 				F56C87EF131F42ED000AD0F6 /* TextureDatabase.cpp */,
 				F56C87F0131F42ED000AD0F6 /* TextureDatabase.h */,
 				F56C87F1131F42ED000AD0F6 /* ThumbLoader.cpp */,
@@ -7071,6 +7076,7 @@
 				DFDB00251516403A005079A4 /* DirectoryCache.cpp in Sources */,
 				DFDB00261516403A005079A4 /* FileCache.cpp in Sources */,
 				DFDB00271516403A005079A4 /* MemBufferCache.cpp in Sources */,
+				7C1A89CE1526722200C63311 /* TextureCacheJob.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -513,6 +513,8 @@
 		43EA42B0136C2274002C82A5 /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807114B135DB5CC002F601B /* InputOperations.cpp */; };
 		7C0A7EC013A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */; };
 		7C0A7EC113A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */; };
+		7C1A85651520522500C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A85631520522500C63311 /* TextureCacheJob.cpp */; };
+		7C1A85661520522500C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A85631520522500C63311 /* TextureCacheJob.cpp */; };
 		7C2D6AE40F35453E00DD2E85 /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
 		7C45DBE910F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
 		7C45DBEA10F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
@@ -2487,6 +2489,8 @@
 		6E97BDC40DA2B620003A2A89 /* Socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Socket.h; sourceTree = "<group>"; };
 		7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppParamParser.cpp; sourceTree = "<group>"; };
 		7C0A7EBF13A5DBCE00AFC2BD /* AppParamParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppParamParser.h; sourceTree = "<group>"; };
+		7C1A85631520522500C63311 /* TextureCacheJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureCacheJob.cpp; sourceTree = "<group>"; };
+		7C1A85641520522500C63311 /* TextureCacheJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureCacheJob.h; sourceTree = "<group>"; };
 		7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpecialProtocol.cpp; sourceTree = "<group>"; };
 		7C2D6AE30F35453E00DD2E85 /* SpecialProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialProtocol.h; sourceTree = "<group>"; };
 		7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DAVDirectory.cpp; sourceTree = "<group>"; };
@@ -5265,6 +5269,8 @@
 				E38E1E170D25F9FD00618676 /* Temperature.h */,
 				7C8A14541154CB2600E5FCFA /* TextureCache.cpp */,
 				7C8A14551154CB2600E5FCFA /* TextureCache.h */,
+				7C1A85631520522500C63311 /* TextureCacheJob.cpp */,
+				7C1A85641520522500C63311 /* TextureCacheJob.h */,
 				7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */,
 				7C8A187B115B2A8200E5FCFA /* TextureDatabase.h */,
 				E38E1E180D25F9FD00618676 /* ThumbLoader.cpp */,
@@ -8188,6 +8194,7 @@
 				DF93D6B31444A8B1007C6459 /* ZipFile.cpp in Sources */,
 				DF93D7F21444B54A007C6459 /* HDHomeRunFile.cpp in Sources */,
 				DF93D7F61444B568007C6459 /* HDHomeRunDirectory.cpp in Sources */,
+				7C1A85661520522500C63311 /* TextureCacheJob.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9125,6 +9132,7 @@
 				DF93D6CE1444A8B1007C6459 /* ZipFile.cpp in Sources */,
 				DF93D7F31444B54A007C6459 /* HDHomeRunFile.cpp in Sources */,
 				DF93D7F71444B568007C6459 /* HDHomeRunDirectory.cpp in Sources */,
+				7C1A85651520522500C63311 /* TextureCacheJob.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -868,6 +868,7 @@
     <ClCompile Include="..\..\xbmc\SystemGlobals.cpp" />
     <ClCompile Include="..\..\xbmc\Temperature.cpp" />
     <ClCompile Include="..\..\xbmc\TextureCache.cpp" />
+    <ClCompile Include="..\..\xbmc\TextureCacheJob.cpp" />
     <ClCompile Include="..\..\xbmc\TextureDatabase.cpp" />
     <ClCompile Include="..\..\xbmc\threads\Atomics.cpp" />
     <ClCompile Include="..\..\xbmc\threads\Event.cpp" />
@@ -1790,6 +1791,7 @@
     <ClInclude Include="..\..\xbmc\system.h" />
     <ClInclude Include="..\..\xbmc\Temperature.h" />
     <ClInclude Include="..\..\xbmc\TextureCache.h" />
+    <ClInclude Include="..\..\xbmc\TextureCacheJob.h" />
     <ClInclude Include="..\..\xbmc\TextureDatabase.h" />
     <ClInclude Include="..\..\xbmc\threads\Atomics.h" />
     <ClInclude Include="..\..\xbmc\threads\Condition.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2093,6 +2093,9 @@
     <ClCompile Include="..\..\xbmc\TextureCache.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\TextureCacheJob.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\TextureDatabase.cpp">
       <Filter>utils</Filter>
     </ClCompile>
@@ -4685,6 +4688,9 @@
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\TextureCache.h">
+      <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\TextureCacheJob.h">
       <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\Temperature.h">

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3544,11 +3544,11 @@ void CGUIInfoManager::SetCurrentSong(CFileItem &item)
   }
   else
     m_currentFile->SetMusicThumb();
-    if (!m_currentFile->HasProperty("fanart_image"))
-    {
-      if (m_currentFile->CacheLocalFanart())
-        m_currentFile->SetProperty("fanart_image", m_currentFile->GetCachedFanart());
-    }
+  if (!m_currentFile->HasProperty("fanart_image"))
+  {
+    if (m_currentFile->CacheLocalFanart())
+      m_currentFile->SetProperty("fanart_image", m_currentFile->GetCachedFanart());
+  }
   m_currentFile->FillInDefaultIcon();
 
   CMusicInfoLoader::LoadAdditionalTagInfo(m_currentFile);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4057,10 +4057,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, CStdSt
   case LISTITEM_ICON:
     {
       CStdString strThumb = item->GetThumbnailImage();
-      if(!strThumb.IsEmpty() && !g_TextureManager.CanLoad(strThumb))
-        strThumb = "";
-
-      if(strThumb.IsEmpty() && !item->GetIconImage().IsEmpty())
+      if (strThumb.IsEmpty())
         strThumb = item->GetIconImage();
       if (fallback)
         *fallback = item->GetIconImage();

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1080,7 +1080,7 @@ TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const CStdString &format)
   return TIME_FORMAT_GUESS;
 }
 
-CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
+CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fallback)
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
     return GetSkinVariableString(info, false);
@@ -1108,7 +1108,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
     if (window)
     {
       CFileItemPtr item = window->GetCurrentListItem();
-      strLabel = GetItemLabel(item.get(), info);
+      strLabel = GetItemLabel(item.get(), info, fallback);
     }
 
     return strLabel;
@@ -2663,7 +2663,7 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const GUIInfo &info, int conte
 }
 
 /// \brief Examines the multi information sent and returns the string as appropriate
-CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWindow)
+CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWindow, CStdString *fallback)
 {
   if (info.m_info == SKIN_STRING)
   {
@@ -2699,7 +2699,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
     }
 
     if (item) // If we got a valid item, do the lookup
-      return GetItemImage(item.get(), info.m_info); // Image prioritizes images over labels (in the case of music item ratings for instance)
+      return GetItemImage(item.get(), info.m_info, fallback); // Image prioritizes images over labels (in the case of music item ratings for instance)
   }
   else if (info.m_info == PLAYER_TIME)
   {
@@ -2843,14 +2843,14 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
 }
 
 /// \brief Obtains the filename of the image to show from whichever subsystem is needed
-CStdString CGUIInfoManager::GetImage(int info, int contextWindow)
+CStdString CGUIInfoManager::GetImage(int info, int contextWindow, CStdString *fallback)
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
     return GetSkinVariableString(info, true);
 
   if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
   {
-    return GetMultiInfoLabel(m_multiInfo[info - MULTI_INFO_START], contextWindow);
+    return GetMultiInfoLabel(m_multiInfo[info - MULTI_INFO_START], contextWindow, fallback);
   }
   else if (info == WEATHER_CONDITIONS)
     return g_weatherManager.GetInfo(WEATHER_IMAGE_CURRENT_ICON);
@@ -2864,6 +2864,8 @@ CStdString CGUIInfoManager::GetImage(int info, int contextWindow)
   else if (info == MUSICPLAYER_COVER)
   {
     if (!g_application.IsPlayingAudio()) return "";
+    if (fallback)
+      *fallback = "DefaultAlbumCover.png";
     return m_currentFile->HasThumbnail() ? m_currentFile->GetThumbnailImage() : "DefaultAlbumCover.png";
   }
   else if (info == MUSICPLAYER_RATING)
@@ -2879,6 +2881,8 @@ CStdString CGUIInfoManager::GetImage(int info, int contextWindow)
   else if (info == VIDEOPLAYER_COVER)
   {
     if (!g_application.IsPlayingVideo()) return "";
+    if (fallback)
+      *fallback = "DefaultVideoCover.png";
     if(m_currentMovieThumb.IsEmpty())
       return m_currentFile->HasThumbnail() ? m_currentFile->GetThumbnailImage() : "DefaultVideoCover.png";
     else return m_currentMovieThumb;
@@ -2887,7 +2891,7 @@ CStdString CGUIInfoManager::GetImage(int info, int contextWindow)
   {
     CGUIWindow *window = GetWindowWithCondition(contextWindow, WINDOW_CONDITION_IS_MEDIA_WINDOW);
     if (window)
-      return GetItemImage(&const_cast<CFileItemList&>(((CGUIMediaWindow*)window)->CurrentDirectory()), LISTITEM_THUMB);
+      return GetItemImage(&const_cast<CFileItemList&>(((CGUIMediaWindow*)window)->CurrentDirectory()), LISTITEM_THUMB, fallback);
   }
   else if (info == CONTAINER_TVSHOWTHUMB)
   {
@@ -2909,10 +2913,10 @@ CStdString CGUIInfoManager::GetImage(int info, int contextWindow)
     {
       CFileItemPtr item = window->GetCurrentListItem();
       if (item)
-        return GetItemImage(item.get(), info);
+        return GetItemImage(item.get(), info, fallback);
     }
   }
-  return GetLabel(info, contextWindow);
+  return GetLabel(info, contextWindow, fallback);
 }
 
 CStdString CGUIInfoManager::GetDate(bool bNumbersOnly)
@@ -3822,7 +3826,7 @@ bool CGUIInfoManager::GetItemInt(int &value, const CGUIListItem *item, int info)
   return false;
 }
 
-CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info)
+CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, CStdString *fallback)
 {
   if (!item) return "";
 
@@ -4058,6 +4062,8 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info)
 
       if(strThumb.IsEmpty() && !item->GetIconImage().IsEmpty())
         strThumb = item->GetIconImage();
+      if (fallback)
+        *fallback = item->GetIconImage();
       return strThumb;
     }
   case LISTITEM_OVERLAY:
@@ -4205,7 +4211,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info)
   return "";
 }
 
-CStdString CGUIInfoManager::GetItemImage(const CFileItem *item, int info)
+CStdString CGUIInfoManager::GetItemImage(const CFileItem *item, int info, CStdString *fallback)
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
     return GetSkinVariableString(info, true, item);
@@ -4238,7 +4244,7 @@ CStdString CGUIInfoManager::GetItemImage(const CFileItem *item, int info)
     break;
   }  /* switch (info) */
 
-  return GetItemLabel(item, info);
+  return GetItemLabel(item, info, fallback);
 }
 
 bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -611,9 +611,9 @@ public:
    \sa GetItemInt, GetMultiInfoInt
    */
   bool GetInt(int &value, int info, int contextWindow = 0, const CGUIListItem *item = NULL) const;
-  CStdString GetLabel(int info, int contextWindow = 0);
+  CStdString GetLabel(int info, int contextWindow = 0, CStdString *fallback = NULL);
 
-  CStdString GetImage(int info, int contextWindow);
+  CStdString GetImage(int info, int contextWindow, CStdString *fallback = NULL);
 
   CStdString GetTime(TIME_FORMAT format = TIME_FORMAT_GUESS) const;
   CStdString GetLcdTime( int _eInfo ) const;
@@ -673,8 +673,8 @@ public:
 
   void ResetCache();
   bool GetItemInt(int &value, const CGUIListItem *item, int info) const;
-  CStdString GetItemLabel(const CFileItem *item, int info);
-  CStdString GetItemImage(const CFileItem *item, int info);
+  CStdString GetItemLabel(const CFileItem *item, int info, CStdString *fallback = NULL);
+  CStdString GetItemImage(const CFileItem *item, int info, CStdString *fallback = NULL);
 
   // Called from tuxbox service thread to update current status
   void UpdateFromTuxBox();
@@ -725,7 +725,7 @@ protected:
 
   bool GetMultiInfoBool(const GUIInfo &info, int contextWindow = 0, const CGUIListItem *item = NULL);
   bool GetMultiInfoInt(int &value, const GUIInfo &info, int contextWindow = 0) const;
-  CStdString GetMultiInfoLabel(const GUIInfo &info, int contextWindow = 0);
+  CStdString GetMultiInfoLabel(const GUIInfo &info, int contextWindow = 0, CStdString *fallback = NULL);
   int TranslateListItem(const Property &info);
   int TranslateMusicPlayerString(const CStdString &info) const;
   TIME_FORMAT TranslateTimeFormat(const CStdString &format);

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -31,6 +31,7 @@
 #include "guilib/GraphicContext.h"
 #include "utils/log.h"
 #include "TextureCache.h"
+#include "TextureCacheJob.h"
 
 using namespace std;
 
@@ -48,43 +49,43 @@ CImageLoader::~CImageLoader()
 
 bool CImageLoader::DoWork()
 {
-  bool needsCaching = false;
+  bool needsChecking = false;
 
   CStdString texturePath = g_TextureManager.GetTexturePath(m_path);
-  CStdString loadPath = CTextureCache::Get().CheckCachedImage(texturePath, true, needsCaching); 
+  CStdString loadPath = CTextureCache::Get().CheckCachedImage(texturePath, true, needsChecking); 
 
-  // If empty, then go on to validate and cache image as appropriate
-  // If hit, continue down and load image
   if (loadPath.IsEmpty())
   {
-    CFileItem file(m_path, false);
+    // not in our texture cache, so try and load directly and then cache the result
+    bool flipped;
+    unsigned int width, height;
+    CStdString image = CTextureCacheJob::DecodeImageURL(texturePath, width, height, flipped);
 
-    // Validate file URL to see if it is an image
-    if ((file.IsPicture() && !(file.IsZIP() || file.IsRAR() || file.IsCBR() || file.IsCBZ() )) 
-       || file.GetMimeType().Left(6).Equals("image/")) // ignore non-pictures
-    { 
-      needsCaching = true;
-      loadPath = texturePath;
-    }
-  }
+    if (image.IsEmpty())
+      return false; // nothing to load
 
-  m_texture = new CTexture();
-  unsigned int start = XbmcThreads::SystemClockMillis();
-  if (!m_texture->LoadFromFile(loadPath, min(g_graphicsContext.GetWidth(), 2048), min(g_graphicsContext.GetHeight(), 1080), g_guiSettings.GetBool("pictures.useexifrotation")))
-  {
-    delete m_texture;
-    m_texture = NULL;
+    m_texture = CTextureCacheJob::LoadImage(image, width, height, flipped);
+
+    if (m_texture)
+      CTextureCache::Get().BackgroundCacheTexture(texturePath, m_texture, width, height);
   }
   else
   {
-    if (needsCaching)
-    { // fire off a caching job
-      CTextureCache::Get().BackgroundCacheImage(texturePath);
+    // direct route - load the image
+    m_texture = new CTexture();
+    unsigned int start = XbmcThreads::SystemClockMillis();
+    if (!m_texture->LoadFromFile(loadPath, min(g_graphicsContext.GetWidth(), 2048), min(g_graphicsContext.GetHeight(), 1080), g_guiSettings.GetBool("pictures.useexifrotation")))
+    {
+      delete m_texture;
+      m_texture = NULL;
+      return false;
     }
     if (XbmcThreads::SystemClockMillis() - start > 100)
       CLog::Log(LOGDEBUG, "%s - took %u ms to load %s", __FUNCTION__, XbmcThreads::SystemClockMillis() - start, loadPath.c_str());
-  }
 
+    if (needsChecking)
+      CTextureCache::Get().BackgroundCacheImage(texturePath);
+  }
   return true;
 }
 

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -74,7 +74,7 @@ bool CImageLoader::DoWork()
     // direct route - load the image
     m_texture = new CTexture();
     unsigned int start = XbmcThreads::SystemClockMillis();
-    if (!m_texture->LoadFromFile(loadPath, min(g_graphicsContext.GetWidth(), 2048), min(g_graphicsContext.GetHeight(), 1080), g_guiSettings.GetBool("pictures.useexifrotation")))
+    if (!m_texture->LoadFromFile(loadPath, g_graphicsContext.GetWidth(), g_graphicsContext.GetHeight(), g_guiSettings.GetBool("pictures.useexifrotation")))
     {
       delete m_texture;
       m_texture = NULL;

--- a/xbmc/Makefile.in
+++ b/xbmc/Makefile.in
@@ -23,6 +23,7 @@ SRCS=Application.cpp \
      SystemGlobals.cpp \
      Temperature.cpp \
      TextureCache.cpp \
+     TextureCacheJob.cpp \
      TextureDatabase.cpp \
      ThumbLoader.cpp \
      ThumbnailCache.cpp \

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -151,6 +151,11 @@ void CTextureCache::BackgroundCacheImage(const CStdString &url)
   AddJob(new CTextureCacheJob(url, cacheHash));
 }
 
+void CTextureCache::BackgroundCacheTexture(const CStdString &url, const CBaseTexture *texture, unsigned int max_width, unsigned int max_height)
+{
+  AddJob(new CTextureCacheJob(url, texture, max_width, max_height));
+}
+
 CStdString CTextureCache::CacheImageFile(const CStdString &url)
 {
   // Cache image so that the texture manager can load it.

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -65,6 +65,7 @@ CStdString CTextureCache::CCacheJob::CacheImage(const CStdString &url, const CSt
   // unwrap the URL as required
   CStdString image(url);
   bool fullSize = true;
+  bool flipped = false;
   if (url.compare(0, 8, "image://") == 0)
   {
     // format is image://[type@]<url_encoded_path>?options
@@ -99,6 +100,10 @@ CStdString CTextureCache::CCacheJob::CacheImage(const CStdString &url, const CSt
       {
         fullSize = false;
       }
+      else if (option == "flipped")
+      {
+        flipped = true;
+      }
     }
   }
 
@@ -109,7 +114,13 @@ CStdString CTextureCache::CCacheJob::CacheImage(const CStdString &url, const CSt
 
   CStdString logMessage = oldHash.IsEmpty() ? "Caching" : "Recaching";
   CStdString cacheURL = CTextureCache::GetCachedPath(cacheFile);
-  if (fullSize)
+  if (flipped)
+  {
+    CLog::Log(LOGDEBUG, "%s flipped image '%s' as '%s'", logMessage.c_str(), image.c_str(), cacheFile.c_str());
+    if (CPicture::ConvertFile(image, cacheURL, 0, 1920, 1080, 90, true))
+      return hash;
+  }
+  else if (fullSize)
   {
     CLog::Log(LOGDEBUG, "%s full image '%s' as '%s'", logMessage.c_str(), image.c_str(), cacheFile.c_str());
     if (CPicture::CacheFanart(image, cacheURL))

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -419,3 +419,15 @@ CStdString CTextureCache::GetUniqueImage(const CStdString &url, const CStdString
   hash.Format("generated/%c/%s%s", hex[0], hex.c_str(), extension.c_str());
   return GetCachedPath(hash);
 }
+
+bool CTextureCache::Export(const CStdString &image, const CStdString &destination)
+{
+  CStdString cachedImage(GetCachedImage(image));
+  if (!cachedImage.IsEmpty())
+  {
+    if (CFile::Cache(cachedImage, destination))
+      return true;
+    CLog::Log(LOGERROR, "%s failed exporting '%s' to '%s'", __FUNCTION__, cachedImage.c_str(), destination.c_str());
+  }
+  return false;
+}

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -112,10 +112,12 @@ public:
    */
   static CStdString GetCachedPath(const CStdString &file);
 
-  /*! \brief retrieve a wrapped URL for a thumb file
+  /*! \brief retrieve a wrapped URL for a image file
    \param image name of the file
-   \return full wrapped URL of the thumb file
+   \param type type of file containing the image (picture, video, music)
+   \return full wrapped URL of the image file
    */
+  static CStdString GetWrappedImageURL(const CStdString &image, const CStdString &type);
   static CStdString GetWrappedThumbURL(const CStdString &image);
 
   /*! \brief get a unique image path to associate with the given URL, useful for caching images

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -128,6 +128,15 @@ public:
    */
   static CStdString GetUniqueImage(const CStdString &url, const CStdString &extension);
 
+  /*! \brief Add this image to the database
+   Thread-safe wrapper of CTextureDatabase::AddCachedTexture
+   \param image url of the original image
+   \param cacheFile url of the cached image
+   \param hash hash of the original image
+   \return true if we successfully added to the database, false otherwise.
+   */
+  bool AddCachedTexture(const CStdString &image, const CStdString &cacheFile, const CStdString &hash);
+
 private:
   /* \brief Job class for creating .dds versions of textures
    */
@@ -179,15 +188,6 @@ private:
    \return true if this is a cached image, false otherwise.
    */
   bool IsCachedImage(const CStdString &image) const;
-
-  /*! \brief Add this image to the database
-   Thread-safe wrapper of CTextureDatabase::AddCachedTexture
-   \param image url of the original image
-   \param cacheFile url of the cached image
-   \param hash hash of the original image
-   \return true if we successfully added to the database, false otherwise.
-   */
-  bool AddCachedTexture(const CStdString &image, const CStdString &cacheFile, const CStdString &hash);
 
   /*! \brief Get an image from the database
    Thread-safe wrapper of CTextureDatabase::GetCachedTexture

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -56,14 +56,15 @@ public:
 
    Check and return URL to cached image if it exists; If not, return empty string.
    If the image is cached, return URL (for original image or .dds version if requested)
-   Created .dds of image if requested as per settings.
+   Creates a .dds of image if requested via returnDDS and the image doesn't need recaching.
 
    \param image url of the image to check
    \param returnDDS if we're allowed to return a DDS version, defaults to true
+   \param needsRecaching [out] whether the image needs recaching.
    \return cached url of this image
    \sa GetCachedImage
    */ 
-   CStdString CheckCachedImage(const CStdString &image, bool returnDDS = true);
+  CStdString CheckCachedImage(const CStdString &image, bool returnDDS, bool &needsRecaching);
 
   /*! \brief This function is a wrapper around CheckCacheImage and CacheImageFile.
   
@@ -77,6 +78,15 @@ public:
    */
   CStdString CheckAndCacheImage(const CStdString &image, bool returnDDS = true);
 
+  /*! \brief Cache image (if required) using a background job
+
+   Essentially a threaded version of CheckAndCacheImage.
+
+   \param image url of the image to cache
+   \sa CheckAndCacheImage
+   */
+  void BackgroundCacheImage(const CStdString &image);
+
   /*! \brief Take image URL and add it to image cache
 
    Takes the URL to an image. Caches and adds to the database.
@@ -86,7 +96,7 @@ public:
    \sa CCacheJob::CacheImage
    */  
   CStdString CacheImageFile(const CStdString &url);
-  
+
   /*! \brief retrieve the cached version of the given image (if it exists)
    \param image url of the image
    \return cached url of this image, empty if none exists
@@ -189,13 +199,22 @@ private:
    */
   bool IsCachedImage(const CStdString &image) const;
 
+  /*! \brief retrieve the cached version of the given image (if it exists)
+   \param image url of the image
+   \param cacheHash [out] set to the hash of the cached image if it needs checking
+   \return cached url of this image, empty if none exists
+   \sa ClearCachedImage
+   */
+  CStdString GetCachedImage(const CStdString &image, CStdString &cacheHash);
+
   /*! \brief Get an image from the database
    Thread-safe wrapper of CTextureDatabase::GetCachedTexture
    \param image url of the original image
    \param cacheFile [out] url of the cached original (if available)
+   \param cacheHash [out] the hash of the cached image if it requires recaching, empty otherwise.
    \return true if we have a cached version of this image, false otherwise.
    */
-  bool GetCachedTexture(const CStdString &url, CStdString &cacheFile);
+  bool GetCachedTexture(const CStdString &url, CStdString &cacheFile, CStdString &cacheHash);
 
   /*! \brief Clear an image from the database
    Thread-safe wrapper of CTextureDatabase::ClearCachedTexture

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -113,10 +113,10 @@ public:
    */
   void ClearCachedImage(const CStdString &image, bool deleteSource = false);
 
-  /*! \brief retrieve a cache file (relative to the cache path) to associate with the given image
-   Use GetCachedPath(GetCacheFile(url)) for the full path to the file.
+  /*! \brief retrieve a cache file (relative to the cache path) to associate with the given image, excluding extension
+   Use GetCachedPath(GetCacheFile(url)+extension) for the full path to the file.
    \param url location of the image
-   \return a "unique" filename for the associated cache file.
+   \return a "unique" filename for the associated cache file, excluding extension
    */
   static CStdString GetCacheFile(const CStdString &url);
 

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -154,45 +154,6 @@ public:
    */
   bool Export(const CStdString &image, const CStdString &destination);
 private:
-  /* \brief Job class for creating .dds versions of textures
-   */
-  class CDDSJob : public CJob
-  {
-  public:
-    CDDSJob(const CStdString &original);
-
-    virtual const char* GetType() const { return "ddscompress"; };
-    virtual bool operator==(const CJob *job) const;
-    virtual bool DoWork();
-
-    CStdString m_original;
-  };
-
-  /*! \brief Job class for caching textures
-   */
-  class CCacheJob : public CJob
-  {
-  public:
-    CCacheJob(const CStdString &url, const CStdString &oldHash);
-
-    virtual const char* GetType() const { return "cacheimage"; };
-    virtual bool operator==(const CJob *job) const;
-    virtual bool DoWork();
-
-    /*! \brief Cache an image either full size or thumb sized
-     \param url URL of image to cache
-     \param relativeCacheFile relative URL of cached version
-     \param oldHash hash of any previously cached version - if the hashes match, we don't cache the image
-     \return hash of the image that we cached, empty on failure
-     */
-    static CStdString CacheImage(const CStdString &url, const CStdString &relativeCacheFile, const CStdString &oldHash = "");
-
-    CStdString m_url;
-    CStdString m_relativeCacheFile;
-    CStdString m_hash;
-    CStdString m_oldHash;
-  };
-
   // private construction, and no assignements; use the provided singleton methods
   CTextureCache();
   CTextureCache(const CTextureCache&);
@@ -229,13 +190,6 @@ private:
    \return true if we had a cached version of this image, false otherwise.
    */
   bool ClearCachedTexture(const CStdString &url, CStdString &cacheFile);
-
-  /*! \brief retrieve a hash for the given image
-   Combines the size, ctime and mtime of the image file into a "unique" hash
-   \param url location of the image
-   \return a hash string for this image
-   */
-  CStdString GetImageHash(const CStdString &url) const;
 
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
 

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -100,7 +100,8 @@ public:
    */
   void ClearCachedImage(const CStdString &image, bool deleteSource = false);
 
-  /*! \brief retrieve the cache file to associate with the given image
+  /*! \brief retrieve a cache file (relative to the cache path) to associate with the given image
+   Use GetCachedPath(GetCacheFile(url)) for the full path to the file.
    \param url location of the image
    \return a "unique" filename for the associated cache file.
    */
@@ -155,14 +156,14 @@ private:
 
     /*! \brief Cache an image either full size or thumb sized
      \param url URL of image to cache
-     \param original URL of cached version
+     \param relativeCacheFile relative URL of cached version
      \param oldHash hash of any previously cached version - if the hashes match, we don't cache the image
      \return hash of the image that we cached, empty on failure
      */
-    static CStdString CacheImage(const CStdString &url, const CStdString &original, const CStdString &oldHash = "");
+    static CStdString CacheImage(const CStdString &url, const CStdString &relativeCacheFile, const CStdString &oldHash = "");
 
     CStdString m_url;
-    CStdString m_original;
+    CStdString m_relativeCacheFile;
     CStdString m_hash;
     CStdString m_oldHash;
   };

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -147,6 +147,12 @@ public:
    */
   bool AddCachedTexture(const CStdString &image, const CStdString &cacheFile, const CStdString &hash);
 
+  /*! \brief Export a (possibly) cached image to a file
+   \param image url of the original image
+   \param destination url of the destination image
+   \return true if we successfully exported the file, false otherwise.
+   */
+  bool Export(const CStdString &image, const CStdString &destination);
 private:
   /* \brief Job class for creating .dds versions of textures
    */

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -25,6 +25,8 @@
 #include "utils/JobManager.h"
 #include "TextureDatabase.h"
 
+class CBaseTexture;
+
 /*!
  \ingroup textures
  \brief Texture cache class for handling the caching of images.
@@ -86,6 +88,7 @@ public:
    \sa CheckAndCacheImage
    */
   void BackgroundCacheImage(const CStdString &image);
+  void BackgroundCacheTexture(const CStdString &image, const CBaseTexture *texture, unsigned int max_width, unsigned int max_height);
 
   /*! \brief Take image URL and add it to image cache
 

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -30,6 +30,7 @@
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 #include "URL.h"
+#include "FileItem.h"
 
 CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CStdString &oldHash)
 {
@@ -106,6 +107,12 @@ CStdString CTextureCacheJob::CacheImage(const CStdString &url, const CStdString 
   CStdString hash = GetImageHash(image);
   if (hash.IsEmpty() || hash == oldHash)
     return hash;
+
+  // Validate file URL to see if it is an image
+  CFileItem file(image, false);
+  if (!(file.IsPicture() && !(file.IsZIP() || file.IsRAR() || file.IsCBR() || file.IsCBZ() ))
+      && !file.GetMimeType().Left(6).Equals("image/")) // ignore non-pictures
+    return "";
 
   CStdString logMessage = oldHash.IsEmpty() ? "Caching" : "Recaching";
   CStdString cacheURL = CTextureCache::GetCachedPath(cacheFile);

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -38,7 +38,7 @@ CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CStdString &oldH
 {
   m_url = url;
   m_oldHash = oldHash;
-  m_relativeCacheFile = CTextureCache::GetCacheFile(m_url);
+  m_cachePath = CTextureCache::GetCacheFile(m_url);
   m_texture = NULL;
   m_maxWidth = m_maxHeight = 0;
 }
@@ -52,7 +52,7 @@ CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CBaseTexture *te
     m_texture = NULL;
   m_maxWidth = max_width;
   m_maxHeight = max_height;
-  m_relativeCacheFile = CTextureCache::GetCacheFile(m_url);
+  m_cachePath = CTextureCache::GetCacheFile(m_url);
 }
 
 CTextureCacheJob::~CTextureCacheJob()
@@ -65,7 +65,7 @@ bool CTextureCacheJob::operator==(const CJob* job) const
   if (strcmp(job->GetType(),GetType()) == 0)
   {
     const CTextureCacheJob* cacheJob = dynamic_cast<const CTextureCacheJob*>(job);
-    if (cacheJob && cacheJob->m_relativeCacheFile == m_relativeCacheFile)
+    if (cacheJob && cacheJob->m_cachePath == m_cachePath)
       return true;
   }
   return false;
@@ -89,14 +89,19 @@ bool CTextureCacheJob::DoWork()
     m_texture = LoadImage(image, width, height, flipped);
   if (m_texture)
   {
+    if (m_texture->HasAlpha())
+      m_cacheFile = m_cachePath + ".png";
+    else
+      m_cacheFile = m_cachePath + ".jpg";
+
     if (width > 0 && height > 0)
       CLog::Log(LOGDEBUG, "%s image '%s' at %dx%d with orientation %d as '%s'", m_oldHash.IsEmpty() ? "Caching" : "Recaching", image.c_str(),
-                width, height, texture->GetOrientation(), m_relativeCacheFile.c_str());
+                width, height, m_texture->GetOrientation(), m_cacheFile.c_str());
     else
       CLog::Log(LOGDEBUG, "%s image '%s' fullsize with orientation %d as '%s'", m_oldHash.IsEmpty() ? "Caching" : "Recaching", image.c_str(),
-                texture->GetOrientation(), m_relativeCacheFile.c_str());
+                m_texture->GetOrientation(), m_cacheFile.c_str());
 
-    return CPicture::CacheTexture(m_texture, width, height, CTextureCache::GetCachedPath(m_relativeCacheFile));
+    return CPicture::CacheTexture(m_texture, width, height, CTextureCache::GetCachedPath(m_cacheFile));
   }
   return false;
 }

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -1,0 +1,180 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "TextureCacheJob.h"
+#include "TextureCache.h"
+#include "guilib/Texture.h"
+#include "guilib/DDSImage.h"
+#include "settings/Settings.h"
+#include "utils/log.h"
+#include "filesystem/File.h"
+#include "pictures/Picture.h"
+#include "utils/URIUtils.h"
+#include "utils/StringUtils.h"
+#include "URL.h"
+
+CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CStdString &oldHash)
+{
+  m_url = url;
+  m_oldHash = oldHash;
+  m_relativeCacheFile = CTextureCache::GetCacheFile(m_url);
+}
+
+bool CTextureCacheJob::operator==(const CJob* job) const
+{
+  if (strcmp(job->GetType(),GetType()) == 0)
+  {
+    const CTextureCacheJob* cacheJob = dynamic_cast<const CTextureCacheJob*>(job);
+    if (cacheJob && cacheJob->m_relativeCacheFile == m_relativeCacheFile)
+      return true;
+  }
+  return false;
+}
+
+bool CTextureCacheJob::DoWork()
+{
+  m_hash = CacheImage(m_url, m_relativeCacheFile, m_oldHash);
+  return !m_hash.IsEmpty();
+}
+
+CStdString CTextureCacheJob::CacheImage(const CStdString &url, const CStdString &cacheFile, const CStdString &oldHash)
+{
+  // unwrap the URL as required
+  CStdString image(url);
+  bool fullSize = true;
+  bool flipped = false;
+  if (url.compare(0, 8, "image://") == 0)
+  {
+    // format is image://[type@]<url_encoded_path>?options
+    CURL thumbURL(url);
+
+    if (!thumbURL.GetUserName().IsEmpty())
+      return ""; // we don't re-cache special images (eg picturefolder/video embedded thumbs)
+
+    image = thumbURL.GetHostName();
+    CURL::Decode(image);
+
+    CStdString optionString = thumbURL.GetOptions().Mid(1);
+    optionString.TrimRight('/'); // in case XBMC adds a slash
+
+    std::vector<CStdString> options;
+    StringUtils::SplitString(optionString, "&", options);
+    for (std::vector<CStdString>::iterator i = options.begin(); i != options.end(); i++)
+    {
+      CStdString option, value;
+      int pos = i->Find('=');
+      if (pos != -1)
+      {
+        option = i->Left(pos);
+        value  = i->Mid(pos + 1);
+      }
+      else
+      {
+        option = *i;
+        value = "";
+      }
+      if (option == "size" && value == "thumb")
+      {
+        fullSize = false;
+      }
+      else if (option == "flipped")
+      {
+        flipped = true;
+      }
+    }
+  }
+
+  // generate the hash
+  CStdString hash = GetImageHash(image);
+  if (hash.IsEmpty() || hash == oldHash)
+    return hash;
+
+  CStdString logMessage = oldHash.IsEmpty() ? "Caching" : "Recaching";
+  CStdString cacheURL = CTextureCache::GetCachedPath(cacheFile);
+  if (flipped)
+  {
+    CLog::Log(LOGDEBUG, "%s flipped image '%s' as '%s'", logMessage.c_str(), image.c_str(), cacheFile.c_str());
+    if (CPicture::ConvertFile(image, cacheURL, 0, 1920, 1080, 90, true))
+     return hash;
+  }
+  else if (fullSize)
+  {
+    CLog::Log(LOGDEBUG, "%s full image '%s' as '%s'", logMessage.c_str(), image.c_str(), cacheFile.c_str());
+    if (CPicture::CacheFanart(image, cacheURL))
+      return hash;
+  }
+  else
+  {
+    CLog::Log(LOGDEBUG, "%s thumb image '%s' as '%s'", logMessage.c_str(), image.c_str(), cacheFile.c_str());
+    if (CPicture::CacheThumb(image, cacheURL))
+      return hash;
+  }
+  return "";
+}
+
+CStdString CTextureCacheJob::GetImageHash(const CStdString &url)
+{
+  struct __stat64 st;
+  if (XFILE::CFile::Stat(url, &st) == 0)
+  {
+    int64_t time = st.st_mtime;
+    if (!time)
+      time = st.st_ctime;
+    if (time || st.st_size)
+    {
+      CStdString hash;
+      hash.Format("d%"PRId64"s%"PRId64, time, st.st_size);
+      return hash;
+    }
+  }
+  CLog::Log(LOGDEBUG, "%s - unable to stat url %s", __FUNCTION__, url.c_str());
+  return "";
+}
+
+CTextureDDSJob::CTextureDDSJob(const CStdString &original)
+{
+  m_original = original;
+}
+
+bool CTextureDDSJob::operator==(const CJob* job) const
+{
+  if (strcmp(job->GetType(),GetType()) == 0)
+  {
+    const CTextureDDSJob* ddsJob = dynamic_cast<const CTextureDDSJob*>(job);
+    if (ddsJob && ddsJob->m_original == m_original)
+      return true;
+  }
+  return false;
+}
+
+bool CTextureDDSJob::DoWork()
+{
+  CTexture texture;
+  if (URIUtils::GetExtension(m_original).Equals(".dds"))
+    return false;
+  if (texture.LoadFromFile(m_original))
+  { // convert to DDS
+    CDDSImage dds;
+    CLog::Log(LOGDEBUG, "Creating DDS version of: %s", m_original.c_str());
+    return dds.Create(URIUtils::ReplaceExtension(m_original, ".dds"), texture.GetWidth(), texture.GetHeight(), texture.GetPitch(), texture.GetPixels(), 40);
+  }
+  return false;
+}

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -66,7 +66,7 @@ public:
   static CBaseTexture *LoadImage(const CStdString &image, unsigned int width, unsigned int height, bool flipped);
 
   CStdString m_url;
-  CStdString m_relativeCacheFile;
+  CStdString m_cacheFile;
   CStdString m_hash;
   CStdString m_oldHash;
 private:
@@ -80,6 +80,7 @@ private:
   unsigned int  m_maxWidth;
   unsigned int  m_maxHeight;
   CBaseTexture *m_texture;
+  CStdString    m_cachePath;
 };
 
 /* \brief Job class for creating .dds versions of textures

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -1,0 +1,75 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#pragma once
+
+#include "utils/StdString.h"
+#include "utils/Job.h"
+
+/*!
+ \ingroup textures
+ \brief Job class for caching textures
+ 
+ Handles loading and caching of textures.
+ */
+class CTextureCacheJob : public CJob
+{
+public:
+  CTextureCacheJob(const CStdString &url, const CStdString &oldHash);
+
+  virtual const char* GetType() const { return "cacheimage"; };
+  virtual bool operator==(const CJob *job) const;
+  virtual bool DoWork();
+
+  /*! \brief Cache an image either full size or thumb sized
+   \param url URL of image to cache
+   \param relativeCacheFile relative URL of cached version
+   \param oldHash hash of any previously cached version - if the hashes match, we don't cache the image
+   \return hash of the image that we cached, empty on failure
+   */
+  static CStdString CacheImage(const CStdString &url, const CStdString &relativeCacheFile, const CStdString &oldHash = "");
+
+  CStdString m_url;
+  CStdString m_relativeCacheFile;
+  CStdString m_hash;
+  CStdString m_oldHash;
+private:
+  /*! \brief retrieve a hash for the given image
+   Combines the size, ctime and mtime of the image file into a "unique" hash
+   \param url location of the image
+   \return a hash string for this image
+   */
+  static CStdString GetImageHash(const CStdString &url);
+};
+
+/* \brief Job class for creating .dds versions of textures
+ */
+class CTextureDDSJob : public CJob
+{
+public:
+  CTextureDDSJob(const CStdString &original);
+
+  virtual const char* GetType() const { return "ddscompress"; };
+  virtual bool operator==(const CJob *job) const;
+  virtual bool DoWork();
+
+  CStdString m_original;
+};

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -24,6 +24,8 @@
 #include "utils/StdString.h"
 #include "utils/Job.h"
 
+class CBaseTexture;
+
 /*!
  \ingroup textures
  \brief Job class for caching textures
@@ -39,13 +41,27 @@ public:
   virtual bool operator==(const CJob *job) const;
   virtual bool DoWork();
 
-  /*! \brief Cache an image either full size or thumb sized
-   \param url URL of image to cache
-   \param relativeCacheFile relative URL of cached version
-   \param oldHash hash of any previously cached version - if the hashes match, we don't cache the image
-   \return hash of the image that we cached, empty on failure
+  /*! \brief Decode an image URL to the underlying image, width, height and orientation
+   \param url wrapped URL of the image
+   \param width width derived from URL
+   \param height height derived from URL
+   \param flipped whether the image is flipped horizontally
+   \return URL of the underlying image file.
    */
-  static CStdString CacheImage(const CStdString &url, const CStdString &relativeCacheFile, const CStdString &oldHash = "");
+  static CStdString DecodeImageURL(const CStdString &url, unsigned int &width, unsigned int &height, bool &flipped);
+
+  /*! \brief Load an image at a given target size and orientation.
+
+   Doesn't necessarily load the image at the desired size - the loader *may* decide to load it slightly larger
+   or smaller than the desired size for speed reasons.
+
+   \param image the URL of the image file.
+   \param width the desired maximum width.
+   \param height the desired maximum height.
+   \param flipped whether the image should be flipped horizontally.
+   \return a pointer to a CBaseTexture object, NULL if failed.
+   */
+  static CBaseTexture *LoadImage(const CStdString &image, unsigned int width, unsigned int height, bool flipped);
 
   CStdString m_url;
   CStdString m_relativeCacheFile;

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -36,6 +36,8 @@ class CTextureCacheJob : public CJob
 {
 public:
   CTextureCacheJob(const CStdString &url, const CStdString &oldHash);
+  CTextureCacheJob(const CStdString &url, const CBaseTexture *texture, unsigned int max_width, unsigned int max_height);
+  virtual ~CTextureCacheJob();
 
   virtual const char* GetType() const { return "cacheimage"; };
   virtual bool operator==(const CJob *job) const;
@@ -74,6 +76,10 @@ private:
    \return a hash string for this image
    */
   static CStdString GetImageHash(const CStdString &url);
+
+  unsigned int  m_maxWidth;
+  unsigned int  m_maxHeight;
+  CBaseTexture *m_texture;
 };
 
 /* \brief Job class for creating .dds versions of textures

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -280,3 +280,20 @@ void CTextureDatabase::SetTextureForPath(const CStdString &url, const CStdString
   }
   return;
 }
+
+void CTextureDatabase::ClearTextureForPath(const CStdString &url, const CStdString &type)
+{
+  try
+  {
+    if (NULL == m_pDB.get()) return;
+    if (NULL == m_pDS.get()) return;
+
+    CStdString sql = PrepareSQL("DELETE FROM path WHERE url='%s' and type='%s'", url.c_str(), type.c_str());
+    m_pDS->exec(sql.c_str());
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s failed on url '%s'", __FUNCTION__, url.c_str());
+  }
+  return;
+}

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -92,6 +92,10 @@ bool CTextureDatabase::UpdateOldVersion(int version)
       }
       m_pDS->close();
     }
+    if (version < 8)
+    { // get rid of old cached thumbs as they were previously set to the cached thumb name instead of the source thumb
+      m_pDS->exec("delete from path");
+    }
   }
   catch (...)
   {

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -38,9 +38,10 @@ public:
    Used for retrieval of previously discovered images to save
    stat() on the filesystem all the time
    \param url path that may be associated with a texture
+   \param type type of image to look for
    \return URL of the texture associated with the given path
    */
-  CStdString GetTextureForPath(const CStdString &url);
+  CStdString GetTextureForPath(const CStdString &url, const CStdString &type);
 
   /*! \brief Set a texture associated with the given path
    Used for setting of previously discovered images to save
@@ -48,9 +49,10 @@ public:
    the actual image path, not the cached image path (the image will be
    cached at load time.)
    \param url path that was used to find the texture
+   \param type type of image to associate
    \param texture URL of the texture to associate with the path
    */
-  void SetTextureForPath(const CStdString &url, const CStdString &texture);
+  void SetTextureForPath(const CStdString &url, const CStdString &type, const CStdString &texture);
 
 protected:
   /*! \brief retrieve a hash for the given url
@@ -62,6 +64,6 @@ protected:
 
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 8; };
+  virtual int GetMinVersion() const { return 9; };
   const char *GetBaseDBName() const { return "Textures"; };
 };

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -54,6 +54,14 @@ public:
    */
   void SetTextureForPath(const CStdString &url, const CStdString &type, const CStdString &texture);
 
+  /*! \brief Clear a texture associated with the given path
+   \param url path that was used to find the texture
+   \param type type of image to associate
+   \param texture URL of the texture to associate with the path
+   \sa GetTextureForPath, SetTextureForPath
+   */
+  void ClearTextureForPath(const CStdString &url, const CStdString &type);
+
 protected:
   /*! \brief retrieve a hash for the given url
    Computes a hash of the current url to use for lookups in the database

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -72,6 +72,6 @@ protected:
 
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 10; };
+  virtual int GetMinVersion() const { return 11; };
   const char *GetBaseDBName() const { return "Textures"; };
 };

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -35,7 +35,7 @@ public:
   bool ClearCachedTexture(const CStdString &originalURL, CStdString &cacheFile);
 
   /*! \brief Get a texture associated with the given path
-   Used for retrieval of previously discovered (and cached) images to save
+   Used for retrieval of previously discovered images to save
    stat() on the filesystem all the time
    \param url path that may be associated with a texture
    \return URL of the texture associated with the given path
@@ -43,8 +43,10 @@ public:
   CStdString GetTextureForPath(const CStdString &url);
 
   /*! \brief Set a texture associated with the given path
-   Used for setting of previously discovered (and cached) images to save
-   stat() on the filesystem all the time
+   Used for setting of previously discovered images to save
+   stat() on the filesystem all the time. Should be used to set
+   the actual image path, not the cached image path (the image will be
+   cached at load time.)
    \param url path that was used to find the texture
    \param texture URL of the texture to associate with the path
    */
@@ -60,6 +62,6 @@ protected:
 
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 7; };
+  virtual int GetMinVersion() const { return 8; };
   const char *GetBaseDBName() const { return "Textures"; };
 };

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -60,6 +60,6 @@ protected:
 
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 6; };
+  virtual int GetMinVersion() const { return 7; };
   const char *GetBaseDBName() const { return "Textures"; };
 };

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -64,6 +64,6 @@ protected:
 
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 9; };
+  virtual int GetMinVersion() const { return 10; };
   const char *GetBaseDBName() const { return "Textures"; };
 };

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -78,17 +78,6 @@ CStdString CThumbLoader::GetCachedThumb(const CFileItem &item)
   return "";
 }
 
-bool CThumbLoader::CheckAndCacheThumb(CFileItem &item)
-{
-  if (item.HasThumbnail() && !g_TextureManager.CanLoad(item.GetThumbnailImage()))
-  {
-    CStdString thumb = CTextureCache::Get().CheckAndCacheImage(item.GetThumbnailImage());
-    item.SetThumbnailImage(thumb);
-    return !thumb.IsEmpty();
-  }
-  return false;
-}
-
 CThumbExtractor::CThumbExtractor(const CFileItem& item, const CStdString& listpath, bool thumb, const CStdString& target)
 {
   m_listpath = listpath;
@@ -311,7 +300,7 @@ bool CProgramThumbLoader::LoadItem(CFileItem *pItem)
 bool CProgramThumbLoader::FillThumb(CFileItem &item)
 {
   // no need to do anything if we already have a thumb set
-  if (CheckAndCacheThumb(item) || item.HasThumbnail())
+  if (item.HasThumbnail())
     return true;
 
   // see whether we have a cached image for this item
@@ -327,7 +316,10 @@ bool CProgramThumbLoader::FillThumb(CFileItem &item)
     }
   }
   if (!thumb.IsEmpty())
-    item.SetThumbnailImage(CTextureCache::Get().CheckAndCacheImage(thumb));
+  {
+    CTextureCache::Get().BackgroundCacheImage(thumb);
+    item.SetThumbnailImage(thumb);
+  }
   return true;
 }
 

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -70,12 +70,19 @@ bool CThumbLoader::LoadRemoteThumb(CFileItem *pItem)
   return pItem->HasThumbnail();
 }
 
-CStdString CThumbLoader::GetCachedThumb(const CFileItem &item)
+CStdString CThumbLoader::GetCachedImage(const CFileItem &item, const CStdString &type)
 {
   CTextureDatabase db;
   if (db.Open())
-    return db.GetTextureForPath(item.GetPath());
+    return db.GetTextureForPath(item.GetPath(), type);
   return "";
+}
+
+void CThumbLoader::SetCachedImage(const CFileItem &item, const CStdString &type, const CStdString &image)
+{
+  CTextureDatabase db;
+  if (db.Open())
+    db.SetTextureForPath(item.GetPath(), type, image);
 }
 
 CThumbExtractor::CThumbExtractor(const CFileItem& item, const CStdString& listpath, bool thumb, const CStdString& target)
@@ -304,16 +311,12 @@ bool CProgramThumbLoader::FillThumb(CFileItem &item)
     return true;
 
   // see whether we have a cached image for this item
-  CStdString thumb = GetCachedThumb(item);
+  CStdString thumb = GetCachedImage(item, "thumb");
   if (thumb.IsEmpty())
   {
     thumb = GetLocalThumb(item);
     if (!thumb.IsEmpty())
-    {
-      CTextureDatabase db;
-      if (db.Open())
-        db.SetTextureForPath(item.GetPath(), thumb);
-    }
+      SetCachedImage(item, "thumb", thumb);
   }
   if (!thumb.IsEmpty())
   {

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -238,17 +238,9 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
       cachedThumb = strPath + "auto-" + strFileName;
       if (CFile::Exists(cachedThumb))
       {
-        // this is abit of a hack to avoid loading zero sized images
-        // which we know will fail. They will just display empty image
-        // we should really have some way for the texture loader to
-        // do fallbacks to default images for a failed image instead
-        struct __stat64 st;
-        if(CFile::Stat(cachedThumb, &st) == 0 && st.st_size > 0)
-        {
-          pItem->SetProperty("HasAutoThumb", true);
-          pItem->SetProperty("AutoThumbImage", cachedThumb);
-          pItem->SetThumbnailImage(cachedThumb);
-        }
+        pItem->SetProperty("HasAutoThumb", true);
+        pItem->SetProperty("AutoThumbImage", cachedThumb);
+        pItem->SetThumbnailImage(cachedThumb);
       }
       else if (!pItem->m_bIsFolder && pItem->IsVideo() && g_guiSettings.GetBool("myvideos.extractthumb") &&
                g_guiSettings.GetBool("myvideos.extractflags"))

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -324,20 +324,18 @@ bool CProgramThumbLoader::FillThumb(CFileItem &item)
 
   // see whether we have a cached image for this item
   CStdString thumb = GetCachedThumb(item);
-  if (!thumb.IsEmpty())
+  if (thumb.IsEmpty())
   {
+    thumb = GetLocalThumb(item);
+    if (!thumb.IsEmpty())
+    {
+      CTextureDatabase db;
+      if (db.Open())
+        db.SetTextureForPath(item.GetPath(), thumb);
+    }
+  }
+  if (!thumb.IsEmpty())
     item.SetThumbnailImage(CTextureCache::Get().CheckAndCacheImage(thumb));
-    return true;
-  }
-  thumb = GetLocalThumb(item);
-  if (!thumb.IsEmpty())
-  {
-    CTextureDatabase db;
-    if (db.Open())
-      db.SetTextureForPath(item.GetPath(), thumb);
-    thumb = CTextureCache::Get().CheckAndCacheImage(thumb);
-  }
-  item.SetThumbnailImage(thumb);
   return true;
 }
 

--- a/xbmc/ThumbLoader.h
+++ b/xbmc/ThumbLoader.h
@@ -69,12 +69,19 @@ public:
 
   bool LoadRemoteThumb(CFileItem *pItem);
 
-  /*! \brief Checks whether the given item has a thumb listed in the texture database
-   \param item CFileItem to check for a thumb
-   \return the thumb associated with this item
-   \sa CheckAndCacheThumb
+  /*! \brief Checks whether the given item has an image listed in the texture database
+   \param item CFileItem to check
+   \param type the type of image to retrieve
+   \return the image associated with this item
    */
-  static CStdString GetCachedThumb(const CFileItem &item);
+  static CStdString GetCachedImage(const CFileItem &item, const CStdString &type);
+
+  /*! \brief Associate an image with the given item in the texture database
+   \param item CFileItem to associate the image with
+   \param type the type of image
+   \param image the URL of the image
+   */
+  static void SetCachedImage(const CFileItem &item, const CStdString &type, const CStdString &image);
 };
 
 class CVideoThumbLoader : public CThumbLoader, public CJobQueue

--- a/xbmc/ThumbLoader.h
+++ b/xbmc/ThumbLoader.h
@@ -69,13 +69,6 @@ public:
 
   bool LoadRemoteThumb(CFileItem *pItem);
 
-  /*! \brief Checks whether the given item has a thumb that needs caching, and if so caches it.
-   \param item CFileItem to check for a cachable thumb.
-   \return true if we successfully cache a thumb, false otherwise.
-   \sa GetCachedThumb
-   */
-  static bool CheckAndCacheThumb(CFileItem &item);
-
   /*! \brief Checks whether the given item has a thumb listed in the texture database
    \param item CFileItem to check for a thumb
    \return the thumb associated with this item

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -160,7 +160,8 @@ void CURL::Parse(const CStdString& strURL1)
   CStdString strProtocol2 = GetTranslatedProtocol();
   if(m_strProtocol.Equals("rss") ||
      m_strProtocol.Equals("rar") ||
-     m_strProtocol.Equals("addons"))
+     m_strProtocol.Equals("addons") ||
+     m_strProtocol.Equals("image"))
     sep = "?";
   else
   if(strProtocol2.Equals("http")

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -558,7 +558,7 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
         { // store the thumb for this share
           CTextureDatabase db;
           if (db.Open())
-            db.SetTextureForPath(item->GetPath(), strThumb);
+            db.SetTextureForPath(item->GetPath(), "thumb", strThumb);
         }
         if (!cachedThumb.IsEmpty())
           XFILE::CFile::Cache(strThumb, cachedThumb);

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -558,12 +558,10 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
         { // store the thumb for this share
           CTextureDatabase db;
           if (db.Open())
-          {
-            cachedThumb = CTextureCache::GetUniqueImage(item->GetPath(), URIUtils::GetExtension(strThumb));
-            db.SetTextureForPath(item->GetPath(), cachedThumb);
-          }
+            db.SetTextureForPath(item->GetPath(), strThumb);
         }
-        XFILE::CFile::Cache(strThumb, cachedThumb);
+        if (!cachedThumb.IsEmpty())
+          XFILE::CFile::Cache(strThumb, cachedThumb);
       }
 
       CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -73,9 +73,9 @@ void CGUIImage::UpdateInfo(const CGUIListItem *item)
     return;
 
   if (item)
-    SetFileName(m_info.GetItemLabel(item, true));
+    SetFileName(m_info.GetItemLabel(item, true, &m_currentFallback));
   else
-    SetFileName(m_info.GetLabel(m_parentID, true));
+    SetFileName(m_info.GetLabel(m_parentID, true, &m_currentFallback));
 }
 
 void CGUIImage::AllocateOnDemand()
@@ -97,7 +97,12 @@ void CGUIImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions
 {
   // check whether our image failed to allocate, and if so drop back to the fallback image
   if (m_texture.FailedToAlloc() && !m_texture.GetFileName().Equals(m_info.GetFallback()))
-    m_texture.SetFileName(m_info.GetFallback());
+  {
+    if (!m_currentFallback.IsEmpty() && !m_texture.GetFileName().Equals(m_currentFallback))
+      m_texture.SetFileName(m_currentFallback);
+    else
+      m_texture.SetFileName(m_info.GetFallback());
+  }
 
   if (m_crossFadeTime)
   {

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -114,6 +114,7 @@ protected:
   CGUITexture m_texture;
   std::vector<CFadingTexture *> m_fadingTextures;
   CStdString m_currentTexture;
+  CStdString m_currentFallback;
 
   unsigned int m_crossFadeTime;
   unsigned int m_currentFadeTime;

--- a/xbmc/guilib/GUIInfoTypes.cpp
+++ b/xbmc/guilib/GUIInfoTypes.cpp
@@ -139,7 +139,7 @@ void CGUIInfoLabel::SetLabel(const CStdString &label, const CStdString &fallback
   Parse(label, context);
 }
 
-CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage) const
+CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, CStdString *fallback) const
 {
   CStdString label;
   for (unsigned int i = 0; i < m_info.size(); i++)
@@ -149,9 +149,9 @@ CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage) const
     {
       CStdString infoLabel;
       if (preferImage)
-        infoLabel = g_infoManager.GetImage(portion.m_info, contextWindow);
+        infoLabel = g_infoManager.GetImage(portion.m_info, contextWindow, fallback);
       if (infoLabel.IsEmpty())
-        infoLabel = g_infoManager.GetLabel(portion.m_info, contextWindow);
+        infoLabel = g_infoManager.GetLabel(portion.m_info, contextWindow, fallback);
       if (!infoLabel.IsEmpty())
         label += portion.GetLabel(infoLabel);
     }
@@ -165,7 +165,7 @@ CStdString CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage) const
   return label;
 }
 
-CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImages) const
+CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImages, CStdString *fallback) const
 {
   if (!item->IsFileItem()) return "";
   CStdString label;
@@ -176,9 +176,9 @@ CStdString CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImag
     {
       CStdString infoLabel;
       if (preferImages)
-        infoLabel = g_infoManager.GetItemImage((const CFileItem *)item, portion.m_info);
+        infoLabel = g_infoManager.GetItemImage((const CFileItem *)item, portion.m_info, fallback);
       else
-        infoLabel = g_infoManager.GetItemLabel((const CFileItem *)item, portion.m_info);
+        infoLabel = g_infoManager.GetItemLabel((const CFileItem *)item, portion.m_info, fallback);
       if (!infoLabel.IsEmpty())
         label += portion.GetLabel(infoLabel);
     }

--- a/xbmc/guilib/GUIInfoTypes.h
+++ b/xbmc/guilib/GUIInfoTypes.h
@@ -75,8 +75,8 @@ public:
   CGUIInfoLabel(const CStdString &label, const CStdString &fallback = "", int context = 0);
 
   void SetLabel(const CStdString &label, const CStdString &fallback, int context = 0);
-  CStdString GetLabel(int contextWindow, bool preferImage = false) const;
-  CStdString GetItemLabel(const CGUIListItem *item, bool preferImage = false) const;
+  CStdString GetLabel(int contextWindow, bool preferImage = false, CStdString *fallback = NULL) const;
+  CStdString GetItemLabel(const CGUIListItem *item, bool preferImage = false, CStdString *fallback = NULL) const;
   bool IsConstant() const;
   bool IsEmpty() const;
 

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -73,13 +73,13 @@ void CGUIListItemLayout::Process(CGUIListItem *item, int parentID, unsigned int 
 {
   if (m_invalidated)
   { // need to update our item
+    m_invalidated = false;
     // could use a dynamic cast here if RTTI was enabled.  As it's not,
     // let's use a static cast with a virtual base function
     CFileItem *fileItem = item->IsFileItem() ? (CFileItem *)item : new CFileItem(*item);
     m_isPlaying.Update(item);
     m_group.SetInvalid();
     m_group.UpdateInfo(fileItem);
-    m_invalidated = false;
     // delete our temporary fileitem
     if (!item->IsFileItem())
       delete fileItem;

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -654,9 +654,7 @@ bool CGUITextureBase::SetFileName(const CStdString& filename)
 
 int CGUITextureBase::GetOrientation() const
 {
-  if (m_isAllocated == LARGE)
-    return m_info.orientation;
-  // otherwise multiply our orientations
+  // multiply our orientations
   static char orient_table[] = { 0, 1, 2, 3, 4, 5, 6, 7,
                                  1, 0, 3, 2, 5, 4, 7, 6,
                                  2, 3, 0, 1, 6, 7, 4, 5,

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -195,7 +195,7 @@ bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxW
   if (URIUtils::GetExtension(texturePath).Equals(".jpg") || URIUtils::GetExtension(texturePath).Equals(".tbn"))
   {
     CJpegIO jpegfile;
-    if (jpegfile.Open(texturePath))
+    if (jpegfile.Open(texturePath, maxWidth, maxHeight))
     {
       if (jpegfile.Width() > 0 && jpegfile.Height() > 0)
       {

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -47,6 +47,27 @@ CBaseTexture::CBaseTexture(unsigned int width, unsigned int height, unsigned int
   Allocate(width, height, format);
 }
 
+CBaseTexture::CBaseTexture(const CBaseTexture &copy)
+{
+  m_imageWidth = copy.m_imageWidth;
+  m_imageHeight = copy.m_imageHeight;
+  m_textureWidth = copy.m_textureWidth;
+  m_textureHeight = copy.m_textureHeight;
+  m_format = copy.m_format;
+  m_orientation = copy.m_orientation;
+  m_hasAlpha = copy.m_hasAlpha;
+#ifndef HAS_DX
+  m_texture = 0;
+#endif
+  m_pixels = NULL;
+  m_loadedToGPU = false;
+  if (copy.m_pixels)
+  {
+    m_pixels = new unsigned char[GetPitch() * GetRows()];
+    memcpy(m_pixels, copy.m_pixels, GetPitch() * GetRows());
+  }
+}
+
 CBaseTexture::~CBaseTexture()
 {
   delete[] m_pixels;

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -83,6 +83,7 @@ public:
   unsigned int GetWidth() const { return m_imageWidth; }
   unsigned int GetHeight() const { return m_imageHeight; }
   int GetOrientation() const { return m_orientation; }
+  void SetOrientation(int orientation) { m_orientation = orientation; }
 
   void Update(unsigned int width, unsigned int height, unsigned int pitch, unsigned int format, const unsigned char *pixels, bool loadToGPU);
   void Allocate(unsigned int width, unsigned int height, unsigned int format);

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -54,6 +54,8 @@ class CBaseTexture
 
 public:
   CBaseTexture(unsigned int width = 0, unsigned int height = 0, unsigned int format = XB_FMT_A8R8G8B8);
+  CBaseTexture(const CBaseTexture &copy);
+
   virtual ~CBaseTexture();
 
   bool LoadFromFile(const CStdString& texturePath, unsigned int maxHeight = 0, unsigned int maxWidth = 0,

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -229,7 +229,7 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
     if (hasThumbnailField)
     {
       if (item->HasThumbnail())
-        object["thumbnail"] = item->GetThumbnailImage().c_str();
+        object["thumbnail"] = CTextureCache::Get().CheckAndCacheImage(item->GetThumbnailImage());
       else if (item->HasVideoInfoTag())
       {
         CStdString strPath, strFileName;

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -268,7 +268,7 @@ bool CGUIWindowPictures::Update(const CStdString &strDirectory)
   m_vecItems->SetThumbnailImage("");
   if (g_guiSettings.GetBool("pictures.generatethumbs"))
     m_thumbLoader.Load(*m_vecItems);
-  m_vecItems->SetThumbnailImage(CPictureThumbLoader::GetCachedThumb(*m_vecItems));
+  m_vecItems->SetThumbnailImage(CPictureThumbLoader::GetCachedImage(*m_vecItems, "thumb"));
 
   return true;
 }

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -36,6 +36,18 @@ public:
 
 private:
   static bool CacheImage(const CStdString& sourceUrl, const CStdString& destFile, int width, int height);
+  static void GetScale(unsigned int width, unsigned int height, unsigned int &out_width, unsigned int &out_height);
+  static bool ScaleImage(uint8_t *in_pixels, unsigned int in_width, unsigned int in_height, unsigned int in_pitch,
+                         uint8_t *out_pixels, unsigned int out_width, unsigned int out_height, unsigned int out_pitch);
+  static bool OrientateImage(uint32_t *&pixels, unsigned int &width, unsigned int &height, int orientation);
+
+  static uint32_t *FlipHorizontal(uint32_t *pixels, unsigned int width, unsigned int height);
+  static uint32_t *FlipVertical(uint32_t *pixels, unsigned int width, unsigned int height);
+  static uint32_t *Rotate90CCW(uint32_t *pixels, unsigned int width, unsigned int height);
+  static uint32_t *Rotate270CCW(uint32_t *pixels, unsigned int width, unsigned int height);
+  static uint32_t *Rotate180CCW(uint32_t *pixels, unsigned int width, unsigned int height);
+  static uint32_t *Transpose(uint32_t *pixels, unsigned int width, unsigned int height);
+  static uint32_t *TransposeOffAxis(uint32_t *pixels, unsigned int width, unsigned int height);
 };
 
 //this class calls CreateThumbnailFromSurface in a CJob, so a png file can be written without halting the render thread

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -34,6 +34,12 @@ public:
   static bool CacheThumb(const CStdString& sourceUrl, const CStdString& destFile);
   static bool CacheFanart(const CStdString& SourceUrl, const CStdString& destFile);
 
+  /*! \brief Create a tiled thumb of the given files
+   \param files the files to create the thumb from
+   \param thumb the filename of the thumb
+   */
+  static bool CreateTiledThumb(const std::vector<std::string> &files, const std::string &thumb);
+
 private:
   static bool CacheImage(const CStdString& sourceUrl, const CStdString& destFile, int width, int height);
   static void GetScale(unsigned int width, unsigned int height, unsigned int &out_width, unsigned int &out_height);

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -22,6 +22,8 @@
 #include "utils/StdString.h"
 #include "utils/Job.h"
 
+class CBaseTexture;
+
 class CPicture
 {
 public:
@@ -39,6 +41,15 @@ public:
    \param thumb the filename of the thumb
    */
   static bool CreateTiledThumb(const std::vector<std::string> &files, const std::string &thumb);
+
+  /*! \brief Cache a texture, resizing, rotating and flipping as needed, and saving as a JPG or PNG
+   \param texture a pointer to a CBaseTexture
+   \param max_width maximum width in pixels of cached version
+   \param max_height maximum height in pixels of cached version
+   \param dest the output cache file
+   \return true if successful, false otherwise
+   */
+  static bool CacheTexture(CBaseTexture *texture, uint32_t max_width, uint32_t max_height, const std::string &dest);
 
 private:
   static bool CacheImage(const CStdString& sourceUrl, const CStdString& destFile, int width, int height);

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -90,8 +90,8 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
     }
   }
   else if (!pItem->HasThumbnail())
-  { // folder, zip, cbz, rar, cbr, playlist
-    thumb = GetCachedThumb(*pItem);
+  { // folder, zip, cbz, rar, cbr, playlist may have a previously cached image
+    thumb = GetCachedImage(*pItem, "thumb");
   }
   if (!thumb.IsEmpty())
   {
@@ -133,7 +133,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
     CStdString strTBN(URIUtils::ReplaceExtension(pItem->GetPath(),".tbn"));
     if (CFile::Exists(strTBN))
     {
-      db.SetTextureForPath(pItem->GetPath(), strTBN);
+      db.SetTextureForPath(pItem->GetPath(), "thumb", strTBN);
       CTextureCache::Get().BackgroundCacheImage(strTBN);
       pItem->SetThumbnailImage(strTBN);
       return;
@@ -159,7 +159,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
     thumb = URIUtils::AddFileToFolder(strPath, thumb);
     if (CFile::Exists(thumb))
     {
-      db.SetTextureForPath(pItem->GetPath(), thumb);
+      db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
       CTextureCache::Get().BackgroundCacheImage(thumb);
       pItem->SetThumbnailImage(thumb);
       return;
@@ -213,7 +213,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       { // less than 4 items, so just grab the first thumb
         items.Sort(SORT_METHOD_LABEL, SORT_ORDER_ASC);
         CStdString thumb = CTextureCache::GetWrappedThumbURL(items[0]->GetPath());
-        db.SetTextureForPath(pItem->GetPath(), thumb);
+        db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
         CTextureCache::Get().BackgroundCacheImage(thumb);
         pItem->SetThumbnailImage(thumb);
       }
@@ -228,7 +228,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
         CStdString relativeCacheFile = CTextureCache::GetCacheFile(thumb);
         CPicture::CreateFolderThumb(strFiles, CTextureCache::GetCachedPath(relativeCacheFile));
         CTextureCache::Get().AddCachedTexture(thumb, relativeCacheFile, "");
-        db.SetTextureForPath(pItem->GetPath(), thumb);
+        db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
         pItem->SetThumbnailImage(CTextureCache::GetCachedPath(relativeCacheFile));
       }
     }

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -54,6 +54,9 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
   if (pItem->HasThumbnail() && m_regenerateThumbs)
   {
     CTextureCache::Get().ClearCachedImage(pItem->GetThumbnailImage());
+    CTextureDatabase db;
+    if (db.Open())
+      db.ClearTextureForPath(pItem->GetPath(), "thumb");
     pItem->SetThumbnailImage("");
   }
 

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -79,8 +79,7 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
       // which we know will fail. They will just display empty image
       // we should really have some way for the texture loader to
       // do fallbacks to default images for a failed image instead
-      struct __stat64 st;
-      if (CFile::Exists(autoThumb) && CFile::Stat(autoThumb, &st) == 0 && st.st_size > 0)
+      if (CFile::Exists(autoThumb))
       {
         thumb = autoThumb;
       }

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -223,16 +223,18 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
       else
       {
         // ok, now we've got the files to get the thumbs from, lets create it...
-        // we basically load the 4 thumbs, resample to 62x62 pixels, and add them
-        CStdString strFiles[4];
+        // we basically load the 4 images and combine them
+        vector<string> files;
         for (int thumb = 0; thumb < 4; thumb++)
-          strFiles[thumb] = CTextureCache::Get().CheckAndCacheImage(CTextureCache::GetWrappedThumbURL(items[thumb]->GetPath()), false);
+          files.push_back(items[thumb]->GetPath());
         CStdString thumb = CTextureCache::GetWrappedImageURL(pItem->GetPath(), "picturefolder");
         CStdString relativeCacheFile = CTextureCache::GetCacheFile(thumb);
-        CPicture::CreateFolderThumb(strFiles, CTextureCache::GetCachedPath(relativeCacheFile));
-        CTextureCache::Get().AddCachedTexture(thumb, relativeCacheFile, "");
-        db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
-        pItem->SetThumbnailImage(CTextureCache::GetCachedPath(relativeCacheFile));
+        if (CPicture::CreateTiledThumb(files, CTextureCache::GetCachedPath(relativeCacheFile)))
+        {
+          CTextureCache::Get().AddCachedTexture(thumb, relativeCacheFile, "");
+          db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
+          pItem->SetThumbnailImage(CTextureCache::GetCachedPath(relativeCacheFile));
+        }
       }
     }
     // refill in the icon to get it to update

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -229,10 +229,12 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
         CStdString strFiles[4];
         for (int thumb = 0; thumb < 4; thumb++)
           strFiles[thumb] = CTextureCache::Get().CheckAndCacheImage(CTextureCache::GetWrappedThumbURL(items[thumb]->GetPath()), false);
-        CStdString thumb = CTextureCache::GetUniqueImage(pItem->GetPath(), ".png");
-        CPicture::CreateFolderThumb(strFiles, thumb);
+        CStdString thumb = CTextureCache::GetWrappedImageURL(pItem->GetPath(), "picturefolder");
+        CStdString relativeCacheFile = CTextureCache::GetCacheFile(thumb);
+        CPicture::CreateFolderThumb(strFiles, CTextureCache::GetCachedPath(relativeCacheFile));
+        CTextureCache::Get().AddCachedTexture(thumb, relativeCacheFile, "");
         db.SetTextureForPath(pItem->GetPath(), thumb);
-        pItem->SetThumbnailImage(thumb);
+        pItem->SetThumbnailImage(CTextureCache::GetCachedPath(relativeCacheFile));
       }
     }
     // refill in the icon to get it to update

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -228,7 +228,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
         for (int thumb = 0; thumb < 4; thumb++)
           files.push_back(items[thumb]->GetPath());
         CStdString thumb = CTextureCache::GetWrappedImageURL(pItem->GetPath(), "picturefolder");
-        CStdString relativeCacheFile = CTextureCache::GetCacheFile(thumb);
+        CStdString relativeCacheFile = CTextureCache::GetCacheFile(thumb) + ".png";
         if (CPicture::CreateTiledThumb(files, CTextureCache::GetCachedPath(relativeCacheFile)))
         {
           CTextureCache::Get().AddCachedTexture(thumb, relativeCacheFile, "");

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -51,9 +51,6 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
   if (pItem->m_bIsShareOrDrive) return true;
   if (pItem->IsParentFolder()) return true;
 
-  if (CheckAndCacheThumb(*pItem))
-    return true;
-
   if (pItem->HasThumbnail() && m_regenerateThumbs)
   {
     CTextureCache::Get().ClearCachedImage(pItem->GetThumbnailImage());
@@ -98,17 +95,8 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
   }
   if (!thumb.IsEmpty())
   {
-    // TODO: In future, do we want the thumbnail image to be the actual URL, and have the caching
-    //       either done here in a job or done at load time (or both).
-    //
-    //       If so, we need to alter GUIInfoManager::GetItemLabel() to return the thumb image
-    //       even if it can't be loaded by the non-background texture manager.
-    //
-    //       In addition, we'd need to hook up a method for the skinner to display either a fallback
-    //       or preferably the icon image while the thumb loads. This would need support in the
-    //       texture control to load directly-load fallback images before loading slow-load images
-    //       In addition, ideally the infomanager could return a (vector of?) fallbacks
-    pItem->SetThumbnailImage(CTextureCache::Get().CheckAndCacheImage(thumb));
+    CTextureCache::Get().BackgroundCacheImage(thumb);
+    pItem->SetThumbnailImage(thumb);
   }
   pItem->FillInDefaultIcon();
   return true;
@@ -146,7 +134,8 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
     if (CFile::Exists(strTBN))
     {
       db.SetTextureForPath(pItem->GetPath(), strTBN);
-      pItem->SetThumbnailImage(CTextureCache::Get().CheckAndCacheImage(strTBN));
+      CTextureCache::Get().BackgroundCacheImage(strTBN);
+      pItem->SetThumbnailImage(strTBN);
       return;
     }
   }
@@ -171,7 +160,8 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
     if (CFile::Exists(thumb))
     {
       db.SetTextureForPath(pItem->GetPath(), thumb);
-      pItem->SetThumbnailImage(CTextureCache::Get().CheckAndCacheImage(thumb));
+      CTextureCache::Get().BackgroundCacheImage(thumb);
+      pItem->SetThumbnailImage(thumb);
       return;
     }
     if (!pItem->IsPlugin())
@@ -224,7 +214,8 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
         items.Sort(SORT_METHOD_LABEL, SORT_ORDER_ASC);
         CStdString thumb = CTextureCache::GetWrappedThumbURL(items[0]->GetPath());
         db.SetTextureForPath(pItem->GetPath(), thumb);
-        pItem->SetThumbnailImage(CTextureCache::Get().CheckAndCacheImage(thumb));
+        CTextureCache::Get().BackgroundCacheImage(thumb);
+        pItem->SetThumbnailImage(thumb);
       }
       else
       {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1198,12 +1198,12 @@ int CVideoDatabase::AddActor(const CStdString& strActor, const CStdString& strTh
     }
     else
     {
-      const field_value value = m_pDS->fv("idActor");
-      int idActor = value.get_asInt() ;
+      int idActor = m_pDS->fv("idActor").get_asInt();
+      m_pDS->close();
       // update the thumb url's
       if (!strThumb.IsEmpty())
         strSQL=PrepareSQL("update actors set strThumb='%s' where idActor=%i",strThumb.c_str(),idActor);
-      m_pDS->close();
+      m_pDS->exec(strSQL.c_str());
       return idActor;
     }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1214,7 +1214,7 @@ int CVideoDatabase::AddCountry(const CStdString& strCountry)
   return AddToTable("country", "idCountry", "strCountry", strCountry);
 }
 
-int CVideoDatabase::AddActor(const CStdString& strActor, const CStdString& strThumb)
+int CVideoDatabase::AddActor(const CStdString& strActor, const CStdString& thumbURLs)
 {
   try
   {
@@ -1226,7 +1226,7 @@ int CVideoDatabase::AddActor(const CStdString& strActor, const CStdString& strTh
     {
       m_pDS->close();
       // doesnt exists, add it
-      strSQL=PrepareSQL("insert into actors (idActor, strActor, strThumb) values( NULL, '%s','%s')", strActor.c_str(),strThumb.c_str());
+      strSQL=PrepareSQL("insert into actors (idActor, strActor, strThumb) values( NULL, '%s','%s')", strActor.c_str(),thumbURLs.c_str());
       m_pDS->exec(strSQL.c_str());
       int idActor = (int)m_pDS->lastinsertid();
       return idActor;
@@ -1236,8 +1236,8 @@ int CVideoDatabase::AddActor(const CStdString& strActor, const CStdString& strTh
       int idActor = m_pDS->fv("idActor").get_asInt();
       m_pDS->close();
       // update the thumb url's
-      if (!strThumb.IsEmpty())
-        strSQL=PrepareSQL("update actors set strThumb='%s' where idActor=%i",strThumb.c_str(),idActor);
+      if (!thumbURLs.IsEmpty())
+        strSQL=PrepareSQL("update actors set strThumb='%s' where idActor=%i",thumbURLs.c_str(),idActor);
       m_pDS->exec(strSQL.c_str());
       return idActor;
     }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -327,21 +327,36 @@ void CVideoDatabase::CreateViews()
 {
   CLog::Log(LOGINFO, "create episodeview");
   m_pDS->exec("DROP VIEW IF EXISTS episodeview");
-  CStdString episodeview = PrepareSQL("create view episodeview as select episode.*,files.strFileName as strFileName,"
-                                      "path.strPath as strPath,files.playCount as playCount,files.lastPlayed as lastPlayed,files.dateAdded as dateAdded,tvshow.c%02d as strTitle,tvshow.c%02d as strStudio,tvshow.idShow as idShow,"
-                                      "tvshow.c%02d as premiered, tvshow.c%02d as mpaa, tvshow.c%02d as strShowPath from episode "
-                                      "join files on files.idFile=episode.idFile "
-                                      "join tvshowlinkepisode on episode.idEpisode=tvshowlinkepisode.idEpisode "
-                                      "join tvshow on tvshow.idShow=tvshowlinkepisode.idShow "
-                                      "join path on files.idPath=path.idPath",VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_PREMIERED, VIDEODB_ID_TV_MPAA, VIDEODB_ID_TV_BASEPATH);
+  CStdString episodeview = PrepareSQL("CREATE VIEW episodeview AS SELECT "
+                                      "  episode.*,"
+                                      "  files.strFileName AS strFileName,"
+                                      "  path.strPath AS strPath,"
+                                      "  files.playCount AS playCount,"
+                                      "  files.lastPlayed AS lastPlayed,"
+                                      "  files.dateAdded AS dateAdded,"
+                                      "  tvshow.c%02d AS strTitle,"
+                                      "  tvshow.c%02d AS strStudio,"
+                                      "  tvshow.idShow AS idShow,"
+                                      "  tvshow.c%02d AS premiered,"
+                                      "  tvshow.c%02d AS mpaa,"
+                                      "  tvshow.c%02d AS strShowPath "
+                                      "FROM episode"
+                                      "  JOIN files ON"
+                                      "    files.idFile=episode.idFile"
+                                      "  JOIN tvshowlinkepisode ON"
+                                      "    episode.idEpisode=tvshowlinkepisode.idEpisode"
+                                      "  JOIN tvshow ON"
+                                      "    tvshow.idShow=tvshowlinkepisode.idShow"
+                                      "  JOIN path ON"
+                                      "    files.idPath=path.idPath", VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_PREMIERED, VIDEODB_ID_TV_MPAA, VIDEODB_ID_TV_BASEPATH);
   m_pDS->exec(episodeview.c_str());
 
   CLog::Log(LOGINFO, "create tvshowview");
   m_pDS->exec("DROP VIEW IF EXISTS tvshowview");
   CStdString tvshowview = PrepareSQL("CREATE VIEW tvshowview AS SELECT "
-                                     "tvshow.*,"
-                                     "path.strPath AS strPath,"
-                                     "path.dateAdded AS dateAdded,"
+                                     "  tvshow.*,"
+                                     "  path.strPath AS strPath,"
+                                     "  path.dateAdded AS dateAdded,"
                                      "  NULLIF(COUNT(episode.c12), 0) AS totalCount,"
                                      "  COUNT(files.playCount) AS watchedcount,"
                                      "  NULLIF(COUNT(DISTINCT(episode.c12)), 0) AS totalSeasons "
@@ -361,13 +376,33 @@ void CVideoDatabase::CreateViews()
 
   CLog::Log(LOGINFO, "create musicvideoview");
   m_pDS->exec("DROP VIEW IF EXISTS musicvideoview");
-  m_pDS->exec("create view musicvideoview as select musicvideo.*,files.strFileName as strFileName,path.strPath as strPath,files.playCount as playCount,files.lastPlayed as lastPlayed,files.dateAdded as dateAdded "
-              "from musicvideo join files on files.idFile=musicvideo.idFile join path on path.idPath=files.idPath");
+  m_pDS->exec("CREATE VIEW musicvideoview AS SELECT"
+              "  musicvideo.*,"
+              "  files.strFileName as strFileName,"
+              "  path.strPath as strPath,"
+              "  files.playCount as playCount,"
+              "  files.lastPlayed as lastPlayed,"
+              "  files.dateAdded as dateAdded "
+              "FROM musicvideo"
+              "  JOIN files ON"
+              "    files.idFile=musicvideo.idFile"
+              "  JOIN path ON"
+              "    path.idPath=files.idPath");
 
   CLog::Log(LOGINFO, "create movieview");
   m_pDS->exec("DROP VIEW IF EXISTS movieview");
-  m_pDS->exec("create view movieview as select movie.*,files.strFileName as strFileName,path.strPath as strPath,files.playCount as playCount,files.lastPlayed as lastPlayed,files.dateAdded as dateAdded "
-              "from movie join files on files.idFile=movie.idFile join path on path.idPath=files.idPath");
+  m_pDS->exec("CREATE VIEW movieview AS SELECT"
+              "  movie.*,"
+              "  files.strFileName AS strFileName,"
+              "  path.strPath AS strPath,"
+              "  files.playCount AS playCount,"
+              "  files.lastPlayed AS lastPlayed, "
+              "  files.dateAdded AS dateAdded "
+              "FROM movie"
+              "  JOIN files ON"
+              "    files.idFile=movie.idFile"
+              "  JOIN path ON"
+              "    path.idPath=files.idPath");
 }
 
 //********************************************************************************************************************************

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1732,8 +1732,6 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
 {
   try
   {
-    CVideoInfoTag info = details;
-
     int idMovie = GetMovieId(strFilenameAndPath);
     if (idMovie > -1)
       DeleteMovie(strFilenameAndPath, true); // true to keep the table entry
@@ -1750,7 +1748,7 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
     vector<int> vecDirectors;
     vector<int> vecGenres;
     vector<int> vecStudios;
-    AddGenreAndDirectorsAndStudios(info,vecDirectors,vecGenres,vecStudios);
+    AddGenreAndDirectorsAndStudios(details,vecDirectors,vecGenres,vecStudios);
 
     for (unsigned int i = 0; i < vecGenres.size(); ++i)
       AddGenreToMovie(idMovie, vecGenres[i]);
@@ -1762,31 +1760,31 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
       AddStudioToMovie(idMovie, vecStudios[i]);
 
     // add writers...
-    for (unsigned int i = 0; i < info.m_writingCredits.size(); i++)
-      AddWriterToMovie(idMovie, AddActor(info.m_writingCredits[i],""));
+    for (unsigned int i = 0; i < details.m_writingCredits.size(); i++)
+      AddWriterToMovie(idMovie, AddActor(details.m_writingCredits[i],""));
 
     // add cast...
     int order = 0;
-    for (CVideoInfoTag::iCast it = info.m_cast.begin(); it != info.m_cast.end(); ++it)
+    for (CVideoInfoTag::iCast it = details.m_cast.begin(); it != details.m_cast.end(); ++it)
     {
       int idActor = AddActor(it->strName,it->thumbUrl.m_xml);
       AddActorToMovie(idMovie, idActor, it->strRole, order++);
     }
 
     // add sets...
-    for (unsigned int i = 0; i < info.m_set.size(); i++)
-      AddSetToMovie(idMovie, AddSet(info.m_set[i]));
+    for (unsigned int i = 0; i < details.m_set.size(); i++)
+      AddSetToMovie(idMovie, AddSet(details.m_set[i]));
 
     // add countries...
-    for (unsigned int i = 0; i < info.m_country.size(); i++)
-      AddCountryToMovie(idMovie, AddCountry(info.m_country[i]));
+    for (unsigned int i = 0; i < details.m_country.size(); i++)
+      AddCountryToMovie(idMovie, AddCountry(details.m_country[i]));
 
     if (details.HasStreamDetails())
       SetStreamDetailsForFileId(details.m_streamDetails, GetFileId(strFilenameAndPath));
 
     // update our movie table (we know it was added already above)
     // and insert the new row
-    CStdString sql = "update movie set " + GetValueString(info, VIDEODB_ID_MIN, VIDEODB_ID_MAX, DbMovieOffsets);
+    CStdString sql = "update movie set " + GetValueString(details, VIDEODB_ID_MIN, VIDEODB_ID_MAX, DbMovieOffsets);
     sql += PrepareSQL(" where idMovie=%i", idMovie);
     m_pDS->exec(sql.c_str());
     CommitTransaction();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4566,8 +4566,26 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
     CStdString strIn = PrepareSQL("= %i", idShow);
     GetStackedTvShowList(idShow, strIn);
 
-    CStdString strSQL = PrepareSQL("select episode.c%02d,path.strPath,tvshow.c%02d,tvshow.c%02d,tvshow.c%02d,tvshow.c%02d,count(1),count(files.playCount) from episode join tvshowlinkepisode on tvshowlinkepisode.idEpisode=episode.idEpisode join tvshow on tvshow.idShow=tvshowlinkepisode.idShow join files on files.idFile=episode.idFile ", VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_GENRE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_MPAA);
-    CStdString joins = PrepareSQL(" join tvshowlinkpath on tvshowlinkpath.idShow = tvshow.idShow join path on path.idPath = tvshowlinkpath.idPath where tvshow.idShow %s ", strIn.c_str());
+    CStdString strSQL = PrepareSQL("SELECT episode.c%02d,"
+                                   "       path.strPath,"
+                                   "       tvshow.c%02d,"
+                                   "       tvshow.c%02d,"
+                                   "       tvshow.c%02d,"
+                                   "       tvshow.c%02d,"
+                                   "       count(1),"
+                                   "       count(files.playCount) "
+                                   "FROM episode"
+                                   " JOIN tvshowlinkepisode ON"
+                                   "   tvshowlinkepisode.idEpisode=episode.idEpisode"
+                                   " JOIN tvshow ON"
+                                   "   tvshow.idShow=tvshowlinkepisode.idShow"
+                                   " JOIN files ON"
+                                   "   files.idFile=episode.idFile ", VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_GENRE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_MPAA);
+    CStdString joins = PrepareSQL("  JOIN tvshowlinkpath ON"
+                                  "    tvshowlinkpath.idShow = tvshow.idShow"
+                                  "  JOIN path ON"
+                                  "    path.idPath = tvshowlinkpath.idPath "
+                                  "WHERE tvshow.idShow %s ", strIn.c_str());
     CStdString extraJoins, extraWhere;
     if (idActor != -1)
     {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -320,6 +320,13 @@ public:
     int numWatched;
   };
 
+  class CSetInfo
+  {
+  public:
+    CStdString name;
+    int playcount;
+  };
+
   CVideoDatabase(void);
   virtual ~CVideoDatabase(void);
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -689,6 +689,7 @@ protected:
   void GetCommonDetails(std::auto_ptr<dbiplus::Dataset> &pDS, CVideoInfoTag &details);
   bool GetPeopleNav(const CStdString& strBaseDir, CFileItemList& items, const CStdString& type, int idContent=-1);
   bool GetNavCommon(const CStdString& strBaseDir, CFileItemList& items, const CStdString& type, int idContent=-1);
+  void GetCast(const CStdString &table, const CStdString &table_id, int type_id, std::vector<SActorInfo> &cast);
 
   void GetDetailsFromDB(std::auto_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   CStdString GetValueString(const CVideoInfoTag &details, int min, int max, const SDbTableOffsets *offsets) const;


### PR DESCRIPTION
The first 8 commits here are basically cleanups/refactor to make things a little nicer to read, other than 7d27fbcc241d86cd4d13b63e748c6b6d8afc07ab which fixes a bug.

The 9th commit 857bb8a is a bit of a hack - we're updating items offthread, which basically sets the m_invalidated flag.  It's not volatile, and we really shouldn't be doing what we're doing, but it hasn't broken yet.  A proper fix would be updating copies of items and passing them via messages, but that's a fix for another day.

The last commits are changes to the TextureCache to prepare for video thumbs moving to the cache.  Numerous changes here, and probably some more are required before things are a lot nicer, but more discussion is required, and I want to get this in. :)

Features added:
- Change thumb:// URL format to image:// URL to allow other uses - in particular allowing a VFS later on for image transformation for the webserver/upnp as well as caching of multiple versions of the same image (mipmap, only load the size the image control needs etc.)
- Store the original URL in the texture db rather than the cached URL.
- Add fallbacks to the infomanager GetImage() functions so that if the returned image fails to load it can fallback to another image (eg icon).
- Don't bother with URL hashing for the texture cache as the db is fast enough anyway.
- Add exporting functions.
- Refactor the handling of texture re-caching jobs so that it's not done in Get*().  This also reduces the chance (but doesn't fully eliminate) 2 threads caching the same image at the same time (which could lead to corruption).
- Refactor texture caching so it uses CJpegIO for the loading stage, and swscale for scaling, plus add orientation support within XBMC so we don't need to hit CxImage as much.  Basically we only use CxImage now for decoding non-JPG/DDS and encoding to JPG/PNG and writing to disc.
