### PR TITLE
Networkcache

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -1251,6 +1251,7 @@
   <string id="13551">Off</string>
   <string id="13552">%.1f Second</string>
   <string id="13553">%.1f Seconds</string>
+  <string id="13554">Optimize cache for Wi-Fi/HomePlug</string>
 
   <string id="13600">Apple remote</string>
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -23,6 +23,7 @@
 #include "filesystem/File.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "settings/GUISettings.h"
 
 using namespace XFILE;
 
@@ -51,8 +52,12 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
   if (!m_pFile)
     return false;
 
+  unsigned int flags = READ_TRUNCATED | READ_BITRATE | READ_CHUNKED;
+  if (URIUtils::IsOnLAN(strFile) && g_guiSettings.GetBool("videoplayer.slownetworkcache"))
+    flags |= READ_CACHED | READ_ADAPTIVE_CACHE_SIZE;
+
   // open file in binary mode
-  if (!m_pFile->Open(strFile, READ_TRUNCATED | READ_BITRATE | READ_CHUNKED))
+  if (!m_pFile->Open(strFile, flags))
   {
     delete m_pFile;
     m_pFile = NULL;

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -318,6 +318,7 @@ CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
   m_errorCount = 0;
   m_playSpeed = DVD_PLAYSPEED_NORMAL;
   m_caching = CACHESTATE_DONE;
+  m_readrate = 0;
   
 #ifdef DVDDEBUG_MESSAGE_TRACKER
   g_dvdMessageTracker.Init();
@@ -565,7 +566,10 @@ bool CDVDPlayer::OpenDemuxStream()
   int64_t len = m_pInputStream->GetLength();
   int64_t tim = m_pDemuxer->GetStreamLength();
   if(len > 0 && tim > 0)
-    m_pInputStream->SetReadRate(len * 1000 / tim);
+  {
+    m_readrate = len * 1000 / tim;
+    m_pInputStream->SetReadRate(m_readrate);
+  }
 
   return true;
 }
@@ -1058,6 +1062,9 @@ void CDVDPlayer::Process()
 
     // update application with our state
     UpdateApplication(1000);
+
+    //update readrate based on peak bitrate
+    UpdateReadRate();
 
     // if the queues are full, no need to read more
     if ((!m_dvdPlayerAudio.AcceptsData() && m_CurrentAudio.id >= 0)
@@ -3771,6 +3778,18 @@ void CDVDPlayer::UpdateApplication(double timeout)
     }
   }
   m_UpdateApplication = CDVDClock::GetAbsoluteClock();
+}
+
+void CDVDPlayer::UpdateReadRate()
+{
+  //if the combined audio and video bitrate is more than half the readrate
+  //increase the readrate
+  unsigned int bytespersecond = (GetVideoBitrate() + GetAudioBitrate()) / 8;
+  if (bytespersecond * 2 > m_readrate)
+  {
+    m_readrate = bytespersecond * 3;
+    m_pInputStream->SetReadRate(m_readrate);
+  }
 }
 
 bool CDVDPlayer::CanRecord()

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -304,6 +304,7 @@ protected:
 
   void UpdateApplication(double timeout);
   void UpdatePlayState(double timeout);
+  void UpdateReadRate();
   double m_UpdateApplication;
 
   bool m_bAbortRequest;
@@ -312,6 +313,8 @@ protected:
   std::string m_mimetype;  // hold a hint to what content file contains (mime type)
   ECacheState m_caching;
   CFileItem   m_item;
+  unsigned    m_readrate;
+
 
 
   CCurrentStream m_CurrentAudio;

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -232,7 +232,7 @@ bool CFile::Open(const CStdString& strFileName, unsigned int flags)
 
     if (m_flags & READ_CACHED)
     {
-      m_pFile = new CFileCache();
+      m_pFile = new CFileCache((m_flags & READ_ADAPTIVE_CACHE_SIZE) != 0);
       return m_pFile->Open(url);
     }
 

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -60,6 +60,9 @@ public:
 /* calcuate bitrate for file while reading */
 #define READ_BITRATE   0x10
 
+/* base cache size on amount of free ram */
+#define READ_ADAPTIVE_CACHE_SIZE 0x20
+
 class CFileStreamBuffer;
 
 class CFile

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -32,7 +32,7 @@ namespace XFILE
   class CFileCache : public IFile, public CThread
   {
   public:
-    CFileCache();
+    CFileCache(bool adaptiveSize = false);
     CFileCache(CCacheStrategy *pCache, bool bDeleteCache=true);
     virtual ~CFileCache();
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -277,6 +277,7 @@ void CAdvancedSettings::Initialize()
   m_measureRefreshrate = false;
 
   m_cacheMemBufferSize = 1024 * 1024 * 20;
+  m_maxCacheSize = 512 * 1024 * 1024;
 
   m_jsonOutputCompact = true;
   m_jsonTcpPort = 9090;
@@ -646,6 +647,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
     XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
+    XMLUtils::GetUInt(pElement, "maxcachesize", m_maxCacheSize);
   }
 
   pElement = pRootElement->FirstChildElement("jsonrpc");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -308,6 +308,7 @@ class CAdvancedSettings
     int  m_guiDirtyRegionNoFlipTimeout;
 
     unsigned int m_cacheMemBufferSize;
+    unsigned int m_maxCacheSize;
 
     bool m_jsonOutputCompact;
     unsigned int m_jsonTcpPort;

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -696,6 +696,8 @@ void CGUISettings::Initialize()
 #endif
   AddSeparator(vp, "videoplayer.sep5");
   AddBool(vp, "videoplayer.teletextenabled", 23050, true);
+  AddSeparator(vp, "videoplayer.sep6");
+  AddBool(vp, "videoplayer.slownetworkcache", 13554, false);
 
   CSettingsCategory* vid = AddCategory(5, "myvideos", 14081);
 


### PR DESCRIPTION
1. Added an option to do cached reads from the LAN, with the buffer size based on free ram.
2. Increase max readrate based on audio and video bitrates.

Combined these commits help with high bitrate video playback over WiFi and HomePlug networks.
