### PR TITLE
Callback function for xbmc module (xbmc.Monitor)

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		7CCFD9AA1514952700211D82 /* PCMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCFD9A81514952700211D82 /* PCMCodec.cpp */; };
 		7CEE2E6D13D6B7A8000ABF2A /* TimeSmoother.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEE2E6B13D6B7A8000ABF2A /* TimeSmoother.cpp */; };
 		C807119F135DB842002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807119D135DB842002F601B /* InputOperations.cpp */; };
+		C8936060152C86EC00812418 /* PythonMonitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C893605E152C86EC00812418 /* PythonMonitor.cpp */; };
+		C8936063152C86F500812418 /* monitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8936061152C86F500812418 /* monitor.cpp */; };
 		C8EC5D51136954E400CCC10D /* XBMC_keytable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8EC5D4F136954E400CCC10D /* XBMC_keytable.cpp */; };
 		DF0DF16D13A3AF82008ED511 /* NFSDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0DF16A13A3AF82008ED511 /* NFSDirectory.cpp */; };
 		DF34890913FD96390026A711 /* GUIAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF34890713FD96390026A711 /* GUIAction.cpp */; };
@@ -1013,6 +1015,10 @@
 		A192FD47135E46C800D92E9B /* IOSAudioRingBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IOSAudioRingBuffer.h; path = AudioRenderers/IOSAudioRingBuffer.h; sourceTree = "<group>"; };
 		C807119D135DB842002F601B /* InputOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InputOperations.cpp; sourceTree = "<group>"; };
 		C807119E135DB842002F601B /* InputOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InputOperations.h; sourceTree = "<group>"; };
+		C893605E152C86EC00812418 /* PythonMonitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PythonMonitor.cpp; sourceTree = "<group>"; };
+		C893605F152C86EC00812418 /* PythonMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PythonMonitor.h; sourceTree = "<group>"; };
+		C8936061152C86F500812418 /* monitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = monitor.cpp; sourceTree = "<group>"; };
+		C8936062152C86F500812418 /* monitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = monitor.h; sourceTree = "<group>"; };
 		C8EC5D4F136954E400CCC10D /* XBMC_keytable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XBMC_keytable.cpp; sourceTree = "<group>"; };
 		C8EC5D50136954E400CCC10D /* XBMC_keytable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XBMC_keytable.h; sourceTree = "<group>"; };
 		DF0DF16A13A3AF82008ED511 /* NFSDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NFSDirectory.cpp; sourceTree = "<group>"; };
@@ -4707,6 +4713,8 @@
 				F56C758A131EC152000AD0F6 /* keyboard.h */,
 				F56C758B131EC152000AD0F6 /* listitem.cpp */,
 				F56C758C131EC152000AD0F6 /* listitem.h */,
+				C8936061152C86F500812418 /* monitor.cpp */,
+				C8936062152C86F500812418 /* monitor.h */,
 				F56C758D131EC152000AD0F6 /* player.cpp */,
 				F56C758E131EC152000AD0F6 /* player.h */,
 				F56C758F131EC152000AD0F6 /* pyplaylist.cpp */,
@@ -4715,6 +4723,8 @@
 				F5E113AE1435882900175026 /* pyrendercapture.h */,
 				F56C7568131EC152000AD0F6 /* PythonAddon.cpp */,
 				F56C7569131EC152000AD0F6 /* PythonAddon.h */,
+				C893605E152C86EC00812418 /* PythonMonitor.cpp */,
+				C893605F152C86EC00812418 /* PythonMonitor.h */,
 				F56C7591131EC152000AD0F6 /* PythonPlayer.cpp */,
 				F56C7592131EC152000AD0F6 /* PythonPlayer.h */,
 				F56C7593131EC152000AD0F6 /* pyutil.cpp */,
@@ -7066,6 +7076,8 @@
 				DFDB004B1516408F005079A4 /* FileCache.cpp in Sources */,
 				DFDB004C1516408F005079A4 /* MemBufferCache.cpp in Sources */,
 				7C1A89BB152671FB00C63311 /* TextureCacheJob.cpp in Sources */,
+				C8936060152C86EC00812418 /* PythonMonitor.cpp in Sources */,
+				C8936063152C86F500812418 /* monitor.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		7CCFD9991514950700211D82 /* PCMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCFD9971514950700211D82 /* PCMCodec.cpp */; };
 		7CEE2E7F13D6B7D4000ABF2A /* TimeSmoother.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEE2E7D13D6B7D4000ABF2A /* TimeSmoother.cpp */; };
 		C80711AD135DB85F002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C80711AB135DB85F002F601B /* InputOperations.cpp */; };
