### PR TITLE
Disc stubs: Change the displayed disc title when a TV show

### DIFF
--- a/xbmc/dialogs/GUIDialogPlayEject.cpp
+++ b/xbmc/dialogs/GUIDialogPlayEject.cpp
@@ -101,20 +101,8 @@ bool CGUIDialogPlayEject::ShowAndGetInput(const CFileItem & item,
   if (!pDialog)
     return false;
 
-  // Figure out Line 1 of the dialog
-  CStdString strLine1;
-  if (item.GetVideoInfoTag())
-  {
-    strLine1 = item.GetVideoInfoTag()->m_strTitle;
-  }
-  else
-  {
-    strLine1 = URIUtils::GetFileName(item.GetPath());
-    URIUtils::RemoveExtension(strLine1);
-  }
-
-  // Figure out Line 2 of the dialog
-  CStdString strLine2;
+  // Figure out Lines 1 and 2 of the dialog
+  CStdString strLine1, strLine2;
   TiXmlDocument discStubXML;
   if (discStubXML.LoadFile(item.GetPath()))
   {
@@ -122,8 +110,15 @@ bool CGUIDialogPlayEject::ShowAndGetInput(const CFileItem & item,
     if (!pRootElement || strcmpi(pRootElement->Value(), "discstub") != 0)
       CLog::Log(LOGERROR, "Error loading %s, no <discstub> node", item.GetPath().c_str());
     else
+    {
+      XMLUtils::GetString(pRootElement, "title", strLine1);
       XMLUtils::GetString(pRootElement, "message", strLine2);
+    }
   }
+
+  // Use the label for Line 1 if not defined
+  if (strLine1.IsEmpty())
+    strLine1 = item.GetLabel();
 
   // Setup dialog parameters
   pDialog->SetHeading(219);


### PR DESCRIPTION
When a disc stub is used to represent an episode (or episodes) of a TV show, the title displayed in the play/eject dialog will be the title of the episode selected, i.e. "Insert Disc: Episode Title".  This is generally meaningless, as a single episode title is rarely the name of the disc, more likely the disc is a numbered volume of a complete series collection.

The first commit, then, replaces the title with the more meaningful show title, leaving the user to specify the season/disc number in the optional &lt;message&gt; tag, should they so wish.

The second commit takes it a step further, by also allowing the user to specify the title to be displayed in the stub file inside a &lt;title&gt; tag (should the default title still be inaccurate).  This effectively gives the user control over both lines of the dialog.

(Separated into two commits to make it easier for me to drop the second part if deemed unnecessary, but I'll squash if it's all fine.)
