### PR TITLE
fixed: couldn't find path id in video database for local win32 paths

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -386,7 +386,7 @@ int CVideoDatabase::GetPathId(const CStdString& strPath)
 
     URIUtils::AddSlashAtEnd(strPath1);
 
-    strSQL=PrepareSQL("select idPath from path where strPath like '%s'",strPath1.c_str());
+    strSQL=PrepareSQL("select idPath from path where strPath = '%s'",strPath1.c_str());
     m_pDS->query(strSQL.c_str());
     if (!m_pDS->eof())
       idPath = m_pDS->fv("path.idPath").get_asInt();


### PR DESCRIPTION
Backslash is escape char for sql LIKE wildcards - using like with win32 paths containing '\' will not work here.

Apart from that - we aren't really matching pattern here, just looking for exact value, right? If so we can consider doing same in https://github.com/xbmc/xbmc/blob/master/xbmc/video/VideoDatabase.cpp#L792
