### PR TITLE
Fix for ticket #12724: External cuesheet issue

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3033,10 +3033,18 @@ void CFileItemList::Swap(unsigned int item1, unsigned int item2)
 bool CFileItemList::UpdateItem(const CFileItem *item)
 {
   if (!item) return false;
-  CFileItemPtr oldItem = Get(item->GetPath());
-  if (oldItem)
-    *oldItem = *item;
-  return oldItem;
+
+  CSingleLock lock(m_lock);
+  for (unsigned int i = 0; i < m_items.size(); i++)
+  {
+    CFileItemPtr pItem = m_items[i];
+    if (pItem->IsSamePath(item))
+    {
+      *pItem = *item;
+      return true;
+    }
+  }
+  return false;
 }
 
 void CFileItemList::AddSortMethod(SORT_METHOD sortMethod, int buttonLabel, const LABEL_MASKS &labelMasks)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -118,9 +118,11 @@ bool CGUIInfoManager::OnMessage(CGUIMessage &message)
     if (message.GetParam1() == GUI_MSG_UPDATE_ITEM && message.GetItem())
     {
       CFileItemPtr item = boost::static_pointer_cast<CFileItem>(message.GetItem());
-      if (item && m_currentFile->GetPath().Equals(item->GetPath()))
+      if (m_currentFile->IsSamePath(item.get()))
+      {
         *m_currentFile = *item;
-      return true;
+        return true;
+      }
     }
   }
   return false;

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -450,7 +450,7 @@ void CPlayList::UpdateItem(const CFileItem *item)
   for (ivecItems it = m_vecItems.begin(); it != m_vecItems.end(); ++it)
   {
     CFileItemPtr playlistItem = *it;
-    if (playlistItem->GetPath() == item->GetPath())
+    if (playlistItem->IsSamePath(item))
     {
       *playlistItem = *item;
       break;


### PR DESCRIPTION
This improves flac album with external cuesheet support. Exact steps to reproduce the problems
are in the bug report. http://trac.xbmc.org/ticket/12724

1) Three functions which previously compared path1==path2 now call CFileItem::IsSamePath() for the
comparison. IsSamePath() is unchanged. IsSamePath() compares m_lStartOffset as well as the path. This
extra criteria is needed to differentiate among tracks in a flac album.

2) CFileItemList::UpdateItem() has been rewritten to match jmarshall's description of what it is supposed to
do. I don't believe the function worked properly to begin with. See the discussion here: http://forum.xbmc.org/showthread.php?tid=127408
