### PR TITLE
webserver: image transformation handler

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -767,6 +767,7 @@
     <ClCompile Include="..\..\xbmc\network\GUIDialogAccessPoints.cpp" />
     <ClCompile Include="..\..\xbmc\network\GUIDialogNetworkSetup.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.cpp" />
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPImageTransformationHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.cpp" />
     <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPWebinterfaceAddonsHandler.cpp" />
@@ -885,6 +886,7 @@
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\IJSONRPCAnnouncer.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\JSONRPCUtils.h" />
     <ClInclude Include="..\..\xbmc\interfaces\json-rpc\GUIOperations.h" />
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPImageTransformationHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPApiHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPVfsHandler.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2631,6 +2631,9 @@
     <ClCompile Include="..\..\xbmc\filesystem\MemBufferCache.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\network\httprequesthandler\HTTPImageTransformationHandler.cpp">
+      <Filter>network\httprequesthandler</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5299,6 +5302,9 @@
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.h">
+      <Filter>network\httprequesthandler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPImageTransformationHandler.h">
       <Filter>network\httprequesthandler</Filter>
     </ClInclude>
   </ItemGroup>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -37,6 +37,7 @@
 #ifdef HAS_WEB_SERVER
 #include "network/WebServer.h"
 #include "network/httprequesthandler/HTTPVfsHandler.h"
+#include "network/httprequesthandler/HTTPImageTransformationHandler.h"
 #ifdef HAS_HTTPAPI
 #include "network/httprequesthandler/HTTPApiHandler.h"
 #endif
@@ -347,6 +348,7 @@ CApplication::CApplication(void)
 #ifdef HAS_WEB_SERVER
   , m_WebServer(*new CWebServer)
   , m_httpVfsHandler(*new CHTTPVfsHandler)
+  , m_httpImageTransformationHandler(*new CHTTPImageTransformationHandler)
 #ifdef HAS_JSONRPC
   , m_httpJsonRpcHandler(*new CHTTPJsonRpcHandler)
 #endif
@@ -407,6 +409,7 @@ CApplication::~CApplication(void)
 #ifdef HAS_WEB_SERVER
   delete &m_WebServer;
   delete &m_httpVfsHandler;
+  delete &m_httpImageTransformationHandler;
 #ifdef HAS_HTTPAPI
   delete &m_httpApiHandler;
 #endif
@@ -1103,6 +1106,7 @@ bool CApplication::Initialize()
 
 #ifdef HAS_WEB_SERVER
   CWebServer::RegisterRequestHandler(&m_httpVfsHandler);
+  CWebServer::RegisterRequestHandler(&m_httpImageTransformationHandler);
 #ifdef HAS_JSONRPC
   CWebServer::RegisterRequestHandler(&m_httpJsonRpcHandler);
 #endif
@@ -3377,6 +3381,7 @@ void CApplication::Stop(int exitCode)
 
 #ifdef HAS_WEB_SERVER
   CWebServer::UnregisterRequestHandler(&m_httpVfsHandler);
+  CWebServer::UnregisterRequestHandler(&m_httpImageTransformationHandler);
 #ifdef HAS_JSONRPC
   CWebServer::UnregisterRequestHandler(&m_httpJsonRpcHandler);
 #endif

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -72,6 +72,7 @@ class CWebServer;
 #ifdef HAS_WEB_SERVER
 class CWebServer;
 class CHTTPVfsHandler;
+class CHTTPImageTransformationHandler;
 #ifdef HAS_JSONRPC
 class CHTTPJsonRpcHandler;
 #endif
@@ -240,6 +241,7 @@ public:
 #ifdef HAS_WEB_SERVER
   CWebServer& m_WebServer;
   CHTTPVfsHandler& m_httpVfsHandler;
+  CHTTPImageTransformationHandler& m_httpImageTransformationHandler;
 #ifdef HAS_JSONRPC
   CHTTPJsonRpcHandler& m_httpJsonRpcHandler;
 #endif

