### PR TITLE
fixed: lose subtitle after skip backwords or change subtitle language

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -138,11 +138,10 @@ bool CDVDDemuxVobsub::SeekTime(int time, bool backwords, double* startpts)
     if(m_Timestamp->pts > pts)
       break;
   }
-  if(backwords)
-    return true;
-
-  if(m_Timestamps.begin() != m_Timestamp)
+  for(unsigned i=0;i<m_Streams.size() && m_Timestamps.begin() != m_Timestamp;i++)
+  {
     m_Timestamp--;
+  }
   return true;
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -756,8 +756,9 @@ bool CDVDPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
   // check if we should read from subtitle demuxer
   if(m_dvdPlayerSubtitle.AcceptsData() && m_pSubtitleDemuxer )
   {
-    if(m_pSubtitleDemuxer)
-      packet = m_pSubtitleDemuxer->Read();
+    int time = DVD_TIME_TO_MSEC(m_clock.GetClock());
+    m_pSubtitleDemuxer->SeekTime(time, false);
+    packet = m_pSubtitleDemuxer->Read();
 
     if(packet)
     {
@@ -1973,11 +1974,6 @@ void CDVDPlayer::HandleMessages()
         if (m_pDemuxer && m_pDemuxer->SeekTime(time, msg.GetBackward(), &start))
         {
           CLog::Log(LOGDEBUG, "demuxer seek to: %d, success", time);
-          if(m_pSubtitleDemuxer)
-          {
-            if(!m_pSubtitleDemuxer->SeekTime(time, msg.GetBackward()))
-              CLog::Log(LOGDEBUG, "failed to seek subtitle demuxer: %d, success", time);
-          }
           FlushBuffers(!msg.GetFlush(), start, msg.GetAccurate());
         }
         else

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -756,9 +756,8 @@ bool CDVDPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
   // check if we should read from subtitle demuxer
   if(m_dvdPlayerSubtitle.AcceptsData() && m_pSubtitleDemuxer )
   {
-    int time = DVD_TIME_TO_MSEC(m_clock.GetClock());
-    m_pSubtitleDemuxer->SeekTime(time, false);
-    packet = m_pSubtitleDemuxer->Read();
+    if(m_pSubtitleDemuxer)
+      packet = m_pSubtitleDemuxer->Read();
 
     if(packet)
     {
@@ -1974,6 +1973,11 @@ void CDVDPlayer::HandleMessages()
         if (m_pDemuxer && m_pDemuxer->SeekTime(time, msg.GetBackward(), &start))
         {
           CLog::Log(LOGDEBUG, "demuxer seek to: %d, success", time);
+          if(m_pSubtitleDemuxer)
+          {
+            if(!m_pSubtitleDemuxer->SeekTime(time, msg.GetBackward()))
+              CLog::Log(LOGDEBUG, "failed to seek subtitle demuxer: %d, success", time);
+          }
           FlushBuffers(!msg.GetFlush(), start, msg.GetAccurate());
         }
         else

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -863,7 +863,7 @@ int CDVDPlayerVideo::GetLevel()
 void CDVDPlayerVideo::ProcessOverlays(DVDVideoPicture* pSource, double pts)
 {
   // remove any overlays that are out of time
-  m_pOverlayContainer->CleanUp(pts - m_iSubtitleDelay);
+  m_pOverlayContainer->CleanUp(m_pClock->GetClock() - m_iSubtitleDelay);
 
   enum EOverlay
   { OVERLAY_AUTO // select mode auto


### PR DESCRIPTION
This issue is part of Ticket #12750. The problem is vobsub timestamp not sync with the video after seek. Don't know if any better way to solve this.
