### PR TITLE
X11: refresh window after xrandr event

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -845,7 +845,9 @@ msgctxt "#245"
 msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
 msgstr ""
 
-#empty string with id 246
+msgctxt "#246"
+msgid "Monitor"
+msgstr ""
 
 msgctxt "#247"
 msgid "Scripts"

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -801,6 +801,11 @@ bool CApplication::CreateGUI()
     return false;
   }
 
+  // update the window resolutions
+#if defined(HAS_GLX)
+  g_Windowing.UpdateResolutions();
+#endif
+
   // Retrieve the matching resolution based on GUI settings
   g_guiSettings.m_LookAndFeelResolution = g_guiSettings.GetResolution();
   CLog::Log(LOGNOTICE, "Checking resolution %i", g_guiSettings.m_LookAndFeelResolution);
@@ -810,7 +815,6 @@ bool CApplication::CreateGUI()
     g_guiSettings.SetResolution(RES_DESKTOP);
   }
 
-  // update the window resolution
   g_Windowing.SetWindowResolution(g_guiSettings.GetInt("window.width"), g_guiSettings.GetInt("window.height"));
 
   if (g_advancedSettings.m_startFullScreen && g_guiSettings.m_LookAndFeelResolution == RES_WINDOW)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -753,7 +753,7 @@ bool CApplication::CreateGUI()
 
   uint32_t sdlFlags = 0;
 
-#if defined(HAS_SDL_OPENGL) || (HAS_GLES == 2)
+#if (defined(HAS_SDL_OPENGL) || (HAS_GLES == 2)) && !defined(HAS_GLX)
   sdlFlags |= SDL_INIT_VIDEO;
 #endif
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -249,7 +249,7 @@ bool CVDPAU::MakePixmapGL()
   };
 
   GLXFBConfig *fbConfigs;
-  fbConfigs = glXChooseFBConfig(m_Display, DefaultScreen(m_Display), doubleVisAttributes, &num);
+  fbConfigs = glXChooseFBConfig(m_Display, g_Windowing.GetCurrentScreen(), doubleVisAttributes, &num);
   if (fbConfigs==NULL)
   {
     CLog::Log(LOGERROR, "GLX Error: MakePixmap: No compatible framebuffers found");
@@ -300,10 +300,10 @@ bool CVDPAU::MakePixmap(int width, int height)
 
     // Get our window attribs.
   XWindowAttributes wndattribs;
-  XGetWindowAttributes(m_Display, DefaultRootWindow(m_Display), &wndattribs); // returns a status but I don't know what success is
+  XGetWindowAttributes(m_Display, g_Windowing.GetWindow(), &wndattribs); // returns a status but I don't know what success is
 
   m_Pixmap = XCreatePixmap(m_Display,
-                           DefaultRootWindow(m_Display),
+                           g_Windowing.GetWindow(),
                            OutWidth,
                            OutHeight,
                            wndattribs.depth);
@@ -315,7 +315,7 @@ bool CVDPAU::MakePixmap(int width, int height)
 
   XGCValues values = {};
   GC xgc;
-  values.foreground = BlackPixel (m_Display, DefaultScreen (m_Display));
+  values.foreground = BlackPixel (m_Display, g_Windowing.GetCurrentScreen());
   xgc = XCreateGC(m_Display, m_Pixmap, GCForeground, &values);
   XFillRectangle(m_Display, m_Pixmap, xgc, 0, 0, OutWidth, OutHeight);
   XFreeGC(m_Display, xgc);
@@ -707,7 +707,7 @@ void CVDPAU::InitVDPAUProcs()
     m_Display = g_Windowing.GetDisplay();
   }
 
-  int mScreen = DefaultScreen(m_Display);
+  int mScreen = g_Windowing.GetCurrentScreen();
   VdpStatus vdp_st;
 
   // Create Device

--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -180,6 +180,8 @@ static const XBMCKEYTABLE XBMCKeyTable[] =
 , { XBMCK_LAUNCH_APP2,            0,    0, XBMCVK_LAUNCH_APP2,         "launch_app2_pc_icon" }
 , { XBMCK_LAUNCH_FILE_BROWSER,    0,    0, XBMCVK_LAUNCH_FILE_BROWSER, "launch_file_browser" }
 , { XBMCK_LAUNCH_MEDIA_CENTER,    0,    0, XBMCVK_LAUNCH_MEDIA_CENTER, "launch_media_center" }
+, { XBMCK_PLAY,                   0,    0, XBMCVK_MEDIA_PLAY_PAUSE,    "play_pause" }
+, { XBMCK_STOP,                   0,    0, XBMCVK_MEDIA_STOP,          "stop" }
 
 // Function keys
 , { XBMCK_F1,                     0,    0, XBMCVK_F1,            "f1"}

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -45,6 +45,7 @@ public:
   virtual bool IsExtSupported(const char* extension);
 
   virtual void SetVSync(bool vsync);
+  virtual void ResetVSync() { m_bVsyncInit = false; }
 
   virtual void SetViewPort(CRect& viewPort);
   virtual void GetViewPort(CRect& viewPort);

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -378,11 +378,16 @@ void CGUISettings::Initialize()
   AddGroup(4, 13000);
   CSettingsCategory* vs = AddCategory(4, "videoscreen", 21373);
 
+#if defined(HAS_GLX)
+  AddString(vs, "videoscreen.monitor", 246, "", SPIN_CONTROL_TEXT);
+#endif
+
   // this setting would ideally not be saved, as its value is systematically derived from videoscreen.screenmode.
   // contains a DISPLAYMODE
 #if !defined(TARGET_DARWIN_IOS_ATV2)
   AddInt(vs, "videoscreen.screen", 240, 0, -1, 1, 32, SPIN_CONTROL_TEXT);
 #endif
+
   // this setting would ideally not be saved, as its value is systematically derived from videoscreen.screenmode.
   // contains an index to the g_settings.m_ResInfo array. the only meaningful fields are iScreen, iWidth, iHeight.
 #if defined(TARGET_DARWIN)

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -485,6 +485,12 @@ void CGUIWindowSettingsCategory::CreateSettings()
       FillInRefreshRates(strSetting, g_guiSettings.GetResolution(), false);
       continue;
     }
+    else if (strSetting.Equals("videoscreen.monitor"))
+    {
+      AddSetting(pSetting, group->GetWidth(), iControlID);
+      FillInMonitors(strSetting);
+      continue;
+    }
     else if (strSetting.Equals("lookandfeel.skintheme"))
     {
       AddSetting(pSetting, group->GetWidth(), iControlID);
@@ -1394,6 +1400,20 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
     // Cascade
     FillInResolutions("videoscreen.resolution", mode, RES_DESKTOP, true);
   }
+  else if (strSetting.Equals("videoscreen.monitor"))
+  {
+    CSettingString *pSettingString = (CSettingString *)pSettingControl->GetSetting();
+    CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(pSettingControl->GetID());
+    CStdString currentMonitor = pControl->GetCurrentLabel();
+    if (!g_Windowing.IsCurrentOutput(currentMonitor))
+    {
+      g_guiSettings.SetString("videoscreen.monitor", currentMonitor);
+      g_Windowing.UpdateResolutions();
+      DisplayMode mode = g_guiSettings.GetInt("videoscreen.screen");
+      // Cascade
+      FillInResolutions("videoscreen.resolution", mode, RES_DESKTOP, true);
+    }
+  }
   else if (strSetting.Equals("videoscreen.resolution"))
   {
     RESOLUTION nextRes = (RESOLUTION) g_guiSettings.GetInt("videoscreen.resolution");
@@ -2243,17 +2263,51 @@ DisplayMode CGUIWindowSettingsCategory::FillInScreens(CStdString strSetting, RES
     if (g_advancedSettings.m_canWindowed)
       pControl->AddLabel(g_localizeStrings.Get(242), -1);
 
+#if !defined(HAS_GLX)
     for (int idx = 0; idx < g_Windowing.GetNumScreens(); idx++)
     {
       strScreen.Format(g_localizeStrings.Get(241), g_settings.m_ResInfo[RES_DESKTOP + idx].iScreen + 1);
       pControl->AddLabel(strScreen, g_settings.m_ResInfo[RES_DESKTOP + idx].iScreen);
     }
+#else
+    pControl->AddLabel(g_localizeStrings.Get(244), 0);
+#endif
     pControl->SetValue(mode);
     g_guiSettings.SetInt("videoscreen.screen", mode);
   }
 
   return mode;
 }