--- a/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
@@ -1,0 +1,109 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <map>
+#include <sstream>
+
+#include "HTTPImageTransformationHandler.h"
+#include "URL.h"
+#include "filesystem/File.h"
+#include "network/WebServer.h"
+#include "pictures/Picture.h"
+
+using namespace std;
+
+CHTTPImageTransformationHandler::CHTTPImageTransformationHandler()
+  : m_size(0),
+    m_data(NULL)
+{ }
+
+bool CHTTPImageTransformationHandler::CheckHTTPRequest(const HTTPRequest &request)
+{
+  return (request.method == GET &&
+          request.url.find("/transform/image/") == 0 && request.url.size() > 17);
+}
+
+int CHTTPImageTransformationHandler::HandleHTTPRequest(const HTTPRequest &request)
+{
+  CStdString path = request.url.substr(17);
+  CURL::Decode(path);
+  if (!XFILE::CFile::Exists(path))
+  {
+    m_responseCode = MHD_HTTP_NOT_FOUND;
+    m_responseType = HTTPError;
+
+    return MHD_YES;
+  }
+
+  map<string, string> arguments;
+  CWebServer::GetRequestHeaderValues(request.connection, MHD_GET_ARGUMENT_KIND, arguments);
+
+  std::string strWidth = arguments["width"];
+  std::string strHeight = arguments["height"];
+  std::string strQuality = arguments["quality"];
+  std::string format = arguments["format"];
+    
+  int width = -1, height = -1, quality = 65;
+		  
+	if (!strWidth.empty())
+	{
+		istringstream convert(strWidth);
+		if (!(convert >> width) || width <= 0)
+		  width = -1;
+	}
+	if (!strHeight.empty())
+	{
+		istringstream convert(strHeight);
+		if (!(convert >> height) || height <= 0)
+		  height = -1;
+	}
+	if (!strQuality.empty())
+	{
+		istringstream convert(strQuality);
+		if (!(convert >> quality) || quality <= 0)
+	      quality = 65;
+    else if (quality > 100)
+      quality = 100;
+	}
+  if (format.empty() ||
+      (format.compare("jpg") != 0 && format.compare("png") != 0 && format.compare("bmp") != 0))
+		format = "jpg";
+
+  long size = 0;
+  CPicture::EncodeImageToBuffer(path, m_data, size, width, height, format.c_str(), quality);
+
+	if (size > 0 && m_data != NULL)
+	{
+    m_size = (size_t)size;
+    m_responseCode = MHD_HTTP_OK;
+    m_responseType = HTTPMemoryDownloadFreeCopy;
+	}
+  else
+  {
+		m_responseCode = MHD_HTTP_INTERNAL_SERVER_ERROR;
+    m_responseType = HTTPError;
+
+    if (m_data != NULL)
+      free (m_data);
+  }
+
+  return MHD_YES;
+}

--- a/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.h
+++ b/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.h
@@ -1,0 +1,42 @@
+#pragma once
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "IHTTPRequestHandler.h"
+
+class CHTTPImageTransformationHandler : public IHTTPRequestHandler
+{
+public:
+  CHTTPImageTransformationHandler();
+
+  virtual IHTTPRequestHandler* GetInstance() { return new CHTTPImageTransformationHandler(); }
+  virtual bool CheckHTTPRequest(const HTTPRequest &request);
+  virtual int HandleHTTPRequest(const HTTPRequest &request);
+
+  virtual void* GetHTTPResponseData() const { return (void *)m_data; };
+  virtual size_t GetHTTPResonseDataLength() const { return m_size; }
+
+  virtual int GetPriority() const { return 2; }
+
+private:
+  size_t m_size;
+  unsigned char *m_data;
+};

--- a/xbmc/network/httprequesthandler/Makefile
+++ b/xbmc/network/httprequesthandler/Makefile
@@ -1,4 +1,5 @@
 SRCS=HTTPApiHandler.cpp \
+     HTTPImageTransformationHandler.cpp \
      HTTPJsonRpcHandler.cpp \
      HTTPVfsHandler.cpp \
      HTTPWebinterfaceAddonsHandler.cpp \

--- a/xbmc/pictures/DllImageLib.h
+++ b/xbmc/pictures/DllImageLib.h
@@ -97,6 +97,7 @@ public:
     virtual bool CreateFolderThumbnail(const char **, const char *, int, int)=0;
     virtual bool CreateThumbnailFromSurface(BYTE *, unsigned int, unsigned intB, unsigned int, const char *)=0;
     virtual int  ConvertFile(const char *, const char *, float, int, int, unsigned int, bool)=0;
