### PR TITLE
Add support for the new ffmpeg api

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1225,6 +1225,9 @@ if test "$use_external_ffmpeg" = "yes"; then
   # old FFmpeg have this in libavcodec/opt.h instead:
   AC_CHECK_HEADERS([libavutil/opt.h])
 
+  # new FFmpeg have math headers
+  AC_CHECK_HEADERS([libavutil/mathematics.h],,)
+
   # We'll support the use of rgb2rgb.h if it exists.
   AC_CHECK_HEADERS([libswscale/rgb2rgb.h],,)
   AC_CHECK_HEADERS([ffmpeg/rgb2rgb.h],,)

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -48,7 +48,7 @@ extern "C" {
   #endif
   /* for av_vsrc_buffer_add_frame */
   #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,8,0)
-    #include <libavfilter/avcodec.h>
+    #include <libavfilter/vsrc_buffer.h>
   #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
     int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter,
                                  AVFrame *frame);
@@ -83,7 +83,11 @@ public:
   virtual int avfilter_poll_frame(AVFilterLink *link)=0;
   virtual int avfilter_request_frame(AVFilterLink *link)=0;
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,13,0)
+#if LIBAVFILTER_VERSION_MICRO
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
+#else
+  virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts, AVRational pixel_aspect)=0;
+#endif
 #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame)=0;
 #elif LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53,3,0)
@@ -172,7 +176,11 @@ public:
   virtual int avfilter_poll_frame(AVFilterLink *link) { return ::avfilter_poll_frame(link); }
   virtual int avfilter_request_frame(AVFilterLink *link) { return ::avfilter_request_frame(link); }
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,13,0)
+#if LIBAVFILTER_VERSION_MICRO
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, flags); }
+#else
+  virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts, AVRational pixel_aspect) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, pts, pixel_aspect); }
+#endif
 #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame); }
 #elif LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53,3,0)

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -59,6 +59,9 @@ extern "C" {
   #else
     #include <ffmpeg/mem.h>
   #endif
+  #if (defined HAVE_LIBAVUTIL_MATHEMATICS_H)
+    #include <libavutil/mathematics.h>
+  #endif
 #else
   #include "libavutil/avutil.h"
   #include "libavutil/crc.h"

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -814,7 +814,11 @@ int CDVDVideoCodecFFmpeg::FilterProcess(AVFrame* frame)
   if (frame)
   {
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,13,0)
+#if LIBAVFILTER_VERSION_MICRO
     result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame, 0);
+#else
+    result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame, frame->pts, m_pCodecContext->sample_aspect_ratio);
+#endif
 #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
     result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame);
 #elif LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53,3,0)


### PR DESCRIPTION
Hi,
if one builds xbmc with too-new external ffmpeg it fails due to missing new include.

This can be solved by checking for the include in the configure and then just including it when found.

See the attached commit for the fix.

It would be nice to have this also merged to eden branch.

Cheers

Tom
