### PR TITLE
Reset invalidated flag only if we processed control

### DIFF
--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -138,7 +138,10 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
     g_graphicsContext.SetCameraPosition(m_camera);
 
   if (IsVisible())
+  {
     Process(currentTime, dirtyregions);
+    m_bInvalidated = false;
+  }
 
   changed |=  m_controlIsDirty;
 
@@ -152,7 +155,6 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
     g_graphicsContext.RestoreCameraPosition();
   g_graphicsContext.RemoveTransform();
 
-  m_bInvalidated = false;
   m_controlIsDirty = false;
 }
 


### PR DESCRIPTION
This is fix for scrollbar not updating its range if it's not visible (one Jezz_X found in confluence-lite and global search).

Reason for this bug is simple - we don't process not visible controls, but we reset invalid flag every frame - so control simply misses that invalid flag (in scrollbar case - it won't adjust nib size and position).

Alternative fix would be to process not visible control if it has invalided flag set

<pre>if (IsVisible() || m_invalidated)
     Process(currentTime, dirtyregions);</pre>
