### PR TITLE
Improve sorting of mixed sets/movies lists

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4113,6 +4113,10 @@ bool CVideoDatabase::GetSetsNav(const CStdString& strBaseDir, CFileItemList& ite
       m_pDS->close();
     }
 
+    // Handle movie sets as files when sorting
+    if (items.Size() > 0)
+      items.SetSortIgnoreFolders(true);
+
 //    CLog::Log(LOGDEBUG, "%s Time: %d ms", XbmcThreads::SystemClockMillis() - time);
     return true;
   }


### PR DESCRIPTION
These 3 commits make it possible to include movie sets in the library sorting that is available in the GUI. Currently sets are handled as directories/nodes (which they are but in a different sense IMO) and always appear at the top of the list except when sorting my label.

This PR adds the ability to include sets into the sorting and currently supports sorting by rating and by date added. For sorting by rating the SQL query calculates the average rating of the movies belonging to a set and uses that value. For sorting by date added it uses the highest file ID of the movies in a set.

This PR is not meant to be merged but more as a discussion-starter on whether this should (hopefully) be integrated at all and how to integrate sets into the other sorting methods available for movies.
Furthermore the changes in this PR clash with https://github.com/jmarshallnz/xbmc/commit/fd1fc081a949bb373333ba5681c4d2097a47e3a5 from the texture cache PR from @jmarshallnz (maybe those general database fixes/improvement commits could be already merged through a seperate PR?) and with my date added PR and will need adjustments once these PR's have been merged.