+		C893606F152C870600812418 /* monitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C893606D152C870600812418 /* monitor.cpp */; };
+		C8936072152C871400812418 /* PythonMonitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8936070152C871400812418 /* PythonMonitor.cpp */; };
 		C8EC5D26136953E100CCC10D /* XBMC_keytable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8EC5D24136953E100CCC10D /* XBMC_keytable.cpp */; };
 		DF0DF18013A3AF9F008ED511 /* NFSDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0DF17D13A3AF9F008ED511 /* NFSDirectory.cpp */; };
 		DF3488F813FD961A0026A711 /* GUIAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF3488F613FD961A0026A711 /* GUIAction.cpp */; };
@@ -1012,6 +1014,10 @@
 		8D576316048677EA00EA77CD /* XBMC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XBMC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C80711AB135DB85F002F601B /* InputOperations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InputOperations.cpp; sourceTree = "<group>"; };
 		C80711AC135DB85F002F601B /* InputOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InputOperations.h; sourceTree = "<group>"; };
+		C893606D152C870600812418 /* monitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = monitor.cpp; sourceTree = "<group>"; };
+		C893606E152C870600812418 /* monitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = monitor.h; sourceTree = "<group>"; };
+		C8936070152C871400812418 /* PythonMonitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PythonMonitor.cpp; sourceTree = "<group>"; };
+		C8936071152C871400812418 /* PythonMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PythonMonitor.h; sourceTree = "<group>"; };
 		C8EC5D24136953E100CCC10D /* XBMC_keytable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XBMC_keytable.cpp; sourceTree = "<group>"; };
 		C8EC5D25136953E100CCC10D /* XBMC_keytable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XBMC_keytable.h; sourceTree = "<group>"; };
 		DF0DF17D13A3AF9F008ED511 /* NFSDirectory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NFSDirectory.cpp; sourceTree = "<group>"; };
@@ -5063,6 +5069,8 @@
 				F56C856D131F42EA000AD0F6 /* keyboard.h */,
 				F56C856E131F42EA000AD0F6 /* listitem.cpp */,
 				F56C856F131F42EA000AD0F6 /* listitem.h */,
+				C893606D152C870600812418 /* monitor.cpp */,
+				C893606E152C870600812418 /* monitor.h */,
 				F56C8570131F42EA000AD0F6 /* player.cpp */,
 				F56C8571131F42EA000AD0F6 /* player.h */,
 				F56C8572131F42EA000AD0F6 /* pyplaylist.cpp */,
@@ -5071,6 +5079,8 @@
 				F5E1127C14356C4D00175026 /* pyrendercapture.h */,
 				F56C854B131F42E9000AD0F6 /* PythonAddon.cpp */,
 				F56C854C131F42E9000AD0F6 /* PythonAddon.h */,
+				C8936070152C871400812418 /* PythonMonitor.cpp */,
+				C8936071152C871400812418 /* PythonMonitor.h */,
 				F56C8574131F42EA000AD0F6 /* PythonPlayer.cpp */,
 				F56C8575131F42EA000AD0F6 /* PythonPlayer.h */,
 				F56C8576131F42EA000AD0F6 /* pyutil.cpp */,
@@ -7077,6 +7087,8 @@
 				DFDB00261516403A005079A4 /* FileCache.cpp in Sources */,
 				DFDB00271516403A005079A4 /* MemBufferCache.cpp in Sources */,
 				7C1A89CE1526722200C63311 /* TextureCacheJob.cpp in Sources */,
+				C893606F152C870600812418 /* monitor.cpp in Sources */,
+				C8936072152C871400812418 /* PythonMonitor.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -616,6 +616,10 @@
 		C84BF7341349BB74006D6FC9 /* JSONServiceDescription.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C84BF7321349BB74006D6FC9 /* JSONServiceDescription.cpp */; };
 		C85EB75C1174614E0008E5A5 /* Repository.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C85EB75A1174614E0008E5A5 /* Repository.cpp */; };
 		C85EB75D1174614E0008E5A5 /* Repository.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C85EB75A1174614E0008E5A5 /* Repository.cpp */; };
+		C8936052152C86CF00812418 /* monitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8936050152C86CF00812418 /* monitor.cpp */; };
+		C8936053152C86CF00812418 /* monitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8936050152C86CF00812418 /* monitor.cpp */; };
+		C8936056152C86D800812418 /* PythonMonitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8936054152C86D800812418 /* PythonMonitor.cpp */; };
+		C8936057152C86D800812418 /* PythonMonitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8936054152C86D800812418 /* PythonMonitor.cpp */; };
 		C8D0B2AF1265A9A800F0C0AC /* SystemGlobals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8D0B2AE1265A9A800F0C0AC /* SystemGlobals.cpp */; };
 		C8D0B2B01265A9A800F0C0AC /* SystemGlobals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8D0B2AE1265A9A800F0C0AC /* SystemGlobals.cpp */; };
 		C8EC5D0E1369519D00CCC10D /* XBMC_keytable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8EC5D0C1369519D00CCC10D /* XBMC_keytable.cpp */; };