+    virtual int  EncodeImageToBuffer(const char *, BYTE *&, long *, int, int, const char *, unsigned int)=0;
 };
 
 class DllImageLib : public DllDynamic, DllImageLibInterface
@@ -109,6 +110,7 @@ class DllImageLib : public DllDynamic, DllImageLibInterface
   DEFINE_METHOD4(bool, CreateFolderThumbnail, (const char ** p1, const char * p2, int p3, int p4))
   DEFINE_METHOD5(bool, CreateThumbnailFromSurface, (BYTE * p1, unsigned int p2, unsigned int p3, unsigned int p4, const char * p5))
   DEFINE_METHOD7(int, ConvertFile, (const char * p1, const char * p2, float p3, int p4, int p5, unsigned int p6, bool p7))
+  DEFINE_METHOD7(int, EncodeImageToBuffer, (const char * p1, BYTE *& p2, long * p3, int p4, int p5, const char * p6, unsigned int p7)) 
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(ReleaseImage)
     RESOLVE_METHOD(LoadImage)
@@ -117,5 +119,6 @@ class DllImageLib : public DllDynamic, DllImageLibInterface
     RESOLVE_METHOD(CreateFolderThumbnail)
     RESOLVE_METHOD(CreateThumbnailFromSurface)
     RESOLVE_METHOD(ConvertFile)
+    RESOLVE_METHOD(EncodeImageToBuffer)
   END_METHOD_RESOLVE()
 };

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -140,6 +140,25 @@ int CPicture::ConvertFile(const CStdString &srcFile, const CStdString &destFile,
   return ret;
 }
 
+/***This is a new method for writing an image from disk into a buffer. The buffer that is passed in should be empty,
+and it will need to be freed via a call to free()
+This is just a wrapper for loading the DLL and doing the encoding/transform.
+***/
+int CPicture::EncodeImageToBuffer(const CStdString &srcFile, unsigned char *&buffer, long &size, int width, int height, const char * format, unsigned int quality)
+{
+  DllImageLib dll;
+  if (!dll.Load()) return false;
+  BYTE * bytes;
+  int ret = dll.EncodeImageToBuffer(srcFile.c_str(), bytes, &size, width, height, format, quality);
+  buffer = (unsigned char *)bytes;
+  if (ret)
+  {
+    CLog::Log(LOGERROR, "%s: Error %i encoding image to buffer %s", __FUNCTION__, ret, srcFile.c_str());
+    return ret;
+  }
+  return ret;
+}
+
 CThumbnailWriter::CThumbnailWriter(unsigned char* buffer, int width, int height, int stride, const CStdString& thumbFile)
 {
   m_buffer    = buffer;

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -28,6 +28,7 @@ public:
   static bool CreateThumbnailFromMemory(const unsigned char* buffer, int bufSize, const CStdString& extension, const CStdString& thumbFile);
   static bool CreateThumbnailFromSurface(const unsigned char* buffer, int width, int height, int stride, const CStdString &thumbFile);
   static int ConvertFile(const CStdString& srcFile, const CStdString& destFile, float rotateDegrees, int width, int height, unsigned int quality, bool mirror=false);
+  static int EncodeImageToBuffer(const CStdString& srcFile, unsigned char* &buffer, long& size, int width, int height, const char * format="jpg", unsigned int quality=65);
 
   static void CreateFolderThumb(const CStdString *thumbs, const CStdString &folderThumb);
   static bool CreateThumbnail(const CStdString& file, const CStdString& thumbFile, bool checkExistence = false);


### PR DESCRIPTION
This PR uses the work of Brad Mann he provided in #92 but integrates it into the new handler-based approach of our webserver implementation. The functionality stays the same as described in the original PR. The image transformation is accessible by using the following URI:

http://< ip >:< port >/transform/image/< url-encoded-path-to-the-image >?< options >

Currently available options are
- width
- height
- quality
- format

This is a very often requested feature of webinterfaces and JSON-RPC clients especially for mobile devices where a 1920x1080 fanart doesn't make any sense at all so requesting images in smaller dimensions in the first place makes it faster and saves space.
