### PR TITLE
[add] - add orientation info for movies based on ffmpeg hint

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -162,6 +162,7 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   m_dllAvFilter.avfilter_register_all();
 
   m_bSoftware     = hints.software;
+  m_iOrientation  = hints.orientation;
 
   m_formats.push_back(PIX_FMT_YUV420P);
   m_formats.push_back(PIX_FMT_YUVJ420P);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -104,6 +104,7 @@ protected:
 
   int m_iScreenWidth;
   int m_iScreenHeight;
+  int m_iOrientation;// orientation of the video in degress counter clockwise
 
   unsigned int m_uSurfacesCount;
 

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -158,6 +158,7 @@ public:
     bPTSInvalid = false;
     bForcedAspect = false;
     type = STREAM_VIDEO;
+    iOrientation = 0;
   }
 
   virtual ~CDemuxStreamVideo() {}
@@ -171,6 +172,7 @@ public:
   int iProfile; // encoder profile of the stream reported by the decoder. used to qualify hw decoders.
   bool bPTSInvalid; // pts cannot be trusted (avi's).
   bool bForcedAspect; // aspect is forced from container
+  int iOrientation; // orientation of the video in degress counter clockwise
 };
 
 class CDemuxStreamAudio : public CDemuxStream

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1006,7 +1006,12 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
         st->fAspect = SelectAspect(pStream, &st->bForcedAspect) * pStream->codec->width / pStream->codec->height;
         st->iLevel = pStream->codec->level;
         st->iProfile = pStream->codec->profile;
+        st->iOrientation = 0;
 
+        AVDictionaryEntry *rtag = m_dllAvUtil.av_dict_get(pStream->metadata, "rotate", NULL, 0);
+        if (rtag) 
+          st->iOrientation = atoi(rtag->value); 
+        
         if ( m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD) )
         {
           if (pStream->codec->codec_id == CODEC_ID_PROBE)

--- a/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
@@ -150,6 +150,7 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
   profile  = right.profile;
   ptsinvalid = right.ptsinvalid;
   forced_aspect = right.forced_aspect;
+  orientation = right.orientation;
 
   // AUDIO
   channels      = right.channels;
@@ -199,6 +200,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
     profile   = stream->iProfile;
     ptsinvalid = stream->bPTSInvalid;
     forced_aspect = stream->bForcedAspect;
+    orientation = stream->iOrientation;
   }
   else if(  right.type == STREAM_SUBTITLE )
   {

--- a/xbmc/cores/dvdplayer/DVDStreamInfo.h
+++ b/xbmc/cores/dvdplayer/DVDStreamInfo.h
@@ -77,6 +77,7 @@ public:
   int profile; // encoder profile of the stream reported by the decoder. used to qualify hw decoders.
   bool ptsinvalid;  // pts cannot be trusted (avi's).
   bool forced_aspect; // aspect is forced from container
+  int orientation; // orientation of the video in degress counter clockwise
 
   // AUDIO
   int channels;


### PR DESCRIPTION
This exposes any orientation info ffmpeg gives us now. Its based on the patch from this ticket:

http://trac.xbmc.org/ticket/12231

Credits go to acmay

The ffmpeg side is already fine now that we've bumped ffmpeg version.

For completly closing that ticket we need a way to rotate our video. I already discussed this with some other devs some month ago when this ticket was opened. Goal was a GPU based solution. Thats why i didn't merge that software rotation via ffmpeg filters which where part of the attached patch in that ticket, but only expose the orientation info for now.

So i have to ask the GL gurus now - how do wie rotate that damn thing :)