@@ -2627,6 +2631,10 @@
 		C84BF7331349BB74006D6FC9 /* JSONServiceDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSONServiceDescription.h; sourceTree = "<group>"; };
 		C85EB75A1174614E0008E5A5 /* Repository.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Repository.cpp; sourceTree = "<group>"; };
 		C85EB75B1174614E0008E5A5 /* Repository.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Repository.h; sourceTree = "<group>"; };
+		C8936050152C86CF00812418 /* monitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = monitor.cpp; sourceTree = "<group>"; };
+		C8936051152C86CF00812418 /* monitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = monitor.h; sourceTree = "<group>"; };
+		C8936054152C86D800812418 /* PythonMonitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PythonMonitor.cpp; sourceTree = "<group>"; };
+		C8936055152C86D800812418 /* PythonMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PythonMonitor.h; sourceTree = "<group>"; };
 		C8D0B2AE1265A9A800F0C0AC /* SystemGlobals.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemGlobals.cpp; sourceTree = "<group>"; };
 		C8EC5D0C1369519D00CCC10D /* XBMC_keytable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XBMC_keytable.cpp; sourceTree = "<group>"; };
 		C8EC5D0D1369519D00CCC10D /* XBMC_keytable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XBMC_keytable.h; sourceTree = "<group>"; };
@@ -6164,6 +6172,8 @@
 				E38E19F80D25F9FB00618676 /* keyboard.h */,
 				E38E25920D263CE000618676 /* listitem.cpp */,
 				E38E19FA0D25F9FB00618676 /* listitem.h */,
+				C8936050152C86CF00812418 /* monitor.cpp */,
+				C8936051152C86CF00812418 /* monitor.h */,
 				E38E25930D263CE000618676 /* player.cpp */,
 				E38E19FE0D25F9FB00618676 /* player.h */,
 				E38E25940D263CE000618676 /* pyplaylist.cpp */,
@@ -6172,6 +6182,8 @@
 				F5E1125D14356B2400175026 /* pyrendercapture.h */,
 				7CD2CCFE11B38B000009EFC1 /* PythonAddon.cpp */,
 				7CD2CCFF11B38B000009EFC1 /* PythonAddon.h */,
+				C8936054152C86D800812418 /* PythonMonitor.cpp */,
+				C8936055152C86D800812418 /* PythonMonitor.h */,
 				E38E25950D263CE000618676 /* PythonPlayer.cpp */,
 				E38E1A020D25F9FB00618676 /* PythonPlayer.h */,
 				E38E25960D263CE000618676 /* pyutil.cpp */,
@@ -8195,6 +8207,8 @@
 				DF93D7F21444B54A007C6459 /* HDHomeRunFile.cpp in Sources */,
 				DF93D7F61444B568007C6459 /* HDHomeRunDirectory.cpp in Sources */,
 				7C1A85661520522500C63311 /* TextureCacheJob.cpp in Sources */,
+				C8936052152C86CF00812418 /* monitor.cpp in Sources */,
+				C8936056152C86D800812418 /* PythonMonitor.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9133,6 +9147,8 @@
 				DF93D7F31444B54A007C6459 /* HDHomeRunFile.cpp in Sources */,
 				DF93D7F71444B568007C6459 /* HDHomeRunDirectory.cpp in Sources */,
 				7C1A85651520522500C63311 /* TextureCacheJob.cpp in Sources */,
