### PR TITLE
Add support for libav api as it sligthly differ.

### DIFF
--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -48,7 +48,7 @@ extern "C" {
   #endif
   /* for av_vsrc_buffer_add_frame */
   #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,8,0)
-    #include <libavfilter/avcodec.h>
+    #include <libavfilter/vsrc_buffer.h>
   #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
     int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter,
                                  AVFrame *frame);
@@ -83,7 +83,11 @@ public:
   virtual int avfilter_poll_frame(AVFilterLink *link)=0;
   virtual int avfilter_request_frame(AVFilterLink *link)=0;
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,13,0)
+#if LIBAVFILTER_VERSION_MICRO
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
+#else
+  virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts, AVRational pixel_aspect)=0;
+#endif
 #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame)=0;
 #elif LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53,3,0)
@@ -172,7 +176,11 @@ public:
   virtual int avfilter_poll_frame(AVFilterLink *link) { return ::avfilter_poll_frame(link); }
   virtual int avfilter_request_frame(AVFilterLink *link) { return ::avfilter_request_frame(link); }
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,13,0)
+#if LIBAVFILTER_VERSION_MICRO
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, flags); }
+#else
+  virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts, AVRational pixel_aspect) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, pts, pixel_aspect); }
+#endif
 #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame); }
 #elif LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53,3,0)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -814,7 +814,11 @@ int CDVDVideoCodecFFmpeg::FilterProcess(AVFrame* frame)
   if (frame)
   {
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,13,0)
+#if LIBAVFILTER_VERSION_MICRO
     result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame, 0);
+#else
+    result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame, frame->pts, m_pCodecContext->sample_aspect_ratio);
+#endif
 #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
     result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame);
 #elif LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53,3,0)


### PR DESCRIPTION
The libav use micro version as 0
The ffmpeg use the micro version as 100+

Simply check if the variable is defined then it is not libav.
