### PR TITLE
renamed dowloader to downloader

### DIFF
--- a/lib/libUPnP/Platinum/Source/Core/PltDownloader.h
+++ b/lib/libUPnP/Platinum/Source/Core/PltDownloader.h
@@ -55,7 +55,7 @@ typedef enum {
     PLT_DOWNLOADER_DOWNLOADING,
     PLT_DOWNLOADER_ERROR,
     PLT_DOWNLOADER_SUCCESS
-} Plt_DowloaderState;
+} Plt_DownloaderState;
 
 /*----------------------------------------------------------------------
 |   PLT_Downloader class
@@ -70,7 +70,7 @@ public:
 
     NPT_Result Start();
     NPT_Result Stop();
-    Plt_DowloaderState GetState() { return m_State; }
+    Plt_DownloaderState GetState() { return m_State; }
 
     // PLT_HttpClientTask method
     NPT_Result ProcessResponse(NPT_Result                    res, 
@@ -85,7 +85,7 @@ private:
     NPT_OutputStreamReference m_Output;
     PLT_TaskManager*          m_TaskManager;
     PLT_HttpDownloadTask*     m_Task;
-    Plt_DowloaderState        m_State;
+    Plt_DownloaderState        m_State;
 };
 
 #endif /* _PLT_DOWNLOADER_H_ */


### PR DESCRIPTION
As I was testing something, I ran across what I think is a typo in the name of a typedef enum. I have no idea what this does or if we're even allowed to change it. The copyright notice is titled <pre>"| Copyright (c) 2004-2008, Plutinosoft, LLC."</pre> The only references I could locate are within this file. XBMC continues to compile and run for me with this change.