+				C8936053152C86CF00812418 /* monitor.cpp in Sources */,
+				C8936057152C86D800812418 /* PythonMonitor.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -650,6 +650,9 @@
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\listitem.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\monitor.cpp">
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\player.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -661,6 +664,9 @@
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonPlayer.cpp">
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonMonitor.cpp">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug (OpenGL)|Win32'">..\..\project\BuildDependencies\include\python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\pyutil.cpp">
@@ -1604,11 +1610,13 @@
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\infotagvideo.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\keyboard.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\listitem.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\monitor.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\player.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyjsonrpc.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyplaylist.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyrendercapture.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonAddon.h" />
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonMonitor.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonPlayer.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pyutil.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\window.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1925,6 +1925,9 @@
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\listitem.cpp">
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\monitor.cpp">
+      <Filter>interfaces\python\xbmcmodule</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\player.cpp">
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClCompile>
@@ -1932,6 +1935,9 @@
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonAddon.cpp">
+      <Filter>interfaces\python\xbmcmodule</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonMonitor.cpp">
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClCompile>
     <ClCompile Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonPlayer.cpp">
@@ -4534,6 +4540,9 @@
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\listitem.h">
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\monitor.h">
+      <Filter>interfaces\python\xbmcmodule</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\player.h">
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClInclude>
@@ -4544,6 +4553,9 @@
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonAddon.h">
+      <Filter>interfaces\python\xbmcmodule</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonMonitor.h">
       <Filter>interfaces\python\xbmcmodule</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\PythonPlayer.h">

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -48,6 +48,7 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "GUIWindowAddonBrowser.h"
 #include "utils/log.h"
+#include "interfaces/python/XBPython.h"
 
 using namespace std;
 using namespace ADDON;
@@ -534,7 +535,10 @@ void CGUIDialogAddonSettings::SaveSettings(void)
     m_addon->UpdateSetting(i->first, i->second);
 
   if (m_saveToDisk)
+  { 
     m_addon->SaveSettings();
+    g_pythonParser.OnSettingsChanged(m_addon->ID());
+  } 
 }
 
 void CGUIDialogAddonSettings::FreeSections()

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -41,6 +41,10 @@
 
 #include "threads/SystemClock.h"
 #include "addons/Addon.h"
+#include "interfaces/AnnouncementManager.h"
+#include "interfaces/python/xbmcmodule/PythonMonitor.h"
+
+using namespace ANNOUNCEMENT;
 
 extern "C" HMODULE __stdcall dllLoadLibraryA(LPCSTR file);
 extern "C" BOOL __stdcall dllFreeLibrary(HINSTANCE hLibModule);
@@ -71,10 +75,13 @@ XBPython::XBPython()
   m_ThreadId          = CThread::GetCurrentThreadId();
   m_iDllScriptCounter = 0;
   m_vecPlayerCallbackList.clear();
+  m_vecMonitorCallbackList.clear();
+  CAnnouncementManager::AddAnnouncer(this);
 }
 
 XBPython::~XBPython()
 {
+  CAnnouncementManager::RemoveAnnouncer(this);
 }
 
 // message all registered callbacks that xbmc stopped playing
@@ -89,6 +96,27 @@ void XBPython::OnPlayBackEnded()
       ((IPlayerCallback*)(*it))->OnPlayBackEnded();
       it++;
     }
+  }
+}
+
+void XBPython::Announce(AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data)
+{
+  if (flag & VideoLibrary)
+  {
+   if (strcmp(message, "OnScanFinished") == 0)
+    OnDatabaseUpdated("video");
+  }
+  else if (flag & AudioLibrary)
+  {
+   if (strcmp(message, "OnScanFinished") == 0)
+    OnDatabaseUpdated("music");
+  }
+  else if (flag & GUI)
+  {
+   if (strcmp(message, "OnScreensaverDeactivated") == 0)
+     OnScreensaverDeactivated();   
+   else if (strcmp(message, "OnScreensaverActivated") == 0)
+     OnScreensaverActivated();
   }
 }
 
@@ -170,6 +198,82 @@ void XBPython::UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback)
       it++;
   }
 }
+
+void XBPython::RegisterPythonMonitorCallBack(CPythonMonitor* pCallback)
+{
+  CSingleLock lock(m_critSection);
+  m_vecMonitorCallbackList.push_back(pCallback);
+}
+
+void XBPython::UnregisterPythonMonitorCallBack(CPythonMonitor* pCallback)
+{
+  CSingleLock lock(m_critSection);
+  MonitorCallbackList::iterator it = m_vecMonitorCallbackList.begin();
+  while (it != m_vecMonitorCallbackList.end())
+  {
+    if (*it == pCallback)
+      it = m_vecMonitorCallbackList.erase(it);
+    else
+      it++;
+  }
+}
+
+void XBPython::OnSettingsChanged(const CStdString &ID)
+{
+  CSingleLock lock(m_critSection);
+  if (m_bInitialized)
+  {
+    MonitorCallbackList::iterator it = m_vecMonitorCallbackList.begin();
+    while (it != m_vecMonitorCallbackList.end())
+    { 
+      if (((CPythonMonitor*)(*it))->Id == ID)  
+        ((CPythonMonitor*)(*it))->OnSettingsChanged();
+      it++;
+    }
+  }  
+}  
+
+void XBPython::OnScreensaverActivated()
+{
+  CSingleLock lock(m_critSection);
+  if (m_bInitialized)
+  {
+    MonitorCallbackList::iterator it = m_vecMonitorCallbackList.begin();
+    while (it != m_vecMonitorCallbackList.end())
+    {
+      ((CPythonMonitor*)(*it))->OnScreensaverActivated();
+      it++;
+    }
+  }  
+} 
+
+void XBPython::OnScreensaverDeactivated()
+{
+  CSingleLock lock(m_critSection);
+  if (m_bInitialized)
+  {
+    MonitorCallbackList::iterator it = m_vecMonitorCallbackList.begin();
+    while (it != m_vecMonitorCallbackList.end())
+    {
+      ((CPythonMonitor*)(*it))->OnScreensaverDeactivated();
+      it++;
+    }
+  }  
+} 
+
+void XBPython::OnDatabaseUpdated(const std::string &database)
+{
+ CSingleLock lock(m_critSection);
+ if (m_bInitialized)
+ {
+  MonitorCallbackList::iterator it = m_vecMonitorCallbackList.begin();
+  while (it != m_vecMonitorCallbackList.end())
+  {
+   ((CPythonMonitor*)(*it))->OnDatabaseUpdated(database);
+   it++;
+  }
+ }  
+} 
 
 /**
 * Check for file and print an error if needed

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -24,6 +24,7 @@
 #include "XBPyThread.h"
 #include "cores/IPlayer.h"
 #include "threads/CriticalSection.h"
+#include "interfaces/IAnnouncer.h"
 #include "addons/IAddon.h"
 
 #include <vector>
@@ -36,12 +37,16 @@ typedef struct {
 }PyElem;
 
 class LibraryLoader;
+class CPythonMonitor;
 
 typedef std::vector<PyElem> PyList;
 typedef std::vector<PVOID> PlayerCallbackList;
+typedef std::vector<PVOID> MonitorCallbackList;
 typedef std::vector<LibraryLoader*> PythonExtensionLibraries;
 
-class XBPython : public IPlayerCallback
+class XBPython : 
+  public IPlayerCallback,
+  public ANNOUNCEMENT::IAnnouncer
 {
 public:
   XBPython();
@@ -52,8 +57,15 @@ public:
   virtual void OnPlayBackResumed();
   virtual void OnPlayBackStopped();
   virtual void OnQueueNextItem() {};
+  virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
   void RegisterPythonPlayerCallBack(IPlayerCallback* pCallback);
   void UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback);
+  void RegisterPythonMonitorCallBack(CPythonMonitor* pCallback);
+  void UnregisterPythonMonitorCallBack(CPythonMonitor* pCallback);
+  void OnSettingsChanged(const CStdString &strings);
+  void OnScreensaverActivated();
+  void OnScreensaverDeactivated();
+  void OnDatabaseUpdated(const std::string &database);
   void Initialize();
   void Finalize();
   void FinalizeScript();
@@ -117,6 +129,7 @@ private:
   //Vector with list of threads used for running scripts
   PyList              m_vecPyList;
   PlayerCallbackList  m_vecPlayerCallbackList;
+  MonitorCallbackList m_vecMonitorCallbackList;
   LibraryLoader*      m_pDll;
 
   // any global events that scripts should be using

--- a/xbmc/interfaces/python/xbmcmodule/Makefile.in
+++ b/xbmc/interfaces/python/xbmcmodule/Makefile.in
@@ -22,10 +22,12 @@ SRCS=action.cpp \
      infotagvideo.cpp \
      keyboard.cpp \
      listitem.cpp \
+     monitor.cpp \
      player.cpp \
      pyplaylist.cpp \
      pyrendercapture.cpp \
      PythonAddon.cpp \
+     PythonMonitor.cpp \
      PythonPlayer.cpp \
      pyutil.cpp \
      window.cpp \

--- a/xbmc/interfaces/python/xbmcmodule/PythonMonitor.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/PythonMonitor.cpp
@@ -1,0 +1,131 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "PythonMonitor.h"
+#include "pyutil.h"
+#include "pythreadstate.h"
+#include "../XBPython.h"
+#include "threads/Atomics.h"
+
+using namespace PYXBMC;
+
+struct SPyEvent
+{
+  SPyEvent(CPythonMonitor* monitor
+         , const std::string &function, const std::string &arg = "")
+  {
+    m_monitor   = monitor;
+    m_monitor->Acquire();
+    m_function = function;
+    m_arg = arg;
+  }
+
+  ~SPyEvent()
+  {
+    m_monitor->Release();
+  }
+
+  std::string    m_function;
+  std::string    m_arg;
+  CPythonMonitor* m_monitor;
+};
+
+/*
+ * called from python library!
+ */
+static int SPyEvent_Function(void* e)
+{
+  SPyEvent* object = (SPyEvent*)e;
+  PyObject* ret    = NULL;
+
+  if(object->m_monitor->m_callback)
+  { 
+    if (!object->m_arg.empty())
+      ret = PyObject_CallMethod(object->m_monitor->m_callback, (char*)object->m_function.c_str(), "(s)", object->m_arg.c_str());
+    else
+      ret = PyObject_CallMethod(object->m_monitor->m_callback, (char*)object->m_function.c_str(), NULL);
+  }
+
+  if(ret)
+  {
+    Py_DECREF(ret);
+  }
+
+  CPyThreadState pyState;
+  delete object;
+
+  return 0;
+
+}
+
+CPythonMonitor::CPythonMonitor()
+{
+  m_callback = NULL;
+  m_refs     = 1;
+  g_pythonParser.RegisterPythonMonitorCallBack(this);
+}
+
+void CPythonMonitor::Release()
+{
+  if(AtomicDecrement(&m_refs) == 0)
+    delete this;
+}
+
+void CPythonMonitor::Acquire()
+{
+  AtomicIncrement(&m_refs);
+}
+
+CPythonMonitor::~CPythonMonitor(void)
+{
+  g_pythonParser.UnregisterPythonMonitorCallBack(this);
+}
+
+void CPythonMonitor::OnSettingsChanged()
+{
+  PyXBMC_AddPendingCall(m_state, SPyEvent_Function, new SPyEvent(this, "onSettingsChanged"));
+  g_pythonParser.PulseGlobalEvent();
+}
+
+void CPythonMonitor::OnScreensaverActivated()
+{
+  PyXBMC_AddPendingCall(m_state, SPyEvent_Function, new SPyEvent(this, "onScreensaverActivated"));
+  g_pythonParser.PulseGlobalEvent();
+}
+
+void CPythonMonitor::OnScreensaverDeactivated()
+{
+  PyXBMC_AddPendingCall(m_state, SPyEvent_Function, new SPyEvent(this, "onScreensaverDeactivated"));
+  g_pythonParser.PulseGlobalEvent();
+}
+
+void CPythonMonitor::OnDatabaseUpdated(const std::string &database)
+{
+ PyXBMC_AddPendingCall(m_state, SPyEvent_Function, new SPyEvent(this, "onDatabaseUpdated", database));
+ g_pythonParser.PulseGlobalEvent();
+}
+
+void CPythonMonitor::SetCallback(PyThreadState *state, PyObject *object)
+{
+  /* python lock should be held */
+  m_callback = object;
+  m_state    = state;
+}

