### PR TITLE
release: version bumps for 12.0 alpha1

### DIFF
--- a/addons/xbmc.addon/addon.xml
+++ b/addons/xbmc.addon/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.addon" version="11.0" provider-name="Team XBMC">
+<addon id="xbmc.addon" version="11.9.1" provider-name="Team XBMC">
   <requires>
     <import addon="xbmc.core" version="0.1"/>
   </requires>

--- a/configure.in
+++ b/configure.in
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT([xbmc], [11.0], [http://trac.xbmc.org])
+AC_INIT([xbmc], [11.9.1], [http://trac.xbmc.org])
 AC_CONFIG_HEADERS([xbmc/config.h])
 AH_TOP([#pragma once])
 m4_include([m4/ax_python_devel.m4])

--- a/tools/darwin/packaging/xbmc-atv2/mkdeb-xbmc-atv2.sh
+++ b/tools/darwin/packaging/xbmc-atv2/mkdeb-xbmc-atv2.sh
@@ -44,8 +44,8 @@ fi
 
 PACKAGE=org.xbmc.xbmc-atv2
 
-VERSION=10.0
-REVISION=9
+VERSION=12.0
+REVISION=0~alpha1
 ARCHIVE=${PACKAGE}_${VERSION}-${REVISION}_iphoneos-arm.deb
 
 echo Creating $PACKAGE package version $VERSION revision $REVISION

--- a/tools/darwin/packaging/xbmc-ios/mkdeb-xbmc-ios.sh
+++ b/tools/darwin/packaging/xbmc-ios/mkdeb-xbmc-ios.sh
@@ -45,8 +45,8 @@ fi
 
 PACKAGE=org.xbmc.xbmc-ios
 
-VERSION=10.0
-REVISION=9
+VERSION=12.0
+REVISION=0~alpha1
 ARCHIVE=${PACKAGE}_${VERSION}-${REVISION}_iphoneos-arm.deb
 
 echo Creating $PACKAGE package version $VERSION revision $REVISION

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -421,9 +421,9 @@ namespace INFO
 #define CONTROL_GROUP_HAS_FOCUS     29999
 #define CONTROL_HAS_FOCUS           30000
 
-#define VERSION_MAJOR 11
+#define VERSION_MAJOR 12
 #define VERSION_MINOR 0
-#define VERSION_TAG "-PRE"
+#define VERSION_TAG "-ALPHA1"
 
 #define LISTITEM_START              35000
 #define LISTITEM_THUMB              (LISTITEM_START)

--- a/xbmc/osx/Info.plist
+++ b/xbmc/osx/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>XBMC</string>
 	<key>CFBundleGetInfoString</key>
-	<string>11.0.pre</string>
+	<string>12.0.alpha1</string>
 	<key>CFBundleIconFile</key>
 	<string>xbmc.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>11.0.pre</string>
+	<string>12.0.alpha1</string>
 	<key>CFBundleVersion</key>
 	<string>r####</string>
 	<key>CFBundleSignature</key>

--- a/xbmc/win32/XBMC_PC.rc
+++ b/xbmc/win32/XBMC_PC.rc
@@ -53,8 +53,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 10,05,0,0
- PRODUCTVERSION 10,05,0,0
+ FILEVERSION 11,9,1,0
+ PRODUCTVERSION 11,9,1,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -71,12 +71,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Team XBMC"
             VALUE "FileDescription", "XBMC"
-            VALUE "FileVersion", "PRE-11.0"
+            VALUE "FileVersion", "12.0-ALPHA1"
             VALUE "InternalName", "XBMC.exe"
             VALUE "LegalCopyright", "Copyright (c) Team XBMC.  All rights reserved."
             VALUE "OriginalFilename", "XBMC.exe"
             VALUE "ProductName", "XBMC for Windows"
-            VALUE "ProductVersion", "PRE-11.0"
+            VALUE "ProductVersion", "12.0-ALPHA1"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
This needs to go in before much else...

These are the standard bumps, and the new one that keeps xbmc.addon inline.