+
+void CGUIWindowSettingsCategory::FillInMonitors(CStdString strSetting)
+{
+  // we expect "videoscreen.monitor" but it might be hidden on some platforms,
+  // so check that we actually have a visable control.
+  CBaseSettingControl *control = GetSetting(strSetting);
+  if (control)
+  {
+    control->SetDelayed();
+    CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(control->GetID());
+    pControl->Clear();
+
+    std::vector<CStdString> monitors;
+    g_Windowing.GetConnectedOutputs(&monitors);
+
+    int currentMonitor = 0;
+    for (unsigned int i=0; i<monitors.size(); ++i)
+    {
+      if(g_settings.m_ResInfo[RES_DESKTOP].strOutput.Equals(monitors[i]))
+      {
+        currentMonitor = i;
+      }
+      pControl->AddLabel(monitors[i], i);
+    }
+
+    pControl->SetValue(currentMonitor);
+    g_guiSettings.SetString("videoscreen.monitor", g_settings.m_ResInfo[RES_DESKTOP].strOutput);
+  }
+}
+
 
 void CGUIWindowSettingsCategory::FillInResolutions(CStdString strSetting, DisplayMode mode, RESOLUTION res, bool UserChange)
 {
@@ -2376,13 +2430,15 @@ void CGUIWindowSettingsCategory::OnRefreshRateChanged(RESOLUTION nextRes)
   RESOLUTION lastRes = g_graphicsContext.GetVideoResolution();
   bool cancelled = false;
 
+  bool outputChanged = !g_Windowing.IsCurrentOutput(g_guiSettings.GetString("videoscreen.monitor"));
+
   g_guiSettings.SetResolution(nextRes);
-  g_graphicsContext.SetVideoResolution(nextRes);
+  g_graphicsContext.SetVideoResolution(nextRes, outputChanged);
 
   if (!CGUIDialogYesNo::ShowAndGetInput(13110, 13111, 20022, 20022, -1, -1, cancelled, 10000))
   {
     g_guiSettings.SetResolution(lastRes);
-    g_graphicsContext.SetVideoResolution(lastRes);
+    g_graphicsContext.SetVideoResolution(lastRes, outputChanged);
 
     DisplayMode mode = FillInScreens("videoscreen.screen", lastRes);
     FillInResolutions("videoscreen.resolution", mode, lastRes, false);

--- a/xbmc/settings/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/GUIWindowSettingsCategory.h
@@ -50,6 +50,7 @@ protected:
   void FillInSoundSkins(CSetting *pSetting);
   void FillInLanguages(CSetting *pSetting, const std::vector<CStdString> &languages = std::vector<CStdString>(), const std::vector<CStdString> &languageKeys = std::vector<CStdString>());
   DisplayMode FillInScreens(CStdString strSetting, RESOLUTION res);
+  void FillInMonitors(CStdString strSetting);
   void FillInResolutions(CStdString strSetting, DisplayMode mode, RESOLUTION res, bool UserChange);
   void FillInRefreshRates(CStdString strSetting, RESOLUTION res, bool UserChange);
   void OnRefreshRateChanged(RESOLUTION resolution);

--- a/xbmc/settings/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/GUIWindowSettingsScreenCalibration.cpp
@@ -117,6 +117,7 @@ bool CGUIWindowSettingsScreenCalibration::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_DEINIT:
     {
+      g_settings.UpdateCalibrations();
       g_settings.Save();
       g_graphicsContext.SetCalibrating(false);
       g_windowManager.ShowOverlay(OVERLAY_STATE_SHOWN);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -335,6 +335,7 @@ public:
   int GetCurrentProfileId() const;
 
   std::vector<RESOLUTION_INFO> m_ResInfo;
+  std::vector<RESOLUTION_INFO> m_Calibrations;
 
   // utility functions for user data folders
 
@@ -386,6 +387,9 @@ public:
   static bool GetString(const TiXmlElement* pRootElement, const char *strTagName, CStdString& strValue, const CStdString& strDefaultValue);
   bool GetString(const TiXmlElement* pRootElement, const char *strTagName, char *szValue, const CStdString& strDefaultValue);
   bool GetSource(const CStdString &category, const TiXmlNode *source, CMediaSource &share);
+
+  void ApplyCalibrations();
+  void UpdateCalibrations();
 protected:
   void GetSources(const TiXmlElement* pRootElement, const CStdString& strTagName, VECSOURCES& items, CStdString& strDefault);
   bool SetSources(TiXmlNode *root, const char *section, const VECSOURCES &shares, const char *defaultPath);

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -159,7 +159,11 @@
 #ifndef HAS_SDL_OPENGL
 #define HAS_SDL_OPENGL
 #endif
+#ifdef HAVE_X11
+#define HAS_X11_WIN_EVENTS
+#else
 #define HAS_SDL_WIN_EVENTS
+#endif
 #endif
 #define HAS_LINUX_NETWORK
 #define HAS_LIRC

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -251,7 +251,7 @@ bool CVideoReferenceClock::SetupGLX()
   }
 
   bool          ExtensionFound = false;
-  istringstream Extensions(glXQueryExtensionsString(m_Dpy, DefaultScreen(m_Dpy)));
+  istringstream Extensions(glXQueryExtensionsString(m_Dpy, g_Windowing.GetCurrentScreen()));
   string        ExtensionStr;
 
   while (!ExtensionFound)
@@ -278,7 +278,7 @@ bool CVideoReferenceClock::SetupGLX()
     m_bIsATI = true;
   }
 
-  m_vInfo = glXChooseVisual(m_Dpy, DefaultScreen(m_Dpy), singleBufferAttributes);
+  m_vInfo = glXChooseVisual(m_Dpy, g_Windowing.GetCurrentScreen(), singleBufferAttributes);
   if (!m_vInfo)
   {
     CLog::Log(LOGDEBUG, "CVideoReferenceClock: glXChooseVisual returned NULL");
@@ -289,15 +289,16 @@ bool CVideoReferenceClock::SetupGLX()
   {
     Swa.border_pixel = 0;
     Swa.event_mask = StructureNotifyMask;
-    Swa.colormap = XCreateColormap(m_Dpy, RootWindow(m_Dpy, m_vInfo->screen), m_vInfo->visual, AllocNone );
+    Swa.colormap = XCreateColormap(m_Dpy, g_Windowing.GetWindow(), m_vInfo->visual, AllocNone );
     SwaMask = CWBorderPixel | CWColormap | CWEventMask;
 
-    m_Window = XCreateWindow(m_Dpy, RootWindow(m_Dpy, m_vInfo->screen), 0, 0, 256, 256, 0,
+    m_Window = XCreateWindow(m_Dpy, g_Windowing.GetWindow(), 0, 0, 256, 256, 0,
                            m_vInfo->depth, InputOutput, m_vInfo->visual, SwaMask, &Swa);
   }
   else
   {
-    m_pixmap = XCreatePixmap(m_Dpy, DefaultRootWindow(m_Dpy), 256, 256, m_vInfo->depth);
+    Window window = g_Windowing.GetWindow();
+    m_pixmap = XCreatePixmap(m_Dpy, window, 256, 256, m_vInfo->depth);
     if (!m_pixmap)
     {
       CLog::Log(LOGDEBUG, "CVideoReferenceClock: unable to create pixmap");
@@ -364,7 +365,7 @@ bool CVideoReferenceClock::SetupGLX()
 
   //set up receiving of RandR events, we'll get one when the refreshrate changes
   XRRQueryExtension(m_Dpy, &m_RREventBase, &ReturnV);
-  XRRSelectInput(m_Dpy, RootWindow(m_Dpy, m_vInfo->screen), RRScreenChangeNotifyMask);
+  XRRSelectInput(m_Dpy, g_Windowing.GetWindow(), RRScreenChangeNotifyMask);
 
   UpdateRefreshrate(true); //forced refreshrate update
   m_MissedVblanks = 0;
@@ -499,7 +500,7 @@ int CVideoReferenceClock::GetRandRRate()
   int RefreshRate;
   XRRScreenConfiguration *CurrInfo;
 
-  CurrInfo = XRRGetScreenInfo(m_Dpy, RootWindow(m_Dpy, m_vInfo->screen));
+  CurrInfo = XRRGetScreenInfo(m_Dpy, g_Windowing.GetWindow());
   RefreshRate = XRRConfigCurrentRate(CurrInfo);
   XRRFreeScreenConfigInfo(CurrInfo);
 

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -122,6 +122,18 @@ CVideoReferenceClock::CVideoReferenceClock() : CThread("CVideoReferenceClock")
 #endif
 }
 
+CVideoReferenceClock::~CVideoReferenceClock()
+{
+#if defined(HAS_GLX)
+  // some ATI voodoo, if we don't close the display, we crash on exit
+  if (m_Dpy)
+  {
+    XCloseDisplay(m_Dpy);
+    m_Dpy = NULL;
+  }
+#endif
+}
+
 void CVideoReferenceClock::Process()
 {
   bool SetupSuccess = false;
@@ -131,6 +143,10 @@ void CVideoReferenceClock::Process()
   //register callback
   m_D3dCallback.Reset();
   g_Windowing.Register(&m_D3dCallback);
+#endif
+#if defined(HAS_GLX)
+  g_Windowing.Register(this);
+  m_xrrEvent = false;
 #endif
 
   while(!m_bStop)
@@ -192,6 +208,16 @@ void CVideoReferenceClock::Process()
     //clean up the vblank clock
 #if defined(HAS_GLX) && defined(HAS_XRANDR)
     CleanupGLX();
+    if (m_xrrEvent)
+    {
+      m_releaseEvent.Set();
+      while (!m_bStop)
+      {
+        if (m_resetEvent.WaitMSec(100))
+          break;
+      }
+      m_xrrEvent = false;
+    }
 #elif defined(_WIN32) && defined(HAS_DX)
     CleanupD3D();
 #elif defined(TARGET_DARWIN)
@@ -203,6 +229,9 @@ void CVideoReferenceClock::Process()
 #if defined(_WIN32) && defined(HAS_DX)
   g_Windowing.Unregister(&m_D3dCallback);
 #endif
+#if defined(HAS_GLX)
+  g_Windowing.Unregister(this);
+#endif
 }
 
 bool CVideoReferenceClock::WaitStarted(int MSecs)
@@ -212,6 +241,24 @@ bool CVideoReferenceClock::WaitStarted(int MSecs)
 }
 
 #if defined(HAS_GLX) && defined(HAS_XRANDR)
+
+void CVideoReferenceClock::OnLostDevice()
+{
+  if (!m_xrrEvent)
+  {
+    m_releaseEvent.Reset();
+    m_resetEvent.Reset();
+    m_xrrEvent = true;
+    m_releaseEvent.Wait();
+  }
+}
+
+void CVideoReferenceClock::OnResetDevice()
+{
+  m_xrrEvent = false;
+  m_resetEvent.Set();
+}
+
 bool CVideoReferenceClock::SetupGLX()
 {
   int singleBufferAttributes[] = {
@@ -362,10 +409,6 @@ bool CVideoReferenceClock::SetupGLX()
     CLog::Log(LOGDEBUG, "CVideoReferenceClock: RandR not supported");
     return false;
   }
-
-  //set up receiving of RandR events, we'll get one when the refreshrate changes
-  XRRQueryExtension(m_Dpy, &m_RREventBase, &ReturnV);
-  XRRSelectInput(m_Dpy, g_Windowing.GetWindow(), RRScreenChangeNotifyMask);
 
   UpdateRefreshrate(true); //forced refreshrate update
   m_MissedVblanks = 0;
@@ -567,6 +610,9 @@ void CVideoReferenceClock::RunGLX()
 
   while(!m_bStop)
   {
+    if (m_xrrEvent)
+      return;
+
     //wait for the next vblank
     if (!m_bIsATI)
     {
@@ -630,7 +676,6 @@ void CVideoReferenceClock::RunGLX()
       UpdateClock((int)(VblankCount - PrevVblankCount), true);
       SingleLock.Leave();
       SendVblankSignal();
-      UpdateRefreshrate();
       IsReset = false;
     }
     else if (!m_bStop)
@@ -1167,23 +1212,10 @@ bool CVideoReferenceClock::UpdateRefreshrate(bool Forced /*= false*/)
 
 #if defined(HAS_GLX) && defined(HAS_XRANDR)
 
-  //check for RandR events
-  bool   GotEvent = Forced || m_RefreshChanged == 2;
-  XEvent Event;
-  while (XCheckTypedEvent(m_Dpy, m_RREventBase + RRScreenChangeNotify, &Event))
-  {
-    if (Event.type == m_RREventBase + RRScreenChangeNotify)
-    {
-      CLog::Log(LOGDEBUG, "CVideoReferenceClock: Received RandR event %i", Event.type);
-      GotEvent = true;
-    }
-    XRRUpdateConfiguration(&Event);
-  }
-
   if (!Forced)
     m_RefreshChanged = 0;
 
-  if (!GotEvent) //refreshrate did not change
+  if (!Forced) //refreshrate did not change
     return false;
 
   //the refreshrate can be wrong on nvidia drivers, so read it from nvidia-settings when it's available

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -31,6 +31,7 @@
   #include <X11/X.h>
   #include <X11/Xlib.h>
   #include <GL/glx.h>
+  #include "guilib/DispResource.h"
 #elif defined(_WIN32) && defined(HAS_DX)
   #include <d3d9.h>
   #include "guilib/D3DResource.h"
@@ -57,9 +58,13 @@ class CD3DCallback : public ID3DResource
 #endif
 
 class CVideoReferenceClock : public CThread
+#if defined(HAS_GLX)
+                            ,public IDispResource
+#endif
 {
   public:
     CVideoReferenceClock();
+    virtual ~CVideoReferenceClock();
 
     int64_t GetTime(bool interpolated = true);
     int64_t GetFrequency();
@@ -74,6 +79,11 @@ class CVideoReferenceClock : public CThread
 
 #if defined(TARGET_DARWIN)
     void VblankHandler(int64_t nowtime, double fps);
+#endif
+
+#if defined(HAS_GLX)
+    virtual void OnLostDevice();
+    virtual void OnResetDevice();
 #endif
 
   private:
@@ -122,7 +132,8 @@ class CVideoReferenceClock : public CThread
     GLXContext   m_Context;
     Pixmap       m_pixmap;
     GLXPixmap    m_glPixmap;
-    int          m_RREventBase;
+    bool         m_xrrEvent;
+    CEvent       m_releaseEvent, m_resetEvent;
 
     bool         m_UseNvSettings;
     bool         m_bIsATI;

--- a/xbmc/windowing/Makefile
+++ b/xbmc/windowing/Makefile
@@ -1,6 +1,7 @@
 SRCS=WinEventsSDL.cpp \
      WinEventsLinux.cpp \
      WinSystem.cpp \
+     WinEventsX11.cpp \
      
 LIB=windowing.a
 

--- a/xbmc/windowing/WinEvents.h
+++ b/xbmc/windowing/WinEvents.h
@@ -55,6 +55,10 @@ public:
 #include "WinEventsSDL.h"
 #define CWinEvents CWinEventsSDL
 
+#elif defined(TARGET_LINUX) && defined(HAS_X11_WIN_EVENTS)
+#include "WinEventsX11.h"
+#define CWinEvents CWinEventsX11
+
 #elif defined(TARGET_LINUX) && defined(HAS_LINUX_EVENTS)
 #include "WinEventsLinux.h"
 #define CWinEvents CWinEventsLinux

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -358,6 +358,8 @@ bool CWinEventsX11::MessagePump()
         if (WinEvents->m_xic)
           XSetICFocus(WinEvents->m_xic);
         g_application.m_AppFocused = true;
+        memset(&(WinEvents->m_lastKey), 0, sizeof(XBMC_Event));
+        WinEvents->m_keymodState = 0;
         if (serial == xevent.xfocus.serial)
           break;
         g_Windowing.NotifyAppFocusChange(g_application.m_AppFocused);
@@ -369,6 +371,7 @@ bool CWinEventsX11::MessagePump()
         if (WinEvents->m_xic)
           XUnsetICFocus(WinEvents->m_xic);
         g_application.m_AppFocused = false;
+        memset(&(WinEvents->m_lastKey), 0, sizeof(XBMC_Event));
         g_Windowing.NotifyAppFocusChange(g_application.m_AppFocused);
         serial = xevent.xfocus.serial;
         break;

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -516,9 +516,16 @@ bool CWinEventsX11::MessagePump()
         break;
       }
 
+      case EnterNotify:
+      {
+        g_Windowing.NotifyMouseCoverage(true);
+        break;
+      }
+
       // lose mouse coverage
       case LeaveNotify:
       {
+        g_Windowing.NotifyMouseCoverage(false);
         g_Mouse.SetActive(false);
         break;
       }

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -31,6 +31,7 @@
 #include "X11/keysymdef.h"
 #include "X11/XF86keysym.h"
 #include "utils/log.h"
+#include "utils/CharsetConverter.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/MouseStat.h"
 
@@ -160,7 +161,6 @@ CWinEventsX11::CWinEventsX11()
   m_display = 0;
   m_window = 0;
   m_keybuf = 0;
-  m_utf16buf = 0;
 }
 
 CWinEventsX11::~CWinEventsX11()
@@ -169,12 +169,6 @@ CWinEventsX11::~CWinEventsX11()
   {
     free(m_keybuf);
     m_keybuf = 0;
-  }
-
-  if (m_utf16buf)
-  {
-    free(m_utf16buf);
-    m_utf16buf = 0;
   }
 
   if (m_xic)
@@ -202,7 +196,6 @@ bool CWinEventsX11::Init(Display *dpy, Window win)
   WinEvents->m_display = dpy;
   WinEvents->m_window = win;
   WinEvents->m_keybuf = (char*)malloc(32*sizeof(char));
-  WinEvents->m_utf16buf = (uint16_t*)malloc(32*sizeof(uint16_t));
   WinEvents->m_keymodState = 0;
   WinEvents->m_wmDeleteMessage = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
   WinEvents->m_structureChanged = false;
@@ -432,8 +425,6 @@ bool CWinEventsX11::MessagePump()
         }
 
         Status status;
-        int utf16size;
-        int utf16length;
         int len;
         len = Xutf8LookupString(WinEvents->m_xic, &xevent.xkey,
                                 WinEvents->m_keybuf, sizeof(WinEvents->m_keybuf),
@@ -452,36 +443,29 @@ bool CWinEventsX11::MessagePump()
           case XLookupChars:
           case XLookupBoth:
           {
-            if (len == 0)
-              break;
-            utf16size = len * sizeof(uint16_t);
-            if (utf16size > sizeof(WinEvents->m_utf16buf))
-            {
-              WinEvents->m_utf16buf = (uint16_t *)realloc(WinEvents->m_utf16buf,utf16size);
-              if (WinEvents->m_utf16buf == NULL)
-              {
-                break;
-              }
-            }
-            utf16length = Utf8ToUnicode(WinEvents->m_keybuf, len, WinEvents->m_utf16buf, utf16size);
-            if (utf16length < 0)
+            CStdString   data(WinEvents->m_keybuf, len);
+            CStdStringW keys;
+            g_charsetConverter.utf8ToW(data, keys, false);
+
+            if (keys.length() == 0)
             {
               break;
             }
-            for (unsigned int i = 0; i < utf16length - 1; i++)
+
+            for (unsigned int i = 0; i < keys.length() - 1; i++)
             {
               newEvent.key.keysym.sym = XBMCK_UNKNOWN;
-              newEvent.key.keysym.unicode = WinEvents->m_utf16buf[i];
+              newEvent.key.keysym.unicode = keys[i];
               newEvent.key.state = xevent.xkey.state;
               newEvent.key.type = xevent.xkey.type;
               ret |= ProcessKey(newEvent, 500);
             }
-            if (utf16length > 0)
+            if (keys.length() > 0)
             {
               newEvent.key.keysym.scancode = xevent.xkey.keycode;
               xkeysym = XLookupKeysym(&xevent.xkey, 0);
               newEvent.key.keysym.sym = LookupXbmcKeySym(xkeysym);
-              newEvent.key.keysym.unicode = WinEvents->m_utf16buf[utf16length - 1];
+              newEvent.key.keysym.unicode = keys[keys.length() - 1];
               newEvent.key.state = xevent.xkey.state;
               newEvent.key.type = xevent.xkey.type;
 
@@ -740,87 +724,6 @@ bool CWinEventsX11::ProcessKeyRepeat()
     }
   }
   return false;
-}
-
-int CWinEventsX11::Utf8ToUnicode(const char *utf8, const int utf8Length, uint16_t *utf16, const int utf16MaxLength)
-{
-  // p moves over the output buffer.  max_ptr points to the next to the last slot of the buffer.
-  uint16_t *p = utf16;
-  uint16_t const *const maxPtr = utf16 + utf16MaxLength;
-
-  // end_of_input points to the last byte of input as opposed to the next to the last byte.
-  char const *const endOfInput = utf8 + utf8Length - 1;
-
-  while (utf8 <= endOfInput)
-  {
-    unsigned char const c = *utf8;
-    if (p >= maxPtr)
-    {
-      //No more output space.
-      return -1;
-    }
-    if (c < 0x80)
-    {
-      //One byte ASCII.
-      *p++ = c;
-      utf8 += 1;
-    }
-    else if (c < 0xC0)
-    {
-      // Follower byte without preceding leader bytes.
-      return -1;
-    }
-    // 11 bits
-    else if (c < 0xE0)
-    {
-      // Two byte sequence.  We need one follower byte.
-      if (endOfInput - utf8 < 1 || (((utf8[1] ^ 0x80)) & 0xC0))
-      {
-        return -1;
-      }
-      *p++ = (uint16_t)(((c & 0x1F) << 6) + (utf8[1] & 0x3F));
-      utf8 += 2;
-    }
-    // 16 bis
-    else if (c < 0xF0)
-    {
-      // Three byte sequence.  We need two follower byte.
-      if (endOfInput - utf8 < 2 || ((utf8[1] ^ 0x80) & 0xC0) || ((utf8[2] ^ 0x80) & 0xC0))
-      {
-        return -1;
-      }
-      *p++ = (uint16_t)(((c & 0xF) << 12) + ((utf8[1] & 0x3F) << 6) + (utf8[2] & 0x3F));
-      utf8 += 3;
-    }
-    // 21 bits
-    else if (c < 0xF8)
-    {
-      int plane;
-      // Four byte sequence.  We need three follower bytes.
-      if (endOfInput - utf8 < 3 || ((utf8[1] ^ 0x80) & 0xC0) ||
-          ((utf8[2] ^ 0x80) & 0xC0) || ((utf8[3] ^ 0x80) & 0xC0))
-      {
-        return -1;
-      }
-      uint32_t unicode = ((c & 0x7) << 18) + ((utf8[1] & 0x3F) << 12) +
-                          ((utf8[2] & 0x3F) << 6) + (utf8[3] & 0x3F);
-      utf8 += 4;
-      CLog::Log(LOGERROR, "CWinEventsX11::Utf8ToUnicode: 4 byte unicode not supported");
-    }
-    // 26 bits
-    else if (c < 0xFC)
-    {
-      CLog::Log(LOGERROR, "CWinEventsX11::Utf8ToUnicode: 4 byte unicode not supported");
-      utf8 += 5;
-    }
-    // 31 bit
-    else
-    {
-      CLog::Log(LOGERROR, "CWinEventsX11::Utf8ToUnicode: 4 byte unicode not supported");
-      utf8 += 6;
-    }
-  }
-  return p - utf16;
 }
 
 XBMCKey CWinEventsX11::LookupXbmcKeySym(KeySym keysym)

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -34,6 +34,10 @@
 #include "guilib/GUIWindowManager.h"
 #include "input/MouseStat.h"
 
+#ifdef HAS_SDL_JOYSTICK
+#include "input/SDLJoystick.h"
+#endif
+
 CWinEventsX11* CWinEventsX11::WinEvents = 0;
 
 static uint32_t SymMappingsX11[][2] =
@@ -545,6 +549,28 @@ bool CWinEventsX11::MessagePump()
   }// while
 
   ret |= ProcessKeyRepeat();
+
+#ifdef HAS_SDL_JOYSTICK
+  SDL_Event event;
+  while (SDL_PollEvent(&event))
+  {
+    switch(event.type)
+    {
+      case SDL_JOYBUTTONUP:
+      case SDL_JOYBUTTONDOWN:
+      case SDL_JOYAXISMOTION:
+      case SDL_JOYBALLMOTION:
+      case SDL_JOYHATMOTION:
+        g_Joystick.Update(event);
+        ret = true;
+        break;
+
+      default:
+        break;
+    }
+    memset(&event, 0, sizeof(SDL_Event));
+  }
+#endif
 
   return ret;
 }

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -1,0 +1,764 @@
+/*
+*      Copyright (C) 2005-2012 Team XBMC
+*      http://www.xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#include "system.h"
+
+#ifdef HAS_X11_WIN_EVENTS
+
+#include "WinEvents.h"
+#include "WinEventsX11.h"
+#include "Application.h"
+#include <X11/Xlib.h>
+#include "X11/WinSystemX11GL.h"
+#include "X11/keysymdef.h"
+#include "X11/XF86keysym.h"
+#include "utils/log.h"
+#include "guilib/GUIWindowManager.h"
+#include "input/MouseStat.h"
+
+CWinEventsX11* CWinEventsX11::WinEvents = 0;
+
+static uint32_t SymMappingsX11[][2] =
+{
+  {XK_BackSpace, XBMCK_BACKSPACE}
+, {XK_Tab, XBMCK_TAB}
+, {XK_Clear, XBMCK_CLEAR}
+, {XK_Return, XBMCK_RETURN}
+, {XK_Pause, XBMCK_PAUSE}
+, {XK_Escape, XBMCK_ESCAPE}
+, {XK_Delete, XBMCK_DELETE}
+// multi-media keys
+, {XF86XK_Back, XBMCK_BROWSER_BACK}
+, {XF86XK_Forward, XBMCK_BROWSER_FORWARD}
+, {XF86XK_Refresh, XBMCK_BROWSER_REFRESH}
+, {XF86XK_Stop, XBMCK_BROWSER_STOP}
+, {XF86XK_Search, XBMCK_BROWSER_SEARCH}
+, {XF86XK_Favorites, XBMCK_BROWSER_FAVORITES}
+, {XF86XK_HomePage, XBMCK_BROWSER_HOME}
+, {XF86XK_AudioMute, XBMCK_VOLUME_MUTE}
+, {XF86XK_AudioLowerVolume, XBMCK_VOLUME_DOWN}
+, {XF86XK_AudioRaiseVolume, XBMCK_VOLUME_UP}
+, {XF86XK_AudioNext, XBMCK_MEDIA_NEXT_TRACK}
+, {XF86XK_AudioPrev, XBMCK_MEDIA_PREV_TRACK}
+, {XF86XK_AudioStop, XBMCK_MEDIA_STOP}
+, {XF86XK_AudioPause, XBMCK_MEDIA_PLAY_PAUSE}
+, {XF86XK_Mail, XBMCK_LAUNCH_MAIL}
+, {XF86XK_Select, XBMCK_LAUNCH_MEDIA_SELECT}
+, {XF86XK_Launch0, XBMCK_LAUNCH_APP1}
+, {XF86XK_Launch1, XBMCK_LAUNCH_APP2}
+, {XF86XK_WWW, XBMCK_LAUNCH_FILE_BROWSER}
+, {XF86XK_AudioMedia, XBMCK_LAUNCH_MEDIA_CENTER }
+  // Numeric keypad
+, {XK_KP_0, XBMCK_KP0}
+, {XK_KP_1, XBMCK_KP1}
+, {XK_KP_2, XBMCK_KP2}
+, {XK_KP_3, XBMCK_KP3}
+, {XK_KP_4, XBMCK_KP4}
+, {XK_KP_5, XBMCK_KP5}
+, {XK_KP_6, XBMCK_KP6}
+, {XK_KP_7, XBMCK_KP7}
+, {XK_KP_8, XBMCK_KP8}
+, {XK_KP_9, XBMCK_KP9}
+, {XK_KP_Separator, XBMCK_KP_PERIOD}
+, {XK_KP_Divide, XBMCK_KP_DIVIDE}
+, {XK_KP_Multiply, XBMCK_KP_MULTIPLY}
+, {XK_KP_Subtract, XBMCK_KP_MINUS}
+, {XK_KP_Add, XBMCK_KP_PLUS}
+, {XK_KP_Enter, XBMCK_KP_ENTER}
+, {XK_KP_Equal, XBMCK_KP_EQUALS}
+  // Arrows + Home/End pad
+, {XK_Up, XBMCK_UP}
+, {XK_Down, XBMCK_DOWN}
+, {XK_Right, XBMCK_RIGHT}
+, {XK_Left, XBMCK_LEFT}
+, {XK_Insert, XBMCK_INSERT}
+, {XK_Home, XBMCK_HOME}
+, {XK_End, XBMCK_END}
+, {XK_Page_Up, XBMCK_PAGEUP}
+, {XK_Page_Down, XBMCK_PAGEDOWN}
+  // Function keys
+, {XK_F1, XBMCK_F1}
+, {XK_F2, XBMCK_F2}
+, {XK_F3, XBMCK_F3}
+, {XK_F4, XBMCK_F4}
+, {XK_F5, XBMCK_F5}
+, {XK_F6, XBMCK_F6}
+, {XK_F7, XBMCK_F7}
+, {XK_F8, XBMCK_F8}
+, {XK_F9, XBMCK_F9}
+, {XK_F10, XBMCK_F10}
+, {XK_F11, XBMCK_F11}
+, {XK_F12, XBMCK_F12}
+, {XK_F13, XBMCK_F13}
+, {XK_F14, XBMCK_F14}
+, {XK_F15, XBMCK_F15}
+  // Key state modifier keys
+, {XK_Num_Lock, XBMCK_NUMLOCK}
+, {XK_Caps_Lock, XBMCK_CAPSLOCK}
+, {XK_Scroll_Lock, XBMCK_SCROLLOCK}
+, {XK_Shift_R, XBMCK_RSHIFT}
+, {XK_Shift_L, XBMCK_LSHIFT}
+, {XK_Control_R, XBMCK_RCTRL}
+, {XK_Control_L, XBMCK_LCTRL}
+, {XK_Alt_R, XBMCK_RALT}
+, {XK_Alt_L, XBMCK_LALT}
+, {XK_Meta_R, XBMCK_RMETA}
+, {XK_Meta_L, XBMCK_LMETA}
+, {XK_Super_L, XBMCK_LSUPER}
+, {XK_Super_R, XBMCK_RSUPER}
+, {XK_Mode_switch, XBMCK_MODE}
+, {XK_Multi_key, XBMCK_COMPOSE}
+  // Miscellaneous function keys
+, {XK_Help, XBMCK_HELP}
+, {XK_Print, XBMCK_PRINT}
+//, {0, XBMCK_SYSREQ}
+, {XK_Break, XBMCK_BREAK}
+, {XK_Menu, XBMCK_MENU}
+, {XF86XK_PowerOff, XBMCK_POWER}
+, {XK_EcuSign, XBMCK_EURO}
+, {XK_Undo, XBMCK_UNDO}
+  /* Media keys */
+, {XF86XK_Eject, XBMCK_EJECT}
+, {XF86XK_Stop, XBMCK_STOP}
+, {XF86XK_AudioRecord, XBMCK_RECORD}
+, {XF86XK_AudioRewind, XBMCK_REWIND}
+, {XF86XK_Phone, XBMCK_PHONE}
+, {XF86XK_AudioPlay, XBMCK_PLAY}
+, {XF86XK_AudioRandomPlay, XBMCK_SHUFFLE}
+, {XF86XK_AudioForward, XBMCK_FASTFORWARD}
+};
+
+
+CWinEventsX11::CWinEventsX11()
+{
+  m_display = 0;
+  m_window = 0;
+  m_keybuf = 0;
+  m_utf16buf = 0;
+}
+
+CWinEventsX11::~CWinEventsX11()
+{
+  if (m_keybuf);
+  {
+    free(m_keybuf);
+    m_keybuf = 0;
+  }
+
+  if (m_utf16buf)
+  {
+    free(m_utf16buf);
+    m_utf16buf = 0;
+  }
+
+  if (m_xic)
+  {
+    XUnsetICFocus(m_xic);
+    XDestroyIC(m_xic);
+    m_xic = 0;
+  }
+
+  if (m_xim)
+  {
+    XCloseIM(m_xim);
+    m_xim = 0;
+  }
+
+  m_symLookupTable.clear();
+}
+
+bool CWinEventsX11::Init(Display *dpy, Window win)
+{
+  if (WinEvents)
+    return true;
+
+  WinEvents = new CWinEventsX11();
+  WinEvents->m_display = dpy;
+  WinEvents->m_window = win;
+  WinEvents->m_keybuf = (char*)malloc(32*sizeof(char));
+  WinEvents->m_utf16buf = (uint16_t*)malloc(32*sizeof(uint16_t));
+  WinEvents->m_keymodState = 0;
+  WinEvents->m_wmDeleteMessage = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
+  WinEvents->m_structureChanged = false;
+  memset(&(WinEvents->m_lastKey), 0, sizeof(XBMC_Event));
+
+  // open input method
+  char *old_locale = NULL, *old_modifiers = NULL;
+  char res_name[8];
+  const char *p;
+  size_t n;
+
+  // set resource name to xbmc, not used
+  strcpy(res_name, "xbmc");
+
+  // save current locale, this should be "C"
+  p = setlocale(LC_ALL, NULL);
+  if (p)
+  {
+    old_locale = (char*)malloc(strlen(p) +1);
+    strcpy(old_locale, p);
+  }
+  p = XSetLocaleModifiers(NULL);
+  if (p)
+  {
+    old_modifiers = (char*)malloc(strlen(p) +1);
+    strcpy(old_modifiers, p);
+  }
+
+  // set users preferences and open input method
+  p = setlocale(LC_ALL, "");
+  XSetLocaleModifiers("");
+  WinEvents->m_xim = XOpenIM(WinEvents->m_display, NULL, res_name, res_name);
+
+  // restore old locale
+  if (old_locale)
+  {
+    setlocale(LC_ALL, old_locale);
+    free(old_locale);
+  }
+  if (old_modifiers)
+  {
+    XSetLocaleModifiers(old_modifiers);
+    free(old_modifiers);
+  }
+
+  WinEvents->m_xic = NULL;
+  if (WinEvents->m_xim)
+  {
+    WinEvents->m_xic = XCreateIC(WinEvents->m_xim,
+                                 XNClientWindow, WinEvents->m_window,
+                                 XNFocusWindow, WinEvents->m_window,
+                                 XNInputStyle, XIMPreeditNothing | XIMStatusNothing,
+                                 XNResourceName, res_name,
+                                 XNResourceClass, res_name,
+                                 NULL);
+  }
+
+  if (!WinEvents->m_xic)
+    CLog::Log(LOGWARNING,"CWinEventsX11::Init - no input method found");
+
+  // build Keysym lookup table
+  for (unsigned int i = 0; i < sizeof(SymMappingsX11)/(2*sizeof(uint32_t)); ++i)
+  {
+    WinEvents->m_symLookupTable[SymMappingsX11[i][0]] = SymMappingsX11[i][1];
+  }
+
+  return true;
+}
+
+void CWinEventsX11::Quit()
+{
+  if (!WinEvents)
+    return;
+
+  delete WinEvents;
+  WinEvents = 0;
+}
+
+bool CWinEventsX11::HasStructureChanged()
+{
+  if (!WinEvents)
+    return false;
+
+  bool ret = WinEvents->m_structureChanged;
+  WinEvents->m_structureChanged = false;
+  return ret;
+}
+
+bool CWinEventsX11::MessagePump()
+{
+  if (!WinEvents)
+    return false;
+
+  bool ret = false;
+  XEvent xevent;
+  unsigned long serial = 0;
+
+  while (WinEvents && XPending(WinEvents->m_display))
+  {
+    memset(&xevent, 0, sizeof (XEvent));
+    XNextEvent(WinEvents->m_display, &xevent);
+
+    //  ignore events generated by auto-repeat
+    if (xevent.type == KeyRelease && XPending(WinEvents->m_display))
+    {
+      XEvent peekevent;
+      XPeekEvent(WinEvents->m_display, &peekevent);
+      if ((peekevent.type == KeyPress) &&
+          (peekevent.xkey.keycode == xevent.xkey.keycode) &&
+          ((peekevent.xkey.time - xevent.xkey.time) < 2))
+      {
+        XNextEvent(WinEvents->m_display, &peekevent);
+        continue;
+      }
+    }
+
+    if (XFilterEvent(&xevent, None))
+      continue;
+
+    switch (xevent.type)
+    {
+      case MapNotify:
+      {
+        g_application.m_AppActive = true;
+        break;
+      }
+
+      case UnmapNotify:
+      {
+        g_application.m_AppActive = false;
+        break;
+      }
+
+      case FocusIn:
+      {
+        if (WinEvents->m_xic)
+          XSetICFocus(WinEvents->m_xic);
+        g_application.m_AppFocused = true;
+        if (serial == xevent.xfocus.serial)
+          break;
+        g_Windowing.NotifyAppFocusChange(g_application.m_AppFocused);
+        break;
+      }
+
+      case FocusOut:
+      {
+        if (WinEvents->m_xic)
+          XUnsetICFocus(WinEvents->m_xic);
+        g_application.m_AppFocused = false;
+        g_Windowing.NotifyAppFocusChange(g_application.m_AppFocused);
+        serial = xevent.xfocus.serial;
+        break;
+      }
+
+      case Expose:
+      {
+        g_windowManager.MarkDirty();
+        break;
+      }
+
+      case ConfigureNotify:
+      {
+        if (xevent.xconfigure.window != WinEvents->m_window)
+          break;
+
+        WinEvents->m_structureChanged = true;
+        XBMC_Event newEvent;
+        memset(&newEvent, 0, sizeof(newEvent));
+        newEvent.type = XBMC_VIDEORESIZE;
+        newEvent.resize.w = xevent.xconfigure.width;
+        newEvent.resize.h = xevent.xconfigure.height;
+        ret |= g_application.OnEvent(newEvent);
+        g_windowManager.MarkDirty();
+        break;
+      }
+
+      case ClientMessage:
+      {
+        if (xevent.xclient.data.l[0] == WinEvents->m_wmDeleteMessage)
+          if (!g_application.m_bStop) g_application.getApplicationMessenger().Quit();
+        break;
+      }
+
+      case KeyPress:
+      {
+        XBMC_Event newEvent;
+        memset(&newEvent, 0, sizeof(newEvent));
+        newEvent.type = XBMC_KEYDOWN;
+        KeySym xkeysym;
+
+        // fallback if we have no IM
+        if (!WinEvents->m_xic)
+        {
+          static XComposeStatus state;
+          char keybuf[32];
+          xkeysym = XLookupKeysym(&xevent.xkey, 0);
+          newEvent.key.keysym.sym = LookupXbmcKeySym(xkeysym);
+          newEvent.key.keysym.scancode = xevent.xkey.keycode;
+          newEvent.key.state = xevent.xkey.state;
+          newEvent.key.type = xevent.xkey.type;
+          if (XLookupString(&xevent.xkey, keybuf, sizeof(keybuf), NULL, &state))
+          {
+            newEvent.key.keysym.unicode = keybuf[0];
+          }
+          ret |= ProcessKey(newEvent, 500);
+          break;
+        }
+
+        Status status;
+        int utf16size;
+        int utf16length;
+        int len;
+        len = Xutf8LookupString(WinEvents->m_xic, &xevent.xkey,
+                                WinEvents->m_keybuf, sizeof(WinEvents->m_keybuf),
+                                &xkeysym, &status);
+        if (status == XBufferOverflow)
+        {
+          WinEvents->m_keybuf = (char*)realloc(WinEvents->m_keybuf, len*sizeof(char));
+          len = Xutf8LookupString(WinEvents->m_xic, &xevent.xkey,
+                                  WinEvents->m_keybuf, sizeof(WinEvents->m_keybuf),
+                                  &xkeysym, &status);
+        }
+        switch (status)
+        {
+          case XLookupNone:
+            break;
+          case XLookupChars:
+          case XLookupBoth:
+          {
+            if (len == 0)
+              break;
+            utf16size = len * sizeof(uint16_t);
+            if (utf16size > sizeof(WinEvents->m_utf16buf))
+            {
+              WinEvents->m_utf16buf = (uint16_t *)realloc(WinEvents->m_utf16buf,utf16size);
+              if (WinEvents->m_utf16buf == NULL)
+              {
+                break;
+              }
+            }
+            utf16length = Utf8ToUnicode(WinEvents->m_keybuf, len, WinEvents->m_utf16buf, utf16size);
+            if (utf16length < 0)
+            {
+              break;
+            }
+            for (unsigned int i = 0; i < utf16length - 1; i++)
+            {
+              newEvent.key.keysym.sym = XBMCK_UNKNOWN;
+              newEvent.key.keysym.unicode = WinEvents->m_utf16buf[i];
+              newEvent.key.state = xevent.xkey.state;
+              newEvent.key.type = xevent.xkey.type;
+              ret |= ProcessKey(newEvent, 500);
+            }
+            if (utf16length > 0)
+            {
+              newEvent.key.keysym.scancode = xevent.xkey.keycode;
+              xkeysym = XLookupKeysym(&xevent.xkey, 0);
+              newEvent.key.keysym.sym = LookupXbmcKeySym(xkeysym);
+              newEvent.key.keysym.unicode = WinEvents->m_utf16buf[utf16length - 1];
+              newEvent.key.state = xevent.xkey.state;
+              newEvent.key.type = xevent.xkey.type;
+
+              ret |= ProcessKey(newEvent, 500);
+            }
+            break;
+          }
+
+          case XLookupKeySym:
+          {
+            newEvent.key.keysym.scancode = xevent.xkey.keycode;
+            newEvent.key.keysym.sym = LookupXbmcKeySym(xkeysym);
+            newEvent.key.state = xevent.xkey.state;
+            newEvent.key.type = xevent.xkey.type;
+            ret |= ProcessKey(newEvent, 500);
+            break;
+          }
+
+        }// switch status
+        break;
+      } //KeyPress
+
+      case KeyRelease:
+      {
+        XBMC_Event newEvent;
+        KeySym xkeysym;
+        memset(&newEvent, 0, sizeof(newEvent));
+        newEvent.type = XBMC_KEYUP;
+        xkeysym = XLookupKeysym(&xevent.xkey, 0);
+        newEvent.key.keysym.scancode = xevent.xkey.keycode;
+        newEvent.key.keysym.sym = LookupXbmcKeySym(xkeysym);
+        newEvent.key.state = xevent.xkey.state;
+        newEvent.key.type = xevent.xkey.type;
+        ret |= ProcessKey(newEvent, 0);
+        break;
+      }
+
+      // lose mouse coverage
+      case LeaveNotify:
+      {
+        g_Mouse.SetActive(false);
+        break;
+      }
+
+      case MotionNotify:
+      {
+        XBMC_Event newEvent;
+        memset(&newEvent, 0, sizeof(newEvent));
+        newEvent.type = XBMC_MOUSEMOTION;
+        newEvent.motion.xrel = (int16_t)xevent.xmotion.x_root;
+        newEvent.motion.yrel = (int16_t)xevent.xmotion.y_root;
+        newEvent.motion.x = (int16_t)xevent.xmotion.x;
+        newEvent.motion.y = (int16_t)xevent.xmotion.y;
+        ret |= g_application.OnEvent(newEvent);
+        break;
+      }
+
+      case ButtonPress:
+      {
+        XBMC_Event newEvent;
+        memset(&newEvent, 0, sizeof(newEvent));
+        newEvent.type = XBMC_MOUSEBUTTONDOWN;
+        newEvent.button.button = (unsigned char)xevent.xbutton.button;
+        newEvent.button.state = XBMC_PRESSED;
+        newEvent.button.x = (int16_t)xevent.xbutton.x;
+        newEvent.button.y = (int16_t)xevent.xbutton.y;
+        ret |= g_application.OnEvent(newEvent);
+        break;
+      }
+
+      case ButtonRelease:
+      {
+        XBMC_Event newEvent;
+        memset(&newEvent, 0, sizeof(newEvent));
+        newEvent.type = XBMC_MOUSEBUTTONUP;
+        newEvent.button.button = (unsigned char)xevent.xbutton.button;
+        newEvent.button.state = XBMC_RELEASED;
+        newEvent.button.x = (int16_t)xevent.xbutton.x;
+        newEvent.button.y = (int16_t)xevent.xbutton.y;
+        ret |= g_application.OnEvent(newEvent);
+        break;
+      }
+
+      default:
+      {
+        break;
+      }
+    }// switch event.type
+  }// while
+
+  ret |= ProcessKeyRepeat();
+
+  return ret;
+}
+
+bool CWinEventsX11::ProcessKey(XBMC_Event &event, int repeatDelay)
+{
+  if (event.type == XBMC_KEYDOWN)
+  {
+    // check key modifiers
+    switch(event.key.keysym.sym)
+    {
+      case XBMCK_LSHIFT:
+        WinEvents->m_keymodState |= XBMCKMOD_LSHIFT;
+        break;
+      case XBMCK_RSHIFT:
+        WinEvents->m_keymodState |= XBMCKMOD_RSHIFT;
+        break;
+      case XBMCK_LCTRL:
+        WinEvents->m_keymodState |= XBMCKMOD_LCTRL;
+        break;
+      case XBMCK_RCTRL:
+        WinEvents->m_keymodState |= XBMCKMOD_RCTRL;
+        break;
+      case XBMCK_LALT:
+        WinEvents->m_keymodState |= XBMCKMOD_LALT;
+        break;
+      case XBMCK_RALT:
+        WinEvents->m_keymodState |= XBMCKMOD_RCTRL;
+        break;
+      case XBMCK_LMETA:
+        WinEvents->m_keymodState |= XBMCKMOD_LMETA;
+        break;
+      case XBMCK_RMETA:
+        WinEvents->m_keymodState |= XBMCKMOD_RMETA;
+        break;
+      case XBMCK_MODE:
+        WinEvents->m_keymodState |= XBMCKMOD_MODE;
+        break;
+      default:
+        break;
+    }
+    event.key.keysym.mod = (XBMCMod)WinEvents->m_keymodState;
+    memcpy(&(WinEvents->m_lastKey), &event, sizeof(event));
+    WinEvents->m_repeatKeyTimeout.Set(repeatDelay);
+
+    bool ret = ProcessShortcuts(event);
+    if (ret)
+      return ret;
+  }
+  else if (event.type == XBMC_KEYUP)
+  {
+    switch(event.key.keysym.sym)
+    {
+      case XBMCK_LSHIFT:
+        WinEvents->m_keymodState &= ~XBMCKMOD_LSHIFT;
+        break;
+      case XBMCK_RSHIFT:
+        WinEvents->m_keymodState &= ~XBMCKMOD_RSHIFT;
+        break;
+      case XBMCK_LCTRL:
+        WinEvents->m_keymodState &= ~XBMCKMOD_LCTRL;
+        break;
+      case XBMCK_RCTRL:
+        WinEvents->m_keymodState &= ~XBMCKMOD_RCTRL;
+        break;
+      case XBMCK_LALT:
+        WinEvents->m_keymodState &= ~XBMCKMOD_LALT;
+        break;
+      case XBMCK_RALT:
+        WinEvents->m_keymodState &= ~XBMCKMOD_RCTRL;
+        break;
+      case XBMCK_LMETA:
+        WinEvents->m_keymodState &= ~XBMCKMOD_LMETA;
+        break;
+      case XBMCK_RMETA:
+        WinEvents->m_keymodState &= ~XBMCKMOD_RMETA;
+        break;
+      case XBMCK_MODE:
+        WinEvents->m_keymodState &= ~XBMCKMOD_MODE;
+        break;
+      default:
+        break;
+    }
+    event.key.keysym.mod = (XBMCMod)WinEvents->m_keymodState;
+    memset(&(WinEvents->m_lastKey), 0, sizeof(event));
+  }
+
+  return g_application.OnEvent(event);
+}
+
+bool CWinEventsX11::ProcessShortcuts(XBMC_Event& event)
+{
+  if (event.key.keysym.mod & XBMCKMOD_ALT)
+  {
+    switch(event.key.keysym.sym)
+    {
+      case XBMCK_TAB:  // ALT+TAB to minimize/hide
+        g_application.Minimize();
+        return true;
+
+      default:
+        return false;
+    }
+  }
+  return false;
+}
+
+bool CWinEventsX11::ProcessKeyRepeat()
+{
+  if (WinEvents && (WinEvents->m_lastKey.type == XBMC_KEYDOWN))
+  {
+    if (WinEvents->m_repeatKeyTimeout.IsTimePast())
+    {
+      return ProcessKey(WinEvents->m_lastKey, 10);
+    }
+  }
+  return false;
+}
+
+int CWinEventsX11::Utf8ToUnicode(const char *utf8, const int utf8Length, uint16_t *utf16, const int utf16MaxLength)
+{
+  // p moves over the output buffer.  max_ptr points to the next to the last slot of the buffer.
+  uint16_t *p = utf16;
+  uint16_t const *const maxPtr = utf16 + utf16MaxLength;
+
+  // end_of_input points to the last byte of input as opposed to the next to the last byte.
+  char const *const endOfInput = utf8 + utf8Length - 1;
+
+  while (utf8 <= endOfInput)
+  {
+    unsigned char const c = *utf8;
+    if (p >= maxPtr)
+    {
+      //No more output space.
+      return -1;
+    }
+    if (c < 0x80)
+    {
+      //One byte ASCII.
+      *p++ = c;
+      utf8 += 1;
+    }
+    else if (c < 0xC0)
+    {
+      // Follower byte without preceding leader bytes.
+      return -1;
+    }
+    // 11 bits
+    else if (c < 0xE0)
+    {
+      // Two byte sequence.  We need one follower byte.
+      if (endOfInput - utf8 < 1 || (((utf8[1] ^ 0x80)) & 0xC0))
+      {
+        return -1;
+      }
+      *p++ = (uint16_t)(((c & 0x1F) << 6) + (utf8[1] & 0x3F));
+      utf8 += 2;
+    }
+    // 16 bis
+    else if (c < 0xF0)
+    {
+      // Three byte sequence.  We need two follower byte.
+      if (endOfInput - utf8 < 2 || ((utf8[1] ^ 0x80) & 0xC0) || ((utf8[2] ^ 0x80) & 0xC0))
+      {
+        return -1;
+      }
+      *p++ = (uint16_t)(((c & 0xF) << 12) + ((utf8[1] & 0x3F) << 6) + (utf8[2] & 0x3F));
+      utf8 += 3;
+    }
+    // 21 bits
+    else if (c < 0xF8)
+    {
+      int plane;
+      // Four byte sequence.  We need three follower bytes.
+      if (endOfInput - utf8 < 3 || ((utf8[1] ^ 0x80) & 0xC0) ||
+          ((utf8[2] ^ 0x80) & 0xC0) || ((utf8[3] ^ 0x80) & 0xC0))
+      {
+        return -1;
+      }
+      uint32_t unicode = ((c & 0x7) << 18) + ((utf8[1] & 0x3F) << 12) +
+                          ((utf8[2] & 0x3F) << 6) + (utf8[3] & 0x3F);
+      utf8 += 4;
+      CLog::Log(LOGERROR, "CWinEventsX11::Utf8ToUnicode: 4 byte unicode not supported");
+    }
+    // 26 bits
+    else if (c < 0xFC)
+    {
+      CLog::Log(LOGERROR, "CWinEventsX11::Utf8ToUnicode: 4 byte unicode not supported");
+      utf8 += 5;
+    }
+    // 31 bit
+    else
+    {
+      CLog::Log(LOGERROR, "CWinEventsX11::Utf8ToUnicode: 4 byte unicode not supported");
+      utf8 += 6;
+    }
+  }
+  return p - utf16;
+}
+
+XBMCKey CWinEventsX11::LookupXbmcKeySym(KeySym keysym)
+{
+  // try direct mapping first
+  std::map<uint32_t, uint32_t>::iterator it;
+  it = WinEvents->m_symLookupTable.find(keysym);
+  if (it != WinEvents->m_symLookupTable.end())
+  {
+    return (XBMCKey)(it->second);
+  }
+
+  // try ascii mappings
+  if (keysym>>8 == 0x00)
+    return (XBMCKey)(keysym & 0xFF);
+
+  return (XBMCKey)keysym;
+}
+#endif