--- a/xbmc/interfaces/python/xbmcmodule/PythonMonitor.h
+++ b/xbmc/interfaces/python/xbmcmodule/PythonMonitor.h
@@ -1,0 +1,51 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#pragma once
+
+#include <Python.h>
+#include <string>
+
+int Py_XBMC_Event_OnSettingsChanged(void* arg);
+int Py_XBMC_Event_OnScreensaverActivated(void* arg);
+int Py_XBMC_Event_OnScreensaverDeactivated(void* arg);
+int Py_XBMC_Event_OnDatabaseUpdated(void* arg);
+
+class CPythonMonitor
+{
+public:
+  CPythonMonitor();
+  void    SetCallback(PyThreadState *state, PyObject *object);
+  void    OnSettingsChanged();
+  void    OnScreensaverActivated();
+  void    OnScreensaverDeactivated();
+  void    OnDatabaseUpdated(const std::string &database);
+  
+  void    Acquire();
+  void    Release();
+
+  PyObject* m_callback;
+  PyThreadState *m_state;
+  std::string Id;
+protected:
+  ~CPythonMonitor(void);
+  long   m_refs;
+};

--- a/xbmc/interfaces/python/xbmcmodule/monitor.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/monitor.cpp
@@ -1,0 +1,150 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "monitor.h"
+#include "pyutil.h"
+#include "pythreadstate.h"
+#include "PythonMonitor.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace PYXBMC
+{
+  PyObject* Monitor_New(PyTypeObject *type, PyObject *args, PyObject *kwds)
+  {
+    Monitor *self;
+
+    self = (Monitor*)type->tp_alloc(type, 0);
+    if (!self) return NULL;
+    std::string addonId;
+    if (!PyXBMCGetAddonId(addonId) || addonId.empty())
+    {
+      PyErr_SetString((PyObject*)self, "Unable to identify addon");
+      return NULL;
+    }    
+    CPyThreadState pyState;
+    self->pMonitor = new CPythonMonitor();
+    pyState.Restore();
+    self->pMonitor->Id = addonId;    
+    self->pMonitor->SetCallback(PyThreadState_Get(), (PyObject*)self);
+ 
+    return (PyObject*)self;
+  }
+
+  void Monitor_Dealloc(Monitor* self)
+  {
+    self->pMonitor->SetCallback(NULL, NULL);
+
+    CPyThreadState pyState;
+    self->pMonitor->Release();
+    pyState.Restore();
+      
+    self->pMonitor = NULL;
+    self->ob_type->tp_free((PyObject*)self);
+  }
+
+
+  // Monitor_onSettingsChanged
+  PyDoc_STRVAR(onSettingsChanged__doc__,
+               "onSettingsChanged() -- onSettingsChanged method.\n"
+               "\n"
+               "Will be called when addon settings are changed");
+
+  PyObject* Monitor_OnSettingsChanged(PyObject *self, PyObject *args)
+  {
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+
+  // Monitor_onScreensaverActivated
+  PyDoc_STRVAR(onScreensaverActivated__doc__,
+               "onScreenSaverStarted() -- onScreensaverActivated method.\n"
+               "\n"
+               "Will be called when screensaver kicks in");
+  
+  PyObject* Monitor_OnScreensaverActivated(PyObject *self, PyObject *args)
+  {
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+
+  // Monitor_onScreensaverDeactivated
+  PyDoc_STRVAR(onScreensaverDeactivated__doc__,
+               "onScreensaverDeactivated() -- onScreensaverDeactivated method.\n"
+               "\n"
+               "Will be called when screensaver goes off");
+  
+  PyObject* Monitor_OnScreensaverDeactivated(PyObject *self, PyObject *args)
+  {
+    Py_INCREF(Py_None);
+    return Py_None;
+  }  
+
+  // Monitor_onDatabaseUpdated
+  PyDoc_STRVAR(onDatabaseUpdated__doc__,
+               "onDatabaseUpdated(database) -- onDatabaseUpdated method.\n"
+               "\n"
+               "database - video/music as string"
+               "\n"
+               "Will be called when database gets updated and return video or music to indicate which DB has been changed");
+  
+  PyObject* Monitor_OnDatabaseUpdated(PyObject *self, PyObject *args)
+  {
+   Py_INCREF(Py_None);
+   return Py_None;
+  }  
+ 
+  PyMethodDef Monitor_methods[] = {
+    {(char*)"onSettingsChanged", (PyCFunction)Monitor_OnSettingsChanged, METH_VARARGS, onSettingsChanged__doc__},
+    {(char*)"onScreensaverActivated", (PyCFunction)Monitor_OnScreensaverActivated, METH_VARARGS, onScreensaverActivated__doc__},
+    {(char*)"onScreensaverDeactivated", (PyCFunction)Monitor_OnScreensaverDeactivated, METH_VARARGS, onScreensaverDeactivated__doc__},
+    {(char*)"onDatabaseUpdated", (PyCFunction)Monitor_OnDatabaseUpdated, METH_VARARGS  , onDatabaseUpdated__doc__},
+    {NULL, NULL, 0, NULL}
+  };
+
+  PyDoc_STRVAR(monitor__doc__,
+    "Monitor class.\n"
+    "\n"
+    "Monitor() -- Creates a new Monitor to notify addon about changes.\n"
+    "\n");
+
+  PyTypeObject Monitor_Type;
+
+  void initMonitor_Type()
+  {
+    PyXBMCInitializeTypeObject(&Monitor_Type);
+
+    Monitor_Type.tp_name = (char*)"xbmc.Monitor";
+    Monitor_Type.tp_basicsize = sizeof(Monitor);
+    Monitor_Type.tp_dealloc = (destructor)Monitor_Dealloc;
+    Monitor_Type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
+    Monitor_Type.tp_doc = monitor__doc__;
+    Monitor_Type.tp_methods = Monitor_methods;
+    Monitor_Type.tp_base = 0;
+    Monitor_Type.tp_new = Monitor_New;
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/xbmc/interfaces/python/xbmcmodule/monitor.h
+++ b/xbmc/interfaces/python/xbmcmodule/monitor.h
@@ -1,0 +1,43 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+#pragma once
+
+#include <Python.h>
+#include "PythonMonitor.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace PYXBMC
+{
+  typedef struct {
+    PyObject_HEAD
+    CPythonMonitor* pMonitor;
+  } Monitor;
+
+  extern PyTypeObject Monitor_Type;
+  void initMonitor_Type();
+}
+  
+#ifdef __cplusplus
+}
+#endif

--- a/xbmc/interfaces/python/xbmcmodule/pyutil.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/pyutil.cpp
@@ -140,8 +140,27 @@ namespace PYXBMC
     memset(type_object, 0, sizeof(PyTypeObject));
     memcpy(type_object, &py_type_object_header, size);
   }
-}
 
+  bool PyXBMCGetAddonId(std::string &addonId)
+  {
+    // we need to retrieve the addon's ID from python using
+    // __xbmcaddonid__ so let's get a reference to the main
+    // module and global dictionary
+    PyObject* main_module = PyImport_AddModule((char*)"__main__");
+    PyObject* global_dict = PyModule_GetDict(main_module);
+    
+    // extract a reference to the function "func_name"
+    // from the global dictionary
+    PyObject* pyid = PyDict_GetItemString(global_dict, "__xbmcaddonid__");
+    
+    // if we were unable to retrieve the addon's ID return false
+    if (pyid == NULL)
+     return false;
+    
+    addonId = PyString_AsString(pyid);
+    return true;
+  }
+}
 
 struct SPending
 {

--- a/xbmc/interfaces/python/xbmcmodule/pyutil.h
+++ b/xbmc/interfaces/python/xbmcmodule/pyutil.h
@@ -42,6 +42,8 @@ namespace PYXBMC
 
   void  PyXBMCInitializeTypeObject(PyTypeObject* type_object);
   void  PyXBMCWaitForThreadMessage(int message, int param1, int param2);
+ 
+  bool  PyXBMCGetAddonId(std::string &addonId);
 }
 
 // Python doesn't play nice with PyXBMC_AddPendingCall

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -54,6 +54,7 @@
 #include "pythreadstate.h"
 #include "utils/log.h"
 #include "pyrendercapture.h"
