### PR TITLE
Windows: Create minidumps for threads terminated by exceptions

### DIFF
--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -161,6 +161,7 @@ DWORD WINAPI CThread::staticThread(LPVOID* data)
   catch (const win32_exception &e)
   {
     e.writelog(__FUNCTION__);
+    e.write_minidump();
     if( pThread->IsAutoDelete() )
     {
       delete pThread;
@@ -190,10 +191,12 @@ DWORD WINAPI CThread::staticThread(LPVOID* data)
   catch (const access_violation &e)
   {
     e.writelog(__FUNCTION__);
+    e.write_minidump();
   }
   catch (const win32_exception &e)
   {
     e.writelog(__FUNCTION__);
+    e.write_minidump();
   }
 #endif
   catch(...)
@@ -209,10 +212,12 @@ DWORD WINAPI CThread::staticThread(LPVOID* data)
   catch (const access_violation &e)
   {
     e.writelog(__FUNCTION__);
+    e.write_minidump();
   }
   catch (const win32_exception &e)
   {
     e.writelog(__FUNCTION__);
+    e.write_minidump();
   }
 #endif
   catch(...)

--- a/xbmc/utils/Win32Exception.cpp
+++ b/xbmc/utils/Win32Exception.cpp
@@ -92,7 +92,6 @@ void win32_exception::writelog(const char *prefix)  const
 bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
 {
   // Create the dump file where the xbmc.exe resides
-  CStdString errorMsg;
   bool returncode = false;
   CStdString dumpFileName;
   SYSTEMTIME stLocalTime;

--- a/xbmc/utils/Win32Exception.h
+++ b/xbmc/utils/Win32Exception.h
@@ -54,12 +54,13 @@ public:
     unsigned code() const { return mCode; };
     virtual void writelog(const char *prefix) const;
 protected:
-    win32_exception(const EXCEPTION_RECORD& info);
+    win32_exception(EXCEPTION_POINTERS* info);
     static void translate(unsigned code, EXCEPTION_POINTERS* info);
 private:
     const char* mWhat;
     Address mWhere;
     unsigned mCode;
+    EXCEPTION_POINTERS *mExceptionPointers;
 };
 
 class access_violation: public win32_exception
@@ -80,6 +81,6 @@ protected:
 private:
     access_type mAccessType;
     Address mBadAddress;
-    access_violation(const EXCEPTION_RECORD& info);
+    access_violation(EXCEPTION_POINTERS* info);
 };
 #endif

--- a/xbmc/utils/Win32Exception.h
+++ b/xbmc/utils/Win32Exception.h
@@ -55,6 +55,7 @@ public:
     Address where() const { return mWhere; };
     unsigned code() const { return mCode; };
     virtual void writelog(const char *prefix) const;
+    bool write_minidump() const { return write_minidump(mExceptionPointers); };
     static bool write_minidump(EXCEPTION_POINTERS* pEp);
 protected:
     win32_exception(EXCEPTION_POINTERS* info);

--- a/xbmc/utils/Win32Exception.h
+++ b/xbmc/utils/Win32Exception.h
@@ -25,6 +25,7 @@
 #include <windows.h>
 #endif
 #include <exception>
+#include "utils/StdString.h"
 
 #ifdef _LINUX
 
@@ -49,10 +50,12 @@ public:
     typedef const void* Address; // OK on Win32 platform
 
     static void install_handler();
+    static void set_version(CStdString version) { mVersion = version; };
     virtual const char* what() const { return mWhat; };
     Address where() const { return mWhere; };
     unsigned code() const { return mCode; };
     virtual void writelog(const char *prefix) const;
+    static bool write_minidump(EXCEPTION_POINTERS* pEp);
 protected:
     win32_exception(EXCEPTION_POINTERS* info);
     static void translate(unsigned code, EXCEPTION_POINTERS* info);
@@ -61,6 +64,7 @@ private:
     Address mWhere;
     unsigned mCode;
     EXCEPTION_POINTERS *mExceptionPointers;
+    static CStdString mVersion;
 };
 
 class access_violation: public win32_exception


### PR DESCRIPTION
Hopefully with this and build symbol files it will be easier to figure out what crashed XBMC or a thread on a user's computer.

The PR will create the dumps in the same directory as the debug logs, with file names like:
XBMC majorminortag gitrev datetime.dmp

In case the exception happens before XBMC directories settings were initialized (unlikely), I'm not sure what's the best location for the dump. I thought of a few possibilities:
- in the same directory as the exe. Maybe a problem for restricted users? It's what the PR implements at the moment
- in the root of a user's Windows profile
- in Windows temp directory. Same as the task manager would do.

What do you think, keeping in mind there are regular and portable installs?
