### PR TITLE
moved "hideallitems" tag from advancedsettings.xml to GUISettings

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1234,6 +1234,7 @@
   <string id="13430">Allow hardware acceleration (OpenMax)</string>
   <string id="13431">Pixel Shaders</string>
   <string id="13432">Allow hardware acceleration (VideoToolbox)</string>
+  <string id="13433">Hide "All Items" button</string>
 
   <string id="13500">A/V sync method</string>
   <string id="13501">Audio clock</string>

--- a/language/German/strings.xml
+++ b/language/German/strings.xml
@@ -1267,7 +1267,8 @@
   <string id="13430">Hardwarebeschleunigung erlauben (OpenMax)</string>
   <string id="13431">Pixel Shaders</string>
   <string id="13432">Hardwarebeschleunigung erlauben (VideoToolbox)</string>
-
+  <string id="13433">Verstecke "Alle-Items" Einträge</string>
+  
   <string id="13500">A/V Sync Methode</string>
   <string id="13501">Audio Takt</string>
   <string id="13502">Video Takt (Verwerfe/Dupliziere Audio)</string>

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -47,6 +47,7 @@
 #include "FileItem.h"
 #include "utils/StringUtils.h"
 #include "guilib/LocalizeStrings.h"
+#include "settings/GUISettings.h"
 
 using namespace std;
 using namespace XFILE::MUSICDATABASEDIRECTORY;
@@ -276,7 +277,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
   CFileItemPtr pItem;
 
   // always hide "all" items
-  if (g_advancedSettings.m_bMusicLibraryHideAllItems)
+  if (g_guiSettings.GetBool("musiclibrary.hideallitems"))
     return;
 
   // no need for "all" item when only one item

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -51,6 +51,7 @@
 #include "utils/StringUtils.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/Variant.h"
+#include "settings/GUISettings.h"
 
 using namespace std;
 using namespace XFILE::VIDEODATABASEDIRECTORY;
@@ -282,7 +283,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
   CFileItemPtr pItem;
 
   // always hide "all" items
-  if (g_advancedSettings.m_bVideoLibraryHideAllItems)
+  if (g_guiSettings.GetBool("videolibrary.hideallitems"))
     return;
 
   // no need for "all" item when only one item

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -192,7 +192,6 @@ void CAdvancedSettings::Initialize()
   m_dvdThumbs = "folder.jpg|Folder.jpg|folder.JPG|Folder.JPG";
   m_fanartImages = "fanart.jpg|fanart.png";
 
-  m_bMusicLibraryHideAllItems = false;
   m_bMusicLibraryAllItemsOnBottom = false;
   m_bMusicLibraryAlbumsSortByArtistThenYear = false;
   m_iMusicLibraryRecentlyAddedItems = 25;
@@ -202,7 +201,6 @@ void CAdvancedSettings::Initialize()
   m_musicItemSeparator = " / ";
   m_videoItemSeparator = " / ";
 
-  m_bVideoLibraryHideAllItems = false;
   m_bVideoLibraryAllItemsOnBottom = false;
   m_iVideoLibraryRecentlyAddedItems = 25;
   m_bVideoLibraryHideRecentlyAddedItems = false;
@@ -585,7 +583,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   pElement = pRootElement->FirstChildElement("musiclibrary");
   if (pElement)
   {
-    XMLUtils::GetBoolean(pElement, "hideallitems", m_bMusicLibraryHideAllItems);
     XMLUtils::GetInt(pElement, "recentlyaddeditems", m_iMusicLibraryRecentlyAddedItems, 1, INT_MAX);
     XMLUtils::GetBoolean(pElement, "prioritiseapetags", m_prioritiseAPEv2tags);
     XMLUtils::GetBoolean(pElement, "allitemsonbottom", m_bMusicLibraryAllItemsOnBottom);
@@ -598,7 +595,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   pElement = pRootElement->FirstChildElement("videolibrary");
   if (pElement)
   {
-    XMLUtils::GetBoolean(pElement, "hideallitems", m_bVideoLibraryHideAllItems);
     XMLUtils::GetBoolean(pElement, "allitemsonbottom", m_bVideoLibraryAllItemsOnBottom);
     XMLUtils::GetInt(pElement, "recentlyaddeditems", m_iVideoLibraryRecentlyAddedItems, 1, INT_MAX);
     XMLUtils::GetBoolean(pElement, "hiderecentlyaddeditems", m_bVideoLibraryHideRecentlyAddedItems);

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -267,6 +267,7 @@ void CGUISettings::Initialize()
   CSettingsCategory* ml = AddCategory(3,"musiclibrary",14022);
   AddBool(NULL, "musiclibrary.enabled", 418, true);
   AddBool(ml, "musiclibrary.showcompilationartists", 13414, true);
+  AddBool(ml, "musiclibrary.hideallitems", 13433, false);
   AddSeparator(ml,"musiclibrary.sep1");
   AddBool(ml,"musiclibrary.downloadinfo", 20192, false);
   AddDefaultAddon(ml, "musiclibrary.albumsscraper", 20193, "metadata.albums.allmusic.com", ADDON_SCRAPER_ALBUMS);
@@ -591,7 +592,7 @@ void CGUISettings::Initialize()
   flattenTVShowOptions.insert(make_pair(20421, 1));
   flattenTVShowOptions.insert(make_pair(20422, 2));
   AddInt(vdl, "videolibrary.flattentvshows", 20412, 1, flattenTVShowOptions, SPIN_CONTROL_TEXT);
-
+  AddBool(vdl, "videolibrary.hideallitems", 13433, false);
   AddBool(vdl, "videolibrary.groupmoviesets", 20458, false);
   AddBool(vdl, "videolibrary.updateonstartup", 22000, false);
   AddBool(vdl, "videolibrary.backgroundupdate", 22001, false);


### PR DESCRIPTION
This is one of the things that I always wondered why it is not integrated in the GUI.
Hiding the all items entry is one of the first things I do when installing a new XBMC.
Also I saw several threads in the forum where users asked for this feature and did not know about the possibility to handle this via as.xml

Basically this was some coding excercise for me. Maybe your interested. Any comments?
Any whitespace grinches?

cheers,
mad-max
