### PR TITLE
Fix addonversion equals

### DIFF
--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -163,11 +163,8 @@ namespace ADDON
     ret &= (v1_0 != v1_0_0) && (v1_0 < v1_0_0) && (v1_0_0 > v1_0) &&
            (v1_00 != v1_0_0) && (v1_00 < v1_0_0) && (v1_0_0 > v1_00);
 
-    // These aren't totally sane
-    // BEWARE: neither (v1_0 == v1_00) nor (v1_0 < v1_00) nor (v1_0 > v1_00) are true
-    ret &= (v1_0 != v1_00) && !(v1_0 < v1_00) && !(v1_0 > v1_00);
-    // BEWARE: neither (v1_1 == v1_01) nor (v1_1 < v1_01) nor (v1_1 > v1_01) are true
-    ret &= (v1_1 != v1_01) && !(v1_1 < v1_01) && !(v1_1 > v1_01);
+    ret &= (v1_0 == v1_00) && !(v1_0 < v1_00) && !(v1_0 > v1_00);
+    ret &= (v1_1 == v1_01) && !(v1_1 < v1_01) && !(v1_1 > v1_01);
 
     return ret;
   }

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -112,9 +112,9 @@ namespace ADDON
 
     int result = CompareComponent(Upstream(), other.Upstream());
     if (result)
-      return (-1 == result);
+      return (result < 0);
 
-    return (-1 == CompareComponent(Revision(), other.Revision()));
+    return (CompareComponent(Revision(), other.Revision()) < 0);
   }
 
   CStdString AddonVersion::Print() const

--- a/xbmc/addons/AddonVersion.cpp
+++ b/xbmc/addons/AddonVersion.cpp
@@ -117,6 +117,13 @@ namespace ADDON
     return (CompareComponent(Revision(), other.Revision()) < 0);
   }
 
+  bool AddonVersion::operator==(const AddonVersion& other) const
+  {
+    return Epoch() == other.Epoch()
+      && CompareComponent(Upstream(), other.Upstream()) == 0
+      && CompareComponent(Revision(), other.Revision()) == 0;
+  }
+
   CStdString AddonVersion::Print() const
   {
     CStdString out;

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -27,6 +27,18 @@
 
 namespace ADDON
 {
+  /* \brief Addon versioning using the debian versioning scheme
+
+    AddonVersion uses debian versioning, which means in the each section of the period
+    separated version string, numbers are compared numerically rather than lexicographically,
+    thus any preceding zeros are ignored.
+
+    i.e. 1.00 is considered the same as 1.0, and 1.01 is considered the same as 1.1.
+
+    Further, 1.0 < 1.0.0
+
+    See here for more info: http://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
+    */
   class AddonVersion : public boost::totally_ordered<AddonVersion> {
   public:
     AddonVersion(const AddonVersion& other) : mUpstream(NULL), mRevision(NULL) { *this = other; }

--- a/xbmc/addons/AddonVersion.h
+++ b/xbmc/addons/AddonVersion.h
@@ -62,13 +62,6 @@ namespace ADDON
     free(mRevision);
   }
 
-  inline bool AddonVersion::operator==(const AddonVersion& other) const
-  {
-    return Epoch() == other.Epoch()
-      && strcmp(Upstream(), other.Upstream()) == 0
-      && strcmp(Revision(), other.Revision()) == 0;
-  }
-
   inline AddonVersion& AddonVersion::operator=(const AddonVersion& other)
   {
     free(mUpstream);


### PR DESCRIPTION
Commit f6ec198de2f4f15d14a3f05f70383071ad43b208 notes an inconsistency in the way AddonVersion comparisons are done.

In particular, note that 1.0 != 1.00 yet 1.0 is neither less than or greater than 1.00.

Similarly, 1.01 != 1.1, yet 1.1 is neither less than or greater than 1.01.

The problem is due to AddonVersion::operator==() performing lexicographical comparisons rather than the numerical comparisons done in AddonVersion::operator<().

Given that AddonVersion derives from boost::totally_ordered this is just plain wrong, as clearly it's not totally ordered.

We fix this by ensuring operator==() performs the same operations as operator<()