+#include "monitor.h"
 
 // include for constants
 #include "pyutil.h"
@@ -1029,6 +1030,7 @@ namespace PYXBMC
     initPlayListItem_Type();
     initInfoTagMusic_Type();
     initInfoTagVideo_Type();
+    initMonitor_Type();
 
 #ifdef HAS_PYRENDERCAPTURE
     initRenderCapture_Type();
@@ -1039,7 +1041,8 @@ namespace PYXBMC
         PyType_Ready(&PlayList_Type) < 0 ||
         PyType_Ready(&PlayListItem_Type) < 0 ||
         PyType_Ready(&InfoTagMusic_Type) < 0 ||
-        PyType_Ready(&InfoTagVideo_Type) < 0) return;
+        PyType_Ready(&InfoTagVideo_Type) < 0 ||
+        PyType_Ready(&Monitor_Type) < 0) return;
 
 #ifdef HAS_PYRENDERCAPTURE
     if (PyType_Ready(&RenderCapture_Type) < 0)
@@ -1066,6 +1069,7 @@ namespace PYXBMC
     Py_INCREF(&PlayListItem_Type);
     Py_INCREF(&InfoTagMusic_Type);
     Py_INCREF(&InfoTagVideo_Type);
+    Py_INCREF(&Monitor_Type);
 
 #ifdef HAS_PYRENDERCAPTURE
     Py_INCREF(&RenderCapture_Type);
