### PR TITLE
refactor dvdplayervideo demux queue to include codec buffering

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -207,6 +207,21 @@ public:
    */
   virtual void SetDropState(bool bDrop) = 0;
 
+  /*
+   * returns the number of demuxer bytes in any internal buffers
+   */
+  virtual int GetDataSize(void)
+  {
+    return 0;
+  }
+
+  /*
+   * returns the time in seconds for demuxer bytes in any internal buffers
+   */
+  virtual double GetTimeSize(void)
+  {
+    return 0;
+  }
 
   enum EFilterFlags {
     FILTER_NONE                =  0x0,

--- a/xbmc/cores/dvdplayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/dvdplayer/DVDMessageQueue.cpp
@@ -253,10 +253,23 @@ int CDVDMessageQueue::GetLevel() const
   if(m_iDataSize == 0)
     return 0;
 
-  if(m_TimeBack  == DVD_NOPTS_VALUE
-  || m_TimeFront == DVD_NOPTS_VALUE
-  || m_TimeFront <= m_TimeBack)
+  if(IsDataBased())
     return min(100, 100 * m_iDataSize / m_iMaxDataSize);
 
   return min(100, MathUtils::round_int(100.0 * m_TimeSize * (m_TimeFront - m_TimeBack) / DVD_TIME_BASE ));
+}
+
+int CDVDMessageQueue::GetTimeSize() const
+{
+  if(IsDataBased())
+    return 0;
+  else
+    return (m_TimeFront - m_TimeBack) / DVD_TIME_BASE;
+}
+
+bool CDVDMessageQueue::IsDataBased() const
+{
+  return (m_TimeBack == DVD_NOPTS_VALUE  ||
+          m_TimeFront == DVD_NOPTS_VALUE ||
+          m_TimeFront <= m_TimeBack);
 }

--- a/xbmc/cores/dvdplayer/DVDMessageQueue.h
+++ b/xbmc/cores/dvdplayer/DVDMessageQueue.h
@@ -107,6 +107,7 @@ public:
   }
 
   int GetDataSize() const               { return m_iDataSize; }
+  int GetTimeSize() const;
   unsigned GetPacketCount(CDVDMsg::Message type);
   bool ReceivedAbortRequest()           { return m_bAbortRequest; }
   void WaitUntilEmpty();
@@ -118,7 +119,9 @@ public:
   void SetMaxDataSize(int iMaxDataSize) { m_iMaxDataSize = iMaxDataSize; }
   void SetMaxTimeSize(double sec)       { m_TimeSize  = 1.0 / std::max(1.0, sec); }
   int GetMaxDataSize() const            { return m_iMaxDataSize; }
+  double GetMaxTimeSize() const         { return m_TimeSize; }
   bool IsInited() const                 { return m_bInitialized; }
+  bool IsDataBased() const;
 
 private:
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1068,8 +1068,8 @@ void CDVDPlayer::Process()
     }
 
     // always yield to players if they have data
-    if((m_dvdPlayerAudio.m_messageQueue.GetDataSize() > 0 || m_CurrentAudio.id < 0)
-    && (m_dvdPlayerVideo.m_messageQueue.GetDataSize() > 0 || m_CurrentVideo.id < 0))
+    if((m_dvdPlayerAudio.HasData() || m_CurrentAudio.id < 0)
+    && (m_dvdPlayerVideo.HasData() || m_CurrentVideo.id < 0))
       Sleep(0);
 
     DemuxPacket* pPacket = NULL;
@@ -1155,8 +1155,8 @@ void CDVDPlayer::Process()
       SetCaching(CACHESTATE_DONE);
 
       // while players are still playing, keep going to allow seekbacks