--- a/xbmc/windowing/WinEventsX11.cpp
+++ b/xbmc/windowing/WinEventsX11.cpp
@@ -161,6 +161,7 @@ CWinEventsX11::CWinEventsX11()
   m_display = 0;
   m_window = 0;
   m_keybuf = 0;
+  m_keybuf_len = 0;
 }
 
 CWinEventsX11::~CWinEventsX11()
@@ -195,7 +196,8 @@ bool CWinEventsX11::Init(Display *dpy, Window win)
   WinEvents = new CWinEventsX11();
   WinEvents->m_display = dpy;
   WinEvents->m_window = win;
-  WinEvents->m_keybuf = (char*)malloc(32*sizeof(char));
+  WinEvents->m_keybuf_len = 32*sizeof(char);
+  WinEvents->m_keybuf = (char*)malloc(WinEvents->m_keybuf_len);
   WinEvents->m_keymodState = 0;
   WinEvents->m_wmDeleteMessage = XInternAtom(dpy, "WM_DELETE_WINDOW", False);
   WinEvents->m_structureChanged = false;
@@ -427,13 +429,14 @@ bool CWinEventsX11::MessagePump()
         Status status;
         int len;
         len = Xutf8LookupString(WinEvents->m_xic, &xevent.xkey,
-                                WinEvents->m_keybuf, sizeof(WinEvents->m_keybuf),
+                                WinEvents->m_keybuf, WinEvents->m_keybuf_len,
                                 &xkeysym, &status);
         if (status == XBufferOverflow)
         {
-          WinEvents->m_keybuf = (char*)realloc(WinEvents->m_keybuf, len*sizeof(char));
+          WinEvents->m_keybuf_len = len;
+          WinEvents->m_keybuf = (char*)realloc(WinEvents->m_keybuf, WinEvents->m_keybuf_len);
           len = Xutf8LookupString(WinEvents->m_xic, &xevent.xkey,
-                                  WinEvents->m_keybuf, sizeof(WinEvents->m_keybuf),
+                                  WinEvents->m_keybuf, WinEvents->m_keybuf_len,
                                   &xkeysym, &status);
         }
         switch (status)

