### PR TITLE
Remove unneeded Reset() calls.

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2776,7 +2776,6 @@ bool CVideoDatabase::GetResumePoint(CVideoInfoTag& tag) const
 CVideoInfoTag CVideoDatabase::GetDetailsForMovie(auto_ptr<Dataset> &pDS, bool needsCast /* = false */)
 {
   CVideoInfoTag details;
-  details.Reset();
 
   DWORD time = XbmcThreads::SystemClockMillis();
   int idMovie = pDS->fv(0).get_asInt();

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -367,7 +367,6 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
   bool bHasInfo=false;
 
   CVideoInfoTag movieDetails;
-  movieDetails.Reset();
   if (info)
   {
     m_database.Open(); // since we can be called from the music library


### PR DESCRIPTION
Reset() is already called in the constructor i.e: CVideoInfoTag() { Reset(); };
