### PR TITLE
[windows] Enable shader based HQ scalers for DXVA renderer

### DIFF
--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -1043,5 +1043,17 @@ bool CRenderSystemDX::SupportsStereo(RENDER_STEREO_MODE mode) const
   }
 }
 
+void CRenderSystemDX::FlushGPU()
+{
+  IDirect3DQuery9* pEvent = NULL;
+
+  m_pD3DDevice->CreateQuery(D3DQUERYTYPE_EVENT, &pEvent);
+  if (pEvent != NULL)
+  {
+    pEvent->Issue(D3DISSUE_END);
+    while (S_FALSE == pEvent->GetData(NULL, 0, D3DGETDATA_FLUSH))
+      Sleep(1);
+  }
+}
 
 #endif

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -78,6 +78,8 @@ public:
 
   virtual void Project(float &x, float &y, float &z);
 
+  void FlushGPU();
+
   LPDIRECT3DDEVICE9 Get3DDevice() { return m_pD3DDevice; }
   int GetBackbufferCount() const { return m_D3DPP.BackBufferCount; }
 


### PR DESCRIPTION
The patch enables pixel shader based scaling with DXVA rendering. This is practically a dusted down patch from CrystalP with an added GPU flush. The flush is required to prevent stuttering in ION (and possibly other cards). The impact on image quality depends on the GPU. Some do only bilinear even if they would have the ponies to do better; in those cases the quality improvement is very noticeable.

According to my tests, thanks to CrystalP's scaler speedup it can now do 1080p upscaling from any source up to 60 fps on the 40 shader Ati 3450 using 'optimized' scalers and tops out at ~45 fps using unoptimized ones. More powerful GPUs should do 60 fps even with unoptimized scalers easily.

By default, the DXVA renderer will default to DXVA scaling when scaling method is set to "Automatic" for a number of reasons (see in comments).