--- a/xbmc/windowing/WinEventsX11.h
+++ b/xbmc/windowing/WinEventsX11.h
@@ -47,6 +47,7 @@ protected:
   Window m_window;
   Atom m_wmDeleteMessage;
   char *m_keybuf;
+  size_t m_keybuf_len;
   XIM m_xim;
   XIC m_xic;
   XBMC_Event m_lastKey;

--- a/xbmc/windowing/WinEventsX11.h
+++ b/xbmc/windowing/WinEventsX11.h
@@ -1,0 +1,57 @@
+/*
+*      Copyright (C) 2005-2012 Team XBMC
+*      http://www.xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+#pragma once
+
+#include "WinEvents.h"
+#include <X11/Xlib.h>
+#include "threads/SystemClock.h"
+#include <map>
+
+class CWinEventsX11 : public CWinEventsBase
+{
+public:
+  CWinEventsX11();
+  virtual ~CWinEventsX11();
+  static bool Init(Display *dpy, Window win);
+  static void Quit();
+  static bool HasStructureChanged();
+  static bool MessagePump();
+
+protected:
+  static int Utf8ToUnicode(const char *utf8, const int utf8Length, uint16_t *utf16, const int utf16MaxLength);
+  static XBMCKey LookupXbmcKeySym(KeySym keysym);
+  static bool ProcessKey(XBMC_Event &event, int repeatDelay);
+  static bool ProcessKeyRepeat();
+  static bool ProcessShortcuts(XBMC_Event& event);
+  static CWinEventsX11 *WinEvents;
+  Display *m_display;
+  Window m_window;
+  Atom m_wmDeleteMessage;
+  char *m_keybuf;
+  uint16_t *m_utf16buf;
+  XIM m_xim;
+  XIC m_xic;
+  XBMC_Event m_lastKey;
+  XbmcThreads::EndTime m_repeatKeyTimeout;
+  std::map<uint32_t,uint32_t> m_symLookupTable;
+  int m_keymodState;
+  bool m_structureChanged;
+};

--- a/xbmc/windowing/WinEventsX11.h
+++ b/xbmc/windowing/WinEventsX11.h
@@ -33,6 +33,8 @@ public:
   static bool Init(Display *dpy, Window win);
   static void Quit();
   static bool HasStructureChanged();
+  static void PendingResize(int width, int height);
+  static void SetXRRFailSafeTimer(int millis);
   static bool MessagePump();
 
 protected:
@@ -54,4 +56,7 @@ protected:
   std::map<uint32_t,uint32_t> m_symLookupTable;
   int m_keymodState;
   bool m_structureChanged;
+  int m_RREventBase;
+  XbmcThreads::EndTime m_xrrFailSafeTimer;
+  bool m_xrrEventPending;
 };

--- a/xbmc/windowing/WinEventsX11.h
+++ b/xbmc/windowing/WinEventsX11.h
@@ -38,7 +38,6 @@ public:
   static bool MessagePump();
 
 protected:
-  static int Utf8ToUnicode(const char *utf8, const int utf8Length, uint16_t *utf16, const int utf16MaxLength);
   static XBMCKey LookupXbmcKeySym(KeySym keysym);
   static bool ProcessKey(XBMC_Event &event, int repeatDelay);
   static bool ProcessKeyRepeat();
@@ -48,7 +47,6 @@ protected:
   Window m_window;
   Atom m_wmDeleteMessage;
   char *m_keybuf;
-  uint16_t *m_utf16buf;
   XIM m_xim;
   XIC m_xic;
   XBMC_Event m_lastKey;

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -99,6 +99,7 @@ public:
   std::vector<RESOLUTION_WHR> ScreenResolutions(int screen);
   std::vector<REFRESHRATE> RefreshRates(int screen, int width, int height);
   REFRESHRATE DefaultRefreshRate(int screen, std::vector<REFRESHRATE> rates);
+  virtual bool HasCalibration(const RESOLUTION_INFO &resInfo) { return true; };
 
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, int screen, int width, int height, float refreshRate, uint32_t dwFlags = 0);

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -501,7 +501,7 @@ bool CWinSystemX11::Show(bool raise)
 
 void CWinSystemX11::CheckDisplayEvents()
 {
-#if defined(HAS_XRANDR)
+#if defined(HAS_XRANDR) && defined(HAS_SDL_VIDEO_X11)
   bool bGotEvent(false);
   bool bTimeout(false);
   XEvent Event;
@@ -557,8 +557,12 @@ void CWinSystemX11::OnLostDevice()
       (*i)->OnLostDevice();
   }
 
+#if defined(HAS_SDL_VIDEO_X11)
   // fail safe timer
   m_dpyLostTime = CurrentHostCounter();
+#else
+  CWinEvents::SetXRRFailSafeTimer(3000);
+#endif
 }
 
 void CWinSystemX11::Register(IDispResource *resource)

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -524,19 +524,25 @@ void CWinSystemX11::CheckDisplayEvents()
 
   if (bGotEvent || bTimeout)
   {
-    CLog::Log(LOGDEBUG, "%s - notify display reset event", __FUNCTION__);
-    RefreshWindow();
-
-    CSingleLock lock(m_resourceSection);
-
-    // tell any shared resources
-    for (vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); i++)
-      (*i)->OnResetDevice();
+    NotifyXRREvent();
 
     // reset fail safe timer
     m_dpyLostTime = 0;
   }
 #endif
+}
+
+void CWinSystemX11::NotifyXRREvent()
+{
+  CLog::Log(LOGDEBUG, "%s - notify display reset event", __FUNCTION__);
+  RefreshWindow();
+
+  CSingleLock lock(m_resourceSection);
+
+  // tell any shared resources
+  for (vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); i++)
+    (*i)->OnResetDevice();
+
 }
 
 void CWinSystemX11::OnLostDevice()

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -23,7 +23,6 @@
 
 #ifdef HAS_GLX
 
-#include <SDL/SDL_syswm.h>
 #include "WinSystemX11.h"
 #include "settings/Settings.h"
 #include "guilib/Texture.h"
@@ -32,13 +31,16 @@
 #include "XRandR.h"
 #include <vector>
 #include "threads/SingleLock.h"
-#include <X11/Xlib.h>
 #include "cores/VideoRenderers/RenderManager.h"
 #include "utils/TimeUtils.h"
+#include "settings/GUISettings.h"
 
 #if defined(HAS_XRANDR)
 #include <X11/extensions/Xrandr.h>
 #endif
+
+#include "../WinEvents.h"
+#include "input/MouseStat.h"
 
 using namespace std;
 
@@ -46,12 +48,12 @@ CWinSystemX11::CWinSystemX11() : CWinSystemBase()
 {
   m_eWindowSystem = WINDOW_SYSTEM_X11;
   m_glContext = NULL;
-  m_SDLSurface = NULL;
   m_dpy = NULL;
   m_glWindow = 0;
-  m_wmWindow = 0;
   m_bWasFullScreenBeforeMinimize = false;
+  m_bIgnoreNextFocusMessage = false;
   m_dpyLostTime = 0;
+  m_invisibleCursor = 0;
 
   XSetErrorHandler(XErrorHandler);
 }
@@ -64,18 +66,6 @@ bool CWinSystemX11::InitWindowSystem()
 {
   if ((m_dpy = XOpenDisplay(NULL)))
   {
-
-    SDL_EnableUNICODE(1);
-    // set repeat to 10ms to ensure repeat time < frame time
-    // so that hold times can be reliably detected
-    SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, 10);
-
-    SDL_GL_SetAttribute(SDL_GL_RED_SIZE,   8);
-    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
-    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE,  8);
-    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
-    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-
     return CWinSystemBase::InitWindowSystem();
   }
   else
@@ -113,37 +103,8 @@ bool CWinSystemX11::DestroyWindowSystem()
 
 bool CWinSystemX11::CreateNewWindow(const CStdString& name, bool fullScreen, RESOLUTION_INFO& res, PHANDLE_EVENT_FUNC userFunction)
 {
-  RESOLUTION_INFO& desktop = g_settings.m_ResInfo[RES_DESKTOP];
-
-  if (fullScreen &&
-      (res.iWidth != desktop.iWidth || res.iHeight != desktop.iHeight ||
-       res.fRefreshRate != desktop.fRefreshRate || res.iScreen != desktop.iScreen))
-  {
-    //on the first call to SDL_SetVideoMode, SDL stores the current displaymode
-    //SDL restores the displaymode on SDL_QUIT(), if we change the displaymode
-    //before the first call to SDL_SetVideoMode, SDL changes the displaymode back
-    //to the wrong mode on exit
-
-    CLog::Log(LOGINFO, "CWinSystemX11::CreateNewWindow initializing to desktop resolution first");
-    if (!SetFullScreen(true, desktop, false))
-      return false;
-  }
-
   if(!SetFullScreen(fullScreen, res, false))
     return false;
-
-  CTexture iconTexture;
-  iconTexture.LoadFromFile("special://xbmc/media/icon.png");
-
-  SDL_WM_SetIcon(SDL_CreateRGBSurfaceFrom(iconTexture.GetPixels(), iconTexture.GetWidth(), iconTexture.GetHeight(), 32, iconTexture.GetPitch(), 0xff0000, 0x00ff00, 0x0000ff, 0xff000000L), NULL);
-  SDL_WM_SetCaption("XBMC Media Center", NULL);
-
-  // register XRandR Events
-#if defined(HAS_XRANDR)
-  int iReturn;
-  XRRQueryExtension(m_dpy, &m_RREventBase, &iReturn);
-  XRRSelectInput(m_dpy, m_wmWindow, RRScreenChangeNotifyMask);
-#endif
 
   m_bWindowCreated = true;
   return true;
@@ -151,6 +112,28 @@ bool CWinSystemX11::CreateNewWindow(const CStdString& name, bool fullScreen, RES
 
 bool CWinSystemX11::DestroyWindow()
 {
+  if (!m_glWindow)
+    return true;
+
+  if (m_glContext)
+    glXMakeCurrent(m_dpy, None, NULL);
+
+  if (m_invisibleCursor)
+  {
+    XUndefineCursor(m_dpy, m_glWindow);
+    XFreeCursor(m_dpy, m_invisibleCursor);
+    m_invisibleCursor = 0;
+  }
+
+  CWinEvents::Quit();
+
+  XUnmapWindow(m_dpy, m_glWindow);
+  XSync(m_dpy,TRUE);
+  XUngrabKeyboard(m_dpy, CurrentTime);
+  XUngrabPointer(m_dpy, CurrentTime);
+  XDestroyWindow(m_dpy, m_glWindow);
+  m_glWindow = 0;
+
   return true;
 }
 
@@ -160,65 +143,105 @@ bool CWinSystemX11::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
   && m_nHeight == newHeight)
     return true;
 
+  if (!SetWindow(newWidth, newHeight, false))
+  {
+    return false;
+  }
+
+  RefreshGlxContext();
   m_nWidth  = newWidth;
   m_nHeight = newHeight;
-
-  int options = SDL_OPENGL;
-  if (m_bFullScreen)
-    options |= SDL_FULLSCREEN;
-  else
-    options |= SDL_RESIZABLE;
-
-  if ((m_SDLSurface = SDL_SetVideoMode(m_nWidth, m_nHeight, 0, options)))
-  {
-    RefreshGlxContext();
-    return true;
-  }
+  m_bFullScreen = false;
 
   return false;
 }
 
+void CWinSystemX11::RefreshWindow()
+{
+  g_xrandr.Query(true);
+  XOutput out  = g_xrandr.GetCurrentOutput();
+  XMode   mode = g_xrandr.GetCurrentMode(out.name);
+
+  // only overwrite desktop resolution, if we are not in fullscreen mode
+  if (!g_graphicsContext.IsFullScreenVideo())
+  {
+    CLog::Log(LOGDEBUG, "CWinSystemX11::RefreshWindow - store desktop resolution, width: %d, height: %d, hz: %2.2f", mode.w, mode.h, mode.hz);
+    UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], 0, mode.w, mode.h, mode.hz);
+    g_settings.m_ResInfo[RES_DESKTOP].strId     = mode.id;
+    g_settings.m_ResInfo[RES_DESKTOP].strOutput = out.name;
+  }
+
+  RESOLUTION_INFO res;
+  unsigned int i;
+  bool found(false);
+  for (i = RES_DESKTOP; i < g_settings.m_ResInfo.size(); ++i)
+  {
+    if (g_settings.m_ResInfo[i].strId == mode.id)
+    {
+      found = true;
+      break;
+    }
+  }
+
+  if (!found)
+  {
+    CLog::Log(LOGERROR, "CWinSystemX11::RefreshWindow - could not find resolution");
+    return;
+  }
+
+  if (g_graphicsContext.IsFullScreenRoot())
+    g_graphicsContext.SetVideoResolution((RESOLUTION)i, true);
+  else
+    g_graphicsContext.SetVideoResolution(RES_WINDOW, true);
+}
+
 bool CWinSystemX11::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
-  m_nWidth      = res.iWidth;
-  m_nHeight     = res.iHeight;
-  m_bFullScreen = fullScreen;
 
 #if defined(HAS_XRANDR)
   XOutput out;
   XMode mode;
-  out.name = res.strOutput;
-  mode.w   = res.iWidth;
-  mode.h   = res.iHeight;
-  mode.hz  = res.fRefreshRate;
-  mode.id  = res.strId;
- 
-  if(m_bFullScreen)
+
+  if (fullScreen)
   {
+    out.name = res.strOutput;
+    mode.w   = res.iWidth;
+    mode.h   = res.iHeight;
+    mode.hz  = res.fRefreshRate;
+    mode.id  = res.strId;
+  }
+  else
+  {
+    out.name = g_settings.m_ResInfo[RES_DESKTOP].strOutput;
+    mode.w   = g_settings.m_ResInfo[RES_DESKTOP].iWidth;
+    mode.h   = g_settings.m_ResInfo[RES_DESKTOP].iHeight;
+    mode.hz  = g_settings.m_ResInfo[RES_DESKTOP].fRefreshRate;
+    mode.id  = g_settings.m_ResInfo[RES_DESKTOP].strId;
+  }
+ 
+  XOutput currout  = g_xrandr.GetCurrentOutput();
+  XMode   currmode = g_xrandr.GetCurrentMode(currout.name);
+
+  // only call xrandr if mode changes
+  if (currout.name != out.name || currmode.w != mode.w || currmode.h != mode.h ||
+      currmode.hz != mode.hz || currmode.id != mode.id)
+  {
+    CLog::Log(LOGNOTICE, "CWinSystemX11::SetFullScreen - calling xrandr");
     OnLostDevice();
     g_xrandr.SetMode(out, mode);
   }
-  else
-    g_xrandr.RestoreState();
 #endif
 
-  int options = SDL_OPENGL;
-  if (m_bFullScreen)
-    options |= SDL_FULLSCREEN;
-  else
-    options |= SDL_RESIZABLE;
+  if (!SetWindow(res.iWidth, res.iHeight, fullScreen))
+    return false;
 
-  if ((m_SDLSurface = SDL_SetVideoMode(m_nWidth, m_nHeight, 0, options)))
-  {
-    if ((m_SDLSurface->flags & SDL_OPENGL) != SDL_OPENGL)
-      CLog::Log(LOGERROR, "CWinSystemX11::SetFullScreen SDL_OPENGL not set, SDL_GetError:%s", SDL_GetError());
+  RefreshGlxContext();
 
-    RefreshGlxContext();
+  m_nWidth      = res.iWidth;
+  m_nHeight     = res.iHeight;
+  m_bFullScreen = fullScreen;
 
-    return true;
-  }
-
-  return false;
+  return true;
 }
 
 void CWinSystemX11::UpdateResolutions()
@@ -318,17 +341,10 @@ bool CWinSystemX11::IsSuitableVisual(XVisualInfo *vInfo)
 bool CWinSystemX11::RefreshGlxContext()
 {
   bool retVal = false;
-  SDL_SysWMinfo info;
-  SDL_VERSION(&info.version);
-  if (SDL_GetWMInfo(&info) <= 0)
-  {
-    CLog::Log(LOGERROR, "Failed to get window manager info from SDL");
-    return false;
-  }
 
-  if(m_glWindow == info.info.x11.window && m_glContext)
+  if (m_glContext)
   {
-    CLog::Log(LOGERROR, "GLX: Same window as before, refreshing context");
+    CLog::Log(LOGDEBUG, "CWinSystemX11::RefreshGlxContext: refreshing context");
     glXMakeCurrent(m_dpy, None, NULL);
     glXMakeCurrent(m_dpy, m_glWindow, m_glContext);
     return true;
@@ -340,8 +356,6 @@ bool CWinSystemX11::RefreshGlxContext()
   int availableVisuals    = 0;
   vMask.screen = DefaultScreen(m_dpy);
   XWindowAttributes winAttr;
-  m_glWindow = info.info.x11.window;
-  m_wmWindow = info.info.x11.wmwindow;
 
   /* Assume a depth of 24 in case the below calls to XGetWindowAttributes()
      or XGetVisualInfo() fail. That shouldn't happen unless something is
@@ -412,7 +426,10 @@ bool CWinSystemX11::RefreshGlxContext()
 
 void CWinSystemX11::ShowOSMouse(bool show)
 {
-  SDL_ShowCursor(show ? 1 : 0);
+  if (show)
+    XUndefineCursor(m_dpy,m_glWindow);
+  else if (m_invisibleCursor)
+    XDefineCursor(m_dpy,m_glWindow, m_invisibleCursor);
 }
 
 void CWinSystemX11::ResetOSScreensaver()
@@ -426,8 +443,6 @@ void CWinSystemX11::ResetOSScreensaver()
     {
       m_screensaverReset.StartZero();
       XResetScreenSaver(m_dpy);
-      //need to flush the output buffer, since we don't check for events on m_dpy
-      XFlush(m_dpy);
     }
   }
   else
@@ -441,13 +456,27 @@ void CWinSystemX11::NotifyAppActiveChange(bool bActivated)
   if (bActivated && m_bWasFullScreenBeforeMinimize && !g_graphicsContext.IsFullScreenRoot())
     g_graphicsContext.ToggleFullScreenRoot();
 }
+
+void CWinSystemX11::NotifyAppFocusChange(bool bGaining)
+{
+  if (bGaining && m_bWasFullScreenBeforeMinimize && !m_bIgnoreNextFocusMessage &&
+      !g_graphicsContext.IsFullScreenRoot())
+    g_graphicsContext.ToggleFullScreenRoot();
+  if (!bGaining)
+    m_bIgnoreNextFocusMessage = false;
+}
+
 bool CWinSystemX11::Minimize()
 {
   m_bWasFullScreenBeforeMinimize = g_graphicsContext.IsFullScreenRoot();
   if (m_bWasFullScreenBeforeMinimize)
+  {
+    m_bIgnoreNextFocusMessage = true;
     g_graphicsContext.ToggleFullScreenRoot();
+  }
 
-  SDL_WM_IconifyWindow();
+  XIconifyWindow(m_dpy, m_glWindow, DefaultScreen(m_dpy));
+
   return true;
 }
 bool CWinSystemX11::Restore()
@@ -456,13 +485,13 @@ bool CWinSystemX11::Restore()
 }
 bool CWinSystemX11::Hide()
 {
-  XUnmapWindow(m_dpy, m_wmWindow);
+  XUnmapWindow(m_dpy, m_glWindow);
   XSync(m_dpy, False);
   return true;
 }
 bool CWinSystemX11::Show(bool raise)
 {
-  XMapWindow(m_dpy, m_wmWindow);
+  XMapWindow(m_dpy, m_glWindow);
   XSync(m_dpy, False);
   return true;
 }
@@ -493,6 +522,7 @@ void CWinSystemX11::CheckDisplayEvents()
   if (bGotEvent || bTimeout)
   {
     CLog::Log(LOGDEBUG, "%s - notify display reset event", __FUNCTION__);
+    RefreshWindow();
 
     CSingleLock lock(m_resourceSection);
 
@@ -544,6 +574,153 @@ int CWinSystemX11::XErrorHandler(Display* dpy, XErrorEvent* error)
             buf, error->type, error->serial, (int)error->error_code, (int)error->request_code, (int)error->minor_code);
 
   return 0;
+}
+
+bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen)
+{
+  bool changeWindow = false;
+  bool changeSize = false;
+  bool mouseActive = false;
+  float mouseX, mouseY;
+
+  if (m_glWindow && (m_bFullScreen != fullscreen))
+  {
+    mouseActive = g_Mouse.IsActive();
+    if (mouseActive)
+    {
+      Window root_return, child_return;
+      int root_x_return, root_y_return;
+      int win_x_return, win_y_return;
+      unsigned int mask_return;
+      bool isInWin = XQueryPointer(m_dpy, m_glWindow, &root_return, &child_return,
+                                   &root_x_return, &root_y_return,
+                                   &win_x_return, &win_y_return,
+                                   &mask_return);
+      if (isInWin)
+      {
+        mouseX = (float)win_x_return/m_nWidth;
+        mouseY = (float)win_y_return/m_nHeight;
+        g_Mouse.SetActive(false);
+      }
+      else
+        mouseActive = false;
+    }
+    DestroyWindow();
+  }
+
+  // create main window
+  if (!m_glWindow)
+  {
+    GLint att[] =
+    {
+      GLX_RGBA,
+      GLX_RED_SIZE, 8,
+      GLX_GREEN_SIZE, 8,
+      GLX_BLUE_SIZE, 8,
+      GLX_ALPHA_SIZE, 8,
+      GLX_DEPTH_SIZE, 24,
+      GLX_DOUBLEBUFFER,
+      None
+    };
+    Colormap cmap;
+    XSetWindowAttributes swa;
+    XVisualInfo *vi;
+
+    vi = glXChooseVisual(m_dpy, DefaultScreen(m_dpy), att);
+    cmap = XCreateColormap(m_dpy, RootWindow(m_dpy, vi->screen), vi->visual, AllocNone);
+
+    int def_vis = (vi->visual == DefaultVisual(m_dpy, vi->screen));
+    swa.override_redirect = fullscreen ? True : False;
+    swa.border_pixel = fullscreen ? 0 : 5;
+    swa.background_pixel = def_vis ? BlackPixel(m_dpy, vi->screen) : 0;
+    swa.colormap = cmap;
+    swa.background_pixel = def_vis ? BlackPixel(m_dpy, vi->screen) : 0;
+    swa.event_mask = FocusChangeMask | KeyPressMask | KeyReleaseMask |
+                     ButtonPressMask | ButtonReleaseMask | PointerMotionMask |
+                     PropertyChangeMask | StructureNotifyMask | KeymapStateMask |
+                     EnterWindowMask | LeaveWindowMask | ExposureMask;
+    unsigned long mask = CWBackPixel | CWBorderPixel | CWColormap | CWOverrideRedirect | CWEventMask;
+
+    m_glWindow = XCreateWindow(m_dpy, RootWindow(m_dpy, vi->screen),
+                    0, 0, width, height, 0, vi->depth,
+                    InputOutput, vi->visual,
+                    mask, &swa);
+
+    // define invisible cursor
+    Pixmap bitmapNoData;
+    XColor black;
+    static char noData[] = { 0,0,0,0,0,0,0,0 };
+    black.red = black.green = black.blue = 0;
+
+    bitmapNoData = XCreateBitmapFromData(m_dpy, m_glWindow, noData, 8, 8);
+    m_invisibleCursor = XCreatePixmapCursor(m_dpy, bitmapNoData, bitmapNoData,
+                                            &black, &black, 0, 0);
+    XFreePixmap(m_dpy, bitmapNoData);
+    XDefineCursor(m_dpy,m_glWindow, m_invisibleCursor);
+
+    //init X11 events
+    CWinEvents::Init(m_dpy, m_glWindow);
+
+    changeWindow = true;
+    changeSize = true;
+  }
+
+  if (!CWinEvents::HasStructureChanged() && ((width != m_nWidth) || (height != m_nHeight)))
+  {
+    changeSize = true;
+  }
+
+  if (changeSize || changeWindow)
+  {
+    XResizeWindow(m_dpy, m_glWindow, width, height);
+  }
+
+  if (changeWindow)
+  {
+    if (!fullscreen)
+    {
+      XWMHints wm_hints;
+      XClassHint class_hints;
+      XTextProperty windowName, iconName;
+      std::string titleString = "XBMC Media Center";
+      char *title = (char*)titleString.c_str();
+
+      XStringListToTextProperty(&title, 1, &windowName);
+      XStringListToTextProperty(&title, 1, &iconName);
+      wm_hints.initial_state = NormalState;
+      wm_hints.input = True;
+      wm_hints.icon_pixmap = None;
+      wm_hints.flags = StateHint | IconPixmapHint | InputHint;
+
+      XSetWMProperties(m_dpy, m_glWindow, &windowName, &iconName,
+                            NULL, 0, NULL, &wm_hints,
+                            NULL);
+
+      // register interest in the delete window message
+      Atom wmDeleteMessage = XInternAtom(m_dpy, "WM_DELETE_WINDOW", False);
+      XSetWMProtocols(m_dpy, m_glWindow, &wmDeleteMessage, 1);
+    }
+    XMapRaised(m_dpy, m_glWindow);
+    XSync(m_dpy,TRUE);
+
+    if (changeWindow && mouseActive)
+    {
+      XWarpPointer(m_dpy, None, m_glWindow, 0, 0, 0, 0, mouseX*width, mouseY*height);
+    }
+
+    if (fullscreen)
+    {
+      int result = -1;
+      while (result != GrabSuccess)
+      {
+        result = XGrabPointer(m_dpy, m_glWindow, True, ButtonPressMask, GrabModeAsync, GrabModeAsync, m_glWindow, None, CurrentTime);
+        XbmcThreads::ThreadSleep(100);
+      }
+      XGrabKeyboard(m_dpy, m_glWindow, True, GrabModeAsync, GrabModeAsync, CurrentTime);
+
+    }
+  }
+  return true;
 }
 
 #endif

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -77,9 +77,18 @@ bool CWinSystemX11::InitWindowSystem()
 bool CWinSystemX11::DestroyWindowSystem()
 {
 #if defined(HAS_XRANDR)
-  //restore videomode on exit
+  //restore desktop resolution on exit
   if (m_bFullScreen)
-    g_xrandr.RestoreState();
+  {
+    XOutput out;
+    XMode mode;
+    out.name = g_settings.m_ResInfo[RES_DESKTOP].strOutput;
+    mode.w   = g_settings.m_ResInfo[RES_DESKTOP].iWidth;
+    mode.h   = g_settings.m_ResInfo[RES_DESKTOP].iHeight;
+    mode.hz  = g_settings.m_ResInfo[RES_DESKTOP].fRefreshRate;
+    mode.id  = g_settings.m_ResInfo[RES_DESKTOP].strId;
+    g_xrandr.SetMode(out, mode);
+  }
 #endif
 
   if (m_dpy)

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -35,6 +35,7 @@
 #include "utils/TimeUtils.h"
 #include "settings/GUISettings.h"
 #include "windowing/WindowingFactory.h"
+#include <X11/Xatom.h>
 
 #if defined(HAS_XRANDR)
 #include <X11/extensions/Xrandr.h>
@@ -807,7 +808,7 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const CStd
     cmap = XCreateColormap(m_dpy, RootWindow(m_dpy, vi->screen), vi->visual, AllocNone);
 
     int def_vis = (vi->visual == DefaultVisual(m_dpy, vi->screen));
-    swa.override_redirect = fullscreen ? True : False;
+    swa.override_redirect = False;
     swa.border_pixel = fullscreen ? 0 : 5;
     swa.background_pixel = def_vis ? BlackPixel(m_dpy, vi->screen) : 0;
     swa.colormap = cmap;
@@ -822,6 +823,12 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const CStd
                     out->x, out->y, width, height, 0, vi->depth,
                     InputOutput, vi->visual,
                     mask, &swa);
+
+    if (fullscreen)
+    {
+      Atom fs = XInternAtom(m_dpy, "_NET_WM_STATE_FULLSCREEN", True);
+      XChangeProperty(m_dpy, m_glWindow, XInternAtom(m_dpy, "_NET_WM_STATE", True), XA_ATOM, 32, PropModeReplace, (unsigned char *) &fs, 1);
+    }
 
     // define invisible cursor
     Pixmap bitmapNoData;

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -34,6 +34,7 @@
 #include "cores/VideoRenderers/RenderManager.h"
 #include "utils/TimeUtils.h"
 #include "settings/GUISettings.h"
+#include "windowing/WindowingFactory.h"
 
 #if defined(HAS_XRANDR)
 #include <X11/extensions/Xrandr.h>
@@ -54,6 +55,8 @@ CWinSystemX11::CWinSystemX11() : CWinSystemBase()
   m_bIgnoreNextFocusMessage = false;
   m_dpyLostTime = 0;
   m_invisibleCursor = 0;
+  m_initDone = false;
+  m_bIsInternalXrr = false;
 
   XSetErrorHandler(XErrorHandler);
 }
@@ -66,7 +69,9 @@ bool CWinSystemX11::InitWindowSystem()
 {
   if ((m_dpy = XOpenDisplay(NULL)))
   {
-    return CWinSystemBase::InitWindowSystem();
+    bool ret = CWinSystemBase::InitWindowSystem();
+    m_initDone = true;
+    return ret;
   }
   else
     CLog::Log(LOGERROR, "GLX Error: No Display found");
@@ -103,6 +108,8 @@ bool CWinSystemX11::DestroyWindowSystem()
 
     //we don't call XCloseDisplay() here, since ati keeps a pointer to our m_dpy
     //so instead we just let m_dpy die on exit
+    // i have seen core dumps on ATI if the display is not closed here
+    XCloseDisplay(m_dpy);
   }
 
   // m_SDLSurface is free()'d by SDL_Quit().
@@ -125,7 +132,10 @@ bool CWinSystemX11::DestroyWindow()
     return true;
 
   if (m_glContext)
+  {
+    glFinish();
     glXMakeCurrent(m_dpy, None, NULL);
+  }
 
   if (m_invisibleCursor)
   {
@@ -155,7 +165,7 @@ bool CWinSystemX11::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
   && m_nHeight == newHeight)
     return true;
 
-  if (!SetWindow(newWidth, newHeight, false))
+  if (!SetWindow(newWidth, newHeight, false, g_guiSettings.GetString("videoscreen.monitor")))
   {
     return false;
   }
@@ -164,56 +174,9 @@ bool CWinSystemX11::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
   m_nWidth  = newWidth;
   m_nHeight = newHeight;
   m_bFullScreen = false;
+  m_currentOutput = g_guiSettings.GetString("videoscreen.monitor");
 
   return false;
-}
-
-void CWinSystemX11::RefreshWindow()
-{
-  if (!g_xrandr.Query(true))
-  {
-    CLog::Log(LOGERROR, "WinSystemX11::RefreshWindow - failed to query xrandr");
-    return;
-  }
-  XOutput out  = g_xrandr.GetCurrentOutput();
-  XMode   mode = g_xrandr.GetCurrentMode(out.name);
-
-  RotateResolutions();
-
-  // only overwrite desktop resolution, if we are not in fullscreen mode
-  if (!g_graphicsContext.IsFullScreenVideo())
-  {
-    CLog::Log(LOGDEBUG, "CWinSystemX11::RefreshWindow - store desktop resolution, width: %d, height: %d, hz: %2.2f", mode.w, mode.h, mode.hz);
-    if (!out.isRotated)
-      UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], 0, mode.w, mode.h, mode.hz);
-    else
-      UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], 0, mode.h, mode.w, mode.hz);
-    g_settings.m_ResInfo[RES_DESKTOP].strId     = mode.id;
-    g_settings.m_ResInfo[RES_DESKTOP].strOutput = out.name;
-  }
-
-  RESOLUTION_INFO res;
-  unsigned int i;
-  bool found(false);
-  for (i = RES_DESKTOP; i < g_settings.m_ResInfo.size(); ++i)
-  {
-    if (g_settings.m_ResInfo[i].strId == mode.id)
-    {
-      found = true;
-      break;
-    }
-  }
-
-  if (!found)
-  {
-    CLog::Log(LOGERROR, "CWinSystemX11::RefreshWindow - could not find resolution");
-    return;
-  }
-
-  if (g_graphicsContext.IsFullScreenRoot())
-    g_graphicsContext.SetVideoResolution((RESOLUTION)i, true);
-  else
-    g_graphicsContext.SetVideoResolution(RES_WINDOW, true);
 }
 
 bool CWinSystemX11::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
@@ -240,8 +203,7 @@ bool CWinSystemX11::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     mode.id  = g_settings.m_ResInfo[RES_DESKTOP].strId;
   }
  
-  XOutput currout  = g_xrandr.GetCurrentOutput();
-  XMode   currmode = g_xrandr.GetCurrentMode(currout.name);
+  XMode   currmode = g_xrandr.GetCurrentMode(out.name);
 
   // flip h/w when rotated
   if (m_bIsRotated)
@@ -252,16 +214,17 @@ bool CWinSystemX11::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   }
 
   // only call xrandr if mode changes
-  if (currout.name != out.name || currmode.w != mode.w || currmode.h != mode.h ||
+  if (currmode.w != mode.w || currmode.h != mode.h ||
       currmode.hz != mode.hz || currmode.id != mode.id)
   {
     CLog::Log(LOGNOTICE, "CWinSystemX11::SetFullScreen - calling xrandr");
     OnLostDevice();
+    m_bIsInternalXrr = true;
     g_xrandr.SetMode(out, mode);
   }
 #endif
 
-  if (!SetWindow(res.iWidth, res.iHeight, fullScreen))
+  if (!SetWindow(res.iWidth, res.iHeight, fullScreen, g_guiSettings.GetString("videoscreen.monitor")))
     return false;
 
   RefreshGlxContext();
@@ -269,6 +232,7 @@ bool CWinSystemX11::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   m_nWidth      = res.iWidth;
   m_nHeight     = res.iHeight;
   m_bFullScreen = fullScreen;
+  m_currentOutput = g_guiSettings.GetString("videoscreen.monitor");
 
   return true;
 }
@@ -277,19 +241,33 @@ void CWinSystemX11::UpdateResolutions()
 {
   CWinSystemBase::UpdateResolutions();
 
+  if (!m_initDone)
+    return;
 
 #if defined(HAS_XRANDR)
-  if(g_xrandr.Query())
+  CStdString currentMonitor;
+  int numScreens = XScreenCount(m_dpy);
+  g_xrandr.SetNumScreens(numScreens);
+  if(g_xrandr.Query(true))
   {
-    XOutput out  = g_xrandr.GetCurrentOutput();
-    XMode   mode = g_xrandr.GetCurrentMode(out.name);
-    m_bIsRotated = out.isRotated;
+    currentMonitor = g_guiSettings.GetString("videoscreen.monitor");
+    // check if the monitor is connected
+    XOutput *out = g_xrandr.GetOutput(currentMonitor);
+    if (!out)
+    {
+      // choose first output
+      currentMonitor = g_xrandr.GetModes()[0].name;
+      out = g_xrandr.GetOutput(currentMonitor);
+      g_guiSettings.SetString("videoscreen.monitor", currentMonitor);
+    }
+    XMode mode = g_xrandr.GetCurrentMode(currentMonitor);
+    m_bIsRotated = out->isRotated;
     if (!m_bIsRotated)
-      UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], 0, mode.w, mode.h, mode.hz);
+      UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], out->screen, mode.w, mode.h, mode.hz);
     else
-      UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], 0, mode.h, mode.w, mode.hz);
+      UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], out->screen, mode.h, mode.w, mode.hz);
     g_settings.m_ResInfo[RES_DESKTOP].strId     = mode.id;
-    g_settings.m_ResInfo[RES_DESKTOP].strOutput = out.name;
+    g_settings.m_ResInfo[RES_DESKTOP].strOutput = currentMonitor;
   }
   else
 #endif
@@ -300,23 +278,26 @@ void CWinSystemX11::UpdateResolutions()
     UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], 0, w, h, 0.0);
   }
 
-
 #if defined(HAS_XRANDR)
 
+  // erase previous stored modes
+  if (g_settings.m_ResInfo.size() > RES_CUSTOM)
+  {
+    std::vector<RESOLUTION_INFO>::iterator firstCustom = g_settings.m_ResInfo.begin()+RES_CUSTOM;
+    g_settings.m_ResInfo.erase(firstCustom, g_settings.m_ResInfo.end());
+  }
+
   CLog::Log(LOGINFO, "Available videomodes (xrandr):");
-  vector<XOutput>::iterator outiter;
-  vector<XOutput> outs;
-  outs = g_xrandr.GetModes();
-  CLog::Log(LOGINFO, "Number of connected outputs: %"PRIdS"", outs.size());
+
+  XOutput *out = g_xrandr.GetOutput(currentMonitor);
   string modename = "";
 
-  for (outiter = outs.begin() ; outiter != outs.end() ; outiter++)
+  if (out != NULL)
   {
-    XOutput out = *outiter;
     vector<XMode>::iterator modeiter;
-    CLog::Log(LOGINFO, "Output '%s' has %"PRIdS" modes", out.name.c_str(), out.modes.size());
+    CLog::Log(LOGINFO, "Output '%s' has %"PRIdS" modes", out->name.c_str(), out->modes.size());
 
-    for (modeiter = out.modes.begin() ; modeiter!=out.modes.end() ; modeiter++)
+    for (modeiter = out->modes.begin() ; modeiter!=out->modes.end() ; modeiter++)
     {
       XMode mode = *modeiter;
       CLog::Log(LOGINFO, "ID:%s Name:%s Refresh:%f Width:%d Height:%d",
@@ -332,15 +313,15 @@ void CWinSystemX11::UpdateResolutions()
         res.iWidth  = mode.h;
         res.iHeight = mode.w;
       }
-      if (mode.h>0 && mode.w>0 && out.hmm>0 && out.wmm>0)
-        res.fPixelRatio = ((float)out.wmm/(float)mode.w) / (((float)out.hmm/(float)mode.h));
+      if (mode.h>0 && mode.w>0 && out->hmm>0 && out->wmm>0)
+        res.fPixelRatio = ((float)out->wmm/(float)mode.w) / (((float)out->hmm/(float)mode.h));
       else
         res.fPixelRatio = 1.0f;
 
       CLog::Log(LOGINFO, "Pixel Ratio: %f", res.fPixelRatio);
 
-      res.strMode.Format("%s: %s @ %.2fHz", out.name.c_str(), mode.name.c_str(), mode.hz);
-      res.strOutput    = out.name;
+      res.strMode.Format("%s: %s @ %.2fHz", out->name.c_str(), mode.name.c_str(), mode.hz);
+      res.strOutput    = out->name;
       res.strId        = mode.id;
       res.iSubtitles   = (int)(0.95*mode.h);
       res.fRefreshRate = mode.hz;
@@ -359,28 +340,19 @@ void CWinSystemX11::UpdateResolutions()
 
 }
 
-void CWinSystemX11::RotateResolutions()
+void CWinSystemX11::GetConnectedOutputs(std::vector<CStdString> *outputs)
 {
-#if defined(HAS_XRANDR)
-  XOutput out  = g_xrandr.GetCurrentOutput();
-  if (out.isRotated == m_bIsRotated)
-    return;
-
-  for (unsigned int i = 0; i < g_settings.m_ResInfo.size(); ++i)
+  vector<XOutput> outs;
+  outs = g_xrandr.GetModes();
+  for(unsigned int i=0; i<outs.size(); ++i)
   {
-    int width = g_settings.m_ResInfo[i].iWidth;
-    g_settings.m_ResInfo[i].iWidth = g_settings.m_ResInfo[i].iHeight;
-    g_settings.m_ResInfo[i].iHeight = width;
+    outputs->push_back(outs[i].name);
   }
-  // update desktop resolution
-//  int h = g_settings.m_ResInfo[RES_DESKTOP].iHeight;
-//  int w = g_settings.m_ResInfo[RES_DESKTOP].iWidth;
-//  float hz = g_settings.m_ResInfo[RES_DESKTOP].fRefreshRate;
-//  UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], 0, w, h, hz);
+}
 
-  m_bIsRotated = out.isRotated;
-
-#endif
+bool CWinSystemX11::IsCurrentOutput(CStdString output)
+{
+  return m_currentOutput.Equals(output);
 }
 
 bool CWinSystemX11::IsSuitableVisual(XVisualInfo *vInfo)
@@ -410,8 +382,11 @@ bool CWinSystemX11::RefreshGlxContext()
   if (m_glContext)
   {
     CLog::Log(LOGDEBUG, "CWinSystemX11::RefreshGlxContext: refreshing context");
+    glFinish();
     glXMakeCurrent(m_dpy, None, NULL);
     glXMakeCurrent(m_dpy, m_glWindow, m_glContext);
+    XSync(m_dpy, FALSE);
+    g_Windowing.ResetVSync();
     return true;
   }
 
@@ -477,6 +452,8 @@ bool CWinSystemX11::RefreshGlxContext()
     {
       // make this context current
       glXMakeCurrent(m_dpy, m_glWindow, m_glContext);
+      g_Windowing.ResetVSync();
+      XSync(m_dpy, False);
       retVal = true;
     }
     else
@@ -518,22 +495,50 @@ void CWinSystemX11::ResetOSScreensaver()
 
 void CWinSystemX11::NotifyAppActiveChange(bool bActivated)
 {
-  if (bActivated && m_bWasFullScreenBeforeMinimize && !g_graphicsContext.IsFullScreenRoot())
+  if (bActivated && m_bWasFullScreenBeforeMinimize && !m_bFullScreen)
+  {
     g_graphicsContext.ToggleFullScreenRoot();
+    m_bWasFullScreenBeforeMinimize = false;
+  }
 }
 
 void CWinSystemX11::NotifyAppFocusChange(bool bGaining)
 {
   if (bGaining && m_bWasFullScreenBeforeMinimize && !m_bIgnoreNextFocusMessage &&
-      !g_graphicsContext.IsFullScreenRoot())
+      !m_bFullScreen)
+  {
+    m_bWasFullScreenBeforeMinimize = false;
     g_graphicsContext.ToggleFullScreenRoot();
+  }
   if (!bGaining)
     m_bIgnoreNextFocusMessage = false;
 }
 
+void CWinSystemX11::NotifyMouseCoverage(bool covered)
+{
+  if (!m_bFullScreen)
+    return;
+
+  if (covered)
+  {
+    int result = -1;
+    while (result != GrabSuccess && result != AlreadyGrabbed)
+    {
+      result = XGrabPointer(m_dpy, m_glWindow, True, ButtonPressMask, GrabModeAsync, GrabModeAsync, None, None, CurrentTime);
+      XbmcThreads::ThreadSleep(100);
+    }
+    XGrabKeyboard(m_dpy, m_glWindow, True, GrabModeAsync, GrabModeAsync, CurrentTime);
+  }
+  else
+  {
+    XUngrabKeyboard(m_dpy, CurrentTime);
+    XUngrabPointer(m_dpy, CurrentTime);
+  }
+}
+
 bool CWinSystemX11::Minimize()
 {
-  m_bWasFullScreenBeforeMinimize = g_graphicsContext.IsFullScreenRoot();
+  m_bWasFullScreenBeforeMinimize = m_bFullScreen;
   if (m_bWasFullScreenBeforeMinimize)
   {
     m_bIgnoreNextFocusMessage = true;
@@ -597,13 +602,46 @@ void CWinSystemX11::CheckDisplayEvents()
 void CWinSystemX11::NotifyXRREvent()
 {
   CLog::Log(LOGDEBUG, "%s - notify display reset event", __FUNCTION__);
-  RefreshWindow();
+  m_windowDirty = true;
 
-  CSingleLock lock(m_resourceSection);
+  // if external event update resolutions
+  if (!m_bIsInternalXrr)
+  {
+    UpdateResolutions();
+  }
+  else if (!g_xrandr.Query(true))
+  {
+    CLog::Log(LOGERROR, "WinSystemX11::RefreshWindow - failed to query xrandr");
+    return;
+  }
+  m_bIsInternalXrr = false;
 
-  // tell any shared resources
-  for (vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); i++)
-    (*i)->OnResetDevice();
+  CStdString currentOutput = g_guiSettings.GetString("videoscreen.monitor");
+  XOutput *out = g_xrandr.GetOutput(currentOutput);
+  XMode   mode = g_xrandr.GetCurrentMode(currentOutput);
+
+  RESOLUTION_INFO res;
+  unsigned int i;
+  bool found(false);
+  for (i = RES_DESKTOP; i < g_settings.m_ResInfo.size(); ++i)
+  {
+    if (g_settings.m_ResInfo[i].strId == mode.id)
+    {
+      found = true;
+      break;
+    }
+  }
+
+  if (!found)
+  {
+    CLog::Log(LOGERROR, "CWinSystemX11::RefreshWindow - could not find resolution");
+    i = RES_DESKTOP;
+  }
+
+  if (g_graphicsContext.IsFullScreenRoot())
+    g_graphicsContext.SetVideoResolution((RESOLUTION)i, true);
+  else
+    g_graphicsContext.SetVideoResolution(RES_WINDOW, true);
 
 }
 
@@ -651,14 +689,14 @@ int CWinSystemX11::XErrorHandler(Display* dpy, XErrorEvent* error)
   return 0;
 }
 
-bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen)
+bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const CStdString &output)
 {
   bool changeWindow = false;
   bool changeSize = false;
   bool mouseActive = false;
   float mouseX, mouseY;
 
-  if (m_glWindow && (m_bFullScreen != fullscreen))
+  if (m_glWindow && ((m_bFullScreen != fullscreen) || !m_currentOutput.Equals(output) || m_windowDirty))
   {
     mouseActive = g_Mouse.IsActive();
     if (mouseActive)
@@ -680,6 +718,7 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen)
       else
         mouseActive = false;
     }
+    OnLostDevice();
     DestroyWindow();
   }
 
@@ -701,7 +740,11 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen)
     XSetWindowAttributes swa;
     XVisualInfo *vi;
 
-    vi = glXChooseVisual(m_dpy, DefaultScreen(m_dpy), att);
+    XOutput *out = g_xrandr.GetOutput(output);
+    if (!out)
+      out = g_xrandr.GetOutput(m_currentOutput);
+    m_nScreen = out->screen;
+    vi = glXChooseVisual(m_dpy, m_nScreen, att);
     cmap = XCreateColormap(m_dpy, RootWindow(m_dpy, vi->screen), vi->visual, AllocNone);
 
     int def_vis = (vi->visual == DefaultVisual(m_dpy, vi->screen));
@@ -717,7 +760,7 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen)
     unsigned long mask = CWBackPixel | CWBorderPixel | CWColormap | CWOverrideRedirect | CWEventMask;
 
     m_glWindow = XCreateWindow(m_dpy, RootWindow(m_dpy, vi->screen),
-                    0, 0, width, height, 0, vi->depth,
+                    out->x, out->y, width, height, 0, vi->depth,
                     InputOutput, vi->visual,
                     mask, &swa);
 
@@ -788,14 +831,19 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen)
     if (fullscreen)
     {
       int result = -1;
-      while (result != GrabSuccess)
+      while (result != GrabSuccess && result != AlreadyGrabbed)
       {
-        result = XGrabPointer(m_dpy, m_glWindow, True, ButtonPressMask, GrabModeAsync, GrabModeAsync, m_glWindow, None, CurrentTime);
+        result = XGrabPointer(m_dpy, m_glWindow, True, ButtonPressMask, GrabModeAsync, GrabModeAsync, None, None, CurrentTime);
         XbmcThreads::ThreadSleep(100);
       }
       XGrabKeyboard(m_dpy, m_glWindow, True, GrabModeAsync, GrabModeAsync, CurrentTime);
-
     }
+    CSingleLock lock(m_resourceSection);
+    // tell any shared resources
+    for (vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); i++)
+      (*i)->OnResetDevice();
+
+    m_windowDirty = false;
   }
   return true;
 }

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -272,7 +272,7 @@ void CWinSystemX11::UpdateResolutions()
   else
 #endif
   {
-    int x11screen = DefaultScreen(m_dpy);
+    int x11screen = m_nScreen;
     int w = DisplayWidth(m_dpy, x11screen);
     int h = DisplayHeight(m_dpy, x11screen);
     UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], 0, w, h, 0.0);
@@ -394,7 +394,7 @@ bool CWinSystemX11::RefreshGlxContext()
   XVisualInfo *visuals;
   XVisualInfo *vInfo      = NULL;
   int availableVisuals    = 0;
-  vMask.screen = DefaultScreen(m_dpy);
+  vMask.screen = m_nScreen;
   XWindowAttributes winAttr;
 
   /* Assume a depth of 24 in case the below calls to XGetWindowAttributes()
@@ -545,7 +545,7 @@ bool CWinSystemX11::Minimize()
     g_graphicsContext.ToggleFullScreenRoot();
   }
 
-  XIconifyWindow(m_dpy, m_glWindow, DefaultScreen(m_dpy));
+  XIconifyWindow(m_dpy, m_glWindow, m_nScreen);
 
   return true;
 }

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -170,7 +170,6 @@ bool CWinSystemX11::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
     return false;
   }
 
-  RefreshGlxContext();
   m_nWidth  = newWidth;
   m_nHeight = newHeight;
   m_bFullScreen = false;
@@ -221,13 +220,12 @@ bool CWinSystemX11::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     OnLostDevice();
     m_bIsInternalXrr = true;
     g_xrandr.SetMode(out, mode);
+    return true;
   }
 #endif
 
   if (!SetWindow(res.iWidth, res.iHeight, fullScreen, g_guiSettings.GetString("videoscreen.monitor")))
     return false;
-
-  RefreshGlxContext();
 
   m_nWidth      = res.iWidth;
   m_nHeight     = res.iHeight;
@@ -382,11 +380,8 @@ bool CWinSystemX11::RefreshGlxContext()
   if (m_glContext)
   {
     CLog::Log(LOGDEBUG, "CWinSystemX11::RefreshGlxContext: refreshing context");
-    glFinish();
     glXMakeCurrent(m_dpy, None, NULL);
     glXMakeCurrent(m_dpy, m_glWindow, m_glContext);
-    XSync(m_dpy, FALSE);
-    g_Windowing.ResetVSync();
     return true;
   }
 
@@ -446,14 +441,14 @@ bool CWinSystemX11::RefreshGlxContext()
     {
       glXMakeCurrent(m_dpy, None, NULL);
       glXDestroyContext(m_dpy, m_glContext);
+      XSync(m_dpy, FALSE);
+      m_newGlContext = true;
     }
 
     if ((m_glContext = glXCreateContext(m_dpy, vInfo, NULL, True)))
     {
       // make this context current
       glXMakeCurrent(m_dpy, m_glWindow, m_glContext);
-      g_Windowing.ResetVSync();
-      XSync(m_dpy, False);
       retVal = true;
     }
     else
@@ -720,6 +715,7 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const CStd
     }
     OnLostDevice();
     DestroyWindow();
+    m_windowDirty = true;
   }
 
   // create main window
@@ -838,13 +834,21 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const CStd
       }
       XGrabKeyboard(m_dpy, m_glWindow, True, GrabModeAsync, GrabModeAsync, CurrentTime);
     }
+
+    CDirtyRegionList dr;
+    RefreshGlxContext();
+    XSync(m_dpy, FALSE);
+    g_graphicsContext.Clear(0);
+    g_graphicsContext.Flip(dr);
+    g_Windowing.ResetVSync();
+    m_windowDirty = false;
+
     CSingleLock lock(m_resourceSection);
     // tell any shared resources
     for (vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); i++)
       (*i)->OnResetDevice();
-
-    m_windowDirty = false;
   }
+
   return true;
 }
 

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -522,6 +522,33 @@ void CWinSystemX11::ResetOSScreensaver()
   }
 }
 
+void CWinSystemX11::EnableSystemScreenSaver(bool bEnable)
+{
+  if (!m_dpy)
+    return;
+
+  if (bEnable)
+    XForceScreenSaver(m_dpy, ScreenSaverActive);
+  else
+  {
+    Window root_return, child_return;
+    int root_x_return, root_y_return;
+    int win_x_return, win_y_return;
+    unsigned int mask_return;
+    bool isInWin = XQueryPointer(m_dpy, RootWindow(m_dpy, m_nScreen), &root_return, &child_return,
+                                 &root_x_return, &root_y_return,
+                                 &win_x_return, &win_y_return,
+                                 &mask_return);
+
+    XWarpPointer(m_dpy, None, RootWindow(m_dpy, m_nScreen), 0, 0, 0, 0, root_x_return+300, root_y_return+300);
+    XSync(m_dpy, FALSE);
+    XWarpPointer(m_dpy, None, RootWindow(m_dpy, m_nScreen), 0, 0, 0, 0, 0, 0);
+    XSync(m_dpy, FALSE);
+    XWarpPointer(m_dpy, None, RootWindow(m_dpy, m_nScreen), 0, 0, 0, 0, root_x_return, root_y_return);
+    XSync(m_dpy, FALSE);
+  }
+}
+
 void CWinSystemX11::NotifyAppActiveChange(bool bActivated)
 {
   if (bActivated && m_bWasFullScreenBeforeMinimize && !m_bFullScreen)
@@ -755,6 +782,8 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const CStd
   // create main window
   if (!m_glWindow)
   {
+    EnableSystemScreenSaver(false);
+
     GLint att[] =
     {
       GLX_RGBA,

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -321,7 +321,7 @@ void CWinSystemX11::UpdateResolutions()
       res.strMode.Format("%s: %s @ %.2fHz", out->name.c_str(), mode.name.c_str(), mode.hz);
       res.strOutput    = out->name;
       res.strId        = mode.id;
-      res.iSubtitles   = (int)(0.95*mode.h);
+      res.iSubtitles   = (int)(0.965*mode.h);
       res.fRefreshRate = mode.hz;
       res.bFullScreen  = true;
 
@@ -334,8 +334,42 @@ void CWinSystemX11::UpdateResolutions()
       g_settings.m_ResInfo.push_back(res);
     }
   }
+  g_settings.ApplyCalibrations();
 #endif
+}
 
+bool CWinSystemX11::HasCalibration(const RESOLUTION_INFO &resInfo)
+{
+  XOutput *out = g_xrandr.GetOutput(m_currentOutput);
+
+  // keep calibrations done on a not connected output
+  if (!out->name.Equals(resInfo.strOutput))
+    return true;
+
+  // keep calibrations not updated with resolution data
+  if (resInfo.iWidth == 0)
+    return true;
+
+  float fPixRatio;
+  if (resInfo.iHeight>0 && resInfo.iWidth>0 && out->hmm>0 && out->wmm>0)
+    fPixRatio = ((float)out->wmm/(float)resInfo.iWidth) / (((float)out->hmm/(float)resInfo.iHeight));
+  else
+    fPixRatio = 1.0f;
+
+  if (resInfo.Overscan.left != 0)
+    return true;
+  if (resInfo.Overscan.top != 0)
+    return true;
+  if (resInfo.Overscan.right != resInfo.iWidth)
+    return true;
+  if (resInfo.Overscan.bottom != resInfo.iHeight)
+    return true;
+  if (resInfo.fPixelRatio != fPixRatio)
+    return true;
+  if (resInfo.iSubtitles != (int)(0.965*resInfo.iHeight))
+    return true;
+
+  return false;
 }
 
 void CWinSystemX11::GetConnectedOutputs(std::vector<CStdString> *outputs)

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -52,6 +52,7 @@ public:
   virtual void ResetOSScreensaver();
 
   virtual void NotifyAppActiveChange(bool bActivated);
+  virtual void NotifyAppFocusChange(bool bGaining);
 
   virtual bool Minimize();
   virtual bool Restore() ;
@@ -63,18 +64,20 @@ public:
   // Local to WinSystemX11 only
   Display*  GetDisplay() { return m_dpy; }
   GLXWindow GetWindow() { return m_glWindow; }
+  void RefreshWindow();
 
 protected:
   bool RefreshGlxContext();
   void CheckDisplayEvents();
   void OnLostDevice();
+  bool SetWindow(int width, int height, bool fullscreen);
 
-  SDL_Surface* m_SDLSurface;
+  Window       m_glWindow;
   GLXContext   m_glContext;
-  GLXWindow    m_glWindow;
-  Window       m_wmWindow;
   Display*     m_dpy;
+  Cursor       m_invisibleCursor;
   bool         m_bWasFullScreenBeforeMinimize;
+  bool         m_bIgnoreNextFocusMessage;
   int          m_RREventBase;
   CCriticalSection             m_resourceSection;
   std::vector<IDispResource*>  m_resources;

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -65,6 +65,7 @@ public:
   Display*  GetDisplay() { return m_dpy; }
   GLXWindow GetWindow() { return m_glWindow; }
   void RefreshWindow();
+  void NotifyXRREvent();
 
 protected:
   bool RefreshGlxContext();

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -76,6 +76,7 @@ protected:
   GLXContext   m_glContext;
   Display*     m_dpy;
   Cursor       m_invisibleCursor;
+  Pixmap       m_icon;
   bool         m_bWasFullScreenBeforeMinimize;
   bool         m_bIgnoreNextFocusMessage;
   int          m_RREventBase;
@@ -86,6 +87,7 @@ protected:
 private:
   bool IsSuitableVisual(XVisualInfo *vInfo);
   static int XErrorHandler(Display* dpy, XErrorEvent* error);
+  bool CreateIconPixmap();
 
   CStopWatch m_screensaverReset;
 };

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -61,6 +61,7 @@ public:
   virtual bool Show(bool raise = true);
   virtual void Register(IDispResource *resource);
   virtual void Unregister(IDispResource *resource);
+  virtual bool HasCalibration(const RESOLUTION_INFO &resInfo);
 
   // Local to WinSystemX11 only
   Display*  GetDisplay() { return m_dpy; }

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -48,6 +48,7 @@ public:
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual void UpdateResolutions();
   virtual int  GetNumScreens() { return 1; }
+  virtual int  GetCurrentScreen() { return m_nScreen; }
   virtual void ShowOSMouse(bool show);
   virtual void ResetOSScreensaver();
 

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -72,12 +72,14 @@ protected:
   void CheckDisplayEvents();
   void OnLostDevice();
   bool SetWindow(int width, int height, bool fullscreen);
+  void RotateResolutions();
 
   Window       m_glWindow;
   GLXContext   m_glContext;
   Display*     m_dpy;
   Cursor       m_invisibleCursor;
   Pixmap       m_icon;
+  bool         m_bIsRotated;
   bool         m_bWasFullScreenBeforeMinimize;
   bool         m_bIgnoreNextFocusMessage;
   int          m_RREventBase;

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -51,6 +51,7 @@ public:
   virtual int  GetCurrentScreen() { return m_nScreen; }
   virtual void ShowOSMouse(bool show);
   virtual void ResetOSScreensaver();
+  virtual void EnableSystemScreenSaver(bool bEnable);
 
   virtual void NotifyAppActiveChange(bool bActivated);
   virtual void NotifyAppFocusChange(bool bGaining);

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -92,6 +92,7 @@ protected:
   bool                         m_initDone;
   bool                         m_windowDirty;
   bool                         m_bIsInternalXrr;
+  bool                         m_newGlContext;
 
 private:
   bool IsSuitableVisual(XVisualInfo *vInfo);

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -64,15 +64,16 @@ public:
   // Local to WinSystemX11 only
   Display*  GetDisplay() { return m_dpy; }
   GLXWindow GetWindow() { return m_glWindow; }
-  void RefreshWindow();
   void NotifyXRREvent();
+  void GetConnectedOutputs(std::vector<CStdString> *outputs);
+  bool IsCurrentOutput(CStdString output);
+  void NotifyMouseCoverage(bool covered);
 
 protected:
   bool RefreshGlxContext();
   void CheckDisplayEvents();
   void OnLostDevice();
-  bool SetWindow(int width, int height, bool fullscreen);
-  void RotateResolutions();
+  bool SetWindow(int width, int height, bool fullscreen, const CStdString &output);
 
   Window       m_glWindow;
   GLXContext   m_glContext;
@@ -86,6 +87,10 @@ protected:
   CCriticalSection             m_resourceSection;
   std::vector<IDispResource*>  m_resources;
   uint64_t                     m_dpyLostTime;
+  CStdString                   m_currentOutput;
+  bool                         m_initDone;
+  bool                         m_windowDirty;
+  bool                         m_bIsInternalXrr;
 
 private:
   bool IsSuitableVisual(XVisualInfo *vInfo);

--- a/xbmc/windowing/X11/WinSystemX11GL.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GL.cpp
@@ -24,6 +24,7 @@
 
 #include "WinSystemX11GL.h"
 #include "utils/log.h"
+#include "Application.h"
 
 CWinSystemX11GL::CWinSystemX11GL()
 {
@@ -246,16 +247,24 @@ bool CWinSystemX11GL::CreateNewWindow(const CStdString& name, bool fullScreen, R
 
 bool CWinSystemX11GL::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
+  m_newGlContext = false;
   CWinSystemX11::ResizeWindow(newWidth, newHeight, newLeft, newTop);
   CRenderSystemGL::ResetRenderSystem(newWidth, newHeight, false, 0);
+
+  if (m_newGlContext)
+    g_application.ReloadSkin();
 
   return true;
 }
 
 bool CWinSystemX11GL::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
+  m_newGlContext = false;
   CWinSystemX11::SetFullScreen(fullScreen, res, blankOtherDisplays);
   CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight, fullScreen, res.fRefreshRate);
+
+  if (m_newGlContext)
+    g_application.ReloadSkin();
 
   return true;
 }

--- a/xbmc/windowing/X11/WinSystemX11GL.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GL.cpp
@@ -204,7 +204,7 @@ bool CWinSystemX11GL::CreateNewWindow(const CStdString& name, bool fullScreen, R
     return false;
 
   m_glxext  = " ";
-  m_glxext += (const char*)glXQueryExtensionsString(m_dpy, DefaultScreen(m_dpy));
+  m_glxext += (const char*)glXQueryExtensionsString(m_dpy, m_nScreen);
   m_glxext += " ";
 
   CLog::Log(LOGDEBUG, "GLX_EXTENSIONS:%s", m_glxext.c_str());

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -140,25 +140,6 @@ void CXRandR::SaveState()
   Query(true);
 }
 
-void CXRandR::RestoreState()
-{
-  vector<XOutput>::iterator outiter;
-  for (outiter=m_current.begin() ; outiter!=m_current.end() ; outiter++)
-  {
-    vector<XMode> modes = (*outiter).modes;
-    vector<XMode>::iterator modeiter;
-    for (modeiter=modes.begin() ; modeiter!=modes.end() ; modeiter++)
-    {
-      XMode mode = *modeiter;
-      if (mode.isCurrent)
-      {
-        SetMode(*outiter, mode);
-        return;
-      }
-    }
-  }
-}
-
 bool CXRandR::SetMode(XOutput output, XMode mode)
 {
   if ((output.name == m_currentOutput && mode.id == m_currentMode) || (output.name == "" && mode.id == ""))

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -99,6 +99,13 @@ bool CXRandR::Query(bool force)
     xoutput.y = (output->Attribute("y") != NULL ? atoi(output->Attribute("y")) : 0);
     xoutput.wmm = (output->Attribute("wmm") != NULL ? atoi(output->Attribute("wmm")) : 0);
     xoutput.hmm = (output->Attribute("hmm") != NULL ? atoi(output->Attribute("hmm")) : 0);
+    if (output->Attribute("rotation") != NULL
+        && (strcasecmp(output->Attribute("rotation"), "left") == 0 || strcasecmp(output->Attribute("rotation"), "right") == 0))
+    {
+      xoutput.isRotated = true;
+    }
+    else
+      xoutput.isRotated = false;
 
     if (!xoutput.isConnected)
        continue;

--- a/xbmc/windowing/X11/XRandR.cpp
+++ b/xbmc/windowing/X11/XRandR.cpp
@@ -40,6 +40,7 @@ using namespace std;
 CXRandR::CXRandR(bool query)
 {
   m_bInit = false;
+  m_numScreens = 1;
   if (query)
     Query();
 }
@@ -56,11 +57,21 @@ bool CXRandR::Query(bool force)
     return false;
 
   m_outputs.clear();
-  m_current.clear();
+  // query all screens
+  for(unsigned int screennum=0; screennum<m_numScreens; ++screennum)
+  {
+    if(!Query(force, screennum))
+      return false;
+  }
+  return true;
+}
 
+bool CXRandR::Query(bool force, int screennum)
+{
   CStdString cmd;
   cmd  = getenv("XBMC_BIN_HOME");
   cmd += "/xbmc-xrandr";
+  cmd.append("-q --screen %d", screennum);
 
   FILE* file = popen(cmd.c_str(),"r");
   if (!file)
@@ -80,7 +91,7 @@ bool CXRandR::Query(bool force)
   pclose(file);
 
   TiXmlElement *pRootElement = xmlDoc.RootElement();
-  if (strcasecmp(pRootElement->Value(), "screen") != 0)
+  if (strcasecmp(pRootElement->Value(), "screen") != screennum)
   {
     // TODO ERROR
     return false;
@@ -93,6 +104,7 @@ bool CXRandR::Query(bool force)
     xoutput.name.TrimLeft(" \n\r\t");
     xoutput.name.TrimRight(" \n\r\t");
     xoutput.isConnected = (strcasecmp(output->Attribute("connected"), "true") == 0);
+    xoutput.screen = screennum;
     xoutput.w = (output->Attribute("w") != NULL ? atoi(output->Attribute("w")) : 0);
     xoutput.h = (output->Attribute("h") != NULL ? atoi(output->Attribute("h")) : 0);
     xoutput.x = (output->Attribute("x") != NULL ? atoi(output->Attribute("x")) : 0);
@@ -124,7 +136,6 @@ bool CXRandR::Query(bool force)
       xoutput.modes.push_back(xmode);
       if (xmode.isCurrent)
       {
-        m_current.push_back(xoutput);
         hascurrent = true;
       }
     }
@@ -248,17 +259,6 @@ bool CXRandR::SetMode(XOutput output, XMode mode)
   return true;
 }
 
-XOutput CXRandR::GetCurrentOutput()
-{
-  Query();
-  for (unsigned int j = 0; j < m_outputs.size(); j++)
-  {
-    if(m_outputs[j].isConnected)
-      return m_outputs[j];
-  }
-  XOutput empty;
-  return empty;
-}
 XMode CXRandR::GetCurrentMode(CStdString outputName)
 {
   Query();
@@ -330,6 +330,43 @@ void CXRandR::LoadCustomModeLinesToAllOutputs(void)
       }
     }
   }
+}
+
+void CXRandR::SetNumScreens(unsigned int num)
+{
+  m_numScreens = num;
+  m_bInit = false;
+}
+
+bool CXRandR::IsOutputConnected(CStdString name)
+{
+  bool result = false;
+  Query();
+
+  for (unsigned int i = 0; i < m_outputs.size(); ++i)
+  {
+    if (m_outputs[i].name == name)
+    {
+      result = true;
+      break;
+    }
+  }
+  return result;
+}
+
+XOutput* CXRandR::GetOutput(CStdString outputName)
+{
+  XOutput *result = 0;
+  Query();
+  for (unsigned int i = 0; i < m_outputs.size(); ++i)
+  {
+    if (m_outputs[i].name == outputName)
+    {
+      result = &m_outputs[i];
+      break;
+    }
+  }
+  return result;
 }
 
 CXRandR g_xrandr;

--- a/xbmc/windowing/X11/XRandR.h
+++ b/xbmc/windowing/X11/XRandR.h
@@ -87,6 +87,7 @@ public:
   int wmm;
   int hmm;
   std::vector<XMode> modes;
+  bool isRotated;
 };
 
 class CXRandR

--- a/xbmc/windowing/X11/XRandR.h
+++ b/xbmc/windowing/X11/XRandR.h
@@ -100,7 +100,6 @@ public:
   bool SetMode(XOutput output, XMode mode);
   void LoadCustomModeLinesToAllOutputs(void);
   void SaveState();
-  void RestoreState();
   //bool Has1080i();
   //bool Has1080p();
   //bool Has720p();

--- a/xbmc/windowing/X11/XRandR.h
+++ b/xbmc/windowing/X11/XRandR.h
@@ -80,6 +80,7 @@ public:
     }
   CStdString name;
   bool isConnected;
+  int screen;
   int w;
   int h;
   int x;
@@ -95,12 +96,15 @@ class CXRandR
 public:
   CXRandR(bool query=false);
   bool Query(bool force=false);
+  bool Query(bool force, int screennum);
   std::vector<XOutput> GetModes(void);
-  XOutput GetCurrentOutput();
   XMode   GetCurrentMode(CStdString outputName);
+  XOutput *GetOutput(CStdString outputName);
   bool SetMode(XOutput output, XMode mode);
   void LoadCustomModeLinesToAllOutputs(void);
   void SaveState();
+  void SetNumScreens(unsigned int num);
+  bool IsOutputConnected(CStdString name);
   //bool Has1080i();
   //bool Has1080p();
   //bool Has720p();
@@ -108,10 +112,10 @@ public:
 
 private:
   bool m_bInit;
-  std::vector<XOutput> m_current;
   std::vector<XOutput> m_outputs;
   CStdString m_currentOutput;
   CStdString m_currentMode;
+  unsigned int m_numScreens;
 };
 
 extern CXRandR g_xrandr;


### PR DESCRIPTION
This fixes 2 issues.

1)
Window/scaling was not refreshed when xrandr (issued by user outside of XBMC) has changed mode. 

2)
On ATI HD series 2000 menu was scrambled after playback stopped and refresh rate was set back to desktop resolution.
