### PR TITLE
incorrect usage of readlink(), strrchr() et. al. (read/write unallocated mem)

### DIFF
--- a/xbmc/linux/LinuxTimezone.cpp
+++ b/xbmc/linux/LinuxTimezone.cpp
@@ -169,14 +169,21 @@ CStdString CLinuxTimezone::GetOSConfiguredTimezone()
 
    // try Slackware approach first
    ssize_t rlrc = readlink("/etc/localtime-copied-from"
-                           , timezoneName, sizeof(timezoneName));
+                           , timezoneName, sizeof(timezoneName)-1);
    if (rlrc != -1)
    {
      timezoneName[rlrc] = '\0';
 
-     const char* p = strrchr(timezoneName+rlrc,'/');
+     char* p = strrchr(timezoneName,'/');
      if (p)
-       p = strrchr(p-1,'/')+1; 
+     { // we want the previous '/'
+       char* q = p;
+       *q = 0;
+       p = strrchr(timezoneName,'/');
+       *q = '/';
+       if (p)
+         p++;
+     }
      return p;
    }
 


### PR DESCRIPTION
See here for further analysis:

http://forum.xbmc.org/showthread.php?tid=126742

Am not sure exactly what the intent of the original dev was (cbxbiker6 in #10635).