-      if(m_dvdPlayerAudio.m_messageQueue.GetDataSize() > 0
-      || m_dvdPlayerVideo.m_messageQueue.GetDataSize() > 0)
+      if(m_dvdPlayerAudio.HasData()
+      || m_dvdPlayerVideo.HasData())
       {
         Sleep(100);
         continue;
@@ -1500,8 +1500,8 @@ bool CDVDPlayer::CheckStartCaching(CCurrentStream& current)
   || (current.type == STREAM_VIDEO && m_dvdPlayerVideo.IsStalled()))
   {
     // don't start caching if it's only a single stream that has run dry
-    if(m_dvdPlayerAudio.m_messageQueue.GetLevel() > 50
-    || m_dvdPlayerVideo.m_messageQueue.GetLevel() > 50)
+    if(m_dvdPlayerAudio.GetLevel() > 50
+    || m_dvdPlayerVideo.GetLevel() > 50)
       return false;
 
     if(m_pInputStream->IsStreamType(DVDSTREAM_TYPE_HTSP)
@@ -3042,8 +3042,8 @@ void CDVDPlayer::FlushBuffers(bool queued, double pts, bool accurate)
     {
       // make sure players are properly flushed, should put them in stalled state
       CDVDMsgGeneralSynchronize* msg = new CDVDMsgGeneralSynchronize(1000, 0);
-      m_dvdPlayerAudio.m_messageQueue.Put(msg->Acquire(), 1);
-      m_dvdPlayerVideo.m_messageQueue.Put(msg->Acquire(), 1);
+      m_dvdPlayerAudio.SendMessage(msg->Acquire(), 1);
+      m_dvdPlayerVideo.SendMessage(msg->Acquire(), 1);
       msg->Wait(&m_bStop, 0);
       msg->Release();
 
@@ -3169,7 +3169,7 @@ int CDVDPlayer::OnDVDNavResult(void* pData, int iMessage)
 
         //Force an aspect ratio that is set in the dvdheaders if available
         m_CurrentVideo.hint.aspect = pStream->GetVideoAspectRatio();
-        if( m_dvdPlayerAudio.m_messageQueue.IsInited() )
+        if( m_dvdPlayerAudio.IsInited() )
           m_dvdPlayerVideo.SendMessage(new CDVDMsgDouble(CDVDMsg::VIDEO_SET_ASPECT, m_CurrentVideo.hint.aspect));
 
         m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NAV);
@@ -3187,7 +3187,7 @@ int CDVDPlayer::OnDVDNavResult(void* pData, int iMessage)
 
         m_dvd.state = DVDSTATE_NORMAL;
 
-        if( m_dvdPlayerVideo.m_messageQueue.IsInited() )
+        if( m_dvdPlayerVideo.IsInited() )
           m_dvdPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
       }
       break;
@@ -3570,8 +3570,8 @@ int CDVDPlayer::GetCacheLevel() const
 
 double CDVDPlayer::GetQueueTime()
 {
-  int a = m_dvdPlayerAudio.m_messageQueue.GetLevel();
-  int v = m_dvdPlayerVideo.m_messageQueue.GetLevel();
+  int a = m_dvdPlayerAudio.GetLevel();
+  int v = m_dvdPlayerVideo.GetLevel();
   return max(a, v) * 8000.0 / 100;
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -105,7 +105,10 @@ public:
 
   // waits until all available data has been rendered
   void WaitForBuffers();
-  bool AcceptsData()                                    { return !m_messageQueue.IsFull(); }
+  bool AcceptsData() const                              { return !m_messageQueue.IsFull(); }
+  bool HasData() const                                  { return m_messageQueue.GetDataSize() > 0; }
+  int  GetLevel() const                                 { return m_messageQueue.GetLevel(); }
+  bool IsInited() const                                 { return m_messageQueue.IsInited(); }
   void SendMessage(CDVDMsg* pMsg, int priority = 0)     { m_messageQueue.Put(pMsg, priority); }
 
   //! Switch codec if needed. Called when the sample rate gotten from the
@@ -122,8 +125,6 @@ public:
   // holds stream information for current playing stream
   CDVDStreamInfo m_streaminfo;
 
-  CDVDMessageQueue m_messageQueue;
-  CDVDMessageQueue& m_messageParent;
   CPTSOutputQueue m_ptsOutput;
   CPTSInputQueue  m_ptsInput;
 
@@ -138,6 +139,9 @@ protected:
   virtual void Process();
 
   int DecodeFrame(DVDAudioFrame &audioframe, bool bDropPacket);
+
+  CDVDMessageQueue m_messageQueue;
+  CDVDMessageQueue& m_messageParent;
 
   double m_audioClock;
 

--- a/xbmc/cores/dvdplayer/DVDPlayerTeletext.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerTeletext.h
@@ -40,13 +40,11 @@ public:
 
   // waits until all available data has been rendered
   void WaitForBuffers() { m_messageQueue.WaitUntilEmpty(); }
-  bool AcceptsData() { return !m_messageQueue.IsFull(); }
+  bool AcceptsData() const { return !m_messageQueue.IsFull(); }
   void SendMessage(CDVDMsg* pMsg) { if(m_messageQueue.IsInited()) m_messageQueue.Put(pMsg); }
 
   TextCacheStruct_t* GetTeletextCache() { return &m_TXTCache; }
   void LoadPage(int p, int sp, unsigned char* buffer);
-
-  CDVDMessageQueue m_messageQueue;
 
 protected:
   virtual void OnExit();
@@ -62,5 +60,6 @@ private:
   int m_speed;
   TextCacheStruct_t  m_TXTCache;
   CCriticalSection m_critSection;
+  CDVDMessageQueue m_messageQueue;
 };
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.h
@@ -56,7 +56,10 @@ public:
   // waits until all available data has been rendered
   // just waiting for packetqueue should be enough for video
   void WaitForBuffers()                             { m_messageQueue.WaitUntilEmpty(); }
-  bool AcceptsData()                                { return !m_messageQueue.IsFull(); }
+  bool AcceptsData() const                          { return !m_messageQueue.IsFull(); }
+  bool HasData() const                              { return m_messageQueue.GetDataSize() > 0; }
+  int  GetLevel();
+  bool IsInited() const                             { return m_messageQueue.IsInited(); }
   void SendMessage(CDVDMsg* pMsg, int priority = 0) { m_messageQueue.Put(pMsg, priority); }
 
 #ifdef HAS_VIDEO_PLAYBACK
@@ -96,9 +99,6 @@ public:
   void SetSpeed(int iSpeed);
 
   // classes
-  CDVDMessageQueue m_messageQueue;
-  CDVDMessageQueue& m_messageParent;
-
   CDVDOverlayContainer* m_pOverlayContainer;
 
   CDVDClock* m_pClock;
@@ -121,6 +121,9 @@ protected:
   void ProcessOverlays(DVDVideoPicture* pSource, double pts);
 #endif
   void ProcessVideoUserData(DVDVideoUserData* pVideoUserData, double pts);
+
+  CDVDMessageQueue m_messageQueue;
+  CDVDMessageQueue& m_messageParent;
 
   double m_iCurrentPts; // last pts displayed
   double m_iVideoDelay;


### PR DESCRIPTION
This extends the dvdplayervideo demux queue to include possible codec buffering. Some hw codecs run external buffers and  dvdplayer/dvdplayervideo needs to include these buffers in making decisions during video startup/playback. Right now we attempt to keep external buffing to a min and pray that we do not cause too much thrashing. This refactor eliminates these games.

This is slightly tricky as the demux queue can be used by size or by time and you have to handle both cases as you do not know which is being used.

1) move dvdplayer demux message queue private and add accessors.
2) change accessors to better indicate their functions and remove unused functions.
3) extend queues to include possible codec buffering.
