### PR TITLE
Bring av_read_frame_flush in line with ffmpeg git.

### DIFF
--- a/lib/xbmc-dll-symbols/DllAvFormat.c
+++ b/lib/xbmc-dll-symbols/DllAvFormat.c
@@ -28,6 +28,7 @@
 #include <libavformat/avformat.h>
 
 /* Taken from libavformat/utils.c */
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(54,0,0)
 static void flush_packet_queue(AVFormatContext *s)
 {
     AVPacketList *pktl;
@@ -53,6 +54,27 @@ static void flush_packet_queue(AVFormatContext *s)
     s->raw_packet_buffer_remaining_size = RAW_PACKET_BUFFER_SIZE;
 #endif
 }
+#else
+static void free_packet_buffer(AVPacketList **pkt_buf, AVPacketList **pkt_buf_end)
+{
+    while (*pkt_buf) {
+        AVPacketList *pktl = *pkt_buf;
+        *pkt_buf = pktl->next;
+        av_free_packet(&pktl->pkt);
+        av_freep(&pktl);
+    }
+    *pkt_buf_end = NULL;
+}
+/* XXX: suppress the packet queue */
+static void flush_packet_queue(AVFormatContext *s)
+{
+    free_packet_buffer(&s->parse_queue,       &s->parse_queue_end);
+    free_packet_buffer(&s->packet_buffer,     &s->packet_buffer_end);
+    free_packet_buffer(&s->raw_packet_buffer, &s->raw_packet_buffer_end);
+
+    s->raw_packet_buffer_remaining_size = RAW_PACKET_BUFFER_SIZE;
+}
+#endif
 
 /* Taken from libavformat/utils.c */
 void av_read_frame_flush(AVFormatContext *s)
@@ -62,7 +84,9 @@ void av_read_frame_flush(AVFormatContext *s)
 
     flush_packet_queue(s);
 
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(54,0,0)
     s->cur_st = NULL;
+#endif
 
     /* for each stream, reset read state */
     for(i = 0; i < s->nb_streams; i++) {
@@ -71,14 +95,25 @@ void av_read_frame_flush(AVFormatContext *s)
         if (st->parser) {
             av_parser_close(st->parser);
             st->parser = NULL;
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(54,0,0)
             av_free_packet(&st->cur_pkt);
+#endif
         }
         st->last_IP_pts = AV_NOPTS_VALUE;
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(54,0,0)
         st->cur_dts = AV_NOPTS_VALUE; /* we set the current DTS to an unspecified origin */
         st->reference_dts = AV_NOPTS_VALUE;
         /* fail safe */
         st->cur_ptr = NULL;
         st->cur_len = 0;
+#else
+#define RELATIVE_TS_BASE (INT64_MAX - (1LL<<48))
+        if(st->first_dts == AV_NOPTS_VALUE) st->cur_dts = RELATIVE_TS_BASE;
+        else                                st->cur_dts = AV_NOPTS_VALUE; /* we set the current DTS to an unspecified origin */
+        st->reference_dts = AV_NOPTS_VALUE;
+
+        st->probe_packets = MAX_PROBE_PACKETS;
+#endif
 
         for(j=0; j<MAX_REORDER_DELAY+1; j++)
             st->pts_buffer[j]= AV_NOPTS_VALUE;


### PR DESCRIPTION
Current version failed to build with ffmpeg git. This patch uses the new code when we are building against libavformat 54.

Maybe it would be a better idea to find another method but meanwhile this fixes xbmc to work with external ffmpeg git.
