### PR TITLE
Execute MarkWatched in another thread.

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -651,10 +651,16 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     }
 
   case CONTEXT_BUTTON_MARK_WATCHED:
-    CGUIWindowVideoBase::MarkWatched(item,true);
-    CUtil::DeleteVideoDatabaseDirectoryCache();
-    Refresh();
-    return true;
+    {
+      int newSelection = m_viewControl.GetSelectedItem() + 1;
+      CGUIWindowVideoBase::MarkWatched(item,true);
+      m_viewControl.SetSelectedItem(newSelection);
+
+      CUtil::DeleteVideoDatabaseDirectoryCache();
+      Refresh();
+
+      return true;
+    }
 
   case CONTEXT_BUTTON_MARK_UNWATCHED:
     CGUIWindowVideoBase::MarkWatched(item,false);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -68,6 +68,8 @@
 #include "pvr/PVRManager.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "utils/URIUtils.h"
+#include "utils/Job.h"
+#include "utils/JobManager.h"
 #include "GUIUserMessages.h"
 #include "addons/Skin.h"
 #include "storage/MediaManager.h"
@@ -1655,57 +1657,81 @@ void CGUIWindowVideoBase::OnDeleteItem(CFileItemPtr item)
     CFileUtils::DeleteItem(item);
 }
 
-void CGUIWindowVideoBase::MarkWatched(const CFileItemPtr &item, bool bMark)
+class CMarkWatchedJob : public CJob
 {
-  if (!CProfilesManager::Get().GetCurrentProfile().canWriteDatabases())
-    return;
-  // dont allow update while scanning
-  if (g_application.IsVideoScanning())
+public:
+  CMarkWatchedJob(const CFileItemPtr& item, bool bMark)
+    : m_item(item), m_bMark(bMark)
   {
-    CGUIDialogOK::ShowAndGetInput(257, 0, 14057, 0);
-    return;
   }
 
-  CVideoDatabase database;
-  if (database.Open())
+  virtual bool DoWork()
   {
-    CFileItemList items;
-    if (item->m_bIsFolder)
-    {
-      CStdString strPath = item->GetPath();
-      CDirectory::GetDirectory(strPath, items);
-    }
-    else
-      items.Add(item);
+    if (!CProfilesManager::Get().GetCurrentProfile().canWriteDatabases())
+      return false;
 
-    for (int i=0;i<items.Size();++i)
+    MarkWatched(m_item, m_bMark);
+
+    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
+    g_windowManager.SendThreadMessage(msg);
+
+    return true;
+  }
+
+  virtual const char *GetType() const { return "markwatched"; };
+
+private:
+  void MarkWatched(const CFileItemPtr &item, bool bMark)
+  {
+    CVideoDatabase database;
+    if (database.Open())
     {
-      CFileItemPtr pItem=items[i];
-      if (pItem->m_bIsFolder)
+      CFileItemList items;
+      if (item->m_bIsFolder)
       {
-        MarkWatched(pItem, bMark);
-        continue;
+        CStdString strPath = item->GetPath();
+        XFILE::CDirectory::GetDirectory(strPath, items);
       }
+      else
+        items.Add(item);
 
-      if (pItem->HasVideoInfoTag() &&
-          (( bMark && pItem->GetVideoInfoTag()->m_playCount) ||
-           (!bMark && !(pItem->GetVideoInfoTag()->m_playCount))))
-        continue;
+      for (int i = 0; i < items.Size(); ++i)
+      {
+        CFileItemPtr pItem = items[i];
+        if (pItem->m_bIsFolder)
+        {
+          MarkWatched(pItem, bMark);
+          continue;
+        }
+
+        if (pItem->HasVideoInfoTag() &&
+            (( bMark && pItem->GetVideoInfoTag()->m_playCount) ||
+             (!bMark && !(pItem->GetVideoInfoTag()->m_playCount))))
+          continue;
 
 #ifdef HAS_UPNP
-      if (!URIUtils::IsUPnP(item->GetPath()) || !UPNP::CUPnP::MarkWatched(*pItem, bMark))
+        if (!URIUtils::IsUPnP(item->GetPath()) || !UPNP::CUPnP::MarkWatched(*pItem, bMark))
 #endif
-      {
-        // Clear resume bookmark
-        if (bMark)
-          database.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
+        {
+          // Clear resume bookmark
+          if (bMark)
+            database.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
 
-        database.SetPlayCount(*pItem, bMark ? 1 : 0);
+          database.SetPlayCount(*pItem, bMark ? 1 : 0);
+        }
       }
+
+      database.Close();
     }
-    
-    database.Close(); 
   }
+
+  const CFileItemPtr &m_item;
+  bool m_bMark;
+};
+
+void CGUIWindowVideoBase::MarkWatched(const CFileItemPtr &pItem, bool bMark)
+{
+  CJobManager::GetInstance().AddJob(new CMarkWatchedJob(pItem, bMark), 0);
 }
 
 //Add change a title's name


### PR DESCRIPTION
Continuation of pull request #644.
- MarkWatched is now executed in another thread
- Harmonisation of the behavior of mark as watched :
  When marking a video as watched in Music mode, xbmc will not select
  the next entry, but it was the case for Video mode.
- Now MarkWatched works, even when scanning

Sorry for another pull request for this feature, I have wipe my old fork, in order to suppress the bad merges from xbmc/master