@@ -1080,6 +1084,7 @@ namespace PYXBMC
     PyModule_AddObject(pXbmcModule, (char*)"PlayListItem", (PyObject*)&PlayListItem_Type);
     PyModule_AddObject(pXbmcModule, (char*)"InfoTagMusic", (PyObject*)&InfoTagMusic_Type);
     PyModule_AddObject(pXbmcModule, (char*)"InfoTagVideo", (PyObject*)&InfoTagVideo_Type);
+    PyModule_AddObject(pXbmcModule, (char*)"Monitor", (PyObject*)&Monitor_Type);
 
     // constants
     PyModule_AddStringConstant(pXbmcModule, (char*)"__author__", (char*)PY_XBMC_AUTHOR);


### PR DESCRIPTION
Something has gone wrong on #834 so here is a new one, sry about that

monitors for:
- onSettingsChanged
- onScreensaverDeactivated
- onScreensaverActivated
- onDatabaseUpdated, will return the database that has been updated (video/music)

xbmc.Monitor will monitor for ScreenSaver activation/deactivation,  Settings changing and database update.

settings changing are quite useful on service addons to allow users to change the settings without deactivating/Activating addon to reload them. only changed addon will get notified.

cptspiff has gone over it but looks like the comments have been lost as I have squashed it down.

as ususal, this is a c/p monster from xbmc.Player callback , if anything needs changing I am all ears 

Cheers,
amet

``` Python
class MyMonitor( xbmc.Monitor ):
    def __init__( self, *args, **kwargs ):
        xbmc.Monitor.__init__( self )

    def onSettingsChanged( self ):
        print "settings changed, fetch new settings" 

    def onScreensaverDeactivated( self ):
        print "screensaver Deactivated" 

    def onScreensaverActivated( self ):    
        print "screensaver Activated"

    def onDatabaseUpdated( self, database ):
        print "%s database updated" %  database  

monitor = MyMonitor()

```
